### PR TITLE
Various improvements to home pages of elliptic curves, over Q and over number fields

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -231,7 +231,8 @@ class ECNF(object):
                                'kodaira_symbol': web_latex(self.local_info.kodaira_symbol()).replace('$', ''),
                                'reduction_type': self.local_info.bad_reduction_type(),
                                 'ord_den_j': max(0,-E.j_invariant().valuation(p)),
-                                'ord_mindisc': self.local_info.discriminant_valuation()
+                                'ord_mindisc': self.local_info.discriminant_valuation(),
+                                'ord_cond': self.local_info.conductor_valuation()
                                })
 
         # URLs of self and related objects:

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -21,8 +21,8 @@ function show_code(system) {
   }
 </script>
 
+{#
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script><script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script><script src="http://aleph.sagemath.org/embedded_sagecell.js">
-  
 
 </script><style type="text/css">
   .sagecell .CodeMirror-scroll {
@@ -45,6 +45,7 @@ function show_code(system) {
   }
 
   </style>
+#}
 
 {#
     <div align ="right">
@@ -57,8 +58,11 @@ function show_code(system) {
 <div>
   <h2>  Base Field   {{ ec.field.knowl()|safe }} </h2>
 <p>
-Generator \({{ ec.field.generator_name() }}\), with minimal polynomial
-\({{ec.field.poly()}}\), class number \({{ec.field.class_number()}}\).
+ {{ KNOWL('nf.generator', 'Generator') }} \({{
+ ec.field.generator_name() }}\), with {{
+ KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
+ \({{ec.field.poly()}}\); {{ KNOWL('nf.class_number', 'class number')
+ }} \({{ec.field.class_number()}}\).
 </p>
 </div>
 
@@ -77,24 +81,24 @@ cellpadding="5";
 </p>
 <p>
   {% if ec.is_minimal %}
-  This is a global minimal model.
+  This is a {{ KNOWL('ec.global_minimal_model','global minimal model')}}.
   {% else %}
-  This is not a global minimal model: it is minimal at all primes except
-  {{ ec.non_min_prime }}.
+  This is not a {{ KNOWL('ec.global_minimal_model','global minimal
+  model')}}: it is {{ KNOWL('ec.local_minimal_model','minimal') }}
+  at all primes except {{ ec.non_min_prime }}.
   {% if ec.has_minimal_model %}
-  However, a minimal model does exist.
+  However, a {{ KNOWL('ec.global_minimal_model','global minimal model')}} does exist.
   {% else %}
-  No global minimal model exists.
+  No {{ KNOWL('ec.global_minimal_model','global minimal model')}} exists.
   {% endif %}
   {% endif %}
 </p>
 
 
-<h2>Invariants</h2>
+<h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
         <table id="invariants">
         <tr>
-          <td>{{ KNOWL('ec.conductor',  title='Conductor') }}</td>
         <td>
          \(\mathfrak{N} \)</td>
         <td>=</td>
@@ -104,7 +108,6 @@ cellpadding="5";
         </tr>
 
         <tr>
-          <td>Conductor {{ KNOWL('ec.conductor_norm',  title='norm') }}</td>
         <td>
          \(N(\mathfrak{N}) \)</td>
         <td>=</td>
@@ -114,9 +117,13 @@ cellpadding="5";
         </tr>
 
         <tr>
-          <td>{{ KNOWL('ec.discriminant',  title='Discriminant ideal') }}</td>
         <td>
-         \((\Delta)\)</td>
+          {% if ec.is_minimal %}
+          \(\mathfrak{D}\)
+          {% else %}
+          \((\Delta)\)
+          {% endif %}
+        </td>
         <td>=</td>
         <td>{{ ec.disc }}</td>
         {% if ec.fact_disc %}
@@ -126,9 +133,13 @@ cellpadding="5";
         </tr>
 
         <tr>
-          <td>Discriminant {{ KNOWL('ec.discriminant_norm',  title='norm') }}</td>
         <td>
-         \(N(\Delta)\)</td>
+          {% if ec.is_minimal %}
+          \(N(\mathfrak{D})\)
+          {% else %}
+          \(N(\Delta)\)
+          {% endif %}
+         </td>
         <td>=</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
@@ -137,9 +148,8 @@ cellpadding="5";
 
 {% if not ec.is_minimal %}
         <tr>
-          <td>{{ KNOWL('ec.discriminant',  title='Minimal Discriminant ideal') }}</td>
         <td>
-         \(\Delta_{min}\)</td>
+         \(\mathfrak{D}\)</td>
         <td>=</td>
         <td>{{ ec.mindisc }}</td>
         {% if ec.fact_mindisc %}
@@ -149,9 +159,8 @@ cellpadding="5";
         </tr>
 
         <tr>
-          <td>Minimal discriminant {{ KNOWL('ec.discriminant_norm',  title='norm') }}</td>
         <td>
-         \(N(\Delta_{min})\)</td>
+         \(N(\mathfrak{D})\)</td>
         <td>=</td>
         <td>{{ ec.mindisc_norm }}</td>
         <td>=</td>
@@ -160,7 +169,6 @@ cellpadding="5";
 {% endif %}
 
         <tr>
-          <td>{{ KNOWL('ec.j_invariant',  title='\(j\)-invariant') }}</td>
         <td>
          \(j\)</td>
         <td>=</td>
@@ -172,7 +180,6 @@ cellpadding="5";
         </tr>
 
         <tr>
-          <td>{{ KNOWL('ec.endomorphism_ring',  title='Endomorphism ring') }}</td>
         <td> \( \text{End} (E) \)</td>
         <td>=</td>
         <td>{{ ec.End }}</td>
@@ -218,8 +225,9 @@ Not yet determined.
 <th>{{KNOWL('ec.q.tamagawa_numbers', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
-<th>ord(\(\Delta_{min}\))</th>
-<th>ord\({}_-(j\))</th>
+<th>{{KNOWL('ec.conductor_valuation', title='ord(\(\mathfrak{N}\))')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\mathfrak{D}\))')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
 </tr>
 {% for pr in ec.local_data %}
 <tr>
@@ -244,12 +252,9 @@ Not yet determined.
    Non-split multiplicative
 {% endif %}
 </td>
-<td align=center>
-{{ pr.ord_mindisc }}
-</td>
-<td align=center>
-{{ pr.ord_den_j }}
-</td>
+<td align=center>{{pr.ord_cond}}</td>
+<td align=center>{{pr.ord_mindisc }}</td>
+<td align=center>{{pr.ord_den_j}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -211,8 +211,12 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </td>
         </tr>
         <tr>
-        <td colspan="4"> 
-           \( \text{Reg} \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.reg }}\)</td>
+        <td colspan="4">\( \text{Reg} \) </td>
+        {% if data.rank==0 %}
+        <td>&nbsp;=&nbsp;</td><td> \(1\)</td>
+        {% else %}
+        <td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.reg }}\)</td>
+        {% endif %}
         </tr>
 
         <tr>
@@ -238,8 +242,11 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         <td colspan="4">
          \( \prod_p c_p \)</td>
         <td>&nbsp;=&nbsp;</td>
-        <td>\( {{ data.bsd.tamagawa_product }} \) &nbsp;=&nbsp;
-        \( {{ data.bsd.tamagawa_factors }} \)</td>
+        <td>\( {{ data.bsd.tamagawa_product }} \)
+          {% if data.bsd.tamagawa_factors %}
+          &nbsp;=&nbsp;\( {{ data.bsd.tamagawa_factors }} \)
+          {% endif %}
+        </td>
         </tr>
 
         <tr>
@@ -268,9 +275,10 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         &nbsp;</td>
         <td>\({{data.bsd.sha }}\)
           {% if data.rank > 1 %}
-          (approximate value)
+          ({{ KNOWL('ec.q.analytic_sha_value',title="rounded") }})
+          {% else %}
+          ({{ KNOWL('ec.q.analytic_sha_value',title="exact") }})
           {% endif %}
-          {{ KNOWL('ec.q.analytic_sha_value',title="?") }}
         </td>
         </tr>
 
@@ -342,6 +350,9 @@ text-align: center;
 <th>{{KNOWL('ec.q.tamagawa_numbers', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
+<th>{{KNOWL('ec.conductor_valuation', title='ord(\(N\))')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\Delta\))')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
 </tr>
 {% for pr in data.local_data %}
 <tr>
@@ -357,6 +368,9 @@ text-align: center;
    Non-split multiplicative
 {% endif %}
 </td>
+<td>{{pr.ord_cond}}</td>
+<td>{{pr.ord_disc}}</td>
+<td>{{pr.ord_den_j}}</td>
 </tr>
 {% endfor %}
 </table>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -163,7 +163,7 @@ class WebEC(object):
             data['j_inv_factor'] = latex(data['j_invariant'].factor())
         data['j_inv_str'] = unicode(str(data['j_invariant']))
         data['j_inv_latex'] = web_latex(data['j_invariant'])
-        data['disc'] = self.E.discriminant()
+        data['disc'] = D = self.E.discriminant()
         data['disc_latex'] = web_latex(data['disc'])
         data['disc_factor'] = latex(data['disc'].factor())
         data['cond_factor'] =latex(N.factor())
@@ -296,7 +296,7 @@ class WebEC(object):
 
         local_data = self.local_data = []
         # if we use E.tamagawa_numbers() it calls E.local_data(p) which
-        # crashes on some curves e.g. 164411a1
+        # used to crash on some curves e.g. 164411a1
         tamagawa_numbers = []
         for p in bad_primes:
             local_info = self.E.local_data(p, algorithm="generic")
@@ -306,9 +306,15 @@ class WebEC(object):
             tamagawa_numbers.append(ZZ(local_info.tamagawa_number()))
             local_data_p['kodaira_symbol'] = web_latex(local_info.kodaira_symbol()).replace('$', '')
             local_data_p['reduction_type'] = local_info.bad_reduction_type()
+            local_data_p['ord_cond'] = local_info.conductor_valuation()
+            local_data_p['ord_disc'] = local_info.discriminant_valuation()
+            local_data_p['ord_den_j'] = max(0,-self.E.j_invariant().valuation(p))
             local_data.append(local_data_p)
 
-        bsd['tamagawa_factors'] = r' \cdot '.join(str(c.factor()) for c in tamagawa_numbers)
+        if len(bad_primes)>1:
+            bsd['tamagawa_factors'] = r' \cdot '.join(str(c.factor()) for c in tamagawa_numbers)
+        else:
+            bsd['tamagawa_factors'] = ''
         bsd['tamagawa_product'] = sage.misc.all.prod(tamagawa_numbers)
 
         cond, iso, num = split_lmfdb_label(self.lmfdb_label)


### PR DESCRIPTION
See commit messages!
Examples to see differences: 
http://localhost:37777/EllipticCurve/2.2.229.1/9.2/a/1 (number field, no global minimal model)
http://localhost:37777/EllipticCurve/2.2.497.1/4.1/d/2 (number field, global minimal model)
http://localhost:37777/EllipticCurve/Q/389/a/1 (Q, rank 2)
http://localhost:37777/EllipticCurve/Q/14/a/1 (Q, rank 0)
http://localhost:37777/EllipticCurve/Q/210/a/1 (Q, rank 1)