### PR TITLE
Genus 2 invariants: merging, normalization and factorization

### DIFF
--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -52,29 +52,29 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
 	
         <tr>
-          <td> \( I_4 \) </td>
-	  <td>&nbsp;:&nbsp;</td>
+          <td> \( I_2 \) </td>
+	  <td>&nbsp;=&nbsp;</td>
 	  <td>\({{ data.data.invs[0] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
 	  <td>{{ data.data.invs_factor_latex[0] }}</td>
         </tr>
 	<tr>
-          <td> \( I_6 \) </td>
-	  <td>&nbsp;:&nbsp;</td>
+          <td> \( I_4 \) </td>
+	  <td>&nbsp;=&nbsp;</td>
 	  <td>\({{ data.data.invs[1] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
 	  <td>{{ data.data.invs_factor_latex[1] }}</td>
         </tr>
 	<tr>
-          <td> \( I_8 \) </td>
-	  <td>&nbsp;:&nbsp;</td>
+          <td> \( I_6 \) </td>
+	  <td>&nbsp;=&nbsp;</td>
 	  <td>\({{ data.data.invs[2] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
 	  <td>{{ data.data.invs_factor_latex[2] }}</td>
         </tr>
 	<tr>
           <td> \( I_{10} \) </td>
-	  <td>&nbsp;:&nbsp;</td>
+	  <td>&nbsp;=&nbsp;</td>
 	  <td>\({{ data.data.invs[3]}}\)</td>
           <td>&nbsp;=&nbsp;</td>
 	  <td>{{ data.data.invs_factor_latex[3] }}</td>
@@ -87,10 +87,11 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 <tr>  <td>\(\mathrm{Aut}(X_{\overline{\Q}})\)</td><td>\(\simeq\)</td>  <td>\({{ data.data.geom_aut_grp}} \) </td> <td>(GAP id : {{data.geom_aut_grp}})</td></tr>
 </table>
 
+<h2> {{ KNOWL('g2c.num_rat_wpts', title='Number of rational Weierstrass points') }} </h2>
+\({{data.data.num_rat_wpts}}\)
+
 <h2> {{ KNOWL('g2c.torsion', title='Torsion') }} </h2>
 \({{data.data.tor_struct}}\)
-
-
 
 <h2> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h2>
 <p>

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -50,32 +50,34 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>&nbsp;=&nbsp;</td>
           <td>{{ data.data.disc_factor_latex }}</td>
         </tr>
-
-	</table>
-
-
-	<h2> {{ KNOWL('g2c.igusa_clebsch', title='Igusa-Clebsch invariants') }} </h2>
-
-	<table>
-	<tr>
+	
+        <tr>
           <td> \( I_4 \) </td>
-	  <td>=</td>
-	  <td>\({{ data.data.igusa_clebsch[0] }}\)</td>
+	  <td>&nbsp;:&nbsp;</td>
+	  <td>\({{ data.data.invs[0] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+	  <td>{{ data.data.invs_factor_latex[0] }}</td>
         </tr>
 	<tr>
           <td> \( I_6 \) </td>
-	  <td>=</td>
-	  <td>\({{ data.data.igusa_clebsch[1] }}\)</td>
+	  <td>&nbsp;:&nbsp;</td>
+	  <td>\({{ data.data.invs[1] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+	  <td>{{ data.data.invs_factor_latex[1] }}</td>
         </tr>
 	<tr>
           <td> \( I_8 \) </td>
-	  <td>=</td>
-	  <td>\({{ data.data.igusa_clebsch[2] }}\)</td>
+	  <td>&nbsp;:&nbsp;</td>
+	  <td>\({{ data.data.invs[2] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+	  <td>{{ data.data.invs_factor_latex[2] }}</td>
         </tr>
 	<tr>
           <td> \( I_{10} \) </td>
-	  <td>=</td>
-	  <td>\({{ data.data.igusa_clebsch[3]}}\)</td>
+	  <td>&nbsp;:&nbsp;</td>
+	  <td>\({{ data.data.invs[3]}}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+	  <td>{{ data.data.invs_factor_latex[3] }}</td>
         </tr>
 	</table>
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -8,11 +8,11 @@ import lmfdb.base
 from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.genus2_curves import g2c_page, g2c_logger
 from lmfdb.genus2_curves.data import group_dict
-import sage.all
+#import sage.all
 from sage.all import latex, matrix, ZZ, QQ, PolynomialRing, factor, implicit_plot
 from lmfdb.hilbert_modular_forms.hilbert_modular_form import teXify_pol
-
 from lmfdb.WebNumberField import *
+from itertools import izip
 
 logger = make_logger("g2c")
 
@@ -122,43 +122,39 @@ def isog_label(label):
     L = label.split(".")
     return L[0]+ "." + L[1]
 
-def scalar_mult(c,P,W):
-    # Scalar multiplication in a weighted projective space
-    l = len(P)
-    Q = [c**(W[n]) * P[n] for n in range(l)]
-    return Q
+def scalar_div(c,P,W):
+    # Scalar division in a weighted projective space
+    return [p//(c**w) for (p,w) in izip(P,W)]
 
 def normalize_invariants(I):
     # This is the tuple of weights for Igusa-Clebsch invariants.
     # It is later refined to deal with curves for which some of these vanish
     # If using Igusa invariants instead, one only needs to modify this to
-    #  W_b = [1,2,3,4,5]
-    W_b = [1,2,3,5]
+    #  W_b = [1, 2, 3, 4, 5]
+    W_b = [1, 2, 3, 5]
     I_b = I
     l_b = len(W_b)
     # Eliminating elements of the weight with zero entries in W_b
     for n in range(l_b):
-        if I[n] == 0:
+        if I_b[n] == 0:
             W_b[n] = 0
     # Smaller invariant tuples obtained by excluding zeroes
-    W_s = [ W_b[n] for n in range(l_b) if I[n] != 0 ]
-    I_s = [ I_b[n] for n in range(l_b) if I[n] != 0 ]
-    l_s = len(W_s)
+    W_s = [W_b[n] for n in range(l_b) if I_b[n] != 0]
+    I_s = [I_b[n] for n in range(l_b) if I_b[n] != 0]
     # Finding the normalized weights, both big and small
     dW = gcd(W_s)
-    W_bn = [ ZZ(w/dW) for w in W_b ]
-    W_sn = [ ZZ(w/dW) for w in W_s ]
+    W_bn = [w//dW for w in W_b]
+    W_sn = [w//dW for w in W_s]
     # Normalization of the invariants by the appropriate weight
     dI = gcd(I_s)
-    Fac = dI.factor()
-    ps = [ fac[0] for fac in Fac]
-    prod = 1
-    for p in ps:
-        e = floor(min([ valuation(I_s[n],p)/W_sn[n] for n in range(l_s) ]))
-        prod = prod * p**e
+    if dI == 1:
+        return I
+    ps = dI.prime_divisors()
+    Z = zip(I_s, W_sn)
+    c = prod([p**floor(min([ floor(valuation(i,p)/w) for (i,w) in Z ])) for p in ps], 1)
     # Final weighted multiplication
-    I_n = scalar_mult(1/prod,I,W_bn)
-    I_n = [ ZZ(i) for i in I_n ]
+    I_n = scalar_div(c, I,W_bn)
+    I_n = [ZZ(i) for i in I_n]
     return I_n
 # We may want to preserve some factors in the gcd here to factor the invariants when these get bigger, though currently this is not needed
 
@@ -220,6 +216,7 @@ class WebG2C(object):
         #data['igusa_clebsch'] = [ZZ(a) for a in self.igusa_clebsch]
         data['invs'] = normalize_invariants([ZZ(a) for a in self.igusa_clebsch])
         data['invs_factor_latex'] = [web_latex(factor(i)) for i in data['invs']]
+        data['num_rat_wpts'] = ZZ(self.num_rat_wpts)
         if len(self.torsion) == 0:
             data['tor_struct'] = '\mathrm{trivial}'
         else:
@@ -285,3 +282,8 @@ class WebG2C(object):
              ('%s' % self.cond, url_for(".by_conductor", conductor=self.cond)),
              ('%s' % iso, url_for(".by_double_iso_label", conductor=self.cond, iso_label=iso)),
              ('Genus 2 curve %s' % num, url_for(".by_g2c_label", label=self.label))]
+
+    def render_curve_webpage_by_label(label):
+        credit = credit_string
+        data = WebG2C.by_label(label)
+        return render_template("curve_g2.html", credit=credit, **data)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -283,7 +283,7 @@ class WebG2C(object):
              ('%s' % iso, url_for(".by_double_iso_label", conductor=self.cond, iso_label=iso)),
              ('Genus 2 curve %s' % num, url_for(".by_g2c_label", label=self.label))]
 
-    def render_curve_webpage_by_label(label):
-        credit = credit_string
-        data = WebG2C.by_label(label)
-        return render_template("curve_g2.html", credit=credit, **data)
+#    def render_curve_webpage_by_label(label):
+#        credit = credit_string
+#        data = WebG2C.by_label(label)
+#        return render_template("curve_g2.html", credit=credit, **data)


### PR DESCRIPTION
This includes a number of changes to pages of genus 2 curves, such as

http://beta.lmfdb.org/Genus2Curve/Q/12500/a/12500/1

(1) The sections on invariants have been merged; as in the case of automorphisms and endomorphisms, the upcoming knowl will have to mention that there are two flavors of these, namely geometric and arithmetic.

(2) The Igusa-Clebsch invariants are now displayed with a colon to indicate that these are homogeneous invariants. Moreover, these invariants have been normalized by dividing out common integral factors (of course respecting the weights of these invariants). This proceeds by an intermediate Sage script; the actual Igusa-Clesch invariants of the given polynomials are therefore not lost and can still be recovered by modifying the source.

(3) Finally, the normalized Igusa-Clebsch invariants are also presented in factored form, as in the case of elliptic curves.