### PR TITLE
Update of #269: small improvements to Hilbert MF pages

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -266,6 +266,7 @@ def render_hmf_webpage(**args):
 
     hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
     nf = WebNumberField(data['field_label'])
+    info['field'] = nf
     info['base_galois_group'] = nf.galois_string()
     info['field_degree'] = nf.degree()
     info['field_disc'] = str(nf.disc())
@@ -361,7 +362,7 @@ def render_hmf_webpage(**args):
     if 'q_expansions' in data:
         info['q_expansions'] = data['q_expansions']
 
-    properties2 = [('Field', '%s' % data['field_label']),
+    properties2 = [('Base Field', '%s' % info['field'].field_pretty()),
                    ('Weight', '%s' % data['weight']),
                    ('Level Norm', '%s' % data['level_norm']),
                    ('Level', '$' + teXify_pol(data['level_ideal']) + '$'),

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -8,6 +8,7 @@ from lmfdb.base import app, getDBConnection
 from flask import Flask, session, g, render_template, url_for, request, redirect, make_response
 from sage.misc.preparser import preparse
 from lmfdb.hilbert_modular_forms import hmf_page, hmf_logger
+from lmfdb.hilbert_modular_forms.hilbert_field import findvar
 
 import sage.all
 from sage.all import Integer, ZZ, QQ, PolynomialRing, NumberField, CyclotomicField, latex, AbelianGroup, polygen, euler_phi
@@ -265,7 +266,8 @@ def render_hmf_webpage(**args):
         numeigs = 20
 
     hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
-    nf = WebNumberField(data['field_label'])
+    gen_name = findvar(data['level_ideal'])
+    nf = WebNumberField(data['field_label'], gen_name=gen_name)
     info['field'] = nf
     info['base_galois_group'] = nf.galois_string()
     info['field_degree'] = nf.degree()

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -266,7 +266,7 @@ def render_hmf_webpage(**args):
         numeigs = 20
 
     hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
-    gen_name = findvar(data['level_ideal'])
+    gen_name = findvar(hmf_field['ideals'])
     nf = WebNumberField(data['field_label'], gen_name=gen_name)
     info['field'] = nf
     info['base_galois_group'] = nf.galois_string()

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -1,16 +1,14 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<div>
-  <h2>  Base field   {{ info.field.knowl()|safe }} </h2>
+<h2>  Base field   {{ info.field.knowl()|safe }} </h2>
 <p>
  {{ KNOWL('nf.generator', 'Generator') }} \({{
  info.field.generator_name() }}\), with {{
  KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
- \({{info.field.poly()}}\); {{ KNOWL('nf.class_number', 'class number')
+ \({{info.field_poly}}\); {{ KNOWL('nf.class_number', 'class number')
  }} \({{info.field.class_number()}}\).
 </p>
-</div>
 
 
   <h2>  Form  </h2>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -1,13 +1,22 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<div>
+  <h2>  Base field   {{ info.field.knowl()|safe }} </h2>
+<p>
+ {{ KNOWL('nf.generator', 'Generator') }} \({{
+ info.field.generator_name() }}\), with {{
+ KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
+ \({{info.field.poly()}}\); {{ KNOWL('nf.class_number', 'class number')
+ }} \({{info.field.class_number()}}\).
+</p>
+</div>
+
 
   <h2>  Form  </h2>
 
 <p>
 <table>
- <tr><td>{{ KNOWL('nf', title='Base Field') }}:<td><A HREF="/NumberField/{{info.field_label }}">{{info.field_label}}</A> </tr>
-<tr><td>Base field defining polynomial:<td> ${{ info.field_poly }}$ </tr>
 <tr><td>{{ KNOWL('mf.hilbert.weight_vector', title='Weight') }}:<td> {{ info.weight }} </tr>
 <tr><td> {{ KNOWL('mf.hilbert.level_norm', title='Level') }}:<td> ${{ info.level_ideal }}$ </tr>
 <tr><td> Label:<td> ${{ info.label_suffix }}$ </tr>
@@ -26,11 +35,13 @@
 
   <h2>  Hecke eigenvalues ({{ KNOWL('mf.hilbert.q_expansion', title='$q$-expansion') }}) </h2>
 
+{% if info.dimension > 1 %}
 <p>
 <table>
 <tr><td> $e$ is a root of the defining polynomial: <td> ${{ info.hecke_polynomial }}$ </tr>
 </table>
 </p>
+{% endif %}
 
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Print full eigenvalues</a>
 &nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -19,8 +19,8 @@
 <tr><td> {{ KNOWL('mf.hilbert.level_norm', title='Level') }}:<td> ${{ info.level_ideal }}$ </tr>
 <tr><td> Label:<td> ${{ info.label_suffix }}$ </tr>
 <tr><td> {{ KNOWL('mf.hilbert.dimension', title='Dimension') }}:<td> {{ info.dimension }} </tr>
-<tr><td> Is CM:<td> {{ info.is_CM }} </tr>
-<tr><td> Is base change:<td> {{ info.is_base_change }} </tr>
+<tr><td> Is {{ KNOWL('mf.cm', title='CM') }} :<td> {{ info.is_CM }} </tr>
+<tr><td> Is {{ KNOWL('mf.base_change', title='base change') }} :<td> {{ info.is_base_change }} </tr>
 <tr><td> Parent newspace dimension:<td> {{ info.newspace_dimension }} </tr>
 </table>
 </p>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -19,8 +19,8 @@
 <tr><td> {{ KNOWL('mf.hilbert.level_norm', title='Level') }}:<td> ${{ info.level_ideal }}$ </tr>
 <tr><td> Label:<td> ${{ info.label_suffix }}$ </tr>
 <tr><td> {{ KNOWL('mf.hilbert.dimension', title='Dimension') }}:<td> {{ info.dimension }} </tr>
-<tr><td> Is CM?:<td> {{ info.is_CM }} </tr>
-<tr><td> Is base change?:<td> {{ info.is_base_change }} </tr>
+<tr><td> Is CM:<td> {{ info.is_CM }} </tr>
+<tr><td> Is base change:<td> {{ info.is_base_change }} </tr>
 <tr><td> Parent newspace dimension:<td> {{ info.newspace_dimension }} </tr>
 </table>
 </p>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -7,10 +7,10 @@
 By {{ KNOWL('nf', title='base field') }}:
 <a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
 <a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
-a <a href="?field_label=3.3.49.1">cubic field</a> of discriminant 49,
-a <a href="?field_label=4.4.725.1">quartic field</a> of discriminant 725,
-a <a href="?field_label=5.5.14641.1">quintic field</a> of discriminant 14641,
-a <a href="?field_label=6.6.300125.1">sextic field</a> of discriminant 300125.
+a <a href="?field_label=3.3.49.1">cubic field</a>{# of discriminant 49#},
+a <a href="?field_label=4.4.725.1">quartic field</a>{# of discriminant 725#},
+a <a href="?field_label=5.5.14641.1">quintic field</a>{# of discriminant 14641#},
+a <a href="?field_label=6.6.300125.1">sextic field</a>{# of discriminant 300125#}.
 </p>
 
 

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -4,9 +4,13 @@
 <h2> Browse {{ KNOWL('mf.hilbert', title='Hilbert cusp forms') }} </h2>
 
 <p>
-By field:
-<a href="?field_label={{'Qsqrt5'}}">{{'Qsqrt5'}}</a>
-<a href="?field_label={{'Qsqrt8'}}">{{'Qsqrt8'}}</a>
+By {{ KNOWL('nf', title='base field') }}:
+<a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
+<a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
+a <a href="?field_label=3.3.49.1">cubic field</a> of discriminant 49,
+a <a href="?field_label=4.4.725.1">quartic field</a> of discriminant 725,
+a <a href="?field_label=5.5.14641.1">quintic field</a> of discriminant 14641,
+a <a href="?field_label=6.6.300125.1">sextic field</a> of discriminant 300125.
 </p>
 
 

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -5,13 +5,24 @@
 
 <p>
 By {{ KNOWL('nf', title='base field') }}:
-<a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
-<a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
-a <a href="?field_label=3.3.49.1">cubic field</a>{# of discriminant 49#},
-a <a href="?field_label=4.4.725.1">quartic field</a>{# of discriminant 725#},
-a <a href="?field_label=5.5.14641.1">quintic field</a>{# of discriminant 14641#},
-a <a href="?field_label=6.6.300125.1">sextic field</a>{# of discriminant 300125#}.
 </p>
+<ul>
+<li>
+Real quadratic fields <a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
+<a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,...
+</li>
+<li>Cubic fields <a href="?field_label=3.3.49.1">3.3.49.1</a>,...
+</li>
+<li>
+Quartic fields <a href="?field_label=4.4.725.1">4.4.725.1</a>,...
+</li>
+<li>
+Quintic fields <a href="?field_label=5.5.14641.1">5.5.14641.1</a>,...
+</li>
+<li>
+Sextic fields <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,...
+</li>
+</ul>
 
 
 <h2> Find a specific form by label </h2>


### PR DESCRIPTION
This is my fixup of jenfns's outstanding pull request from July 29 (the Oregaon workshop).   I tidied it up a bit, and added some small enhancements:  

  1. the web page for an individual Hilbert MF now displays its base field more nicely, consistent with    the similar display for elliptic curves over number fields: see http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-71.1-a for an example.

  2. when the Hecke field is Q it does not bother to tell you that the eigenvalues are in terms of e which has min poly x: compare the previous link with http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-61.2-a (look under the heading Hecke eigenvalues)

  3. In the browse and search page http://localhost:37777/ModularForm/GL2/TotallyReal/ I added oen field of each degree 3, 4, 5, 6 so it does not look as if we only have real quadratics.