### PR TITLE
Update show-ecnf.html

### DIFF
--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -222,9 +222,9 @@ Not yet determined.
 <tr>
 <th>prime</th>
 <th>Norm</th>
-<th>{{KNOWL('ec.q.tamagawa_numbers', title='Tamagawa number')}}</th>
-<th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
-<th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
+<th>{{KNOWL('ec.tamagawa_number', title='Tamagawa number')}}</th>
+<th>{{KNOWL('ec.kodaira_symbol', title='Kodaira symbol')}}</th>
+<th>{{KNOWL('ec.reduction_type', title='Reduction type')}}</th>
 <th>{{KNOWL('ec.conductor_valuation', title='ord(\(\mathfrak{N}\))')}}</th>
 <th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\mathfrak{D}\))')}}</th>
 <th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>


### PR DESCRIPTION
I replaced 'ec.q.xxx' with 'ec.xxx' in a few knowls for the home page of elliptic curves over number fields (and as an experiment, did this directly on github) and created the new knowls needed.

Any ecnf home page will show the new knowl links (and all the relevant knowls should exist unless I mistyped something) in the Local data section , e.g. http://beta.lmfdb.org/EllipticCurve/2.2.5.1/2695.2/b/3