### PR TITLE
remove copyright symbol from credit line on homepages

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -164,7 +164,7 @@
 
 <div id="footer">
     {% if credit -%}
-      &copy; Data computed by {{ credit|safe }}.<br />
+      Data computed by {{ credit|safe }}.<br />
     {%- endif %}
     
     {% if support -%}


### PR DESCRIPTION
Fixes spreadsheet issue #48: remove the copyright symbol from the homepage template.  As agreed at workshop on 2015-07-29.