### PR TITLE
Fix reported by in computing Dirichlet characters for a C_16 field

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -497,7 +497,7 @@ class WebNumberField:
         while p in pram:
             p = P.next(p)
         fres = K.factor(p)[0][0].residue_class_degree()
-        a = p ** fres
+        a = (p ** fres) % f
         S = set(G[a].kernel())
         timeout = 10000
         while len(S) != self.degree():
@@ -505,7 +505,7 @@ class WebNumberField:
             p = P.next(p)
             if p not in pram:
                 fres = K.factor(p)[0][0].residue_class_degree()
-                a = p ** fres
+                a = (p ** fres) % f
                 S = S.intersection(G[a].kernel())
             if timeout == 0:
                 raise Exception('timeout in dirichlet group')


### PR DESCRIPTION
  by keeping integers sent to Conrey character package reasonably sized.

The bug was noticed by John C. from server logs.  When asking for characters, we just reduce the index modulo the character modulus first.