### PR TITLE
Pymongo3

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -90,7 +90,7 @@ def set_locked(knowl, who):
 
 
 def get_knowl(ID, fields={"history": 0, "_keywords": 0}):
-    return get_knowls().find_one({'_id': ID}, projection=fields)
+    return get_knowls().find_one({'_id': ID}, fields)
 
 
 def knowl_title(kid):
@@ -98,7 +98,7 @@ def knowl_title(kid):
     just the title, used in the knowls in the templates for the pages.
     returns None, if knowl does not exist.
     """
-    k = get_knowl(kid, fields=['title'])
+    k = get_knowl(kid, ['title'])
     return k['title'] if k else None
 
 
@@ -106,7 +106,7 @@ def knowl_exists(kid):
     """
     checks, if the given knowl with ID=@kid exists
     """
-    return get_knowl(kid, fields={}) is not None
+    return get_knowl(kid) is not None
 
 
 def extract_cat(kid):
@@ -127,7 +127,7 @@ def refresh_knowl_categories():
     knowl should be a simple set union with the existing list of categories
     """
     # assumes that all actual knowls have a title field
-    cats = set((extract_cat(_['_id']) for _ in get_knowls().find(fields=[])))
+    cats = set((extract_cat(_['_id']) for _ in get_knowls().find({},[])))
     # set the categories list in the categories document in the 'meta' collection
     get_meta().save({'_id': CAT_ID, 'categories': sorted(cats)})
     return str(cats)
@@ -150,8 +150,8 @@ def get_categories():
 def get_knowls_by_category(cat):
     """searching for IDs that start with cat and continue with a dot + at least one char"""
     # TODO later on search for the knowl field 'cat'
-    # return get_knowls().find({'_id' : { "$regex" : r"^%s\..+" % cat }}, fields=['title'])
-    return get_knowls().find({'cat': cat}, fields=['title'])
+    # return get_knowls().find({'_id' : { "$regex" : r"^%s\..+" % cat }}, ['title'])
+    return get_knowls().find({'cat': cat}, ['title'])
 
 import re
 text_keywords = re.compile(r"\b[a-zA-Z0-9-]{3,}\b")
@@ -257,7 +257,7 @@ class Knowl(object):
         a = []
         if len(a_query) > 0:
             users = getDBConnection().userdb.users
-            a = users.find({"$or": a_query}, fields=["full_name"])
+            a = users.find({"$or": a_query}, ["full_name"])
         return a
 
     @property
@@ -326,7 +326,7 @@ class Knowl(object):
         the given fields.
         """
         if not self._title or not self._content:
-            data = get_knowl(self._id, fields=fields)
+            data = get_knowl(self._id, fields)
             if data:
                 self._title = data['title']
                 self._content = data['content']

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -373,7 +373,7 @@ def cleanup():
     from knowl import refresh_knowl_categories, extract_cat, make_keywords, get_knowls
     cats = refresh_knowl_categories()
     knowls = get_knowls()
-    q_knowls = knowls.find(fields=['content', 'title'])
+    q_knowls = knowls.find({}, ['content', 'title'])
     for k in q_knowls:
         kid = k['_id']
         cat = extract_cat(kid)
@@ -387,7 +387,7 @@ def cleanup():
     hcount = 0
     # max allowed history length
     max_h = 50
-    q_knowls = knowls.find({'history': {'$exists': True}}, fields=['history'])
+    q_knowls = knowls.find({'history': {'$exists': True}}, ['history'])
     for k in q_knowls:
         if len(k['history']) <= max_h:
             continue
@@ -442,7 +442,7 @@ def index():
         s_query.update({'cat': cur_cat})  # { "$regex" : r"^%s\..+" % cur_cat }
 
     logger.debug("search query: %s" % s_query)
-    knowls = get_knowls().find(s_query, fields=['title'])
+    knowls = get_knowls().find(s_query, ['title'])
 
     def first_char(k):
         t = k['title']

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_classes.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_classes.py
@@ -3,7 +3,7 @@ r"""
 Contains basic classes for displaying holomorphic modular forms.
 
 """
-from sage.all import vector, is_odd, DirichletGroup, is_even, Gamma1, dimension_new_cusp_forms, kronecker_character_upside_down, loads, Integer, latex, join
+from sage.all import vector, is_odd, DirichletGroup, is_even, Gamma1, dimension_new_cusp_forms, kronecker_character_upside_down, loads, Integer, latex
 from lmfdb.modular_forms.backend.mf_classes import MFDisplay, MFDataTable
 emf_dbname = 'modularforms2'
 from lmfdb.utils import *

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_core.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_core.py
@@ -25,7 +25,7 @@ AUTHOR: Fredrik Stroemberg
 
 """
 
-from sage.all import ZZ, Newform, is_squarefree, squarefree_part, factor, is_square, divisors, DirichletGroup, QQ, xgcd, prime_factors, Gamma0, html, I, ceil, ComplexField, RealField, dimension_cusp_forms, sturm_bound, latex, join, Gamma1
+from sage.all import ZZ, Newform, is_squarefree, squarefree_part, factor, is_square, divisors, DirichletGroup, QQ, xgcd, prime_factors, Gamma0, html, I, ceil, ComplexField, RealField, dimension_cusp_forms, sturm_bound, latex, Gamma1
 import re
 
 from lmfdb.modular_forms.elliptic_modular_forms import emf_logger as logger
@@ -1083,7 +1083,7 @@ def len_as_printed(s, format='latex'):
     subs = re.findall("_{?(\d*)", s)  # a list of all  subscripts
     ssubs = "".join(subs)
     ss = re.sub("\^{?(\d*)}?", "", ss)  # remove exponenents
-    # logger.debug(join([ss,ssubs,sexps]))
+    # logger.debug("".join([ss,ssubs,sexps]))
     tot_len = (ss.count(")") + ss.count("(")) * lenpar
     tot_len += ss.count("q") * lenq
     tot_len += len(re.findall("\d", s)) * lendig

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modforms.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modforms.py
@@ -26,7 +26,7 @@ TODO:
 Fix complex characters. I.e. embedddings and galois conjugates in a consistent way.
 
 """
-from sage.all import ZZ, QQ, DirichletGroup, CuspForms, Gamma0, ModularSymbols, Newforms, trivial_character, is_squarefree, divisors, RealField, ComplexField, prime_range, I, join, gcd, Cusp, Infinity, ceil, CyclotomicField, exp, pi, primes_first_n, euler_phi, RR, prime_divisors, Integer, matrix,NumberField,PowerSeriesRing
+from sage.all import ZZ, QQ, DirichletGroup, CuspForms, Gamma0, ModularSymbols, Newforms, trivial_character, is_squarefree, divisors, RealField, ComplexField, prime_range, I, gcd, Cusp, Infinity, ceil, CyclotomicField, exp, pi, primes_first_n, euler_phi, RR, prime_divisors, Integer, matrix,NumberField,PowerSeriesRing
 from sage.rings.power_series_poly import PowerSeries_poly
 from sage.all import Parent, SageObject, dimension_new_cusp_forms, vector, dimension_modular_forms, dimension_cusp_forms, EisensteinForms, Matrix, floor, denominator, latex, is_prime, prime_pi, next_prime, previous_prime,primes_first_n, previous_prime, factor, loads,save,dumps,deepcopy
 import re
@@ -2351,7 +2351,7 @@ class WebNewForm_class(object):
         if len(sb) <= 1:
             s = r"\(" + s + r"\)"
         else:
-            s = r"\[\begin{align} &" + join(sb, "\cr &") + r"\end{align}\]"
+            s = r"\[\begin{align} &" + "\cr &".join(sb) + r"\end{align}\]"
             
         emf_logger.debug("print_q_exp: prec=".format(prec))
         
@@ -2669,7 +2669,7 @@ def break_line_at(s, brpt=20):
         l = len_as_printed(stmp) + len_as_printed(sl[j])
         #emf_logger.debug("l={0}".format(l))
         if l < brpt:
-            stmp = join([stmp, sl[j]])
+            stmp = "".join([stmp, sl[j]])
         else:
             res.append(stmp)
             stmp = sl[j]

--- a/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
+++ b/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
@@ -35,7 +35,7 @@ def render_picard_maass_forms():
         return render_picard_test()
     if docid is not None:
         return render_picard_maass_forms_get_one(docid)
-    ds = [(_['_id'], _['ev']) for _ in htp.find(fields=['ev'], sort=[('ev', 1)])]
+    ds = [(_['_id'], _['ev']) for _ in htp.find({}, ['ev'], sort=[('ev', 1)])]
     data = None
     # TT= MaassformsPicardDisplay(mwfp_dbname,collection='all',skip=[0],limit=[10],keys=['Eigenvalue'])
     # TT.set_table_browsing()

--- a/lmfdb/scripts/build_Lfunction_db_2.py
+++ b/lmfdb/scripts/build_Lfunction_db_2.py
@@ -18,7 +18,7 @@ def Dirichlet_Lfunctions_iterator(qMax):
 
 
 def EC_iterator():
-    data = set(_["label"] for _ in Lfunctions.ellcurves.curves.find({}, fields=["label"]))
+    data = set(_["label"] for _ in Lfunctions.ellcurves.curves.find({}, ["label"]))
     for c in data:
         yield Lfunction_EC_Q(c["label"])
 

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -124,7 +124,7 @@ def profile(userid):
     user = LmfdbUser(userid)
     bread = base_bread() + [(user.name, url_for('.profile', userid=user.get_id()))]
     userknowls = getDBConnection(
-    ).knowledge.knowls.find({'authors': userid}, fields=['title']).sort([('title', ASC)])
+    ).knowledge.knowls.find({'authors': userid}, ['title']).sort([('title', ASC)])
     userfiles = getDBConnection(
     ).upload.fs.files.find({'metadata.uploader_id': userid, 'metadata.status': 'approved'})
     userfilesmod = getDBConnection(

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -207,7 +207,7 @@ def get_user_list():
     returns a list of tuples: [('user_db_id', 'full_name'),…]
     full_name could be None
     """
-    users_cursor = get_users().find(fields=["full_name"])
+    users_cursor = get_users().find({}, ["full_name"])
     ret = []
     for e in users_cursor:
         name = e['full_name'] or e['_id']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 flask-cache
 flask-login
 flask-markdown
-pymongo==2.8
+pymongo
 pyyaml
 unittest2
 coverage


### PR DESCRIPTION
This completes the job of making the code compatible with pymongo 3, so we no longer have to force pymongo==2.8 in the requirements.txt file.  Also:

The main fix already dealt with was that the Connection() function was renamed MongoClient(), and this was fixed by some recoding in base.py.  The other one is that the "fields" keyword for the find() function has been renamed "projection", with no change in functionality (its effect is to include only certain fields in the results, or exclude some fields).  I had already changed this in one place, but not systematically.

This new branch finishes the job.  There were a dozen or so places, at least, where find(fields=...) was used, mainly in the knowls module.  Instead of putting in a test for pymongo version in each place, or writing a wrapper function around find(), the simplest thing was to make use of the fact that the fields/projection parameter is the second one, the first being the main query.  In a couple of places where the query was blank that meant inserting "{}," before "fields=" (and then deleting "fields=").