### PR TITLE
Fixes bug with code snippets for number fields.

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -122,7 +122,8 @@ class WebNumberField:
             self._data = self._get_dbdata()
         else:
             self._data = data
-        self.make_code_snippets()
+        if self._data is not None:
+            self.make_code_snippets()
 
     # works with a string, or a list of coefficients
     @classmethod


### PR DESCRIPTION
The problem arises when we try to initialize a number field which is not in the database (e.g., a subfield which is not there).  In that case, we will not need the code snippets, and making them causes an error (since it assumes the data for that number field is present).

An example of such a field is currently x^20 - 8*x^19 + 38*x^18 - 133*x^17 + 323*x^16 - 570*x^15 + 608*x^14 + 608*x^13 - 2280*x^12 + 5662*x^11 - 2527*x^10 + 4731*x^9 + 8265*x^8 - 6935*x^7 + 27265*x^6 - 20539*x^5 + 29469*x^4 - 20178*x^3 + 16226*x^2 - 6696*x + 729