### PR TITLE
pymongo3 changes to fix several maass test failures

### DIFF
--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -76,8 +76,9 @@ def getHmfData(label):
     return (f, F_hmf)
 
 def getMaassDb():
-    host = base.getDBConnection().host
-    port = base.getDBConnection().port
+    # NB although base.getDBConnection().PORT works it gives the
+    # default port number of 27017 and not the actual one!
+    host, port = base.getDBConnection().address
     return MaassDB(host=host, port=port)
     
 def getHgmData(label):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
@@ -60,7 +60,12 @@ class MaassDB(object):
 
         try:
             constr = "{0}:{1}".format(host, port)
-            Con = pymongo.Connection(constr)
+            if pymongo.version_tuple[0] < 3:
+                from pymongo import Connection
+                Con = pymongo.Connection(constr)
+            else:
+                from pymongo.mongo_client import MongoClient
+                Con = pymongo.MongoClient(constr)
             self._Con = Con
         except:  # AutoReconnect:
             logger.critical("No database found at {0}".format(constr))

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
@@ -30,8 +30,9 @@ _DB = None
 def connect_db():
     global _DB
     if _DB is None:
-        host = lmfdb.base.getDBConnection().host
-        port = lmfdb.base.getDBConnection().port
+        # NB although base.getDBConnection().PORT works it gives the
+        # default port number of 27017 and not the actual one!
+        host, port = lmfdb.base.getDBConnection().address
         _DB = MaassDB(host=host, port=port, show_collection='all')
     return _DB
 

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
@@ -36,8 +36,9 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, weight = 0, char = 1,
                         xfactor, yfactor, ticlength, xshift)
 
     # Fetch Maass forms from database
-    host = base.getDBConnection().host
-    port = base.getDBConnection().port
+    # NB although base.getDBConnection().PORT works it gives the
+    # default port number of 27017 and not the actual one!
+    host, port = base.getDBConnection().address
     db = MaassDB(host=host, port=port)
     search = {'level1': yMin, 'level2': yMax, 'char': char,
               'R1': xMin, 'R2': xMax, 'Newform' : None, 'weight' : weight}


### PR DESCRIPTION
This fixes some tset failures in Maass forms caused by the pymongo 2 --> 3 change, which wer emissed earlier (sorry).    Compare the result of running the test suite before and after!