### PR TITLE
Ecnf: add twists and fix go-to-label

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -234,10 +234,6 @@ class ECNF(object):
                                 'ord_mindisc': self.local_info.discriminant_valuation()
                                })
 
-        twists = list(db_ecnf().find({"field_label" : self.field_label, "jinv": self.jinv}))
-        self.twists = [[e['short_label'],url_for(".show_ecnf",nf=e['field_label'],conductor_label=e['conductor_label'],class_label=e['iso_label'],number=e['number'])] for e in twists if e['label']!=self.label]
-        no_other_twists = int(len(self.twists)==0)
-
         # URLs of self and related objects:
         self.urls = {}
         self.urls['curve'] = url_for(".show_ecnf", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label, number = self.number)
@@ -255,11 +251,7 @@ class ECNF(object):
 
         self.friends = []
         self.friends += [('Isogeny class '+self.short_class_label, self.urls['class'])]
-        if no_other_twists:
-            self.friends += [('No other twists in database','')]
-        else:
-            for tw in self.twists:
-                self.friends += [('Twist %s' % tw[0], tw[1])]
+        self.friends += [('Twists',url_for('ecnf.index',field_label=self.field_label,jinv=self.jinv))]
         if self.field.is_real_quadratic():
             self.friends += [('Hilbert Modular Form '+self.hmf_label, self.urls['hmf'])]
         if self.field.is_imag_quadratic():

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -234,6 +234,10 @@ class ECNF(object):
                                 'ord_mindisc': self.local_info.discriminant_valuation()
                                })
 
+        twists = list(db_ecnf().find({"field_label" : self.field_label, "jinv": self.jinv}))
+        self.twists = [[e['short_label'],url_for(".show_ecnf",nf=e['field_label'],conductor_label=e['conductor_label'],class_label=e['iso_label'],number=e['number'])] for e in twists if e['label']!=self.label]
+        no_other_twists = int(len(self.twists)==0)
+
         # URLs of self and related objects:
         self.urls = {}
         self.urls['curve'] = url_for(".show_ecnf", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label, number = self.number)
@@ -251,15 +255,20 @@ class ECNF(object):
 
         self.friends = []
         self.friends += [('Isogeny class '+self.short_class_label, self.urls['class'])]
+        if no_other_twists:
+            self.friends += [('No other twists in database','')]
+        else:
+            for tw in self.twists:
+                self.friends += [('Twist %s' % tw[0], tw[1])]
         if self.field.is_real_quadratic():
             self.friends += [('Hilbert Modular Form '+self.hmf_label, self.urls['hmf'])]
         if self.field.is_imag_quadratic():
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
-        
+
         self.properties = [
             ('Base field', self.field.field_pretty()),
             ('Label' , self.label)]
-        
+
         # Plot
         if E.base_field().signature()[0]:
             self.plot = encode_plot(EC_nf_plot(E,self.field.generator_name()))


### PR DESCRIPTION
Related objects now shows Twists, which gives a list of all twists of the curve in the database.
Search by exact label now works (it did not before) and gives a reasonable error page if the label is invalid.