### PR TITLE
EC code snippets now use yaml file

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -1,0 +1,110 @@
+prompt:
+  sage:   'sage:'
+  pari:   'gp:'
+  magma': 'magma:'
+
+logo:
+  sage: '<img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">'
+  pari: '<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">'
+  magma: '<img src = "http://i.stack.imgur.com/0468s.png" width="50px">'
+
+not-implemented:
+  sage:  '# (not yet implemented)'
+  pari:  '\\\\ (not yet implemented)'
+  magma: '// (not yet implemented)'
+
+curve:
+  sage:  'E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")'
+  pari:  'E = ellinit(%s)       \\\\ or E = ellinit("%s")'
+  magma: 'E := EllipticCurve(%s); // or: E := EllipticCurve("%s");'
+
+gens:
+  sage:  'E.gens()'
+  magma: 'Generators(E);'
+
+tors:
+  sage:  'E.torsion_subgroup().gens()'
+  pari:  'elltors(E)'
+  magma: 'TorsionSubgroup(E);'
+
+intpts:
+  sage:  'E.integral_points()'
+  magma: 'IntegralPoints(E);'
+
+cond:
+  sage:  'E.conductor().factor()'
+  pari:  'ellglobalred(E)[1]'
+  magma: 'Conductor(E);'
+
+disc:
+  sage:  'E.dicriminant().factor()'
+  pari:  'E.disc'
+  magma: 'Discriminant(E);'
+
+jinv:
+  sage:  'E.j_invariant().factor()'
+  pari:  'E.j'
+  magma: 'jInvariant(E);'
+
+rank:
+  sage:  'E.rank()'
+  magma: 'Rank(E);'
+
+reg:
+  sage:  'E.regulator()'
+  magma: 'Regulator(E);'
+
+real_period:
+  sage:  'E.period_lattice().omega()'
+  pari:  'E.omega[1]'
+  magma: 'RealPeriod(E);'
+
+cp:
+  sage:  'E.tamagawa_numbers()'
+  pari:  'E.omega[1]'
+  magma: 'RealPeriod(E);'
+
+
+ntors:
+  sage:  'E.torsion_order()'
+  pari:  'elltors(E)[1]'
+  magma: 'OrderTorsionSubgroup(E);'
+
+sha:
+  sage:  'E.sha().an_numerical()'
+  magma: 'MordellWeilShaInformation(E);'
+
+qexp:
+  sage:  'E.q_eigenform(10)'
+  pari:  |
+    'xy = elltaniyama(E);'
+    'deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)'
+  magma: 'ModularForm(E);'
+
+moddeg:
+  sage:  'E.modular_degree()'
+  magma: 'ModularDegree(E);'
+
+L1:
+  sage:  |
+    'r = E.rank()'
+    'E.lseries().dokchitser().derivative(1,r)/r.factorial()'
+  pari:  |
+    'ar = ellanalyticrank(E);'
+    'ar[2]/factorial(ar[1])'
+  magma: 'Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);'
+
+localdata:
+  sage:  'E.local_data()'
+  pari:  'ellglobalred(E)[5]'
+  magma: '[LocalInformation(E,p) : p in BadPrimes(E)];'
+
+galrep:
+  sage:  |
+    'rho = E.galois_representation()'
+    '[rho.image_type(p) for p in rho.non_surjective()]'
+  magma: '[GaloisRepresentation(E,p): p in PrimesUpTo(20)];'
+
+padicreg:
+  sage: '[E.padic_regulator(p) for p in primes(3,20)]'
+

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -1,110 +1,118 @@
 prompt:
   sage:   'sage:'
   pari:   'gp:'
-  magma': 'magma:'
+  magma:  'magma:'
 
 logo:
-  sage: '<img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">'
-  pari: '<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">'
-  magma: '<img src = "http://i.stack.imgur.com/0468s.png" width="50px">'
+  sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
+  pari: <img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
+  magma: <img src = "http://i.stack.imgur.com/0468s.png" width="50px">
 
 not-implemented:
-  sage:  '# (not yet implemented)'
-  pari:  '\\\\ (not yet implemented)'
-  magma: '// (not yet implemented)'
+  sage:  # (not yet implemented)
+  pari:  \\\\ (not yet implemented)
+  magma: // (not yet implemented)
 
 curve:
-  sage:  'E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")'
-  pari:  'E = ellinit(%s)       \\\\ or E = ellinit("%s")'
-  magma: 'E := EllipticCurve(%s); // or: E := EllipticCurve("%s");'
+  sage: |
+    E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")
+  pari: |
+    E = ellinit(%s)       \\\\ or E = ellinit("%s")
+  magma: |
+    E := EllipticCurve(%s); // or: E := EllipticCurve("%s");
 
 gens:
-  sage:  'E.gens()'
-  magma: 'Generators(E);'
+  sage:  E.gens()
+  magma: Generators(E);
 
 tors:
-  sage:  'E.torsion_subgroup().gens()'
-  pari:  'elltors(E)'
-  magma: 'TorsionSubgroup(E);'
+  sage:  E.torsion_subgroup().gens()
+  pari:  elltors(E)
+  magma: TorsionSubgroup(E);
 
 intpts:
-  sage:  'E.integral_points()'
-  magma: 'IntegralPoints(E);'
+  sage:  E.integral_points()
+  magma: IntegralPoints(E);
 
 cond:
-  sage:  'E.conductor().factor()'
-  pari:  'ellglobalred(E)[1]'
-  magma: 'Conductor(E);'
+  sage:  E.conductor().factor()
+  pari:  ellglobalred(E)[1]
+  magma: Conductor(E);
 
 disc:
-  sage:  'E.dicriminant().factor()'
-  pari:  'E.disc'
-  magma: 'Discriminant(E);'
+  sage:  E.dicriminant().factor()
+  pari:  E.disc
+  magma: Discriminant(E);
 
 jinv:
-  sage:  'E.j_invariant().factor()'
-  pari:  'E.j'
-  magma: 'jInvariant(E);'
+  sage:  E.j_invariant().factor()
+  pari:  E.j
+  magma: jInvariant(E);
 
 rank:
-  sage:  'E.rank()'
-  magma: 'Rank(E);'
+  sage:  E.rank()
+  magma: Rank(E);
 
 reg:
-  sage:  'E.regulator()'
-  magma: 'Regulator(E);'
+  sage:  E.regulator()
+  magma: Regulator(E);
 
 real_period:
-  sage:  'E.period_lattice().omega()'
-  pari:  'E.omega[1]'
-  magma: 'RealPeriod(E);'
+  sage:  E.period_lattice().omega()
+  pari:  E.omega[1]
+  magma: RealPeriod(E);
 
 cp:
-  sage:  'E.tamagawa_numbers()'
-  pari:  'E.omega[1]'
-  magma: 'RealPeriod(E);'
+  sage:  E.tamagawa_numbers()
+  pari:  E.omega[1]
+  magma: RealPeriod(E);
 
 
 ntors:
-  sage:  'E.torsion_order()'
-  pari:  'elltors(E)[1]'
-  magma: 'OrderTorsionSubgroup(E);'
+  sage:  E.torsion_order()
+  pari:  elltors(E)[1]
+  magma: OrderTorsionSubgroup(E);
 
 sha:
-  sage:  'E.sha().an_numerical()'
-  magma: 'MordellWeilShaInformation(E);'
+  sage:  E.sha().an_numerical()
+  magma: MordellWeilShaInformation(E);
 
 qexp:
-  sage:  'E.q_eigenform(10)'
+  sage:  E.q_eigenform(10)
   pari:  |
-    'xy = elltaniyama(E);'
-    'deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)'
-  magma: 'ModularForm(E);'
+    xy = elltaniyama(E);
+    deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)
+  magma: ModularForm(E);
 
 moddeg:
-  sage:  'E.modular_degree()'
-  magma: 'ModularDegree(E);'
+  sage:  E.modular_degree()
+  magma: ModularDegree(E);
 
 L1:
   sage:  |
-    'r = E.rank()'
-    'E.lseries().dokchitser().derivative(1,r)/r.factorial()'
+    r = E.rank();
+    E.lseries().dokchitser().derivative(1,r)/r.factorial()
   pari:  |
-    'ar = ellanalyticrank(E);'
-    'ar[2]/factorial(ar[1])'
-  magma: 'Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);'
+    ar = ellanalyticrank(E);
+    ar[2]/factorial(ar[1])
+  magma:
+    Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);
 
 localdata:
-  sage:  'E.local_data()'
-  pari:  'ellglobalred(E)[5]'
-  magma: '[LocalInformation(E,p) : p in BadPrimes(E)];'
+  sage:
+    E.local_data()
+  pari:
+    ellglobalred(E)[5]
+  magma: |
+    [LocalInformation(E,p) : p in BadPrimes(E)];
 
 galrep:
   sage:  |
-    'rho = E.galois_representation()'
-    '[rho.image_type(p) for p in rho.non_surjective()]'
-  magma: '[GaloisRepresentation(E,p): p in PrimesUpTo(20)];'
+    rho = E.galois_representation();
+    [rho.image_type(p) for p in rho.non_surjective()]
+  magma: |
+    [GaloisRepresentation(E,p): p in PrimesUpTo(20)];
 
 padicreg:
-  sage: '[E.padic_regulator(p) for p in primes(3,20)]'
+  sage: [E.padic_regulator(p) for p in primes(3,20)]
 

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -9,17 +9,23 @@ logo:
   magma: <img src = "http://i.stack.imgur.com/0468s.png" width="50px">
 
 not-implemented:
-  sage:  # (not yet implemented)
-  pari:  \\\\ (not yet implemented)
-  magma: // (not yet implemented)
+  sage: |
+    # (not yet implemented)
+  pari: |
+    \\\\ (not yet implemented)
+  magma: |
+    // (not yet implemented)
 
 curve:
   sage: |
-    E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")
+    E = EllipticCurve(%s)    # or
+    E = EllipticCurve("%s")
   pari: |
-    E = ellinit(%s)       \\\\ or E = ellinit("%s")
+    E = ellinit(%s)       \\ or
+    E = ellinit("%s")
   magma: |
-    E := EllipticCurve(%s); // or: E := EllipticCurve("%s");
+    E := EllipticCurve(%s); // or
+    E := EllipticCurve("%s");
 
 gens:
   sage:  E.gens()
@@ -95,7 +101,7 @@ L1:
   pari:  |
     ar = ellanalyticrank(E);
     ar[2]/factorial(ar[1])
-  magma:
+  magma: |
     Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);
 
 localdata:
@@ -114,5 +120,6 @@ galrep:
     [GaloisRepresentation(E,p): p in PrimesUpTo(20)];
 
 padicreg:
-  sage: [E.padic_regulator(p) for p in primes(3,20)]
+  sage: |
+    [E.padic_regulator(p) for p in primes(3,20)]
 

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -8,7 +8,7 @@
 {% for L in codes[item] %}
 {# N.B. whitespace is preserved in the following div since the CSS has
 white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{{codes.prompt[L]}}&nbsp;{{codes[item][L]}}</div>
+<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
 {% endfor %}
 {% endmacro %}
 

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -4,10 +4,10 @@
 <div.ip>span { white-space: nowrap; font-family: serif; }
 </style>
 
-{% macro code(codes, languages, item) %}
-{% for L in languages %}
+{% macro code(codes, item) %}
+{% for L in codes[item] %}
     <div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">
-      {{codes[L]['prompt']}}&nbsp;{{codes[L][item]}}
+      {{codes.prompt[L]}}&nbsp;{{codes[item][L]}}
     </div>
 {% endfor %}
 {% endmacro %}
@@ -85,7 +85,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
     <h2> {{ KNOWL('ec.q.minimal_weierstrass_equation', title='Minimal Weierstrass equation') }} </h2>
 
-    {{ code(data.code,['sage','pari','magma'],'curve') }}
+    {{ code(data.code,'curve') }}
 
     <p> {{ data.data.equation }} </p>
 
@@ -103,20 +103,20 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     {% if data.mw.rank!=0 %}
     <p><h3> Infinite order Mordell-Weil generators </h3>
-      {{ code(data.code,['sage','magma'],'gens') }}
+      {{ code(data.code,'gens') }}
       <div style='overflow:auto'><p> {{ data.mw.generators }} </p></div>
     </p>
     {%endif %}
 
     {% if data.mw.tor_order!=1 %}
     <h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
-      {{ code(data.code,['sage','pari','magma'],'tors') }}
+      {{ code(data.code,'tors') }}
     <p> {{ data.mw.tor_gens }} </p>
     {%endif %}
 
 
     <p><h2> {{ KNOWL('ec.q.integral_points', title='Integral points') }}</h2>
-      {{ code(data.code,['sage','magma'],'intpts') }}
+      {{ code(data.code,'intpts') }}
     {% if data.xintcoords %}
     <div class="ip">
       <p>
@@ -133,7 +133,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,['sage','pari','magma'],'cond') }}
+          {{ code(data.code,'cond') }}
         </td>
         </tr>
         <tr>
@@ -146,7 +146,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,['sage','pari','magma'],'disc') }}
+          {{ code(data.code,'disc') }}
         </td>
         </tr>
         <tr>
@@ -159,7 +159,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,['sage','pari','magma'],'jinv') }}
+          {{ code(data.code,'jinv') }}
         </td>
         </tr>
         <tr>
@@ -189,7 +189,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','magma'],'rank') }}
+          {{ code(data.code,'rank') }}
         </td>
         </tr>
         <tr>
@@ -202,7 +202,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','magma'],'reg') }}
+          {{ code(data.code,'reg') }}
         </td>
         </tr>
         <tr>
@@ -216,7 +216,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','pari','magma'],'real_period') }}
+          {{ code(data.code,'real_period') }}
         </td>
         </tr>
         <tr>
@@ -226,7 +226,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','pari','magma'],'cp') }}
+          {{ code(data.code,'cp') }}
         </td>
         </tr>
         <tr>
@@ -241,7 +241,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','pari','magma'],'ntors') }}
+          {{ code(data.code,'ntors') }}
         </td>
         </tr>
         <tr>
@@ -251,7 +251,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,['sage','magma'],'sha') }}
+          {{ code(data.code,'sha') }}
         </td>
         </tr>
         <tr>
@@ -275,7 +275,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h2> {{KNOWL('ec.q.modular_parametrization', title='Modular invariants')}}</h2>
     <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}} </h3>
-          {{ code(data.code,['sage','pari','magma'],'qexp') }}
+          {{ code(data.code,'qexp') }}
     <p>
     <form>
         <div class="output"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
@@ -286,7 +286,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h3> {{ KNOWL('ec.q.modular_degree', title='Modular degree') }}
       and {{ KNOWL('ec.q.optimal', title='optimality') }}</h3>
-    {{ code(data.code,['sage','magma'],'moddeg') }}
+    {{ code(data.code,'moddeg') }}
       {% if data.data.degree==0 %}
       Not available
       {% else %}
@@ -301,7 +301,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <p>
       <h3> {{KNOWL('ec.q.special_value', title='Special L-value', special_value = data.special_value)}} attached to the curve </h3>
-    {{ code(data.code,['sage','pari','magma'],'L1') }}
+    {{ code(data.code,'L1') }}
     <p>
         \( {{ data.bsd.lder_name }} = {{ data.bsd.lder }} \)
     </p>
@@ -315,7 +315,7 @@ text-align: center;
 }
 </style>
 
-    {{ code(data.code,['sage','pari','magma'],'localdata') }}
+    {{ code(data.code,'localdata') }}
 
 <table id = "local_data">
 <tr>
@@ -373,7 +373,7 @@ data.twoadic_index }}.
 {% endif %}
 
 
-    {{ code(data.code,['sage','magma'],'galrep') }}
+    {{ code(data.code,'galrep') }}
 
 {% if data.data.galois_data %}
 <p>
@@ -412,7 +412,7 @@ representation')}} is surjective for all primes \( p \).
 
     <h2> p-adic data </h2>
 
-    {{ code(data.code,['sage'],'padicreg') }}
+    {{ code(data.code,'padicreg') }}
 
     <p>
 {% if data.bsd.rank==0 %}

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -6,9 +6,9 @@
 
 {% macro code(codes, item) %}
 {% for L in codes[item] %}
-    <div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">
-      {{codes.prompt[L]}}&nbsp;{{codes[item][L]}}
-    </div>
+{# N.B. whitespace is preserved in the following div since the CSS has
+white-space: pre in order to keep line breaks! #}
+<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{{codes.prompt[L]}}&nbsp;{{codes[item][L]}}</div>
 {% endfor %}
 {% endmacro %}
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -365,3 +365,11 @@ class WebEC(object):
 
         for lang in ['sage', 'pari', 'magma']:
             self.code['curve'][lang] = self.code['curve'][lang] % (self.data['ainvs'],self.label)
+
+        for k in self.code:
+            if k != 'prompt':
+                for lang in self.code[k]:
+                    self.code[k][lang] = self.code[k][lang].split("\n")
+                    # remove final empty line
+                    if len(self.code[k][lang][-1])==0:
+                        self.code[k][lang] = self.code[k][lang][:-1]

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -2,6 +2,7 @@
 import re
 import tempfile
 import os
+import yaml
 from pymongo import ASCENDING, DESCENDING
 from flask import url_for, make_response
 import lmfdb.base
@@ -355,130 +356,12 @@ class WebEC(object):
                            ('%s' % num,' ')]
 
     def make_code_snippets(self):
-        sagecode = dict()
-        gpcode = dict()
-        magmacode = dict()
+        # read in code.yaml from current directory:
 
-        # utility function to save typing!
+        _curdir = os.path.dirname(os.path.abspath(__file__))
+        self.code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
 
-        def set_code(key, s, g, m):
-            sagecode[key] = s
-            gpcode[key] = g
-            magmacode[key] = m
+        # Fill in placeholders for this specific curve:
 
-        pari_not_implemented = '\\\\ (not yet implemented)'
-        magma_not_implemented = '// (not yet implemented)'
-
-        # prompt
-        set_code('prompt',
-                 'sage:',
-                 'gp:',
-                 'magma:')
-
-        # logo
-        set_code('logo',
-                 '<img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">',
-                 '<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">',
-                 '<img src = "http://i.stack.imgur.com/0468s.png" width="50px">')
-        # overwrite the above until we get something which looks reasonable
-        set_code('logo', '', '', '')
-
-        # curve
-        set_code('curve',
-                 'E = EllipticCurve(%s)    # or: E = EllipticCurve("%s")'  % (self.data['ainvs'],self.label),
-                 'E = ellinit(%s)       \\\\ or E = ellinit("%s")'         % (self.data['ainvs'],self.label),
-                 'E := EllipticCurve(%s); // or: E := EllipticCurve("%s");' % (self.data['ainvs'],self.label))
-
-        # generators
-        set_code('gens',
-                 'E.gens()',
-                 pari_not_implemented,
-                 'Generators(E);')
-
-        # torsion
-        set_code('tors', 'E.torsion_subgroup().gens()',
-                 'elltors(E)',
-                 'TorsionSubgroup(E);')
-
-        # integral points
-        set_code('intpts', 'E.integral_points()',
-                 pari_not_implemented,
-                 'IntegralPoints(E);')
-
-        # conductor
-        set_code('cond', 'E.conductor().factor()',
-                 'ellglobalred(E)[1]',
-                 'Conductor(E);')
-
-        # discriminant
-        set_code('disc', 'E.dicriminant().factor()',
-                 'E.disc',
-                 'Discriminant(E);')
-
-        # j-invariant
-        set_code('jinv', 'E.j_invariant().factor()',
-                 'E.j',
-                 'jInvariant(E);')
-
-        # rank
-        set_code('rank', 'E.rank()',
-                 pari_not_implemented,
-                 'Rank(E);')
-
-        # regulator
-        set_code('reg', 'E.regulator()',
-                 pari_not_implemented,
-                 'Regulator(E);')
-
-        # regulator
-        set_code('real_period', 'E.period_lattice().omega()',
-                 'E.omega[1]',
-                 'RealPeriod(E);')
-
-        # Tamagawa numbers
-        set_code('cp', 'E.tamagawa_numbers()',
-                 'E.omega[1]',
-                 'RealPeriod(E);')
-
-        # torsion order
-        set_code('ntors', 'E.torsion_order()',
-                 'elltors(E)[1]',
-                 'OrderTorsionSubgroup(E);')
-
-        # analytic order of sha
-        set_code('sha', 'E.sha().an_numerical()',
-                 pari_not_implemented,
-                 'MordellWeilShaInformation(E);')
-
-        # q-expansion of eigenform
-        set_code('qexp', 'E.q_eigenform(10)',
-                 'xy = elltaniyama(E); deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)',
-                 'ModularForm(E);')
-
-        # modular degree
-        set_code('moddeg', 'E.modular_degree()',
-                 pari_not_implemented,
-                 'ModularDegree(E);')
-
-        # special value
-        set_code('L1', 'r = E.rank(); E.lseries().dokchitser().derivative(1,r)/r.factorial()',
-                 'ar = ellanalyticrank(E); ar[2]/factorial(ar[1])',
-                 'Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);')
-
-        # local data
-        set_code('localdata', 'E.local_data()',
-                 'ellglobalred(E)[5]',
-                 '[LocalInformation(E,p) : p in BadPrimes(E)];')
-
-        # mod-l Galois representation
-        set_code('galrep', 'rho = E.galois_representation(); [rho.image_type(p) for p in rho.non_surjective()]',
-                 pari_not_implemented,
-                 '[GaloisRepresentation(E,p): p in PrimesUpTo(20)];')
-
-        # p-adic regulators
-        set_code('padicreg', '[E.padic_regulator(p) for p in primes(3,20)]',
-                 pari_not_implemented,
-                 magma_not_implemented)
-
-
-        self.code = {'sage': sagecode, 'pari': gpcode, 'magma': magmacode}
+        for lang in ['sage', 'pari', 'magma']:
+            self.code['curve'][lang] = self.code['curve'][lang] % (self.data['ainvs'],self.label)

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1597,4 +1597,5 @@ div.codebox {
     border-radius: 5px;
     background-color: #E5E5FF;
     box-shadow: 3px 3px 3px #8080FF;
+    white-space: pre;
 }


### PR DESCRIPTION
As suggested by Harald: the code snippets for sage/pari/magma which appear on elliptic curve home pages now have the code for each language in a separate yaml file.  This is a lot easier to read, and maintain!  Also, the python function make_code_snippets() is almost trivial;  and the html template is simplified -- each code item now "knows" which languages are implemented, so there is no need to pass a list of languages with each call to the code() macro.
The appearance of the web page is unchanged (I hope), this is just a back-end simplification.  Once merged, the same should be done for the genus 2 pages, and number fields -- and independently, we can make a global decision on the style of these "code boxes" whose appearance should be controlled entirely by the codebox css style.
I included the not-implemented and logo items in the yaml file, but they are not used in the web pages,