### PR TITLE
commented out db authentication which did not work anyway

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -35,6 +35,11 @@ def get_logfocus():
 # global db connection instance
 _C = None
 
+# Note: the original intention was to have all databases and
+# collections read-only except to users who could authenticate
+# themselves with a password.  But this never worked, and this list
+# (which is in any case incomplete) is now redundant.
+
 readonly_dbs = ['HTPicard', 'Lfunction', 'Lfunctions', 'MaassWaveForm',
                 'ellcurves', 'elliptic_curves', 'hmfs', 'modularforms', 'modularforms_2010',
                 'mwf_dbname', 'numberfields', 'quadratic_twists', 'test', 'limbo']
@@ -90,6 +95,9 @@ def _init(dbport, readwrite_password, parallel_authentication=False):
     global _C
     logging.info("establishing db connection at port %s ..." % dbport)
     _C = Connection(port=dbport)
+
+    # Disabling authentication completely as it does not work:
+    return
 
     def db_auth_task(db, readonly=False):
         if readonly or readwrite_password == '':


### PR DESCRIPTION
After email exchange with Harald.  The authentication process was originally intended to make most databases read-only except to users who could authenticate, but it did not work.  Also we cannot add new databases to this scheme since no-one remembers the password which was originally used.  One day this could be re-done, but for the moment this just removes a lot of the verbose start-up messages.
