### PR TITLE
Arithtoggle

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1569,7 +1569,9 @@ class Lfunction_genus2_Q(Lfunction):
         # Need an option for the arithmetic normalization, leaving the
         # analytic normalization as the default.
         self.texname = "L(s,A)"
+        self.htmlname = "<em>L</em>(<em>s,A</em>)"
         self.texname_arithmetic = "L(A,s)"
+        self.htmlname_arithmetic = "<em>L</em>(<em>A,s</em>)"
         self.texnamecompleteds = "\\Lambda(s,A)"
         self.texnamecompleted1ms = "\\Lambda(1-s,A)"
         self.texnamecompleteds_arithmetic = "\\Lambda(A,s)"

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1581,6 +1581,7 @@ class Lfunction_genus2_Q(Lfunction):
         self.title_end = ("where $A$ is a genus 2 curve "
                       + "of conductor " + str(isoclass['cond']))
         self.title_arithmetic = "$" + self.texname_arithmetic + "$" + ", " + self.title_end
+        self.title_analytic = "$" + self.texname + "$" + ", " + self.title_end
         self.title = "$" + self.texname + "$" + ", " + self.title_end
 
         constructor_logger(self, args)

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -288,15 +288,12 @@ def lfuncDShtml(L, fmt):
 #        ans = ans + "</td><td valign='top'>"
 
         ans += "<table class='dirichletseries'><tr>"
-      #  ans += "<td valign='top' padding-top='2px'>" + "$" 
         ans += "<td valign='top'>"  # + "$" 
         if fmt == "arithmetic":
-           # ans += L.texname_arithmetic
             ans += "<span class='term'>"
             ans += L.htmlname_arithmetic
             ans += "&thinsp;"
             ans += "&nbsp;=&nbsp;"
-        #    ans += "1<sup>&thinsp;</sup>" + "&thinsp;"
             ans += "1<sup></sup>" + "&nbsp;"
             ans += "</span>"
         elif hasattr(L, 'htmlname'):
@@ -311,9 +308,6 @@ def lfuncDShtml(L, fmt):
             ans += L.texname
             ans += " = "
             ans += "1^{\mathstrut}" + "$"  + "&nbsp;"
-     #   ans += " = "
-     #   # ans = ans + seriescoeff(L.dirichlet_coefficients[0], 0, "literal", "", -6, 5)
-     #   ans = ans + "1^{\mathstrut}" + "$"  + "&nbsp;"
         ans += "</td><td valign='top'>"
 
         if fmt == "arithmetic":

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -301,7 +301,7 @@ def lfuncDShtml(L, fmt):
             ans += L.htmlname
             ans += "&thinsp;"
             ans += "&nbsp;=&nbsp;"
-            ans += "1" + "&nbsp;"
+            ans += "1<sup></sup>" + "&nbsp;"
             ans += "</span>"
         else:
             ans += '$' 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -289,15 +289,32 @@ def lfuncDShtml(L, fmt):
 
         ans += "<table class='dirichletseries'><tr>"
       #  ans += "<td valign='top' padding-top='2px'>" + "$" 
-        ans += "<td valign='top'>" + "$" 
+        ans += "<td valign='top'>"  # + "$" 
         if fmt == "arithmetic":
-            ans += L.texname_arithmetic
+           # ans += L.texname_arithmetic
+            ans += "<span class='term'>"
+            ans += L.htmlname_arithmetic
+            ans += "&thinsp;"
+            ans += "&nbsp;=&nbsp;"
+        #    ans += "1<sup>&thinsp;</sup>" + "&thinsp;"
+            ans += "1<sup></sup>" + "&nbsp;"
+            ans += "</span>"
+        elif hasattr(L, 'htmlname'):
+            ans += "<span class='term'>"
+            ans += L.htmlname
+            ans += "&thinsp;"
+            ans += "&nbsp;=&nbsp;"
+            ans += "1" + "&nbsp;"
+            ans += "</span>"
         else:
+            ans += '$' 
             ans += L.texname
-        ans += " = "
-        # ans = ans + seriescoeff(L.dirichlet_coefficients[0], 0, "literal", "", -6, 5)
-        ans = ans + "1^{\mathstrut}" + "$"  + "&nbsp;"
-        ans = ans + "</td><td valign='top'>"
+            ans += " = "
+            ans += "1^{\mathstrut}" + "$"  + "&nbsp;"
+     #   ans += " = "
+     #   # ans = ans + seriescoeff(L.dirichlet_coefficients[0], 0, "literal", "", -6, 5)
+     #   ans = ans + "1^{\mathstrut}" + "$"  + "&nbsp;"
+        ans += "</td><td valign='top'>"
 
         if fmt == "arithmetic":
             ds_length = len(L.dirichlet_coefficients_arithmetic)

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -472,13 +472,13 @@ def lfuncEPhtml(L,fmt):
     bad_primes = []
     for lf in L.bad_lfactors:
         bad_primes.append(lf[0])
-    eulerlim = 10
+    eulerlim = 25
     good_primes = []
     for j in range(0, eulerlim):
         this_prime = Primes().unrank(j)
         if this_prime not in bad_primes:
             good_primes.append(this_prime)
-    eptable = "<table class='ntdata euler'>\n"
+    eptable = "<table id='eptable' class='ntdata euler'>\n"
     eptable += "<thead>"
     eptable += "<tr class='space'><th class='weight'></th><th class='weight'>$p$</th><th class='weight'>$f_p$</th></tr>\n"
     eptable += "</thead>"
@@ -494,15 +494,33 @@ def lfuncEPhtml(L,fmt):
         goodorbad = ""
     goodorbad = "good"
     firsttime = " class='first'"
-    for j in good_primes:
+    good_primes1 = good_primes[:9]
+    good_primes2 = good_primes[9:]
+    for j in good_primes1:
         this_prime_index = prime_pi(j) - 1
         eptable += ("<tr" + firsttime + "><td>" + goodorbad + "</td><td>" + str(j) + "</td><td>" +
                     "$" + list_to_factored_poly_otherorder(L.localfactors[this_prime_index]) + "$" +
                     "</td></tr>\n")
         goodorbad = ""
         firsttime = ""
+    firsttime = " id='moreep'"
+    for j in good_primes2:
+        this_prime_index = prime_pi(j) - 1
+        eptable += ("<tr" + firsttime +  " class='more nodisplay'" + "><td>" + goodorbad + "</td><td>" + str(j) + "</td><td>" +
+                    "$" + list_to_factored_poly_otherorder(L.localfactors[this_prime_index]) + "$" +
+                    "</td></tr>\n")
+        firsttime = ""
+
+    eptable += "<tr class='less toggle'><td></td><td></td><td> <a onclick='"
+    eptable += 'show_moreless("more"); return true' + "'"
+    eptable += ' href="#moreep" '
+    eptable += ">show more</a></td></tr>\n"
+    eptable += "<tr class='more toggle nodisplay'><td></td><td></td><td> <a onclick='"
+    eptable += 'show_moreless("less"); return true' + "'"
+    eptable += ' href="#eptable" '
+    eptable += ">show less</a></td></tr>\n"
     eptable += "</table>\n"
-    ans += eptable
+    ans += "\n" + eptable
     return(ans)
 
 def lfuncEpSymPower(L):

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -393,6 +393,7 @@ def initLfunction(L, args, request):
 #    if 'title_arithmetic' in L:
     try:
         info['title_arithmetic'] = L.title_arithmetic
+        info['title_analytic'] = L.title_analytic
     except AttributeError:
         pass
     try:

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -22,7 +22,23 @@ function show_normalization(normstyle) {
        $('button.analytic').css('border', '1px solid #EDD');
     }
   }
+
+function show_moreless(ml) {
+    $('.more').hide();
+    $('.less').hide();
+    $('.'+ml).show();
+}
 </script>
+
+<style type="text/css">
+table.ntdata tr.toggle { font-size: 80%; text-align: right; }
+table.ntdata tr.toggle:nth-child(2n) { background: #FFF; }
+table.ntdata tr.toggle a:hover { background: #FFF; }
+/*
+table.ntdata tr.more:last-child { font-size: 80%; text-align: right; }
+table.ntdata tr.more:nth-child(2n) { background: #FFF; }
+*/
+</style>
 
 {% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
  <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: <button class='arithmetic active' onclick="show_normalization('arithmetic'); return false">arithmetic</button>

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -40,7 +40,7 @@ table.ntdata tr.more:nth-child(2n) { background: #FFF; }
 */
 </style>
 
-{% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
+{% if dirichlet_arithmetic -%}
  <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: <button class='arithmetic active' onclick="show_normalization('arithmetic'); return false">arithmetic</button>
 <button class='analytic inactive' onclick="show_normalization('analytic'); return false">analytic</button></div>
 {% elif BETA %}

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -2,27 +2,49 @@
 
 {% block content %}
 
+<script>
+function show_normalization(normstyle) {
+    $('.analytic').hide();
+    $('.arithmetic').hide();
+    $('.'+normstyle).show();
+    $('button.analytic').show();
+    $('button.arithmetic').show();
+    if (normstyle == 'analytic') {
+       $('button.analytic').css('background', '#DFD');
+       $('button.analytic').css('border', '2px solid #ADA');
+       $('button.arithmetic').css('background', '#EEE');
+       $('button.arithmetic').css('border', '1px solid #EDD');
+    }
+    if (normstyle == 'arithmetic') {
+       $('button.arithmetic').css('background', '#DFD');
+       $('button.arithmetic').css('border', '2px solid #ADA');
+       $('button.analytic').css('background', '#EEE');
+       $('button.analytic').css('border', '1px solid #EDD');
+    }
+  }
+</script>
+
 {% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
- <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: <button class='active'>arithmetic</button>
-<button class='inactive'>analytic</button></div>
-{% elif BETA and user_is_authenticated %}
- <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: <button class='inactive'>arithmetic</button>
-<button class='active'>analytic</button></div>
+ <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: <button class='arithmetic active' onclick="show_normalization('arithmetic'); return false">arithmetic</button>
+<button class='analytic inactive' onclick="show_normalization('analytic'); return false">analytic</button></div>
 {% elif BETA %}
 <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: 
 <button class='active'>analytic</button></div>
 {% endif %}
 
  <h2> {{ KNOWL('lfunction.dirichlet_series', title='Dirichlet series') }}</h2>
-{% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
- <div>{{ dirichlet_arithmetic|safe }}</div>
+{% if dirichlet_arithmetic -%}
+ <div class="arithmetic">{{ dirichlet_arithmetic|safe }}</div>
+ <div class="analytic nodisplay">{{ dirichlet|safe }}</div>
 {% else %}
  <div>{{ dirichlet|safe }}</div>
 {% endif %}
 
+
  <h2>{{ KNOWL('lfunction.functional_equation',title='Functional equation') }}</h2>
-{% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
- <div id="functionalEqText">\[{{ functionalequation_arithmetic }}\]</div>
+{% if dirichlet_arithmetic -%}
+ <div id="functionalEqText" class="arithmetic">\[{{ functionalequation_arithmetic }}\]</div>
+ <div id="functionalEqText" class="analytic nodisplay">\[{{ functionalequation }}\]</div>
 {% else %}
  <div id="functionalEqText">\[{{ functionalequation }}\]</div>
 {% endif %}
@@ -32,8 +54,9 @@
 </div>
 
  <h2>{{ KNOWL('lfunction.euler_product', title='Euler product') }}</h2>
-{% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
- <div>{{ eulerproduct_arithmetic|safe }}</div>
+{% if dirichlet_arithmetic -%}
+ <div class="arithmetic">{{ eulerproduct_arithmetic|safe }}</div>
+ <div class="analytic nodisplay">\[{{ eulerproduct }}\]</div>
 {% else %}
  <div>\[{{ eulerproduct }}\]</div>
 {% endif %}
@@ -46,9 +69,9 @@
  {% endif %}
 
 <h2>Particular Values</h2>
-{% if BETA and user_is_authenticated and dirichlet_arithmetic -%}
+{% if dirichlet_arithmetic -%}
    {% if sv_critical_arithmetic or sv_edge_arithmetic %}
-      <div>
+      <div class="arithmetic">
       {% if sv_critical_arithmetic %}
           {{ sv_critical_arithmetic }}
       {% endif %}
@@ -63,6 +86,24 @@
    {% else %}
       <div>Not enough information (Dirichlet series coefficients/sign of the functional equation) to compute special values.</div>
    {% endif %}
+
+   {% if sv_critical or sv_edge %}
+      <div class="analytic nodisplay">
+      {% if sv_critical %}
+          {{ sv_critical }}
+      {% endif %}
+      {% if sv_edge %}
+          {% if Ltype=="riemann" or Ltype=="dedekindzeta" %}
+              <div align="center">Pole at \(s=1\)</div>
+          {% else %}
+              {{ sv_edge }}
+          {% endif %}
+      {% endif %}
+     </div>
+   {% else %}
+      <div>Not enough information (Dirichlet series coefficients/sign of the functional equation) to compute special values.</div>
+   {% endif %}
+
 {% else %}
    {% if sv_critical or sv_edge %}
       <div>

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -59,7 +59,7 @@
 
       {% if title_arithmetic -%}
       <div id="title" class="arithmetic"><span id="title-content">{{ title_arithmetic|safe }}</span></div>
-      <div id="title" class="analytic nodisplay"><span id="title-content">{{ title|safe }}</span></div>
+      <div id="title" class="analytic nodisplay"><span id="title-content">{{ title_analytic|safe }}</span></div>
       {% else %}
       <div id="title"><span id="title-content">{{ title|safe }}</span></div>
       {% endif %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -57,8 +57,9 @@
       {%- endif %} 
       {# this span inside a div thing is necessary to align it at the bottom, see css #}
 
-      {% if user_is_authenticated and title_arithmetic -%}
-      <div id="title"><span id="title-content">{{ title_arithmetic|safe }}</span></div>
+      {% if title_arithmetic -%}
+      <div id="title" class="arithmetic"><span id="title-content">{{ title_arithmetic|safe }}</span></div>
+      <div id="title" class="analytic nodisplay"><span id="title-content">{{ title|safe }}</span></div>
       {% else %}
       <div id="title"><span id="title-content">{{ title|safe }}</span></div>
       {% endif %}


### PR DESCRIPTION
Toggle between arithmetic and analytic normalization on L-function home pages
(assuming the page is available in the arithmetic normalization, currently only true for
L-functions of genus 2 curves).  Also toggle to show more local factors in the Euler product,
when viewing the arithmetic normalization.  Also make the Dirichlet series display nicer by
putting the whole thing in html.

http://localhost:37777/L/Genus2Curve/Q/411062/a/

http://localhost:37777/L/Genus2Curve/Q/1152/a/
