### PR TITLE
Tors(U) replaced with \mu

### DIFF
--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -184,7 +184,7 @@ function show_code(system) {
         <p><h2> {{ KNOWL('nf.multiplicative_gal_module', title='Multiplicative Galois Module Structure') }}</h2>
             <table>
             <tr><td>
-              $U_{K^{gal}}/\textrm{Tors}(U_{K^{gal}}) \cong$ {{nf.unit_galois_action_show()|safe}}
+              $U_{K^{gal}}/\mu_{K^{gal}} \cong$ {{nf.unit_galois_action_show()|safe}}
            </tr>
     {% if nf.unit_galois_action_type_knowl() %}
             <tr><td>


### PR DESCRIPTION
In the description of the Galois structure of the unit group of a number field, replace the cumbersome "U/Tors(U)" with "U/\mu". Also, updated the knowl accordingly.