### PR TITLE
made previous maassdb changes work also on pymnogo<3

### DIFF
--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -78,7 +78,11 @@ def getHmfData(label):
 def getMaassDb():
     # NB although base.getDBConnection().PORT works it gives the
     # default port number of 27017 and not the actual one!
-    host, port = base.getDBConnection().address
+    if pymongo.version_tuple[0] < 3:
+        host = base.getDBConnection().HOST
+        port = base.getDBConnection().PORT
+    else:
+        host, port = base.getDBConnection().address
     return MaassDB(host=host, port=port)
     
 def getHgmData(label):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
@@ -32,7 +32,11 @@ def connect_db():
     if _DB is None:
         # NB although base.getDBConnection().PORT works it gives the
         # default port number of 27017 and not the actual one!
-        host, port = lmfdb.base.getDBConnection().address
+        if pymongo.version_tuple[0] < 3:
+            host = base.getDBConnection().HOST
+            port = base.getDBConnection().PORT
+        else:
+            host, port = lmfdb.base.getDBConnection().address
         _DB = MaassDB(host=host, port=port, show_collection='all')
     return _DB
 

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
@@ -38,7 +38,11 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, weight = 0, char = 1,
     # Fetch Maass forms from database
     # NB although base.getDBConnection().PORT works it gives the
     # default port number of 27017 and not the actual one!
-    host, port = base.getDBConnection().address
+    if pymongo.version_tuple[0] < 3:
+        host = base.getDBConnection().HOST
+        port = base.getDBConnection().PORT
+    else:
+        host, port = base.getDBConnection().address
     db = MaassDB(host=host, port=port)
     search = {'level1': yMin, 'level2': yMax, 'char': char,
               'R1': xMin, 'R2': xMax, 'Newform' : None, 'weight' : weight}


### PR DESCRIPTION
After merging the recent pull request on fixing maassdb errors I pushed to beta but then found that the fix worked only with pymongo >=3, while both beta and prod websites are still running pymongo-2.8 (and Sage-6.5!) so that for example http://beta.lmfdb.org/ModularForm/GL2/Q/Maass/ gives as error.

I will merge this and push to beta right away as it will fix that.