### PR TITLE
right click on math links

### DIFF
--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -64,7 +64,8 @@ MathJax.Hub.Config({
   },
   asciimath2jax: { delimiters: [['#(',')#'], ['#[',']#']] },
   "HTML-CSS": { scale: 85 },
-  menuSettings: { zscale: "150%", zoom: "Double-Click" }
+  menuSettings: { zscale: "150%", zoom: "Double-Click", context: "Browser" }
+
 });
 </script>
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>


### PR DESCRIPTION
If you try to right click on the "Q" in the menu under elliptic curves or genus 2,
it had asked if you want to view the LaTeX source.  Now it gives the option of opening in a new
window or tab.

This means that right clicking on formulas elsewhere in the website do not give the
option of viewing the LaTeX source, but I think that was much less common than wanting
to open a new window to browse elliptic curves/Q.
