### PR TITLE
fix bug which wrongly reported admin status in a user's profile

### DIFF
--- a/lmfdb/users/templates/user-detail.html
+++ b/lmfdb/users/templates/user-detail.html
@@ -6,7 +6,7 @@
    <li>ID: <a href="{{ url_for('.profile', userid=user.get_id()) }}">{{ user.get_id()}}</a></li>
    <li>E-Mail: {{ user.email|obfuscate_email }}</li>
    <li>URL: {% with url = user.url %}<a href="{{url}}">{{url}}</a>{% endwith %} </li>
-   <li>Admin: {{ user_is_admin }}</li>
+   <li>Admin: {{ user.is_admin() }}</li>
    <li>About: {{ user.about }}</li>
   </ul>
 </div>


### PR DESCRIPTION
Go to the URL /users and click on a name.  Before: the user is listed as admin, or not, according to whether the logged in users (you) are admin.  After: it correctly lists the displayed user's status.