### PR TITLE
fixed Sage version code in emf initialization

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
@@ -6,15 +6,19 @@ import flask
 default_prec = 10   # The default number of terms in a q-expansion
 default_bprec = 53  # The default number of bits of precision to compute for floating point data
 default_display_bprec = 26  # The default number of bits of precision to display for floating point data
-from sage.all import version 
-if float(version().split(',')[0].split(' ')[-1]) >= 6.8:
+from sage.env import SAGE_VERSION
+version_major, version_minor = [int(x) for x in SAGE_VERSION.split('.')[:2]]
+if (version_major, version_minor) >= (6,8):
     emf_version = 1.2
 else:
     emf_version = 1.1
+
 EMF_TOP = "Holomorphic Modular Forms"  # The name to use for the top of this catergory
 EMF = "emf"  # The current blueprint name
 emf = flask.Blueprint(EMF, __name__, template_folder="views/templates", static_folder="views/static")
 emf_logger = lmfdb.utils.make_logger(emf)
+emf_logger.info("Initializing elliptic modular forms blueprint with Sage version %s, emf version %s" % (SAGE_VERSION, emf_version))
+
 ### Maximum values for computations
 N_max_comp = 50
 k_max_comp = 12


### PR DESCRIPTION
Small left-over from pull request #297: now handles Sage versions more robustly (and does not crash on version 6.9.beta0, for example). 