### PR TITLE
Changed spelling of zeroes to zeros

### DIFF
--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -22,7 +22,7 @@
   </div>
  {% endif %}
 
- <h2> Imaginary part of the first few zeroes on the {{ KNOWL('lfunction.critical_line', title='critical line') }}</h2>
+ <h2> Imaginary part of the first few zeros on the {{ KNOWL('lfunction.critical_line', title='critical line') }}</h2>
 
  {% if zeroeslink %}
      <div><span id="zeroes"></span></div>

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -151,7 +151,7 @@
 &nbsp;
 &nbsp;
 &nbsp;
-  Zeroes</li>
+  Zeros</li>
     {% endif %}
   </ul>
 


### PR DESCRIPTION
To be consistent with other spellings elsewhere...
