### PR TITLE
Ecnfplot

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,7 +1,7 @@
 from flask import url_for
-from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, NumberField
+from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, rainbow, plot
 from lmfdb.base import app, getDBConnection
-from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input
+from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input, encode_plot
 from lmfdb.number_fields.number_field import parse_field_string, field_pretty
 from lmfdb.WebNumberField import WebNumberField
 
@@ -193,19 +193,22 @@ class ECNF(object):
             ('Base field', self.field.field_pretty()),
             ('Label' , self.label)]
         
-        K.<Kgen> = NumberField(self.field.poly)
+        #Qx = PolynomialRing(QQ,'x')
+        #K = NumberField(polynomial=Qx(self.field.poly()),name='t')
+        K = E.base_field()
         SR = K.embeddings(RR)
         n1 = len(SR)
         if(n1):
-            X = [E.base_extend(s).plot() for s in SR]
-            a = min([xmin(x) for x in X])
-            b = max([xmax(x) for x in X])
+            ER = [E.base_extend(s) for s in SR]
+            X = [e.plot() for e in ER]
+            a = min([x.xmin() for x in X])
+            b = max([x.xmax() for x in X])
             cols = rainbow(n1)
             X = plot([])
             for i in range(n1):
                 s = SR[i]
                 c = cols[i]
-                X += E.base_extend(s).plot(xmin=a,xmax=b,color=c,legend_label=s.im_gens()[0])
+                X += ER[i].plot(xmin=a,xmax=b,color=c,legend_label=str(s.im_gens()[0]))
             self.plot = encode_plot(X)
             self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             self.properties += [(None, self.plot_link)]

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -197,12 +197,15 @@ class ECNF(object):
         SR = K.embeddings(RR)
         n1 = len(SR)
         if(n1):
+            X = [E.base_extend(s).plot() for s in SR]
+            a = min([xmin(x) for x in X])
+            b = max([xmax(x) for x in X])
             cols = rainbow(n1)
             X = plot([])
             for i in range(n1):
                 s = SR[i]
                 c = cols[i]
-                X += E.base_extend(s).plot(color=c,legend_label=s.im_gens()[0])
+                X += E.base_extend(s).plot(xmin=a,xmax=b,color=c,legend_label=s.im_gens()[0])
             self.plot = encode_plot(X)
             self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             self.properties += [(None, self.plot_link)]

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -193,14 +193,12 @@ class ECNF(object):
             ('Base field', self.field.field_pretty()),
             ('Label' , self.label)]
         
-        #Qx = PolynomialRing(QQ,'x')
-        #K = NumberField(polynomial=Qx(self.field.poly()),name='t')
+        # Plot
         K = E.base_field()
         SR = K.embeddings(RR)
         n1 = len(SR)
         if(n1):
-            ER = [E.base_extend(s) for s in SR]
-            X = [e.plot() for e in ER]
+            X = [E.base_extend(s).plot() for s in SR]
             a = min([x.xmin() for x in X])
             b = max([x.xmax() for x in X])
             cols = rainbow(n1)
@@ -208,7 +206,7 @@ class ECNF(object):
             for i in range(n1):
                 s = SR[i]
                 c = cols[i]
-                X += ER[i].plot(xmin=a,xmax=b,color=c,legend_label=str(s.im_gens()[0]))
+                X += E.base_extend(s).plot(xmin=a,xmax=b,color=c,legend_label="$"+self.field.generator_name()+" \mapsto$ "+str(s.im_gens()[0].n(20)))
             self.plot = encode_plot(X)
             self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             self.properties += [(None, self.plot_link)]

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -40,7 +40,9 @@ def make_field(label):
 def EC_R_plot(ainvs,xmin,xmax,ymin,ymax,colour,legend):
    x=var('x')
    y=var('y')
-   return implicit_plot(y**2+ainvs[0]*x*y+ainvs[2]*y-x**3-ainvs[1]*x**2-ainvs[3]*x-ainvs[4],(x,xmin,xmax),(y,ymin,ymax),plot_points=1000,aspect_ratio="automatic",color=colour)+plot(0,xmin=xmin,xmax=xmax,ymin=ymin,ymax=ymax,aspect_ratio="automatic",color=colour,legend_label=legend) # Add an extra plot outside the visible frame because implicit plots are buugy in that their legend does not show (http://trac.sagemath.org/ticket/15903) 
+   c=(xmin+xmax)/2
+   d=(xmax-xmin)
+   return implicit_plot(y**2+ainvs[0]*x*y+ainvs[2]*y-x**3-ainvs[1]*x**2-ainvs[3]*x-ainvs[4],(x,xmin,xmax),(y,ymin,ymax),plot_points=1000,aspect_ratio="automatic",color=colour)+plot(0,xmin=c-1e-5*d,xmax=c+1e-5*d,ymin=ymin,ymax=ymax,aspect_ratio="automatic",color=colour,legend_label=legend) # Add an extra plot outside the visible frame because implicit plots are buugy in that their legend does not show (http://trac.sagemath.org/ticket/15903) 
 
 def EC_nf_plot(E,base_field_gen_name):
     K = E.base_field()

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from sage.all import ZZ, var, PolynomialRing, QQ, GCD
+from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, NumberField
 from lmfdb.base import app, getDBConnection
 from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input
 from lmfdb.number_fields.number_field import parse_field_string, field_pretty
@@ -188,10 +188,26 @@ class ECNF(object):
             self.friends += [('Hilbert Modular Form '+self.hmf_label, self.urls['hmf'])]
         if self.field.is_imag_quadratic():
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
-
+        
         self.properties = [
             ('Base field', self.field.field_pretty()),
-            ('Label' , self.label),
+            ('Label' , self.label)]
+        
+        K.<Kgen> = NumberField(self.field.poly)
+        SR = K.embeddings(RR)
+        n1 = len(SR)
+        if(n1):
+            cols = rainbow(n1)
+            X = plot([])
+            for i in range(n1):
+                s = SR[i]
+                c = cols[i]
+                X += E.base_extend(s).plot(color=c,legend_label=s.im_gens()[0])
+            self.plot = encode_plot(X)
+            self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
+            self.properties += [(None, self.plot_link)]
+
+        self.properties += [
             ('Conductor' , self.cond),
             ('Conductor norm' , self.cond_norm),
             ('j-invariant' , self.j),

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, rainbow, plot
+from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, rainbow, implicit_plot, plot
 from lmfdb.base import app, getDBConnection
 from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input, encode_plot
 from lmfdb.number_fields.number_field import parse_field_string, field_pretty
@@ -36,6 +36,25 @@ def make_field(label):
     if label in field_list:
         return field_list[label]
     return FIELD(label)
+
+def EC_R_plot(ainvs,xmin,xmax,ymin,ymax,colour,legend):
+   x=var('x')
+   y=var('y')
+   return implicit_plot(y**2+ainvs[0]*x*y+ainvs[2]*y-x**3-ainvs[1]*x**2-ainvs[3]*x-ainvs[4],(x,xmin,xmax),(y,ymin,ymax),plot_points=1000,aspect_ratio="automatic",color=colour)+plot(0,xmin=xmin,xmax=xmax,ymin=ymin,ymax=ymax,aspect_ratio="automatic",color=colour,legend_label=legend) # Add an extra plot outside the visible frame because implicit plots are buugy in that their legend does not show (http://trac.sagemath.org/ticket/15903) 
+
+def EC_nf_plot(E,base_field_gen_name):
+    K = E.base_field()
+    SR = K.embeddings(RR)
+    n1 = len(SR)
+    if n1 == 0:
+        return plot([])
+    X = [E.base_extend(s).plot() for s in SR]
+    xmin = min([x.xmin() for x in X])
+    xmax = max([x.xmax() for x in X])
+    ymin = min([x.ymin() for x in X])
+    ymax = max([x.ymax() for x in X])
+    cols = rainbow(n1)
+    return sum([EC_R_plot([SR[i](a) for a in E.ainvs()],xmin,xmax,ymin,ymax,cols[i],"$"+base_field_gen_name+" \mapsto$ "+str(SR[i].im_gens()[0].n(20))) for i in range(n1)])
 
 class ECNF(object):
     """
@@ -194,20 +213,9 @@ class ECNF(object):
             ('Label' , self.label)]
         
         # Plot
-        K = E.base_field()
-        SR = K.embeddings(RR)
-        n1 = len(SR)
+        n1 = len(E.base_field().embeddings(RR))
         if(n1):
-            X = [E.base_extend(s).plot() for s in SR]
-            a = min([x.xmin() for x in X])
-            b = max([x.xmax() for x in X])
-            cols = rainbow(n1)
-            X = plot([])
-            for i in range(n1):
-                s = SR[i]
-                c = cols[i]
-                X += E.base_extend(s).plot(xmin=a,xmax=b,color=c,legend_label="$"+self.field.generator_name()+" \mapsto$ "+str(s.im_gens()[0].n(20)))
-            self.plot = encode_plot(X)
+            self.plot = encode_plot(EC_nf_plot(E,self.field.generator_name()))
             self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             self.properties += [(None, self.plot_link)]
 


### PR DESCRIPTION
Added code to plot elliptic curves defined over number fields. There is one curve drawn for each real embedding of the base field, all on the same picture.

Note: The code is a bit ugly as a workaround has had to be used so as to force Sage to display the legends. When the bug which prevents Sage from normally displaying legends is fixed, this code should be cleaned up.