### PR TITLE
made approximate status of analytic sha clear for rank>1

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -212,7 +212,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4"> 
-           \( \text{Reg} \) </td><td>&nbsp;=&nbsp;</td><td> \({{ data.bsd.reg }}\)</td>
+           \( \text{Reg} \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.reg }}\dots\)</td>
         </tr>
 
         <tr>
@@ -224,7 +224,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4">
-           \( \Omega \) </td><td>&nbsp;=&nbsp;</td><td> \({{ data.bsd.omega }}\)</td>
+           \( \Omega \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.omega }}\dots\)</td>
         </tr>
 
         <tr>
@@ -263,8 +263,16 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4"> &#1064;\(_{\text{an}} \) </td>
+        {% if data.rank > 1 %}
+        <td>&nbsp;&approx;&nbsp;</td>
+        {% else %}
         <td>&nbsp;=&nbsp;</td>
-        <td>\({{ data.bsd.sha }}\)</td>
+        {% endif %}
+        <td>\({{ data.bsd.sha }}\)
+          {% if data.rank > 1 %}
+          ({{ KNOWL('ec.q.analytic_sha_order',title="approximate value")}})
+          {% endif %}
+        </td>
         </tr>
 
         </table>

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -212,7 +212,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4"> 
-           \( \text{Reg} \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.reg }}\dots\)</td>
+           \( \text{Reg} \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.reg }}\)</td>
         </tr>
 
         <tr>
@@ -224,7 +224,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4">
-           \( \Omega \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.omega }}\dots\)</td>
+           \( \Omega \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.omega }}\)</td>
         </tr>
 
         <tr>
@@ -263,15 +263,14 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
         <tr>
         <td colspan="4"> &#1064;\(_{\text{an}} \) </td>
-        {% if data.rank > 1 %}
-        <td>&nbsp;&approx;&nbsp;</td>
-        {% else %}
-        <td>&nbsp;=&nbsp;</td>
-        {% endif %}
-        <td>\({{ data.bsd.sha }}\)
+        <td>&nbsp;
+          {% if data.rank > 1 %}&approx;{% else %}={% endif %}
+        &nbsp;</td>
+        <td>\({{data.bsd.sha }}\)
           {% if data.rank > 1 %}
-          ({{ KNOWL('ec.q.analytic_sha_order',title="approximate value")}})
+          (approximate value)
           {% endif %}
+          {{ KNOWL('ec.q.analytic_sha_value',title="?") }}
         </td>
         </tr>
 


### PR DESCRIPTION
http://beta.lmfdb.org/EllipticCurve/Q/389/a/1 is a rank 2 example
http://beta.lmfdb.org/EllipticCurve/Q/37/a/1 is a rank1 example

I added (approximate value) after the analytic Sha for curves of rank > 1 where the number was computed as floating point and rounded; the words are a link to the knowl for Analytic Sha.

At the same time I changed = to &approx; for the BSD invariants which are not exact.