### PR TITLE
Use new database field when searching for Artin representations.

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -116,6 +116,8 @@ def artin_representation_search(**args):
     elif len(tmp_both) >= 2:
         query["$or"] = tmp_both
 
+    # Only show 1 polynomial per representation
+    query["Show"] = 1
     count_default = 20
     if req.get('count'):
         try:


### PR DESCRIPTION
This makes it so we see only one defining polynomial per representation.
