### PR TITLE
fixed the size of Indecomposable integral representations header

### DIFF
--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -72,8 +72,8 @@ table.reptable td, table.reptable th {
 </pre></td></tr>
     </table> </div> </p>
 {% if info.int_reps %}
-<div><h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>
-</div>
+<p><h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>
+</p>
 <table>
 <tr><td> 
 {% if info['int_reps_complete'] > 0 %}


### PR DESCRIPTION
In the gg-show-group template, replaced a div by a p to make the Indecomposable integral representations header the same size as the others