### PR TITLE
Added conversion of geometric invariants in genus 2

### DIFF
--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -68,6 +68,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>{{ data.data.disc_factor_latex }}</td>
         </tr>
         </table>
+        <br>
         <div class='igusa_clebsch'>
             Igusa-Clebsch invariants:
         </div>
@@ -157,6 +158,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>\({{ data.data.g2[2] }}\)</td>
         </tr>
         <table>
+        <br>
         <div class='igusa_clebsch'>
             Alternative geometric invariants: 
             <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>,

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -67,6 +67,17 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>&nbsp;=&nbsp;</td>
           <td>{{ data.data.disc_factor_latex }}</td>
         </tr>
+        </table>
+        <div class='igusa_clebsch'>
+            Igusa-Clebsch invariants:
+        </div>
+        <div class='igusa nodisplay'>
+            Igusa invariants:
+        </div>
+        <div class='g2 nodisplay'>
+            G2 invariants:
+        </div>
+        <table>
         <tr class='igusa_clebsch'>
           <td> \( I_2 \) </td>
           <td>&nbsp;=&nbsp;</td>
@@ -146,13 +157,22 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>\({{ data.data.g2[2] }}\)</td>
         </tr>
         <table>
+        <div class='igusa_clebsch'>
+            Alternative geometric invariants: 
+            <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>,
+            <a onclick="show_invs('g2'); return false" href='#'>G2</a>
+        </div>
+        <div class='igusa nodisplay'>
+            Alternative geometric invariants: 
+            <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch</a>,
+            <a onclick="show_invs('g2'); return false" href='#'>G2</a>
+        </div>
+        <div class='g2 nodisplay'>
+            Alternative geometric invariants: 
+            <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch</a>,
+            <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>
+        </div>
 
-    <div>
-      Available geometric invariants:
-      <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch</a>&nbsp;/
-      <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>&nbsp;/
-      <a onclick="show_invs('g2'); return false" href='#'>G2</a>
-    </div>
 
     <h2> {{ KNOWL('g2c.aut_grp', title='Automorphism group') }} </h2>
 <table>

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -26,13 +26,7 @@ function show_invs(invstyle) {
     $('.igusa_clebsch').hide();
     $('.igusa').hide();
     $('.g2').hide();
-    if (cur_invstyle == invstyle) {
-      $('.'+invstyle).hide();
-      cur_invstyle = null;
-      } else {
-      $('.'+invstyle).show();
-      cur_invstyle = invstyle;
-    }
+    $('.'+invstyle).show();
   }
 </script>
 

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -20,6 +20,22 @@ function show_code(system) {
   }
 </script>
 
+<script>
+var cur_invstyle = null;
+function show_invs(invstyle) {
+    $('.igusa_clebsch').hide();
+    $('.igusa').hide();
+    $('.g2').hide();
+    if (cur_invstyle == invstyle) {
+      $('.'+invstyle).hide();
+      cur_invstyle = null;
+      } else {
+      $('.'+invstyle).show();
+      cur_invstyle = invstyle;
+    }
+  }
+</script>
+
 <script type="text/javascript"
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script type="text/javascript"
@@ -34,7 +50,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
       Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
         <a onclick="show_code('magma'); return false" href='#'>magma</a>
     </div>
-
+    
     <h2> {{ KNOWL('g2c.minimal_equation', title='Minimal equation') }} </h2>
     <p> ${{ data.data.min_eqn_display }}$ </p>
 
@@ -43,7 +59,6 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h2> {{ KNOWL('g2c.invariants', title='Invariants') }}  </h2>
         <table>
-
         <tr>
           <td> \( N \) </td>
 	  <td>&nbsp;=&nbsp;</td>
@@ -58,36 +73,92 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
           <td>&nbsp;=&nbsp;</td>
           <td>{{ data.data.disc_factor_latex }}</td>
         </tr>
-	
-        <tr>
+        <tr class='igusa_clebsch'>
           <td> \( I_2 \) </td>
-	  <td>&nbsp;=&nbsp;</td>
-	  <td>\({{ data.data.invs[0] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
-	  <td>{{ data.data.invs_factor_latex[0] }}</td>
+          <td>\({{ data.data.ic_norm[0] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.ic_norm_factor_latex[0] }}</td>
         </tr>
-	<tr>
+        <tr class='igusa_clebsch'>
           <td> \( I_4 \) </td>
-	  <td>&nbsp;=&nbsp;</td>
-	  <td>\({{ data.data.invs[1] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
-	  <td>{{ data.data.invs_factor_latex[1] }}</td>
+          <td>\({{ data.data.ic_norm[1] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.ic_norm_factor_latex[1] }}</td>
         </tr>
-	<tr>
+        <tr class='igusa_clebsch'>
           <td> \( I_6 \) </td>
-	  <td>&nbsp;=&nbsp;</td>
-	  <td>\({{ data.data.invs[2] }}\)</td>
           <td>&nbsp;=&nbsp;</td>
-	  <td>{{ data.data.invs_factor_latex[2] }}</td>
+          <td>\({{ data.data.ic_norm[2] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.ic_norm_factor_latex[2] }}</td>
         </tr>
-	<tr>
+        <tr class='igusa_clebsch'>
           <td> \( I_{10} \) </td>
-	  <td>&nbsp;=&nbsp;</td>
-	  <td>\({{ data.data.invs[3]}}\)</td>
           <td>&nbsp;=&nbsp;</td>
-	  <td>{{ data.data.invs_factor_latex[3] }}</td>
+          <td>\({{ data.data.ic_norm[3]}}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.ic_norm_factor_latex[3] }}</td>
         </tr>
-	</table>
+        <tr class='igusa nodisplay'>
+          <td> \( J_2 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.igusa_norm[0] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.igusa_norm_factor_latex[0] }}</td>
+        </tr>
+        <tr class='igusa nodisplay'>
+          <td> \( J_4 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.igusa_norm[1] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.igusa_norm_factor_latex[1] }}</td>
+        </tr>
+        <tr class='igusa nodisplay'>
+          <td> \( J_6 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.igusa_norm[2] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.igusa_norm_factor_latex[2] }}</td>
+        </tr>
+        <tr class='igusa nodisplay'>
+          <td> \( J_8 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.igusa_norm[3] }}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.igusa_norm_factor_latex[3] }}</td>
+        </tr>
+        <tr class='igusa nodisplay'>
+          <td> \( J_{10} \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.igusa_norm[4]}}\)</td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>{{ data.data.igusa_norm_factor_latex[4] }}</td>
+        </tr>
+        <tr class='g2 nodisplay'>
+          <td> \( g_1 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.g2[0] }}\)</td>
+        </tr>
+        <tr class='g2 nodisplay'>
+          <td> \( g_2 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.g2[1] }}\)</td>
+        </tr>
+        <tr class='g2 nodisplay'>
+          <td> \( g_3 \) </td>
+          <td>&nbsp;=&nbsp;</td>
+          <td>\({{ data.data.g2[2] }}\)</td>
+        </tr>
+        <table>
+
+    <div>
+      Convert to preferred geometric invariants:
+      <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch (default)</a>,
+      <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>,
+      <a onclick="show_invs('g2'); return false" href='#'>G2</a>
+    </div>
 
     <h2> {{ KNOWL('g2c.aut_grp', title='Automorphism group') }} </h2>
 <table>

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -154,9 +154,9 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         <table>
 
     <div>
-      Convert to preferred geometric invariants:
-      <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch (default)</a>,
-      <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>,
+      Available geometric invariants:
+      <a onclick="show_invs('igusa_clebsch'); return false" href='#'>Igusa-Clebsch</a>&nbsp;/
+      <a onclick="show_invs('igusa'); return false" href='#'>Igusa</a>&nbsp;/
       <a onclick="show_invs('g2'); return false" href='#'>G2</a>
     </div>
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -136,16 +136,32 @@ def isog_label(label):
     L = label.split(".")
     return L[0]+ "." + L[1]
 
+def igusa_clebsch_to_igusa(I):
+    # Conversion from Igusa-Clebsch to Igusa
+    J2 = I[0]//8
+    J4 = (4*J2**2 - I[1])//96
+    J6 = (8*J2**3 - 160*J2*J4 - I[2])//576
+    J8 = (J2*J6 - J4**2)//4
+    J10 = I[3]//4096
+    return [J2,J4,J6,J8,J10]
+
+def igusa_to_g2(J):
+    # Conversion from Igusa to G2
+    if J[0] != 0:
+        return [J[0]**5/J[4], J[0]**3*J[1]/J[4], J[0]**2*J[2]/J[4]]
+    elif J[1] != 0:
+        return [0, J[1]**5/J[4]**2, J[1]*J[2]/J[4]]
+    else:
+        return [0,0,J[2]**5/J[4]**3]
+
 def scalar_div(c,P,W):
     # Scalar division in a weighted projective space
     return [p//(c**w) for (p,w) in izip(P,W)]
 
-def normalize_invariants(I):
-    # This is the tuple of weights for Igusa-Clebsch invariants.
-    # It is later refined to deal with curves for which some of these vanish
-    # If using Igusa invariants instead, one only needs to modify this to
-    #  W_b = [1, 2, 3, 4, 5]
-    W_b = [1, 2, 3, 5]
+def normalize_invariants(I,W):
+    # Normalizes integral invariants to remove factors
+    # Tuple of weights:
+    W_b = W
     I_b = I
     l_b = len(W_b)
     # Eliminating elements of the weight with zero entries in W_b
@@ -227,10 +243,13 @@ class WebG2C(object):
         data['cond_factor_latex'] = web_latex(factor(int(self.cond)))
         data['aut_grp'] = groupid_to_meaningful(self.aut_grp)
         data['geom_aut_grp'] = groupid_to_meaningful(self.geom_aut_grp)
-        # Retain actual polynomial Igusa-Clebsch invariants:
-        #data['igusa_clebsch'] = [ZZ(a) for a in self.igusa_clebsch]
-        data['invs'] = normalize_invariants([ZZ(a) for a in self.igusa_clebsch])
-        data['invs_factor_latex'] = [web_latex(factor(i)) for i in data['invs']]
+        data['igusa_clebsch'] = [ZZ(a) for a in self.igusa_clebsch]
+        data['igusa'] = igusa_clebsch_to_igusa(data['igusa_clebsch'])
+        data['g2'] = igusa_to_g2(data['igusa'])
+        data['ic_norm'] = normalize_invariants(data['igusa_clebsch'],[1,2,3,5])
+        data['igusa_norm'] = normalize_invariants(data['igusa'],[1,2,3,4,5])
+        data['ic_norm_factor_latex'] = [web_latex(factor(i)) for i in data['ic_norm']]
+        data['igusa_norm_factor_latex'] = [web_latex(factor(j)) for j in data['igusa_norm']]
         data['num_rat_wpts'] = ZZ(self.num_rat_wpts)
         data['two_selmer_rank'] = ZZ(self.two_selmer_rank)
         if len(self.torsion) == 0:
@@ -288,7 +307,7 @@ class WebG2C(object):
                            (None, self.plot_link),
                            ('Conductor','%s' % self.cond),
                            ('Discriminant', '%s' % data['disc']),
-                           ('Invariants', '%s </br> %s </br> %s </br> %s'% tuple(data['invs'])), 
+                           ('Invariants', '%s </br> %s </br> %s </br> %s'% tuple(data['ic_norm'])), 
                            ('Sato-Tate group', '\(%s\)' % data['st_group_name']), 
                            ('\(\mathrm{End}(J_{\overline{\Q}}) \otimes \R\)','\(%s\)' % data['real_geom_end_alg_name']),
                            ('\(\mathrm{GL}_2\)-type','%s' % data['is_gl2_type_name'])]


### PR DESCRIPTION
The pages for individual curves in genus 2 now have a clickable conversion for geometric invariants. The default choice for these, which is displayed when entering the page, are the Igusa-Clebsch invariants. Clicking one of the other choices (Igusa and G2) gives the other commonly used invariants. As before, the Igusa-Clebsch and Igusa invariants are normalized before being displayed.