### PR TITLE
For number fields, use an integral basis which is closer to a power basis

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -101,7 +101,9 @@ def nf_knowl_guts(label, C):
     out += '<br>Signature: '
     out += str(wnf.signature())
     out += '<br>Galois group: '+group_display_knowl(wnf.degree(),wnf.galois_t(),C)
-    out += '<br>Class number: %s %s' % (str(wnf.class_number()),wnf.short_grh_string())
+    out += '<br>Class number: %s ' % str(wnf.class_number())
+    if wnf.can_class_number():
+        out += wnf.short_grh_string()
     out += '</div>'
     out += '<div align="right">'
     out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.number_field_render_webpage", natural=label)),label)

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -101,6 +101,7 @@ def nf_knowl_guts(label, C):
     out += '<br>Signature: '
     out += str(wnf.signature())
     out += '<br>Galois group: '+group_display_knowl(wnf.degree(),wnf.galois_t(),C)
+    out += '<br>Class number: %s' % str(wnf.class_number())
     out += '</div>'
     out += '<div align="right">'
     out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.number_field_render_webpage", natural=label)),label)

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -101,7 +101,7 @@ def nf_knowl_guts(label, C):
     out += '<br>Signature: '
     out += str(wnf.signature())
     out += '<br>Galois group: '+group_display_knowl(wnf.degree(),wnf.galois_t(),C)
-    out += '<br>Class number: %s' % str(wnf.class_number())
+    out += '<br>Class number: %s %s' % (str(wnf.class_number()),wnf.short_grh_string())
     out += '</div>'
     out += '<div align="right">'
     out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.number_field_render_webpage", natural=label)),label)

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -231,6 +231,15 @@ class WebNumberField:
     def haskey(self, key):
         return key in self._data
 
+    # Warning, this produces our prefered integral basis
+    # But, if you have the sage number field do computations,
+    # they will be in terms of a different basis
+    def zk(self):
+        if self.haskey('zk'):
+            zkstrings = self._data['zk']
+            return [str(u) for u in zkstrings]
+        return list(pari(self.poly()).nfbasis())
+
     def subfields(self):
         if not self.haskey('subs'):
             return []

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -352,8 +352,7 @@ def render_field_webpage(args):
         ram_primes = r'\textrm{None}'
     data['frob_data'], data['seeram'] = frobs(nf.K())
     data['phrase'] = group_phrase(n, t, C)
-    zk = pari(nf.K())#          .nf_subst('a')
-    zk = list(zk.nf_get_zk())
+    zk = nf.zk()
     Ra = PolynomialRing(QQ, 'a')
     zk = [latex(Ra(x)) for x in zk]
     zk = ['$%s$' % x for x in zk]


### PR DESCRIPTION
You can test with number field 3.1.23.1.  Currently, the basis is not a power basis.  With this, it is.  Of course, lots of number fields get simpler integral bases with this change.

This also moves generating the integral basis to the webnumberfield class.  This should give more consistency to other objects, and it will first check the database to see if it has an integral basis prestored.  That data needs to be added by an external script (but it has been tested).