### PR TITLE
Fixed routing for /Character/Dirichlet

### DIFF
--- a/lmfdb/DirichletCharacter.py
+++ b/lmfdb/DirichletCharacter.py
@@ -31,7 +31,7 @@ logger = make_logger("DC")
 @app.route("/Character/Dirichlet/<arg1>")
 @app.route("/Character/Dirichlet/<arg1>/<arg2>")
 def render_Character(arg1=None, arg2=None):
-    return DirichletCharacter.render_webpage(request, arg1, arg2)
+    return render_webpage(request, arg1, arg2)
 
 
 def render_webpage(request, arg1, arg2):


### PR DESCRIPTION
I think that at some point someone moved the Dirichlet character routing
from website.py to DirichletCharacter.py. Except that they didn't remove
some routing from website.py, so the new routing wasn't used. Later on
someone came along and removed the extraneous routing in website.py, and
probably didn't check that the website worked after that, because the
routing in website.py was the only correct routing.

This is a small fix to make things work in DirichletCharacter.py.
