### PR TITLE
Added lines to copy-paste defining equations into Sage and Magma

### DIFF
--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -26,12 +26,20 @@ function show_code(system) {
 src="http://code.jquery.com/jquery-latest.min.js"></script>
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 
-    {% set KNOWL_ID = "ec.q.%s"|format(data['label']) %}
+    {% set KNOWL_ID = "g2c.%s"|format(data['label']) %}
 
 <!--<h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>-->
 
+    <div align ="center">
+      Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
+        <a onclick="show_code('magma'); return false" href='#'>magma</a>
+    </div>
+
     <h2> {{ KNOWL('g2c.minimal_equation', title='Minimal equation') }} </h2>
-<p>  ${{ data.data.min_eqn }}$ </p>
+    <p> ${{ data.data.min_eqn_display }}$ </p>
+
+    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp; R.&lt;x&gt; = PolynomialRing(QQ); C = HyperellipticCurve(R({{data.data.min_eqn[0]}}), R({{data.data.min_eqn[1]}}))</div>
+    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> R&lt;x&gt; := PolynomialRing(Rationals()); C := HyperellipticCurve(R!{{data.data.min_eqn[0]}}, R!{{data.data.min_eqn[1]}});</div>
 
     <h2> {{ KNOWL('g2c.invariants', title='Invariants') }}  </h2>
         <table>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -207,7 +207,8 @@ class WebG2C(object):
         #disc = ZZ(self.disc_sign) * ZZ(self.abs_disc)
         data['disc'] = disc
         data['cond'] = ZZ(self.cond)
-        data['min_eqn'] = list_to_min_eqn(self.min_eqn)
+        data['min_eqn'] = self.min_eqn
+        data['min_eqn_display'] = list_to_min_eqn(self.min_eqn)
         data['disc_factor_latex'] = web_latex(factor(data['disc']))
         data['cond_factor_latex'] = web_latex(factor(int(self.cond)))
         data['aut_grp'] = groupid_to_meaningful(self.aut_grp)
@@ -262,7 +263,7 @@ class WebG2C(object):
             ('L-function', url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x)),
             ('Siegel modular form someday', '.')]
         self.downloads = [
-             ('Download Euler factors', '.')]
+             ('Download all stored data', '.')]
         iso = self.label.split('.')[1]
         num = '.'.join(self.label.split('.')[2:4])
         self.plot = encode_plot(eqn_list_to_curve_plot(self.min_eqn))


### PR DESCRIPTION
The genus 2 pages (of specific curves) can now display lines of Sage and Magma code that enable copy-pasting of the curve in question into the user's sessions.

The current code snippets can probably be improved; on the other hand, I see no way to avoid defining a variable in Sage, since the HyperellipticCurve command there requires polynomials. Also in Magma this seems tricky; the coefficient lists of the constituent polynomials can be empty, add Polynomial([]) then gives an error. I have therefore defined a base polynomial ring first in both cases. Any suggestions to work around this are very welcome.

Other small changes:
(1) Changed KNOWL_ID to g2c instead of ec.q;
(2) In the list of downloads in the sidebar, changed the name to suggest downloading all stored data. Note that regardless of the name this is actually not possible, since the relevant code is not yet available.