### PR TITLE
refactoring for pymongo 3

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -11,10 +11,8 @@ import sys
 import logging
 from time import sleep
 from flask import Flask, session, g, render_template, url_for, request, redirect
-from pymongo import Connection
 from pymongo.cursor import Cursor
 from pymongo.errors import AutoReconnect
-from pymongo.connection import Connection
 from sage.all import *
 from functools import wraps
 from werkzeug.contrib.cache import SimpleCache
@@ -32,8 +30,25 @@ def get_logfocus():
     global logfocus
     return logfocus
 
-# global db connection instance
+# global db connection instance (will be set by the first call to
+# getDBConnection() and should always be obtained from that)
 _C = None
+
+def getDBConnection():
+    return _C
+
+def makeDBConnection(dbport):
+    global _C
+    if not _C:
+        logging.info("establishing db connection at port %s ..." % dbport)
+        import pymongo
+        logging.info("using pymongo version %s" % pymongo.version)
+        if pymongo.version_tuple[0] < 3:
+            from pymongo import Connection
+            _C = Connection(port=dbport)
+        else:
+            from pymongo.mongo_client import MongoClient
+            _C = MongoClient(port=dbport)
 
 # Note: the original intention was to have all databases and
 # collections read-only except to users who could authenticate
@@ -92,19 +107,18 @@ def _db_reconnect(func):
 
 
 def _init(dbport, readwrite_password, parallel_authentication=False):
-    global _C
-    logging.info("establishing db connection at port %s ..." % dbport)
-    _C = Connection(port=dbport)
+    makeDBConnection(dbport)
+    C = getDBConnection()
 
     # Disabling authentication completely as it does not work:
     return
 
     def db_auth_task(db, readonly=False):
         if readonly or readwrite_password == '':
-            _C[db].authenticate(readonly_username, readonly_password)
+            C[db].authenticate(readonly_username, readonly_password)
             logging.info("authenticated readonly on database %s" % db)
         else:
-            _C[db].authenticate(readwrite_username, readwrite_password)
+            C[db].authenticate(readwrite_username, readwrite_password)
             logging.info("authenticated readwrite on database %s" % db)
 
     if parallel_authentication:
@@ -130,10 +144,6 @@ def _init(dbport, readwrite_password, parallel_authentication=False):
         for db in readonly_dbs:
             db_auth_task(db, True)
         logging.info(">>> db auth done")
-
-
-def getDBConnection():
-    return _C
 
 app = Flask(__name__)
 

--- a/lmfdb/examples/mapreduce.py
+++ b/lmfdb/examples/mapreduce.py
@@ -4,7 +4,6 @@
 # copyright harald schilly <harald.schilly@gmail.com>
 # license apach 2.0
 
-from pymongo import *
 from bson import Code
 from random import random
 import base

--- a/lmfdb/examples/referencing.py
+++ b/lmfdb/examples/referencing.py
@@ -3,7 +3,6 @@
 # license: Apache 2.0
 
 
-from pymongo import *
 import base
 
 db = base.getDBConnection().db

--- a/lmfdb/examples/searching.py
+++ b/lmfdb/examples/searching.py
@@ -2,7 +2,6 @@
 # copyright: harald schilly <harald.schilly@gmail.com>
 # license: Apache 2.0
 
-from pymongo import *
 import random
 from math import floor, ceil
 from lmfdb import base

--- a/lmfdb/hilbert_modular_forms/import_hmf_data.py
+++ b/lmfdb/hilbert_modular_forms/import_hmf_data.py
@@ -5,15 +5,14 @@ import sys
 import time
 import sage.misc.preparser
 import subprocess
-from pymongo import Connection
+from lmfdb import base
+from lmfdb.website import dbport
 
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_fields = Connection(port=dbport).hmfs.fields
-hmf_fields = Connection(port=dbport).hmfs.fields
-
-fields = Connection(port=dbport).numberfields.fields
-fields = Connection(port=dbport).numberfields.fields
+base._init(dbport, '')
+C = base.getDBConnection()
+hmf_forms = C.hmfs.forms
+hmf_fields = C.hmfs.fields
+fields = C.numberfields.fields
 
 # hmf_forms.create_index('field_label')
 # hmf_forms.create_index('level_norm')

--- a/lmfdb/hilbert_modular_forms/q_expansion.py
+++ b/lmfdb/hilbert_modular_forms/q_expansion.py
@@ -5,15 +5,14 @@ import sys
 import time
 import sage.misc.preparser
 import subprocess
-from pymongo import Connection
+from lmfdb import base
+from lmfdb.website import dbport
+base._init(dbport, '')
+C = base.getDBConnection()
 
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_fields = Connection(port=dbport).hmfs.fields
-hmf_fields = Connection(port=dbport).hmfs.fields
-
-fields = Connection(port=dbport).numberfields.fields
-fields = Connection(port=dbport).numberfields.fields
+hmf_forms = C.hmfs.forms
+hmf_fields = C.hmfs.fields
+fields = C.numberfields.fields
 
 P = PolynomialRing(Rationals(), 3, ['w', 'e', 'x'])
 w, e, x = P.gens()

--- a/lmfdb/hilbert_modular_forms/recompute_AL.py
+++ b/lmfdb/hilbert_modular_forms/recompute_AL.py
@@ -5,15 +5,14 @@ import sys
 import time
 import sage.misc.preparser
 import subprocess
-from pymongo import Connection
+from lmfdb import base
+from lmfdb.website import dbport
+base._init(dbport, '')
+C = base.getDBConnection()
 
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_fields = Connection(port=dbport).hmfs.fields
-hmf_fields = Connection(port=dbport).hmfs.fields
-
-fields = Connection(port=dbport).numberfields.fields
-fields = Connection(port=dbport).numberfields.fields
+hmf_forms = C.hmfs.forms
+hmf_fields = C.hmfs.fields
+fields = C.numberfields.fields
 
 P = PolynomialRing(Rationals(), 3, ['w', 'e', 'x'])
 w, e, x = P.gens()

--- a/lmfdb/hilbert_modular_forms/recompute_AL_modp.py
+++ b/lmfdb/hilbert_modular_forms/recompute_AL_modp.py
@@ -5,15 +5,14 @@ import sys
 import time
 import sage.misc.preparser
 import subprocess
-from pymongo import Connection
+from lmfdb import base
+from lmfdb.website import dbport
+base._init(dbport, '')
+C = base.getDBConnection()
 
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_forms = Connection(port=dbport).hmfs.forms
-hmf_fields = Connection(port=dbport).hmfs.fields
-hmf_fields = Connection(port=dbport).hmfs.fields
-
-fields = Connection(port=dbport).numberfields.fields
-fields = Connection(port=dbport).numberfields.fields
+hmf_forms = C.hmfs.forms
+hmf_fields = C.hmfs.fields
+fields = C.numberfields.fields
 
 P = PolynomialRing(Rationals(), 3, ['w', 'e', 'x'])
 w, e, x = P.gens()

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -90,7 +90,7 @@ def set_locked(knowl, who):
 
 
 def get_knowl(ID, fields={"history": 0, "_keywords": 0}):
-    return get_knowls().find_one({'_id': ID}, fields=fields)
+    return get_knowls().find_one({'_id': ID}, projection=fields)
 
 
 def knowl_title(kid):

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -1,6 +1,5 @@
 # Code for creating plots for browsing L-functions
 
-from pymongo import Connection
 import math
 import cmath
 import datetime

--- a/lmfdb/scripts/build_Lfunction_db.py
+++ b/lmfdb/scripts/build_Lfunction_db.py
@@ -3,8 +3,6 @@ import sys
 from sage.all import DirichletGroup
 from sage.all import CC, EllipticCurve, sqrt
 
-import pymongo
-from pymongo import Connection
 import sage.libs.lcalc.lcalc_Lfunction as lc
 
 from lmfdb import base

--- a/lmfdb/scripts/insert_zeros.py
+++ b/lmfdb/scripts/insert_zeros.py
@@ -2,8 +2,6 @@ import sys
 
 from sage.all import DirichletGroup
 
-import pymongo
-from pymongo import Connection
 import sage.libs.lcalc.lcalc_Lfunction as lc
 
 from lmfdb import base

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -11,8 +11,6 @@ from sage.all import ZZ, latex, AbelianGroup, pari, gap
 
 from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, parse_range, list_to_latex_matrix
 
-from pymongo.connection import Connection
-
 MAX_GROUP_DEGREE = 23
 
 ############  Galois group object


### PR DESCRIPTION
Removed all spurious "from pymongo import Connection" lines, leaving just one in base.py which is called for pymongo version <3 with the new sytax for version >=3.  Also one small change to knowl.py also for pymongo v3.
Tested with Sage-6.7 and pymongo 3.0.2 and Sage-6.6 and pymongo 2.8.  All tests pas except the ones which didn't anyway (because of modular forms changed betwee Sage-6.5 and 6.5 which are not relevant to this).