### PR TITLE
move data upload back into the sidebar

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -76,17 +76,13 @@
    {% endif %}
  {%- endmacro %}
 
+<div id="sidebar">
 {%- include "sidebar.html" -%}
 
-{% if BETA %}
+{{ entry("Data", getUploadedFor(request.path, true) ) }}
 
-      {#  Please keep the commented part, I might reinstate some of it POD
-      #<li><a class = "number_field_galois_groups" href="{{ url_for('number_field_galois_groups.index') }}">Galois Groups (only logged in)</a></li>
-      #}
-{% endif %}
+</div>
 
-   {{ entry("Data", getUploadedFor(request.path, true) ) }}
-  {# {% if user_is_authenticated %} {% endif %} #}
 
 {% else %}
 <style type="text/css">

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -1,6 +1,5 @@
 {%- include "sidebar.css" -%}
 
-<div id="sidebar">
 {% for key, heading, value in sidebar.data %}
 {% if BETA or not value.status %}{# an entire section may be omitted e.g. Motives #}
 
@@ -237,6 +236,4 @@
 {% endif %} {# if value.type == ... #}
 {% endif %} {# if BETA or not value.status #}
 {% endfor %} {# for key, heading, value in sidebar.data #}
-
-</div>
 


### PR DESCRIPTION
The new sidebar code "left out" one item about data upload with the the effect that it appeared badly placed at the top of the main part of every page.  This puts it back where it belongs.  Only noticeable when logged in, but on every page.