### PR TITLE
fix html error on ecnf browse/search page

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -32,7 +32,7 @@ curves defined over {{types[0]}}:
 Curves with interesting properties:
 <ul>
 {% for item in data.highlights %}
-<li><a href="{{item[1]}}">{{item[0]}}</li>
+<li><a href="{{item[1]}}">{{item[0]}}</a></li>
 {% endfor %}
 </ul>
 </p>


### PR DESCRIPTION
Another triviality, fixed by Alina -- without this fix if you click in any of the search boxes on /EllipticCurve it takes you to the last of the highlghts curves, because an <a> tag was not closed.