### PR TITLE
Tests

### DIFF
--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -67,13 +67,10 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/')
         assert 'Browse' in W.data and 'search' in W.data
 
-    #@unittest2.skip("wait extra level")
     def test_dirichletfamily(self):
         W = self.tc.get('/Character/Dirichlet/')
         assert 'Find a specific' in W.data
         assert 'Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\)' in W.data
-        #assert '/Character/Dirichlet/11/3' in W.data, "7th first conductor"
-        #assert 'C_{2}\\times C_{2}' in W.data
 
     def test_dirichletgroup(self):
         W = self.tc.get('/Character/Dirichlet/23')

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -67,11 +67,13 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/')
         assert 'Browse' in W.data and 'search' in W.data
 
-    @unittest2.skip("wait extra level")
+    #@unittest2.skip("wait extra level")
     def test_dirichletfamily(self):
         W = self.tc.get('/Character/Dirichlet/')
-        assert '/Character/Dirichlet/11/3' in W.data, "7th first conductor"
-        assert 'C_{2}\\times C_{2}' in W.data
+        assert 'Find a specific' in W.data
+        assert 'Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\)' in W.data
+        #assert '/Character/Dirichlet/11/3' in W.data, "7th first conductor"
+        #assert 'C_{2}\\times C_{2}' in W.data
 
     def test_dirichletgroup(self):
         W = self.tc.get('/Character/Dirichlet/23')

--- a/lmfdb/symL/symL.py
+++ b/lmfdb/symL/symL.py
@@ -77,7 +77,7 @@ class SymmetricPowerLFunction(SageObject):
         if m % 2 == 0:
             F = F * (1 - p ** (m // 2) * x)
 
-        return F.coeffs()
+        return F.coefficients(sparse=False)
 
     def an_list(self, upperbound=100000):
         from sage.rings.fast_arith import prime_range

--- a/lmfdb/symL/sympowlmfdb.py
+++ b/lmfdb/symL/sympowlmfdb.py
@@ -164,7 +164,7 @@ class SympowLMFDB(SageObject):
         bad_primes_l = [i for i in vv if re.match(r'sp %d: Euler' % n, i)]
 
         bad_primes = [(sage.rings.all.Integer(i.split()[5]),
-                      R(i.split()[7]).coeffs()) for i in bad_primes_l]
+                       R(i.split()[7]).coefficients(sparse=False)) for i in bad_primes_l]
 
         cond_rootn_string = [i for i in vv if re.search('conductor', i)].pop()
         cond_rootn_string = cond_rootn_string.replace(',', ' ')

--- a/lmfdb/test_lfunction.py
+++ b/lmfdb/test_lfunction.py
@@ -166,7 +166,6 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/Plot/EllipticCurve/Q/56.a/')
         assert 'OK' in str(L)
 
-    @unittest2.skip("hypergeometric motives not yet available on master") 
     def test_LHGMZeros(self):
         L = self.tc.get('/L/Zeros/Motive/Hypergeometric/Q/A2.2.2.2_B1.1.1.1_t1.2/')
         assert '4.307350233' in L.data
@@ -184,7 +183,7 @@ class LfunctionTest(LmfdbTest):
         svg = paintSvgFileAll([["GSp4", 1]])
         assert "12.4687" in svg
 
-    @unittest2.skip("Error in holomorphic cusp forms still")
+    #@unittest2.skip("Error in holomorphic cusp forms still")
     def test_paintSVGholo(self):
         svg = paintSvgHolo(4,6,4,6)
         assert "/L/ModularForm/GL2/Q/holomorphic/4/6/0/a/0" in svg

--- a/lmfdb/test_lfunction.py
+++ b/lmfdb/test_lfunction.py
@@ -29,7 +29,6 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/EllipticCurve/Q/56.a/')
         assert 'Graph' in L.data
 
-    #@unittest2.skip("Holomorphic cusp forms not working yet")
     def test_Lemf(self):
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/11/2/0/a/0/')
         assert 'Graph' in L.data
@@ -183,7 +182,6 @@ class LfunctionTest(LmfdbTest):
         svg = paintSvgFileAll([["GSp4", 1]])
         assert "12.4687" in svg
 
-    #@unittest2.skip("Error in holomorphic cusp forms still")
     def test_paintSVGholo(self):
         svg = paintSvgHolo(4,6,4,6)
         assert "/L/ModularForm/GL2/Q/holomorphic/4/6/0/a/0" in svg

--- a/lmfdb/test_tensor_products.py
+++ b/lmfdb/test_tensor_products.py
@@ -17,6 +17,10 @@ class TensorProductTest(LmfdbTest):
         assert '1859' in L.data
 
     def test_modform_artinrep(self):
+        L1 = self.tc.get("ModularForm/GL2/Q/holomorphic/1/12/0/a/")
+        assert "6048q^{6}" in L1.data
+        L2 = self.tc.get("ArtinRepresentation/2/31/1/")
+        assert "(1,2,3)" in L2.data
         L = self.tc.get("TensorProducts/show/?obj1=ModularForm%2FGL2%2FQ%2Fholomorphic%2F1%2F12%2F0%2Fa%2F0&obj2=ArtinRepresentation%2F2%2F31%2F1%2F")
-        assert '961' in L.data 
+        assert '961' in L.data
 


### PR DESCRIPTION
Some more work on failing or skipped tests.  There are now just 3 skipped, and 1 which fails, which is a tensor product of a Modular Forms and an Artin Rep which are fine separately, but which cause a run-time error when tensored together, when trying to access an ap for p=101 when only p<100 are available (the error message in the display comes from modular_forms/elliptic_modular_forms/backend/web_modforms.py, in the function coefficient_n_recursive, around line 1443).