### PR TITLE
please read...

### DIFF
--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -210,6 +210,7 @@ Usage: %s [OPTION]...
   -p, --port=NUM      bind to port NUM (default 37777)
   -h, --host=HOST     bind to host HOST (default "127.0.0.1")
   -l, --log=FILE      log to FILE (default "flasklog")
+  -t, --threading     multithread the database authentications
       --dbport=NUM    bind the MongoDB to the given port (default 37010)
       --debug         enable debug mode
       --logfocus=NAME enter name of logger to focus on
@@ -222,8 +223,8 @@ def main():
     import getopt
     try:
         opts, args = getopt.getopt(sys.argv[1:],
-                                   "p:h:l:",
-                                   ["port=", "host=", "dbport=", "log=", "logfocus=", "debug", "help",
+                                   "p:h:l:t",
+                                   ["port=", "host=", "dbport=", "log=", "logfocus=", "debug", "help", "threading", 
                                     # undocumented, see below
                                     "enable-reloader", "disable-reloader",
                                     "enable-debugger", "disable-debugger",
@@ -235,12 +236,13 @@ def main():
 
     # default options to pass to the app.run()
     options = {"port": 37777, "host": "127.0.0.1", "debug": False}
+    # Default option to pass to _init
+    threading_opt = False 
     # the logfocus can be set to the string-name of a logger you want
     # follow on the debug level and all others will be set to warning
     logfocus = None
     logfile = "flasklog"
     dbport = 37010
-
     for opt, arg in opts:
         if opt == "--help":
             usage()
@@ -249,6 +251,8 @@ def main():
             options["port"] = int(arg)
         elif opt in ("-h", "--host"):
             options["host"] = arg
+        elif opt in ("-t", "--threading"):
+            threading_opt = True
         elif opt in ("-l", "--log"):
             logfile = arg
         elif opt in ("--dbport"):
@@ -285,7 +289,7 @@ def main():
     app.logger.addHandler(file_handler)
 
     import base
-    base._init(dbport, readwrite_password)
+    base._init(dbport, readwrite_password, parallel_authentication = threading_opt)
     base.set_logfocus(logfocus)
     logging.info("... done.")
 


### PR DESCRIPTION
So I prepared a patch and pushed it to what I thought was my github repo, but actually I pushed it to the main master by mistake. Rather than "fixing git history" and likely causing more trouble, I quickly put in a second patch with something like
if True: 
   # like before
else: 
   # authenticate once
to make my change on the master innocuous at the moment. 

On my github fork however I now have a third patch that makes the change active, that I am asking you to pull to the master after testing. In the end the change is that _init now authenticates only once (readonly for safety) through the connection if the pymongo driver is >= 2.0 (which is when the change in the driver was implemented, at least according to the poor documentation). 
I don't think this fits all the experiments we did, but it does work in practice on both of my machines. So please test on your machines before pulling that change from my fork to the master... Harald particularly, make sure the readonly authentication is not problematic (I could edit a knowl through 127.0.0.1:37777, so it should be okay)
