### PR TITLE
Fixed minor display bug in Lfunction_base.py

### DIFF
--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -56,7 +56,7 @@ class Lfunction:
 
     def compute_some_mu_nu(self):
         pairs_fe = zip(self.kappa_fe, self.lambda_fe)
-        self.mu_fe = [lambda_fe/2. for kappa_fe, lambda_fe in pairs_fe if abs(kappa_fe - 0.5) < 0.001]
+        self.mu_fe = [lambda_fe*2. for kappa_fe, lambda_fe in pairs_fe if abs(kappa_fe - 0.5) < 0.001]
         self.nu_fe = [lambda_fe for kappa_fe, lambda_fe in pairs_fe if abs(kappa_fe - 1) < 0.001]
         
         


### PR DESCRIPTION
The functional equation was displayed incorrectly on:
http://www.lmfdb.org//L/SymmetricPower/2/EllipticCurve/Q/11.a/

On this particular page, the factor Gamma_R(s+0.25) appeared instead of Gamma_R(s+1).
The mistake was due to a "/2" instead of "*2".