### PR TITLE
added random elliptic curve function and URL

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -97,6 +97,20 @@ def rational_elliptic_curves(err_args=None):
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
     return render_template("browse_search.html", info=info, credit=credit, title=t, bread=bread, **err_args)
 
+@ec_page.route("/random")
+def random_curve():
+    from sage.misc.prandom import randint
+    n = get_stats().counts()['ncurves']
+    n = randint(0,n-1)
+    return render_curve_webpage_by_label(db_ec().find()[n]['label'])
+
+@ec_page.route("/curve_of_the_day")
+def todays_curve():
+    from datetime import date
+    mordells_birthday = date(1888,1,28)
+    n = (date.today()-mordells_birthday).days
+    return render_curve_webpage_by_label(db_ec().find({'number' : int(1)})[n]['label'])
+
 @ec_page.route("/stats")
 def statistics():
     info = {

--- a/lmfdb/elliptic_curves/templates/browse_search.html
+++ b/lmfdb/elliptic_curves/templates/browse_search.html
@@ -53,6 +53,13 @@ By {{ KNOWL('ec.q.torsion_order', torsion=t,title="torsion order") }}:
 <a href="?torsion={{t}}">{{t}}</a>
 {% endfor %}
 </p>
+<p>
+{#
+<a href={{url_for('.todays_curve')}}>Elliptic curve of the day</a>
+<br>
+#}
+A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the database
+</p>
 
 
 <h2> Find a specific curve or {{


### PR DESCRIPTION
This small patch makes the URL EllipticCurve/Q/random display a random elliptic curve from the database (of curves over Q).
It also adds a link to this from the elliptic curve browse and search page -- I like this since it means that you can go in one click from that page to an individual elliptic curve home page, which was not true before.
(Anyone who looks at the code change will see that I also added another similar function, partly as a joke, but it is not live on the web page).