### PR TITLE
Streamlining display of isogeny classes

### DIFF
--- a/lmfdb/ecnf/templates/show-ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/show-ecnf-isoclass.html
@@ -46,13 +46,9 @@ function show_code(system) {
 
 
 
-<h2>{{ KNOWL('ec.isogeny_matrix',title='Matrix of isogeny degrees') }}</h2>
+<h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>
 
 {% if cl.isogeny_matrix %}
-<p>
-  Rows and columns are indexed by the LMFDB number of the curve in
-  the class.
-</p>
 <p>
   \({{cl.isogeny_matrix_str}}\)
 </p>
@@ -62,9 +58,6 @@ function show_code(system) {
 
 <h2>{{ KNOWL('ec.isogeny_graph',title='Isogeny graph') }}</h2>
 {% if cl.isogeny_matrix %}
-<p>
-  Only edges corresponding to isogenies of prime degree are shown.
-</p>
 <center>
   <img src="{{cl.graph_img}}" />
 </center>

--- a/lmfdb/elliptic_curves/templates/iso_class.html
+++ b/lmfdb/elliptic_curves/templates/iso_class.html
@@ -95,12 +95,9 @@ rank \({{ info.rank}}\).
 
 {% if info.ncurves>1 %}
 
-<h2>Matrix of isogeny degrees</h2>
+<h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>
+
 <div class='sage nodisplay code'>sage: E.isogeny_class().matrix()</div>
-<p>
-  Rows and columns are indexed by the number of the curve in
-  the class.
-</p>
 <p>
   \({{info.isogeny_matrix_str}}\)
 </p>
@@ -109,9 +106,6 @@ rank \({{ info.rank}}\).
 <div class='sage nodisplay code'>
   sage: E.isogeny_graph().plot(edge_labels=True)
 </div>
-<p>
-  Only edges corresponding to isogenies of prime degree are shown.
-</p>
 <center>
   <img src="{{info.graph_img}}" />
 </center>


### PR DESCRIPTION
The conventions on isogeny matrices and graphs are now no longer mentioned by default on every individual page, but rather mentioned in the knowl, thus streamlining the display of the pages.

Also, a link to the knowl on isogeny matrices has been added to the pages of elliptic curves over the rationals.