### PR TITLE
Code snippets for sage/pari/magma for elliptic curve pages

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -24,6 +24,7 @@ function show_code(system) {
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script type="text/javascript"
 src="http://code.jquery.com/jquery-latest.min.js"></script>
+{#
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 
 <style type="text/css">
@@ -40,10 +41,8 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
   .sagecell_sessionContainer {
       margin-bottom:1em;
-  
   }
-
-  </style>
+</style>
 
 
 <script>
@@ -58,6 +57,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 //      }
 //   ))
   </script>
+#}
 
     <div align ="center">
       Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
@@ -65,18 +65,28 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         <a onclick="show_code('magma'); return false" href='#'>magma</a>
     </div>
 
+{#
     <div align = "center">
       {{ KNOWL('sage.test', title='Start a Sage cell', kwargs='n=2')
       }}
     </div>
+#}
 
     {% set KNOWL_ID = "ec.q.%s"|format(data['label']) %}
     <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
     <h2> {{ KNOWL('ec.q.minimal_weierstrass_equation', title='Minimal Weierstrass equation') }} </h2>
 
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E = EllipticCurve({{data.data.ainvs}})  {{ KNOWL('sage.test', title='(evaluate)', code = 'E = EllipticCurve(%s); E'|format(data.data.ainvs))  }}</div>
-    <div class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;E = ellinit({{data.data.ainvs}})  </div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> E := EllipticCurve({{data.data.ainvs}});</div>
+    <div class='sage nodisplay code'>
+      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.curve}}
+{# {{ KNOWL('sage.test', title='(evaluate)', code = 'E =
+    EllipticCurve(%s); E'|format(data.data.ainvs))  }} #}
+    </div>
+    <div class='pari nodisplay code'>
+      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.curve}}
+    </div>
+    <div class='magma nodisplay code'>
+      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.curve}}
+    </div>
 
     <p> {{ data.data.equation }} </p>
 
@@ -94,29 +104,49 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     {% if data.mw.rank!=0 %}
     <p><h3> Infinite order Mordell-Weil generators </h3>
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.gens()</div>
-    <div class='pari nodisplay code'> </div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Generators(E);</div>
+    <div class='sage nodisplay code'>
+      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.gens}}
+    </div>
+    <div class='pari nodisplay code'>
+      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.gens}}
+    </div>
+    <div class='magma nodisplay code'>
+      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.gens}}
+    </div>
     <div style='overflow:auto'><p> {{ data.mw.generators }} </p></div>
     </p>
     {%endif %}
 
     {% if data.mw.tor_order!=1 %}
     <p><h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
-    <div class='sage nodisplay code'> <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.torsion_subgroup().gens() </div>
-    <div class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;elltors(E) </div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> TorsionSubgroup(E);</div>
+    <div class='sage nodisplay code'>
+      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.tors}}
+    </div>
+    <div class='pari nodisplay code'>
+      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.tors}}
+    </div>
+    <div class='magma nodisplay code'>
+      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.tors}}
+    </div>
     <p> {{ data.mw.tor_gens }} </p></p>
     {%endif %}
 
 
     <p><h2> {{ KNOWL('ec.q.integral_points', title='Integral points') }}</h2>
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.integral_points()</div>
-    <div class='pari nodisplay code'> </div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> IntegralPoints(E);</div>
+    <div class='sage nodisplay code'>
+      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.intpts}}
+    </div>
+    <div class='pari nodisplay code'>
+      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.intpts}}
+    </div>
+    <div class='magma nodisplay code'>
+      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.intpts}}
+    </div>
     {% if data.xintcoords %}
     <div class="ip">
+      <p>
       {{data.mw.int_points}}
+      </p>
     </div>
     <div> Note: only one of each pair $\pm P$ is listed. </div>
     {%else %}
@@ -128,9 +158,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.conductor().factor()</span>
-            <span class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;ellglobalred(E)[1]</span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Conductor(E);</span>
+    <div class='sage nodisplay code'>
+      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.cond}}
+    </div>
+    <div class='pari nodisplay code'>
+      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.cond}}
+    </div>
+    <div class='magma nodisplay code'>
+      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.cond}}
+    </div>
         </td>
         </tr>
         <tr>

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -60,9 +60,9 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 #}
 
     <div align ="center">
-      Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
-        <a onclick="show_code('pari'); return false" href='#'>pari</a>,
-        <a onclick="show_code('magma'); return false" href='#'>magma</a>
+      Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
+        <a onclick="show_code('pari'); return false" href='#'>pari/gp</a>,
+        <a onclick="show_code('magma'); return false" href='#'>Magma</a>
     </div>
 
 {#
@@ -180,9 +180,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.discriminant().factor()</span>
-            <span class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;E.disc</span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Discriminant(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.disc}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.disc}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.disc}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -195,9 +201,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.j_invariant().factor()</span>
-            <span class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;E.j</span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> jInvariant(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.jinv}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.jinv}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.jinv}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -227,9 +239,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.rank()</span>
-            <span class='pari nodisplay code'></span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Rank(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.rank}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.rank}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.rank}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -241,9 +259,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.regulator()</span>
-            <span class='pari nodisplay code'></span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Regulator(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.reg}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.reg}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.reg}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -257,9 +281,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.period_lattice().omega()</span>
-            <span class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;E.omega[1]</span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> RealPeriod(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.real_period}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.real_period}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.real_period}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -269,9 +299,15 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.tamagawa_numbers()</span>
-            <span class='pari nodisplay code'></span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> TamagawaNumbers(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.cp}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.cp}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.cp}}
+          </div>
         </td>
         </tr>
         <tr>
@@ -287,21 +323,33 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.torsion_order()</span>
-            <span class='pari nodisplay code'><img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;elltors(E)[1]</span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> OrderTorsionSubgroup(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.ntors}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.ntors}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.ntors}}
+          </div>
         </td>
         </tr>
         <tr>
         <td colspan="4"> \( \#E_{\text{tor}} \)</td>
         <td>&nbsp;=&nbsp;</td><td>\({{ data.mw.tor_order }}\)</td>
         </tr>
-	
+
         <tr>
         <td colspan="4">
-            <span class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.sha().an_numerical()</span>
-            <span class='pari nodisplay code'></span>
-            <span class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> MordellWeilShaInformation(E);</span>
+          <div class='sage nodisplay code'>
+            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.sha}}
+          </div>
+          <div class='pari nodisplay code'>
+            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.sha}}
+          </div>
+          <div class='magma nodisplay code'>
+            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.sha}}
+          </div>
         </td>
         </tr>
         <tr>

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -4,6 +4,14 @@
 <div.ip>span { white-space: nowrap; font-family: serif; }
 </style>
 
+{% macro code(codes, languages, item) %}
+{% for L in languages %}
+    <div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">
+      {{codes[L]['prompt']}}&nbsp;{{codes[L][item]}}
+    </div>
+{% endfor %}
+{% endmacro %}
+
 <script>
 var cur_system = null;
 function show_code(system) {
@@ -15,11 +23,12 @@ function show_code(system) {
       cur_system = null;
       } else {
       $('.'+system).show();
+      $('.'+system).css('display','inline-block');
       cur_system = system;
     }
   }
 </script>
-  
+
 <script type="text/javascript"
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script type="text/javascript"
@@ -76,17 +85,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
     <h2> {{ KNOWL('ec.q.minimal_weierstrass_equation', title='Minimal Weierstrass equation') }} </h2>
 
-    <div class='sage nodisplay code'>
-      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.curve}}
-{# {{ KNOWL('sage.test', title='(evaluate)', code = 'E =
-    EllipticCurve(%s); E'|format(data.data.ainvs))  }} #}
-    </div>
-    <div class='pari nodisplay code'>
-      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.curve}}
-    </div>
-    <div class='magma nodisplay code'>
-      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.curve}}
-    </div>
+    {{ code(data.code,['sage','pari','magma'],'curve') }}
 
     <p> {{ data.data.equation }} </p>
 
@@ -104,44 +103,20 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     {% if data.mw.rank!=0 %}
     <p><h3> Infinite order Mordell-Weil generators </h3>
-    <div class='sage nodisplay code'>
-      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.gens}}
-    </div>
-    <div class='pari nodisplay code'>
-      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.gens}}
-    </div>
-    <div class='magma nodisplay code'>
-      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.gens}}
-    </div>
-    <div style='overflow:auto'><p> {{ data.mw.generators }} </p></div>
+      {{ code(data.code,['sage','magma'],'gens') }}
+      <div style='overflow:auto'><p> {{ data.mw.generators }} </p></div>
     </p>
     {%endif %}
 
     {% if data.mw.tor_order!=1 %}
-    <p><h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
-    <div class='sage nodisplay code'>
-      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.tors}}
-    </div>
-    <div class='pari nodisplay code'>
-      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.tors}}
-    </div>
-    <div class='magma nodisplay code'>
-      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.tors}}
-    </div>
-    <p> {{ data.mw.tor_gens }} </p></p>
+    <h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
+      {{ code(data.code,['sage','pari','magma'],'tors') }}
+    <p> {{ data.mw.tor_gens }} </p>
     {%endif %}
 
 
     <p><h2> {{ KNOWL('ec.q.integral_points', title='Integral points') }}</h2>
-    <div class='sage nodisplay code'>
-      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.intpts}}
-    </div>
-    <div class='pari nodisplay code'>
-      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.intpts}}
-    </div>
-    <div class='magma nodisplay code'>
-      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.intpts}}
-    </div>
+      {{ code(data.code,['sage','magma'],'intpts') }}
     {% if data.xintcoords %}
     <div class="ip">
       <p>
@@ -157,21 +132,12 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         <table>
 
         <tr>
-        <td colspan="4">
-    <div class='sage nodisplay code'>
-      {{data.code.sage.prompt}}&nbsp;{{data.code.sage.cond}}
-    </div>
-    <div class='pari nodisplay code'>
-      {{data.code.gp.prompt}}&nbsp;{{data.code.gp.cond}}
-    </div>
-    <div class='magma nodisplay code'>
-      {{data.code.magma.prompt}}&nbsp;{{data.code.magma.cond}}
-    </div>
+        <td colspan="6">
+          {{ code(data.code,['sage','pari','magma'],'cond') }}
         </td>
         </tr>
         <tr>
-        <td>
-         \( N \) </td>
+        <td>\( N \) </td>
         <td>&nbsp;=&nbsp;</td>
         <td>{{ data.data.cond_latex }}</td>
         <td>&nbsp;=&nbsp;</td>
@@ -179,16 +145,8 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
 
         <tr>
-        <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.disc}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.disc}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.disc}}
-          </div>
+        <td colspan="6">
+          {{ code(data.code,['sage','pari','magma'],'disc') }}
         </td>
         </tr>
         <tr>
@@ -200,16 +158,8 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </tr>
 
         <tr>
-        <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.jinv}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.jinv}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.jinv}}
-          </div>
+        <td colspan="6">
+          {{ code(data.code,['sage','pari','magma'],'jinv') }}
         </td>
         </tr>
         <tr>
@@ -239,39 +189,24 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.rank}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.rank}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.rank}}
-          </div>
+          {{ code(data.code,['sage','magma'],'rank') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4">
-            \( r \) </td><td>&nbsp;=&nbsp;</td><td> \({{ data.rank }}\)
+        <td> \( r \)</td>
+        <td>&nbsp;=&nbsp;</td>
+        <td> \({{ data.rank }}\)
         </td>
         </tr>
 
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.reg}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.reg}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.reg}}
-          </div>
+          {{ code(data.code,['sage','magma'],'reg') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4">\( \text{Reg} \) </td>
+        <td>\( \text{Reg} \) </td>
         {% if data.rank==0 %}
         <td>&nbsp;=&nbsp;</td><td> \(1\)</td>
         {% else %}
@@ -281,38 +216,21 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.real_period}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.real_period}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.real_period}}
-          </div>
+          {{ code(data.code,['sage','pari','magma'],'real_period') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4">
-           \( \Omega \) </td><td>&nbsp;&approx;&nbsp;</td><td> \({{ data.bsd.omega }}\)</td>
+        <td>\( \Omega \) </td><td>&nbsp;&approx;&nbsp;</td>
+        <td> \({{ data.bsd.omega }}\)</td>
         </tr>
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.cp}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.cp}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.cp}}
-          </div>
+          {{ code(data.code,['sage','pari','magma'],'cp') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4">
-         \( \prod_p c_p \)</td>
+        <td>\( \prod_p c_p \)</td>
         <td>&nbsp;=&nbsp;</td>
         <td>\( {{ data.bsd.tamagawa_product }} \)
           {% if data.bsd.tamagawa_factors %}
@@ -323,37 +241,21 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.ntors}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.ntors}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.ntors}}
-          </div>
+          {{ code(data.code,['sage','pari','magma'],'ntors') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4"> \( \#E_{\text{tor}} \)</td>
+        <td> \( \#E_{\text{tor}} \)</td>
         <td>&nbsp;=&nbsp;</td><td>\({{ data.mw.tor_order }}\)</td>
         </tr>
 
         <tr>
         <td colspan="4">
-          <div class='sage nodisplay code'>
-            {{data.code.sage.prompt}}&nbsp;{{data.code.sage.sha}}
-          </div>
-          <div class='pari nodisplay code'>
-            {{data.code.gp.prompt}}&nbsp;{{data.code.gp.sha}}
-          </div>
-          <div class='magma nodisplay code'>
-            {{data.code.magma.prompt}}&nbsp;{{data.code.magma.sha}}
-          </div>
+          {{ code(data.code,['sage','magma'],'sha') }}
         </td>
         </tr>
         <tr>
-        <td colspan="4"> &#1064;\(_{\text{an}} \) </td>
+        <td> &#1064;\(_{\text{an}} \) </td>
         <td>&nbsp;
           {% if data.rank > 1 %}&approx;{% else %}={% endif %}
         &nbsp;</td>
@@ -372,11 +274,8 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 {# %%%%%%%%%%%%%%%% END OF TABLE %%%%%%%%%%%%%%%%%%% #}
 
     <h2> {{KNOWL('ec.q.modular_parametrization', title='Modular invariants')}}</h2>
-    <p><h3> {{KNOWL('ec.q.modular_form', title='Modular form')}} </h3>
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.q_eigenform(10)</div>
-    <div class='pari nodisplay code'>
-<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;xy = elltaniyama(E); deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)</div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> ModularForm(E);</div>
+    <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}} </h3>
+          {{ code(data.code,['sage','pari','magma'],'qexp') }}
     <p>
     <form>
         <div class="output"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
@@ -385,10 +284,9 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     </form>
     </p>
 
-    <p><h3> {{ KNOWL('ec.q.modular_degree', title='Modular degree') }}
+    <h3> {{ KNOWL('ec.q.modular_degree', title='Modular degree') }}
       and {{ KNOWL('ec.q.optimal', title='optimality') }}</h3>
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.modular_degree()</div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> ModularDegree(E);</div>
+    {{ code(data.code,['sage','magma'],'moddeg') }}
       {% if data.data.degree==0 %}
       Not available
       {% else %}
@@ -400,15 +298,11 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
       {% endif %}
       \( \Gamma_0(N) \)-optimal
     </p>
-    
+
     <p>
       <h3> {{KNOWL('ec.q.special_value', title='Special L-value', special_value = data.special_value)}} attached to the curve </h3>
-
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;r = E.rank(); E.lseries().dokchitser().derivative(1,r)/r.factorial()</div>
-    <div class='pari nodisplay code'>
-<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">&nbsp;ar = ellanalyticrank(E); ar[2]/factorial(ar[1])</div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px"> Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);</div>
-
+    {{ code(data.code,['sage','pari','magma'],'L1') }}
+    <p>
         \( {{ data.bsd.lder_name }} = {{ data.bsd.lder }} \)
     </p>
 
@@ -421,12 +315,7 @@ text-align: center;
 }
 </style>
 
-    <div class='sage nodisplay code'><img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">&nbsp;E.local_data()</div>
-   <div class='pari nodisplay code'>
-<img src =
-     "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png"
-     width="50px">&nbsp;BP = factor(ellglobalred(E)[1])[,1]~; vector(length(BP),j,elllocalred(E,BP[j]))</div>
-    <div class='magma nodisplay code'><img src = "http://i.stack.imgur.com/0468s.png" width="50px">[LocalInformation(E,p) : p in BadPrimes(E)];</div>
+    {{ code(data.code,['sage','pari','magma'],'localdata') }}
 
 <table id = "local_data">
 <tr>
@@ -464,10 +353,11 @@ text-align: center;
 
 {% if data.data.CMD %} {% else %}
 {% if data.twoadic_index == 1 %}
-The {{KNOWL('ec.galois_rep',title='2-adic representation')}} attached to this elliptic curve is
-    surjective.
+<p>
+The {{KNOWL('ec.galois_rep',title='2-adic representation')}} attached
+to this elliptic curve is surjective.
+</p>
 {% else %}
-
 <p>
 The image of the {{KNOWL('ec.galois_rep',title='2-adic representation')}} attached to this elliptic curve
 is the subgroup of $\GL(2,\Z_2)$ with {{KNOWL('ec.rouse_label', title='Rouse label')}}
@@ -482,6 +372,8 @@ data.twoadic_index }}.
 {% endif %}
 {% endif %}
 
+
+    {{ code(data.code,['sage','magma'],'galrep') }}
 
 {% if data.data.galois_data %}
 <p>
@@ -519,6 +411,9 @@ representation')}} is surjective for all primes \( p \).
 
 
     <h2> p-adic data </h2>
+
+    {{ code(data.code,['sage'],'padicreg') }}
+
     <p>
 {% if data.bsd.rank==0 %}
 All \(p\)-adic regulators are identically \(1\) since the rank is \(0\).

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -366,7 +366,8 @@ class WebEC(object):
             gpcode[key] = g
             magmacode[key] = m
 
-        pari_not_implemented = '\\\\ (not implemented)'
+        pari_not_implemented = '\\\\ (not yet implemented)'
+        magma_not_implemented = '// (not yet implemented)'
 
         # prompt
         set_code('prompt',
@@ -384,9 +385,9 @@ class WebEC(object):
 
         # curve
         set_code('curve',
-                 'E = EllipticCurve(%s)'   % self.data['ainvs'],
-                 'E = ellinit(%s)'         % self.data['ainvs'],
-                 'E := EllipticCurve(%s);' % self.data['ainvs'])
+                 'E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")'  % (self.data['ainvs'],self.label),
+                 'E = ellinit(%s)       \\\\ or E = ellinit("%s")'         % (self.data['ainvs'],self.label),
+                 'E := EllipticCurve(%s); // or: E := EllipticCurve("%s");' % (self.data['ainvs'],self.label))
 
         # generators
         set_code('gens',
@@ -449,5 +450,35 @@ class WebEC(object):
                  pari_not_implemented,
                  'MordellWeilShaInformation(E);')
 
+        # q-expansion of eigenform
+        set_code('qexp', 'E.q_eigenform(10)',
+                 'xy = elltaniyama(E); deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)',
+                 'ModularForm(E);')
 
-        self.code = {'sage': sagecode, 'gp': gpcode, 'magma': magmacode}
+        # modular degree
+        set_code('moddeg', 'E.modular_degree()',
+                 pari_not_implemented,
+                 'ModularDegree(E);')
+
+        # special value
+        set_code('L1', 'r = E.rank(); E.lseries().dokchitser().derivative(1,r)/r.factorial()',
+                 'ar = ellanalyticrank(E); ar[2]/factorial(ar[1])',
+                 'Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);')
+
+        # local data
+        set_code('localdata', 'E.local_data()',
+                 'ellglobalred(E)[5]',
+                 '[LocalInformation(E,p) : p in BadPrimes(E)];')
+
+        # mod-l Galois representation
+        set_code('galrep', 'rho = E.galois_representation(); [rho.image_type(p) for p in rho.non_surjective()]',
+                 pari_not_implemented,
+                 '[GaloisRepresentation(E,p): p in PrimesUpTo(20)];')
+
+        # p-adic regulators
+        set_code('padicreg', '[E.padic_regulator(p) for p in primes(3,20)]',
+                 pari_not_implemented,
+                 magma_not_implemented)
+
+
+        self.code = {'sage': sagecode, 'pari': gpcode, 'magma': magmacode}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -320,6 +320,8 @@ class WebEC(object):
         cond, iso, num = split_lmfdb_label(self.lmfdb_label)
         data['newform'] =  web_latex(self.E.q_eigenform(10))
 
+        self.make_code_snippets()
+
         self.friends = [
             ('Isogeny class ' + self.lmfdb_iso, url_for(".by_double_iso_label", conductor=N, iso_label=iso)),
             ('Minimal quadratic twist %s %s' % (data['minq_info'], data['minq_label']), url_for(".by_triple_label", conductor=minq_N, iso_label=minq_iso, number=minq_number)),
@@ -351,3 +353,58 @@ class WebEC(object):
                            ('%s' % N, url_for(".by_conductor", conductor=N)),
                            ('%s' % iso, url_for(".by_double_iso_label", conductor=N, iso_label=iso)),
                            ('%s' % num,' ')]
+
+    def make_code_snippets(self):
+        sagecode = dict()
+        gpcode = dict()
+        magmacode = dict()
+
+        #utility function to save typing!
+
+        def set_code(key, s, g, m):
+            sagecode[key] = s
+            gpcode[key] = g
+            magmacode[key] = m
+
+        # prompt
+        set_code('prompt',
+                 '$\\tt sage$: ',
+                 '$\\tt gp?$ ',
+                 '$\\tt Magma>$ ')
+
+        # logo
+        set_code('logo',
+                 '<img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">',
+                 '<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">',
+                 '<img src = "http://i.stack.imgur.com/0468s.png" width="50px">')
+        # overwrite the above until we get something which looks reasonable
+        set_code('logo', '', '', '')
+
+        # curve
+        set_code('curve',
+                 'E = EllipticCurve(%s)'   % self.data['ainvs'],
+                 'E = ellinit(%s)'         % self.data['ainvs'],
+                 'E := EllipticCurve(%s);' % self.data['ainvs'])
+
+        # generators
+        set_code('gens',
+                 'E.gens()',
+                 '(not implemented)',
+                 'Generators(E);')
+
+        # torsion
+        set_code('tors', 'E.torsion_subgroup().gens()',
+                 'elltors(E)',
+                 'TorsionSubgroup(E);')
+
+        # integral points
+        set_code('intpts', 'E.integral_points()',
+                 '(not implemented)',
+                 'IntegralPoints(E);')
+
+        # conductor
+        set_code('cond', 'E.conductor().factor()',
+                 'ellglobalred(E)[1]',
+                 'Conductor(E);')
+
+        self.code = {'sage': sagecode, 'gp': gpcode, 'magma': magmacode}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -359,18 +359,20 @@ class WebEC(object):
         gpcode = dict()
         magmacode = dict()
 
-        #utility function to save typing!
+        # utility function to save typing!
 
         def set_code(key, s, g, m):
             sagecode[key] = s
             gpcode[key] = g
             magmacode[key] = m
 
+        pari_not_implemented = '\\\\ (not implemented)'
+
         # prompt
         set_code('prompt',
-                 '$\\tt sage$: ',
-                 '$\\tt gp?$ ',
-                 '$\\tt Magma>$ ')
+                 'sage:',
+                 'gp:',
+                 'magma:')
 
         # logo
         set_code('logo',
@@ -389,7 +391,7 @@ class WebEC(object):
         # generators
         set_code('gens',
                  'E.gens()',
-                 '(not implemented)',
+                 pari_not_implemented,
                  'Generators(E);')
 
         # torsion
@@ -399,12 +401,53 @@ class WebEC(object):
 
         # integral points
         set_code('intpts', 'E.integral_points()',
-                 '(not implemented)',
+                 pari_not_implemented,
                  'IntegralPoints(E);')
 
         # conductor
         set_code('cond', 'E.conductor().factor()',
                  'ellglobalred(E)[1]',
                  'Conductor(E);')
+
+        # discriminant
+        set_code('disc', 'E.dicriminant().factor()',
+                 'E.disc',
+                 'Discriminant(E);')
+
+        # j-invariant
+        set_code('jinv', 'E.j_invariant().factor()',
+                 'E.j',
+                 'jInvariant(E);')
+
+        # rank
+        set_code('rank', 'E.rank()',
+                 pari_not_implemented,
+                 'Rank(E);')
+
+        # regulator
+        set_code('reg', 'E.regulator()',
+                 pari_not_implemented,
+                 'Regulator(E);')
+
+        # regulator
+        set_code('real_period', 'E.period_lattice().omega()',
+                 'E.omega[1]',
+                 'RealPeriod(E);')
+
+        # Tamagawa numbers
+        set_code('cp', 'E.tamagawa_numbers()',
+                 'E.omega[1]',
+                 'RealPeriod(E);')
+
+        # torsion order
+        set_code('ntors', 'E.torsion_order()',
+                 'elltors(E)[1]',
+                 'OrderTorsionSubgroup(E);')
+
+        # analytic order of sha
+        set_code('sha', 'E.sha().an_numerical()',
+                 pari_not_implemented,
+                 'MordellWeilShaInformation(E);')
+
 
         self.code = {'sage': sagecode, 'gp': gpcode, 'magma': magmacode}

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1588,3 +1588,13 @@ div.box {
 	border: 1px solid #8080FF;
 	background-color: #E5E5FF;
 }
+
+div.codebox {
+    padding: 5px;
+    text-padding: 10px;
+    overflow: auto;
+    border: 1px solid #8080FF;
+    border-radius: 5px;
+    background-color: #E5E5FF;
+    box-shadow: 3px 3px 3px #8080FF;
+}


### PR DESCRIPTION
I have completely rewritten the way code snippets for sage/pari/magma are put into elliptic curve home pages (over Q).  All the actual code strings for all 3 are now defined in the python file, and there is a new macro in the html template which makes adding each code snippet just one very simple line.

I am quite proud of this and think it could be a model to be used elsewhere; it will also make it very much simpler to provide the facility to fownload all the code from a home page -- but I left that for another ticket.

Logos: currently not used, but there is provision to add them again if we find suitable ones.
Names: "Sage" is now officially "Sagemath" so I used that; and we used "pari" where we really meant "gp" so I have put "pari/gp" -- this is in the selction buttons at the top of the page.
Prompts: Sage has "sage: ", gp just has "? " and Magma just has "> ".  The latter two don't look good, and neither did "gp? " and "magma> ", so I went for consistency and have "gp: " and "magma: ".   These can be changed by changing *just one* place in web_ec.py.

The code snippets themselves are essentially unchanged, except that in all three cases I showed how to construct the curve from its label.  (This only works in gp and Sage if an optional package is installed, but anyone using this would surely know that.)

Reviewers, feel free to make comments about the aesthetics, which can be changed, but don't let such issues distract you from the beauty of the new code!