### PR TITLE
Support

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -196,7 +196,8 @@ def ctx_proc_userdata():
     import knowledge
     vars['meta_description'] = knowledge.knowl.Knowl("intro.description").content
     vars['shortthanks'] = r'This project is supported by <a href="%s">grants</a> from the US National Science Foundation and the UK Engineering and Physical Sciences Research Council.' % (url_for('acknowledgment') + "#sponsors")
-    vars['feedbackpage'] = r"https://docs.google.com/spreadsheet/viewform?formkey=dDJXYXBleU1BMTFERFFIdjVXVmJqdlE6MQ"
+    vars['feedbackpage'] = url_for('contact')
+#    vars['feedbackpage'] = r"https://docs.google.com/spreadsheet/viewform?formkey=dDJXYXBleU1BMTFERFFIdjVXVmJqdlE6MQ"
     vars['LINK_EXT'] = lambda a, b: '<a href="%s" target="_blank">%s</a>' % (b, a)
 
     # debug mode?

--- a/lmfdb/lfunctions/templates/LfunctionSimple.html
+++ b/lmfdb/lfunctions/templates/LfunctionSimple.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="announce">
  {{ content|safe }}
-Please report it <a href="{{ feedbackpage }}" target=_blank>here</a>.
+Please report it <a href="{{ feedbackpage }}">here</a>.
 </div>
 <div align="center">
 <input type=button value="Back" onClick="history.go(-1)">

--- a/lmfdb/templates/500.html
+++ b/lmfdb/templates/500.html
@@ -6,15 +6,6 @@
 The page you are looking for has produced a server error.
 </div>
 
-{% if 0 %}
-John Cremona, Kiran Kedlaya and David Roe jointly agreed to remove
-this silly text on 2012-03-29.
-<div>
-Oh nooeess! We are so ashamed. This page is the living proof that
-calculations on the best mathematical website in the world 
-sometimes still go awfully wrong.
-</div>
-{% endif %}
 
 {% if request.referrer %}
 <div>
@@ -23,7 +14,7 @@ please <a href="{{ feedbackpage }}">report that page's URL</a>!
 </div>
 {% endif %}
 
-<div>Please keep your faith in mathematics!</div>
+{# <div>Please keep your faith in mathematics!</div> #}
 
 {% if request.referrer %}
 <div><a href="{{ request.referrer }}">jump back</a></div>

--- a/lmfdb/templates/contact.html
+++ b/lmfdb/templates/contact.html
@@ -1,16 +1,48 @@
 {% extends "homepage.html" %}
 {% block content %}
 
-<h1>Contact Webmaster</h1>
+<h1>Contact LMFDB developers</h1>
 
 <div>
-For questions, inquiries or general issues contact one of the webmasters:
+<p>
+For questions, inquiries, feedback or any other issues, including bug
+reports, please
+<a href="mailto:lmfdb-support@googlegroups.com"
+target="_blank">email</a>
+the <a href="http://groups.google.co.uk/d/forum/lmfdb-support"
+target="_blank">LMFDB support mailing list</a>.
+</p>
 
-<ul>
- <li><a href="http://www.google.com/recaptcha/mailhide/d?k=01L8P0DPA48sLHWiGZaxeEQw==&amp;c=uN8RjiiHQCqegDHyzIW_k9wsidsbKQaztqfCR6QHRpY=" onclick="window.open('http://www.google.com/recaptcha/mailhide/d?k\07501L8P0DPA48sLHWiGZaxeEQw\75\75\46c\75uN8RjiiHQCqegDHyzIW_k9wsidsbKQaztqfCR6QHRpY\075', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;" title="Reveal this e-mail address">Harald Schilly</a></li>
-</ul>
+<p>
+If you see a problem with the production
+site <a href="www.lmfdb.org">www.lmfdb.org</a>, before making a
+report, please first try with the same URL except with 'www' replaced
+by 'beta', that is at <a href="beta.lmfdb.org">beta.lmfdb.org</a>,
+which runs our beta testing website code, since the issue you see may
+have already been addressed.
+</p>
 
-Otherwise use the <a href="{{feedbackpage}}">Feedback Form</a>.
+<p>
+To be most helpful, bug reports should include
+<ol>
+<li>a one line description of the problem
+<li>the exact URL which shows the issue (copied and pasted from the
+  browser location bar)
+<li>a full description of the problem.
+</ol>
+</p>
+
+
+<p>
+The current list of issues being tracked can be found
+<a href="https://github.com/LMFDB/lmfdb/issues"
+target="_blank">here</a>.
+</p>
+
+
+<p>
+Use of the old <a href="{{feedbackpage}}">Feedback Form</a> is deprecated.
+</p>
 </div>
 
 {% endblock %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -17,7 +17,7 @@
             <input type="text" placeholder="search ..." name="q" size="13" />
           </form>
             &middot;
-          <a href="{{ feedbackpage }}" target="_blank">
+          <a href="{{ feedbackpage }}">
              Feedback</a>
             &middot;
           {% if g.show_menu %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -76,17 +76,13 @@
    {% endif %}
  {%- endmacro %}
 
+<div id="sidebar">
 {%- include "sidebar.html" -%}
 
-{% if BETA %}
+{{ entry("Data", getUploadedFor(request.path, true) ) }}
 
-      {#  Please keep the commented part, I might reinstate some of it POD
-      #<li><a class = "number_field_galois_groups" href="{{ url_for('number_field_galois_groups.index') }}">Galois Groups (only logged in)</a></li>
-      #}
-{% endif %}
+</div>
 
-   {{ entry("Data", getUploadedFor(request.path, true) ) }}
-  {# {% if user_is_authenticated %} {% endif %} #}
 
 {% else %}
 <style type="text/css">

--- a/lmfdb/templates/roadmap.html
+++ b/lmfdb/templates/roadmap.html
@@ -7,9 +7,8 @@ Ongoing work on the LMFDB will add more data, include more mathematical
 objects, provide better searching and browsing, and give more detailed
 information about each object in the database.  The lists below
 describe some of the planned enhancements.  To make comments or
-suggestions about the future of LMFDB, please use the 
-<a href="{{ feedbackpage }}">Feedback form</a>
-available at the top of every page.
+suggestions about the future of LMFDB, please see the
+<a href="{{ feedbackpage }}">feedback page</a>.
 
 {# <a href="http://code.google.com/p/lmfdb/issues/list" target="_blank">Bugtracker</a>. #}
 </div>

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -1,6 +1,5 @@
 {%- include "sidebar.css" -%}
 
-<div id="sidebar">
 {% for key, heading, value in sidebar.data %}
 {% if BETA or not value.status %}{# an entire section may be omitted e.g. Motives #}
 
@@ -237,6 +236,4 @@
 {% endif %} {# if value.type == ... #}
 {% endif %} {# if BETA or not value.status #}
 {% endfor %} {# for key, heading, value in sidebar.data #}
-
-</div>
 


### PR DESCRIPTION
New form of the contacts page (click on "contact" at the left of the very bottom line on every page" which no longer links to the feedback form but instead mentions the lmfdb-support mailing list.
