### PR TITLE
Simplified setup

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -6,7 +6,7 @@ Installation
      git clone git@github.com:LMFDB/lmfdb.git lmfdb
   ```
 
-* Make sure you have sage (>=6.4) installed and that
+* Make sure you have sage (>=6.5) installed and that
   `sage` is available from the commandline
 
 * Install dependencies (in the `lmfdb/` directory):

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -1,83 +1,23 @@
 Installation
 ============
 
-  * To contribute, see below on sharing your work.  To simply run a copy of the site move into a new directory and type
+* To contribute, see below on sharing your work. To simply run a copy of the site move into a new directory and type
 ```
     git clone git@github.com:LMFDB/lmfdb.git lmfdb
 ```
 
-  * Install dependencies, i.e. you need Sage. Inside the Sage environment `sage -sh`:
+* Make sure you have sage (>=6.4) installed and that
+  `sage` is available from the commandline
+
+* Install dependencies (in the `lmfdb/` directory):
 ```
-    easy_install -U flask
-    easy_install -U flask-login
-    easy_install -U pymongo
-    easy_install -U flask-markdown
-    easy_install -U flask-cache
-    easy_install -U pyyaml
-    easy_install -U unittest2
-    # optional packages, necessary for contributing:
-    easy_install -U coverage
-    easy_install -U nose
-```
-  * From the command-line:
-    `
     sage -i gap_packages
-    ` 
-  (should check if we really need gap_packages.)
-    `
-    sage -i database_gap 
-    `
-    
-  * Regarding !MathJax: No longer necessary to install !MathJax.
-
-  `
-  ssh -C -N -L 37010:localhost:37010 mongo-user@lmfdb.warwick.ac.uk
-  ` 
-  (please send your public SSH key to Harald Schilly, Jonathan Bober or John Cremona to make it work)
-
-    * -C for compression of communication
-    * -N to not open a remote shell, just a blocking command in the shell (end connection with Ctrl-C)
-  If you don't have access to this server, you can temporarily start your own mongodb server and use it locally. There is no data (obviously) but it will work.
-    * Mongo locally:
-    ` 
-    mongod --port 40000 --dbpath [db_directory] --smallfiles 
-    `
-
-Note: Inside Sage, you might have to update the setuptools first, i.e. ` easy_install -U setuptools `
-
-Optional Parts
---------------
-
-* `dirichlet_conrey.pyx`:
-```
-goto [https://github.com/jwbober/conrey-dirichlet-characters its github page]
-download dirichlet_conrey.pyx and setup.py
-run: `sage setup.py install`
-if it doesn't compile, update sage's cython and then try again:
-    `sage -sh`
-    `easy_install -U cython`
-    `exit`
+    sage -i database_gap
+    sage -i pip
+    sage -pip install -r requirements.txt
 ```
 
-* Lfunction plots:
-
-To get plots locally, for sage <= 6.2, need a patch
-
-From within sage directory
-```
-     git remote add trac git://trac.sagemath.org/sage.git -t master
-     git fetch trac u/chapoton/8621 
-     git checkout -b patch8621 FETCH_HEAD
-```
-
-Then rebuild:
-
-```
-     sage -b
-```
-
-* Memcache:
-
+  * [optional] Memcache:
 ```
    ` easy_install -U python-memcached` or even better and only possible if you have the dev headers: ` easy_install -U pylibmc `
    install *memcached* (e.g. ` apt-get install memcached `)
@@ -87,7 +27,30 @@ Then rebuild:
 Running
 =======
 
-Once everything is setup, `sage -python start-lmfdb.py` should do the trick, but there can be some problems running in debug mode, so you might have omit the `--debug` (`--debug` doesn't work right now, but will soon!).  Once the server is running, visit http://localhost:37777/
+* You need to connect to the lmfdb database
+  ```
+     ssh -C -N -L 37010:localhost:37010 mongo-user@lmfdb.warwick.ac.uk 
+  ```
+  (please send your public SSH key to Harald Schilly, Jonathan Bober or John Cremona to make it work)
+
+    * -C for compression of communication
+    * -N to not open a remote shell, just a blocking command in the shell (end connection with Ctrl-C)
+
+* If you don't have access to this server, you can temporarily start your own mongodb server and use it locally.
+  There is no data (obviously) but it will work.
+  Mongo locally:
+    ` 
+    mongod --port 40000 --dbpath [db_directory] --smallfiles 
+    `
+
+* Then launch the webserver
+  ```
+     sage -python start-lmfdb.py
+  ```
+  should do the trick, but there can be some problems running in debug mode, so you might have omit the `--debug`
+  (`--debug` doesn't work right now, but will soon!).
+
+* Once the server is running, visit http://localhost:37777/
 
 Maybe, you have to suppress loading of your local python libraries: `sage -python -s start-lmfdb.py`
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -2,27 +2,26 @@ Installation
 ============
 
 * To contribute, see below on sharing your work. To simply run a copy of the site move into a new directory and type
-```
-    git clone git@github.com:LMFDB/lmfdb.git lmfdb
-```
+  ```
+     git clone git@github.com:LMFDB/lmfdb.git lmfdb
+  ```
 
 * Make sure you have sage (>=6.4) installed and that
   `sage` is available from the commandline
 
 * Install dependencies (in the `lmfdb/` directory):
-```
-    sage -i gap_packages
-    sage -i database_gap
-    sage -i pip
-    sage -pip install -r requirements.txt
-```
+  ```
+      sage -i gap_packages
+      sage -i database_gap
+      sage -i pip
+      sage -pip install -r requirements.txt
+  ```
 
   * [optional] Memcache:
-```
+
    ` easy_install -U python-memcached` or even better and only possible if you have the dev headers: ` easy_install -U pylibmc `
    install *memcached* (e.g. ` apt-get install memcached `)
-   run the service at 127.0.0.1:11211
-```
+   run the service at `127.0.0.1:11211`
 
 Running
 =======
@@ -33,15 +32,14 @@ Running
   ```
   (please send your public SSH key to Harald Schilly, Jonathan Bober or John Cremona to make it work)
 
-    * -C for compression of communication
-    * -N to not open a remote shell, just a blocking command in the shell (end connection with Ctrl-C)
-
-* If you don't have access to this server, you can temporarily start your own mongodb server and use it locally.
-  There is no data (obviously) but it will work.
-  Mongo locally:
-    ` 
-    mongod --port 40000 --dbpath [db_directory] --smallfiles 
-    `
+  * -C for compression of communication
+  * -N to not open a remote shell, just a blocking command in the shell (end connection with Ctrl-C)
+  * If you don't have access to this server, you can temporarily start your own mongodb server and use it locally.
+    There is no data (obviously) but it will work.
+    Mongo locally:
+    ``` 
+       mongod --port 40000 --dbpath [db_directory] --smallfiles 
+    ``` 
 
 * Then launch the webserver
   ```

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -14,6 +14,7 @@ Installation
       sage -i gap_packages
       sage -i database_gap
       sage -i pip
+      sage -b
       sage -pip install -r requirements.txt
   ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ unittest2
 coverage
 nose
 cython
--e git://github.com/jwbober/conrey-dirichlet-characters.git#egg=dirichlet_conrey
+git+git://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ unittest2
 coverage
 nose
 cython
-git+https://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey
+git+git://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ unittest2
 coverage
 nose
 cython
-git+git://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey
+git+https://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ flask-markdown
 pymongo
 pyyaml
 unittest2
+coverage
+nose
+cython
+-e git://github.com/jwbober/conrey-dirichlet-characters.git#egg=dirichlet_conrey

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 flask-cache
 flask-login
 flask-markdown
-pymongo
+pymongo==2.8
 pyyaml
 unittest2
 coverage


### PR DESCRIPTION
I think I have found a way to make the lmfdb setup much simpler. But some testing would be welcome.

With this patch, on my machine, with a new sage-4.6 freshly downloaded, following the (updated) instructions, that is typing only
```
sage -i gap_packages
sage -i database_gap
sage -i pip
sage -b
sage -pip install -r requirements.txt
```
sets up everything so that all tests (but one on tensor products) pass.

two comments:
- first, I suspect that the problems with the Dirichlet characters on sage 6.4 are due to the fact that everyone
  uses an outdated package dirichlet-conrey. Jonathan and I have made changes in the Arizona workshop.
- this issue is solved here since I use pip to install all packages at once from requirements.txt, including the dirichlet_conrey module directly from Jonathan's github


