### PR TITLE
Adding ranks and generators to eliptic curves over number fields

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -237,7 +237,11 @@ class ECNF(object):
 
         # URLs of self and related objects:
         self.urls = {}
-        self.urls['curve'] = url_for(".show_ecnf", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label, number = self.number)
+        # It's useful to be able to use this class out of context, when calling url_for will fail:
+        try:
+            self.urls['curve'] = url_for(".show_ecnf", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label, number = self.number)
+        except RuntimeError:
+            return
         self.urls['class'] = url_for(".show_ecnf_isoclass", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label)
         self.urls['conductor'] = url_for(".show_ecnf_conductor", nf = self.field_label, conductor_label=self.conductor_label)
         self.urls['field'] = url_for(".show_ecnf1", nf=self.field_label)

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -218,6 +218,19 @@ class ECNF(object):
             self.rk = web_latex(self.rank)
         except AttributeError:
             self.rk = "not recorded"
+        try:
+            self.rk_bnds = web_latex(self.rank_bounds)
+        except AttributeError:
+            self.rk_bnds = "not recorded"
+        except AttributeError:
+            self.rk = "not recorded"
+        try:
+            gens = [E([self.field.parse_NFelt(x) for x in P])
+                    for P in self.gens]
+            self.gens = ",".join([web_latex(P) for P in gens])
+        except AttributeError:
+            self.gens = "not recorded"
+
 #       if rank in self:
 #            self.r = web_latex(self.rank)
 

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RealField, rainbow, implicit_plot, plot, text
+from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RealField, rainbow, implicit_plot, plot, text, Infinity
 from lmfdb.base import app, getDBConnection
 from lmfdb.utils import image_src, web_latex, web_latex_ideal_fact, encode_plot
 from lmfdb.WebNumberField import WebNumberField
@@ -213,26 +213,24 @@ class ECNF(object):
         self.torsion_gens = ",".join([web_latex(P) for P in torsion_gens])
 
 
-        # Rank etc
+        # Rank or bounds
         try:
             self.rk = web_latex(self.rank)
         except AttributeError:
-            self.rk = "not recorded"
+            self.rk = "?"
         try:
-            self.rk_bnds = web_latex(self.rank_bounds)
+            self.rk_bnds = "%s...%s" % tuple(self.rank_bounds)
         except AttributeError:
+            self.rank_bounds = [0,Infinity]
             self.rk_bnds = "not recorded"
-        except AttributeError:
-            self.rk = "not recorded"
+
+        # Generators
         try:
             gens = [E([self.field.parse_NFelt(x) for x in P])
                     for P in self.gens]
-            self.gens = ",".join([web_latex(P) for P in gens])
+            self.gens = ", ".join([web_latex(P) for P in gens])
         except AttributeError:
             self.gens = "not recorded"
-
-#       if rank in self:
-#            self.r = web_latex(self.rank)
 
         # Local data
         self.local_data = []
@@ -297,9 +295,12 @@ class ECNF(object):
             self.base_change = [] # in case it was False instead of []
             self.properties += [('Q-curve' , self.qc)]
 
+        r = self.rk
+        if r=="?":
+            r = self.rk_bnds
         self.properties += [
             ('Torsion order' , self.ntors),
-            ('Rank' , self.rk),
+            ('Rank' , r),
             ]
 
         for E0 in self.base_change:

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -229,8 +229,22 @@ class ECNF(object):
             gens = [E([self.field.parse_NFelt(x) for x in P])
                     for P in self.gens]
             self.gens = ", ".join([web_latex(P) for P in gens])
+            if self.rk == "?":
+                self.reg = "unknown"
+            else:
+                if gens:
+                    self.reg = E.regulator_of_points(gens)
+                else:
+                    self.reg = 1 # otherwise we only get 1.00000...
+
         except AttributeError:
             self.gens = "not recorded"
+            self.reg = "unknown"
+            try:
+                if self.rank==0:
+                    self.reg = 1
+            except AttributeError:
+                pass
 
         # Local data
         self.local_data = []

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -8,11 +8,13 @@ from kraus import (non_minimal_primes, is_global_minimal_model, has_global_minim
 ecnf = None
 nfdb = None
 
+
 def db_ecnf():
     global ecnf
     if ecnf is None:
         ecnf = getDBConnection().elliptic_curves.nfcurves
     return ecnf
+
 
 def db_nfdb():
     global nfdb
@@ -21,37 +23,41 @@ def db_nfdb():
     return nfdb
 
 special_names = {'2.0.4.1': 'i',
-         '2.2.5.1': 'phi',
-         '4.0.125.1': 'zeta5',
-         }
+                 '2.2.5.1': 'phi',
+                 '4.0.125.1': 'zeta5',
+                 }
 
-field_list = {} # cached collection of enhanced WebNumberFields, keyed by label
+field_list = {}  # cached collection of enhanced WebNumberFields, keyed by label
+
 
 def FIELD(label):
     nf = WebNumberField(label, gen_name=special_names.get(label, 'a'))
     nf.parse_NFelt = lambda s: nf.K()([QQ(str(c)) for c in s])
     return nf
 
+
 def make_field(label):
     if label in field_list:
         return field_list[label]
     return FIELD(label)
 
-def EC_R_plot(ainvs,xmin,xmax,ymin,ymax,colour,legend):
-   x=var('x')
-   y=var('y')
-   c=(xmin+xmax)/2
-   d=(xmax-xmin)
-   return implicit_plot(y**2+ainvs[0]*x*y+ainvs[2]*y-x**3-ainvs[1]*x**2-ainvs[3]*x-ainvs[4],(x,xmin,xmax),(y,ymin,ymax),plot_points=1000,aspect_ratio="automatic",color=colour)+plot(0,xmin=c-1e-5*d,xmax=c+1e-5*d,ymin=ymin,ymax=ymax,aspect_ratio="automatic",color=colour,legend_label=legend) # Add an extra plot outside the visible frame because implicit plots are buggy: their legend does not show (http://trac.sagemath.org/ticket/15903) 
 
-def EC_nf_plot(E,base_field_gen_name):
+def EC_R_plot(ainvs, xmin, xmax, ymin, ymax, colour, legend):
+    x = var('x')
+    y = var('y')
+    c = (xmin + xmax) / 2
+    d = (xmax - xmin)
+    return implicit_plot(y ** 2 + ainvs[0] * x * y + ainvs[2] * y - x ** 3 - ainvs[1] * x ** 2 - ainvs[3] * x - ainvs[4], (x, xmin, xmax), (y, ymin, ymax), plot_points=1000, aspect_ratio="automatic", color=colour) + plot(0, xmin=c - 1e-5 * d, xmax=c + 1e-5 * d, ymin=ymin, ymax=ymax, aspect_ratio="automatic", color=colour, legend_label=legend)  # Add an extra plot outside the visible frame because implicit plots are buggy: their legend does not show (http://trac.sagemath.org/ticket/15903)
+
+
+def EC_nf_plot(E, base_field_gen_name):
     K = E.base_field()
     n1 = K.signature()[0]
     if n1 == 0:
         return plot([])
     prec = 53
-    maxprec = 10**6
-    while prec < maxprec: # Try to base change to R. May fail if resulting curve is almost singular, so increase precision.
+    maxprec = 10 ** 6
+    while prec < maxprec:  # Try to base change to R. May fail if resulting curve is almost singular, so increase precision.
         try:
             SR = K.embeddings(RealField(prec))
             X = [E.base_extend(s) for s in SR]
@@ -59,18 +65,20 @@ def EC_nf_plot(E,base_field_gen_name):
         except ArithmeticError:
             prec *= 2
     if prec >= maxprec:
-        return text("Unable to plot",(1,1),fontsize="xx-large")
+        return text("Unable to plot", (1, 1), fontsize="xx-large")
     X = [e.plot() for e in X]
     xmin = min([x.xmin() for x in X])
     xmax = max([x.xmax() for x in X])
     ymin = min([x.ymin() for x in X])
     ymax = max([x.ymax() for x in X])
-    cols = ["blue","red","green","orange","brown"] # Preset colours, because rainbow tends to return too pale ones
+    cols = ["blue", "red", "green", "orange", "brown"]  # Preset colours, because rainbow tends to return too pale ones
     if n1 > len(cols):
         cols = rainbow(n1)
-    return sum([EC_R_plot([SR[i](a) for a in E.ainvs()],xmin,xmax,ymin,ymax,cols[i],"$"+base_field_gen_name+" \mapsto$ "+str(SR[i].im_gens()[0].n(20))) for i in range(n1)])
+    return sum([EC_R_plot([SR[i](a) for a in E.ainvs()], xmin, xmax, ymin, ymax, cols[i], "$" + base_field_gen_name + " \mapsto$ " + str(SR[i].im_gens()[0].n(20))) for i in range(n1)])
+
 
 class ECNF(object):
+
     """
     ECNF Wrapper
     """
@@ -81,7 +89,7 @@ class ECNF(object):
 
             - dbdata: the data from the database
         """
-        #del dbdata["_id"]
+        # del dbdata["_id"]
         self.__dict__.update(dbdata)
         self.field = make_field(self.field_label)
         self.make_E()
@@ -91,13 +99,13 @@ class ECNF(object):
         """
         searches for a specific elliptic curve in the ecnf collection by its label
         """
-        data = db_ecnf().find_one({"label" : label})
+        data = db_ecnf().find_one({"label": label})
         if data:
             return ECNF(data)
         print "No such curve in the database: %s" % label
 
     def make_E(self):
-        coeffs = self.ainvs # list of 5 lists of d strings
+        coeffs = self.ainvs  # list of 5 lists of d strings
         self.ainvs = [self.field.parse_NFelt(x) for x in coeffs]
         self.latex_ainvs = web_latex(self.ainvs)
         from sage.schemes.elliptic_curves.all import EllipticCurve
@@ -109,7 +117,7 @@ class ECNF(object):
         N = E.conductor()
         self.cond = web_latex(N)
         self.cond_norm = web_latex(N.norm())
-        if N.norm()==1:  # since the factorization of (1) displays as "1"
+        if N.norm() == 1:  # since the factorization of (1) displays as "1"
             self.fact_cond = self.cond
         else:
             self.fact_cond = web_latex_ideal_fact(N.factor())
@@ -118,7 +126,7 @@ class ECNF(object):
         D = self.field.K().ideal(E.discriminant())
         self.disc = web_latex(D)
         self.disc_norm = web_latex(D.norm())
-        if D.norm()==1:  # since the factorization of (1) displays as "1"
+        if D.norm() == 1:  # since the factorization of (1) displays as "1"
             self.fact_disc = self.disc
         else:
             self.fact_disc = web_latex_ideal_fact(D.factor())
@@ -134,7 +142,7 @@ class ECNF(object):
         # this model is non-minimal at more than one prime.
         #
         self.non_min_primes = non_minimal_primes(E)
-        self.is_minimal = (len(self.non_min_primes)==0)
+        self.is_minimal = (len(self.non_min_primes) == 0)
         self.has_minimal_model = True
         if not self.is_minimal:
             self.non_min_prime = ','.join([web_latex(P) for P in self.non_min_primes])
@@ -144,28 +152,27 @@ class ECNF(object):
             Dmin = minimal_discriminant_ideal(E)
             self.mindisc = web_latex(Dmin)
             self.mindisc_norm = web_latex(Dmin.norm())
-            if Dmin.norm()==1:  # since the factorization of (1) displays as "1"
+            if Dmin.norm() == 1:  # since the factorization of (1) displays as "1"
                 self.fact_mindisc = self.mindisc
             else:
                 self.fact_mindisc = web_latex_ideal_fact(Dmin.factor())
             self.fact_mindisc_norm = web_latex(Dmin.norm().factor())
 
-
         j = E.j_invariant()
         if j:
             d = j.denominator()
-            n = d*j # numerator exists for quadratic fields only!
+            n = d * j  # numerator exists for quadratic fields only!
             g = GCD(list(n))
-            n1 = n/g
+            n1 = n / g
             self.j = web_latex(n1)
-            if d!=1:
-                if n1>1:
-                #self.j = "("+self.j+")\(/\)"+web_latex(d)
-                    self.j = web_latex(r"\frac{%s}{%s}" % (self.j,d))
+            if d != 1:
+                if n1 > 1:
+                # self.j = "("+self.j+")\(/\)"+web_latex(d)
+                    self.j = web_latex(r"\frac{%s}{%s}" % (self.j, d))
                 else:
                     self.j = web_latex(d)
-                if g>1:
-                    if n1>1:
+                if g > 1:
+                    if n1 > 1:
                         self.j = web_latex(g) + self.j
                     else:
                         self.j = web_latex(g)
@@ -177,7 +184,7 @@ class ECNF(object):
         else:
             try:
                 self.fact_j = web_latex(j.factor())
-            except (ArithmeticError,ValueError): # if not all prime ideal factors principal
+            except (ArithmeticError, ValueError):  # if not all prime ideal factors principal
                 pass
 
         # CM and End(E)
@@ -185,9 +192,9 @@ class ECNF(object):
         self.End = "\(\Z\)"
         if self.cm:
             self.cm_bool = "yes (\(%s\))" % self.cm
-            if self.cm%4==0:
-                d4 = ZZ(self.cm)//4
-                self.End = "\(\Z[\sqrt{%s}]\)"%(d4)
+            if self.cm % 4 == 0:
+                d4 = ZZ(self.cm) // 4
+                self.End = "\(\Z[\sqrt{%s}]\)" % (d4)
             else:
                 self.End = "\(\Z[(1+\sqrt{%s})/2]\)" % self.cm
 
@@ -196,22 +203,21 @@ class ECNF(object):
         try:
             if self.q_curve:
                 self.qc = "yes"
-        except AttributeError: # in case the db entry does not have this field set
+        except AttributeError:  # in case the db entry does not have this field set
             pass
 
         # Torsion
         self.ntors = web_latex(self.torsion_order)
         self.tr = len(self.torsion_structure)
-        if self.tr==0:
+        if self.tr == 0:
             self.tor_struct_pretty = "Trivial"
-        if self.tr==1:
+        if self.tr == 1:
             self.tor_struct_pretty = "\(\Z/%s\Z\)" % self.torsion_structure[0]
-        if self.tr==2:
+        if self.tr == 2:
             self.tor_struct_pretty = r"\(\Z/%s\Z\times\Z/%s\Z\)" % tuple(self.torsion_structure)
         torsion_gens = [E([self.field.parse_NFelt(x) for x in P])
                         for P in self.torsion_gens]
         self.torsion_gens = ",".join([web_latex(P) for P in torsion_gens])
-
 
         # Rank or bounds
         try:
@@ -221,7 +227,7 @@ class ECNF(object):
         try:
             self.rk_bnds = "%s...%s" % tuple(self.rank_bounds)
         except AttributeError:
-            self.rank_bounds = [0,Infinity]
+            self.rank_bounds = [0, Infinity]
             self.rk_bnds = "not recorded"
 
         # Generators
@@ -235,13 +241,13 @@ class ECNF(object):
                 if gens:
                     self.reg = E.regulator_of_points(gens)
                 else:
-                    self.reg = 1 # otherwise we only get 1.00000...
+                    self.reg = 1  # otherwise we only get 1.00000...
 
         except AttributeError:
             self.gens = "not recorded"
             self.reg = "unknown"
             try:
-                if self.rank==0:
+                if self.rank == 0:
                     self.reg = 1
             except AttributeError:
                 pass
@@ -251,72 +257,70 @@ class ECNF(object):
         for p in N.prime_factors():
             self.local_info = E.local_data(p, algorithm="generic")
             self.local_data.append({'p': web_latex(p),
-                               'norm': web_latex(p.norm().factor()),
-                               'tamagawa_number': self.local_info.tamagawa_number(),
-                               'kodaira_symbol': web_latex(self.local_info.kodaira_symbol()).replace('$', ''),
-                               'reduction_type': self.local_info.bad_reduction_type(),
-                                'ord_den_j': max(0,-E.j_invariant().valuation(p)),
-                                'ord_mindisc': self.local_info.discriminant_valuation(),
-                                'ord_cond': self.local_info.conductor_valuation()
-                               })
+                                    'norm': web_latex(p.norm().factor()),
+                                    'tamagawa_number': self.local_info.tamagawa_number(),
+                                    'kodaira_symbol': web_latex(self.local_info.kodaira_symbol()).replace('$', ''),
+                                    'reduction_type': self.local_info.bad_reduction_type(),
+                                    'ord_den_j': max(0, -E.j_invariant().valuation(p)),
+                                    'ord_mindisc': self.local_info.discriminant_valuation(),
+                                    'ord_cond': self.local_info.conductor_valuation()
+                                    })
 
         # URLs of self and related objects:
         self.urls = {}
         # It's useful to be able to use this class out of context, when calling url_for will fail:
         try:
-            self.urls['curve'] = url_for(".show_ecnf", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label, number = self.number)
+            self.urls['curve'] = url_for(".show_ecnf", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label, number=self.number)
         except RuntimeError:
             return
-        self.urls['class'] = url_for(".show_ecnf_isoclass", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label)
-        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf = self.field_label, conductor_label=self.conductor_label)
+        self.urls['class'] = url_for(".show_ecnf_isoclass", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label)
+        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=self.conductor_label)
         self.urls['field'] = url_for(".show_ecnf1", nf=self.field_label)
 
         if self.field.is_real_quadratic():
-            self.hmf_label = "-".join([self.field.label,self.conductor_label,self.iso_label])
+            self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
 
         if self.field.is_imag_quadratic():
-            self.bmf_label = "-".join([self.field.label,self.conductor_label,self.iso_label])
-
+            self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
 
         self.friends = []
-        self.friends += [('Isogeny class '+self.short_class_label, self.urls['class'])]
-        self.friends += [('Twists',url_for('ecnf.index',field_label=self.field_label,jinv=self.jinv))]
+        self.friends += [('Isogeny class ' + self.short_class_label, self.urls['class'])]
+        self.friends += [('Twists', url_for('ecnf.index', field_label=self.field_label, jinv=self.jinv))]
         if self.field.is_real_quadratic():
-            self.friends += [('Hilbert Modular Form '+self.hmf_label, self.urls['hmf'])]
+            self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
         if self.field.is_imag_quadratic():
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
 
         self.properties = [
             ('Base field', self.field.field_pretty()),
-            ('Label' , self.label)]
+            ('Label', self.label)]
 
         # Plot
         if E.base_field().signature()[0]:
-            self.plot = encode_plot(EC_nf_plot(E,self.field.generator_name()))
+            self.plot = encode_plot(EC_nf_plot(E, self.field.generator_name()))
             self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             self.properties += [(None, self.plot_link)]
 
         self.properties += [
-            ('Conductor' , self.cond),
-            ('Conductor norm' , self.cond_norm),
-            ('j-invariant' , self.j),
-            ('CM' , self.cm_bool)]
+            ('Conductor', self.cond),
+            ('Conductor norm', self.cond_norm),
+            ('j-invariant', self.j),
+            ('CM', self.cm_bool)]
 
         if self.base_change:
             self.properties += [('base-change', 'yes: %s' % ','.join([str(lab) for lab in self.base_change]))]
         else:
-            self.base_change = [] # in case it was False instead of []
-            self.properties += [('Q-curve' , self.qc)]
+            self.base_change = []  # in case it was False instead of []
+            self.properties += [('Q-curve', self.qc)]
 
         r = self.rk
-        if r=="?":
+        if r == "?":
             r = self.rk_bnds
         self.properties += [
-            ('Torsion order' , self.ntors),
-            ('Rank' , r),
-            ]
+            ('Torsion order', self.ntors),
+            ('Rank', r),
+        ]
 
         for E0 in self.base_change:
-            self.friends += [('Base-change of %s /\(\Q\)' % E0 , url_for("ec.by_ec_label", label=E0))]
-
+            self.friends += [('Base-change of %s /\(\Q\)' % E0, url_for("ec.by_ec_label", label=E0))]

--- a/lmfdb/ecnf/hmf_check_find.py
+++ b/lmfdb/ecnf/hmf_check_find.py
@@ -263,8 +263,7 @@ def output_magma_field(field_label,K,Plist,outfilename=None, verbose=False):
 
     NOTE:
 
-    Assumes the primes are principal: only the first generator is used
-    in the Magma ideal construction.
+    Does not assumes the primes are principal.
 
     OUTPUT:
 

--- a/lmfdb/ecnf/hmf_check_find.py
+++ b/lmfdb/ecnf/hmf_check_find.py
@@ -17,7 +17,7 @@ from sage.rings.all import ZZ, QQ
 from sage.databases.cremona import cremona_to_lmfdb
 
 print "calling base._init()"
-dbport=37010
+dbport = 37010
 init(dbport, '')
 print "getting connection"
 conn = getDBConnection()
@@ -25,19 +25,21 @@ print "setting nfcurves"
 nfcurves = conn.elliptic_curves.nfcurves
 qcurves = conn.elliptic_curves.curves
 
-######################################################################
+#
 #
 # Code to check conductor labels agree with Hilbert Modular Form level
 # labels for a real quadratic field.  So far run on all curves over
 # Q(sqrt(5)).
 #
-######################################################################
+#
 
 from lmfdb.hilbert_modular_forms.hilbert_field import HilbertNumberField
 
+
 def make_conductor(ecnfdata, hfield):
-    N,c,d = [ZZ(c) for c in ecnfdata['conductor_ideal'][1:-1].split(',')]
-    return hfield.K().ideal([N//d,c+d*hfield.K().gen()])
+    N, c, d = [ZZ(c) for c in ecnfdata['conductor_ideal'][1:-1].split(',')]
+    return hfield.K().ideal([N // d, c + d * hfield.K().gen()])
+
 
 def check_ideal_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=False, verbose=False):
     r""" Go through all curves with the given field label, assumed totally
@@ -49,7 +51,7 @@ def check_ideal_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
     fields = hmfs.fields
     query = {}
     query['field_label'] = field_label
-    query['conductor_norm'] = {'$gte' : int(min_norm)}
+    query['conductor_norm'] = {'$gte': int(min_norm)}
     if max_norm:
         query['conductor_norm']['$lte'] = int(max_norm)
     else:
@@ -62,33 +64,33 @@ def check_ideal_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
     # to distinguish the a_p for forms 2.2.12.1-150.1-a and
     # 2.2.12.1-150.1-b !
     primes = [P['ideal'] for P in K.primes_iter(30)]
-    remap = {} # remap[old_label] = new_label
+    remap = {}  # remap[old_label] = new_label
 
     for ec in cursor:
         fix_needed = False
         cond_label = ec['conductor_label']
         if cond_label in remap:
             new_cond_label = remap[cond_label]
-            fix_needed=(cond_label!=new_cond_label)
+            fix_needed = (cond_label != new_cond_label)
             if not fix_needed:
                 if verbose:
                     print("conductor label %s ok" % cond_label)
         else:
-            conductor = make_conductor(ec,K)
+            conductor = make_conductor(ec, K)
             level = K.ideal(cond_label)
             new_cond_label = K.ideal_label(conductor)
             remap[cond_label] = new_cond_label
-            fix_needed=(cond_label!=new_cond_label)
+            fix_needed = (cond_label != new_cond_label)
 
         if fix_needed:
-            print("conductor label for curve %s is wrong, should be %s not %s" % (ec['label'],new_cond_label, cond_label))
+            print("conductor label for curve %s is wrong, should be %s not %s" % (ec['label'], new_cond_label, cond_label))
             if fix:
                 iso = ec['iso_label']
                 num = str(ec['number'])
                 newlabeldata = {}
                 newlabeldata['conductor_label'] = new_cond_label
-                newlabeldata['short_class_label'] = '-'.join([new_cond_label,iso])
-                newlabeldata['short_label'] = ''.join([newlabeldata['short_class_label'],num])
+                newlabeldata['short_class_label'] = '-'.join([new_cond_label, iso])
+                newlabeldata['short_label'] = ''.join([newlabeldata['short_class_label'], num])
                 newlabeldata['class_label'] = '-'.join([field_label,
                                                         newlabeldata['short_class_label']])
                 newlabeldata['label'] = '-'.join([field_label,
@@ -98,15 +100,16 @@ def check_ideal_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
             if verbose:
                 print("conductor label %s ok" % cond_label)
 
-    return dict([(k,remap[k]) for k in remap if not k==remap[k]])
+    return dict([(k, remap[k]) for k in remap if not k == remap[k]])
 
-######################################################################
+#
 #
 # Code to check isogeny class labels agree with Hilbert Modular Form
 # labels of each level, for a real quadratic field.  Tested on all
 # curves over Q(sqrt(5)).
 #
-######################################################################
+#
+
 
 def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=False, verbose=False):
     r""" Go through all curves with the given field label, assumed totally
@@ -118,8 +121,8 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
     fields = hmfs.fields
     query = {}
     query['field_label'] = field_label
-    query['number'] = 1 # only look at first curve in each isogeny class
-    query['conductor_norm'] = {'$gte' : int(min_norm)}
+    query['number'] = 1  # only look at first curve in each isogeny class
+    query['conductor_norm'] = {'$gte': int(min_norm)}
     if max_norm:
         query['conductor_norm']['$lte'] = int(max_norm)
     else:
@@ -131,7 +134,7 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
     bad_curves = []
     K = HilbertNumberField(field_label)
     primes = [P['ideal'] for P in K.primes_iter(30)]
-    curve_ap = {} # curve_ap[conductor_label] will be a dict iso -> ap
+    curve_ap = {}  # curve_ap[conductor_label] will be a dict iso -> ap
     form_ap = {}  # form_ap[conductor_label]  will be a dict iso -> ap
 
     # Step 1: look at all curves (one per isogeny class), check that
@@ -141,20 +144,20 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
     # e.g. curve_ap[conductor_label][iso_label] = aplist.
 
     for ec in cursor:
-        hmf_label = "-".join([ec['field_label'],ec['conductor_label'],ec['iso_label']])
-        f = forms.find_one({'field_label' : field_label, 'label' : hmf_label})
+        hmf_label = "-".join([ec['field_label'], ec['conductor_label'], ec['iso_label']])
+        f = forms.find_one({'field_label': field_label, 'label': hmf_label})
         if f:
             if verbose:
                 print("hmf with label %s found" % hmf_label)
-            nfound +=1
+            nfound += 1
             ainvsK = [K.K()([QQ(str(c)) for c in ai]) for ai in ec['ainvs']]
             E = EllipticCurve(ainvsK)
             good_flags = [E.has_good_reduction(P) for P in primes]
-            good_primes = [P for (P,flag) in zip(primes,good_flags) if flag]
+            good_primes = [P for (P, flag) in zip(primes, good_flags) if flag]
             aplist = [E.reduction(P).trace_of_frobenius() for P in good_primes[:10]]
             f_aplist = [int(a) for a in f['hecke_eigenvalues'][:30]]
-            f_aplist = [ap for ap,flag in zip(f_aplist,good_flags) if flag][:10]
-            if aplist==f_aplist:
+            f_aplist = [ap for ap, flag in zip(f_aplist, good_flags) if flag][:10]
+            if aplist == f_aplist:
                 nok += 1
                 if verbose:
                     print("Curve %s and newform agree!" % ec['short_label'])
@@ -172,20 +175,20 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
         else:
             if verbose:
                 print("No hmf with label %s found!" % hmf_label)
-            nnotfound +=1
+            nnotfound += 1
 
     # Report progress:
 
-    n = nfound+nnotfound
+    n = nfound + nnotfound
     if nnotfound:
-        print("Out of %s forms, %s were found and %s were not found" % (n,nfound,nnotfound))
+        print("Out of %s forms, %s were found and %s were not found" % (n, nfound, nnotfound))
     else:
-        print("Out of %s classes of curve, all %s had newforms with the same label" % (n,nfound))
-    if nfound==nok:
+        print("Out of %s classes of curve, all %s had newforms with the same label" % (n, nfound))
+    if nfound == nok:
         print("All curves agree with matching newforms")
     else:
-        print("%s curves agree with matching newforms, %s do not" % (nok,nfound-nok))
-        #print("Bad curves: %s" % bad_curves)
+        print("%s curves agree with matching newforms, %s do not" % (nok, nfound - nok))
+        # print("Bad curves: %s" % bad_curves)
 
     # Step 2: for each conductor_label for which there was a
     # discrepancy, create a dict giving the permutation curve -->
@@ -199,7 +202,7 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
         for a in c_dat.keys():
             aplist = c_dat[a]
             for b in f_dat.keys():
-                if aplist==f_dat[b]:
+                if aplist == f_dat[b]:
                     remap[level][a] = b
                     break
     if verbose:
@@ -211,7 +214,7 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
 
     for level in remap.keys():
         perm = remap[level]
-        print("Fixing iso labels for conductor %s using map %s" % (level,perm))
+        print("Fixing iso labels for conductor %s using map %s" % (level, perm))
         query = {}
         query['field_label'] = field_label
         query['conductor_label'] = level
@@ -221,14 +224,14 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
             if iso in perm:
                 new_iso = perm[iso]
                 if verbose:
-                    print("--mapping class %s to class %s" % (iso,new_iso))
+                    print("--mapping class %s to class %s" % (iso, new_iso))
                 num = str(ec['number'])
                 newlabeldata = {}
                 newlabeldata['iso_label'] = new_iso
-                newlabeldata['short_class_label'] = '-'.join([level,new_iso])
+                newlabeldata['short_class_label'] = '-'.join([level, new_iso])
                 newlabeldata['class_label'] = '-'.join([field_label,
                                                         newlabeldata['short_class_label']])
-                newlabeldata['short_label'] = ''.join([newlabeldata['short_class_label'],num])
+                newlabeldata['short_label'] = ''.join([newlabeldata['short_class_label'], num])
                 newlabeldata['label'] = '-'.join([field_label,
                                                   newlabeldata['short_label']])
                 if verbose:
@@ -236,15 +239,16 @@ def check_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, fix=Fal
                 if fix:
                     nfcurves.update({'_id': ec['_id']}, {"$set": newlabeldata}, upsert=True)
 
-############################################################
+#
 #
 # Code to go through HMF database to find newforms which should have
 # associated curves, look to see if a suitable curve exists, and if
 # not to create a Magma script to search for one.
 #
-############################################################
+#
 
-def output_magma_field(field_label,K,Plist,outfilename=None, verbose=False):
+
+def output_magma_field(field_label, K, Plist, outfilename=None, verbose=False):
     r"""
     Writes Magma code to a file to define a number field and list of primes.
 
@@ -271,10 +275,11 @@ def output_magma_field(field_label,K,Plist,outfilename=None, verbose=False):
     define the field `K` and the list `Plist` of primes.
     """
     if outfilename:
-        outfile=file(outfilename, mode="w")
+        outfile = file(outfilename, mode="w")
     disc = K.discriminant()
     name = K.gen()
     pol = K.defining_polynomial()
+
     def output(L):
         if outfilename:
             outfile.write(L)
@@ -282,16 +287,16 @@ def output_magma_field(field_label,K,Plist,outfilename=None, verbose=False):
             sys.stdout.write(L)
     output('print "Field %s";\n' % field_label)
     output("Qx<x> := PolynomialRing(RationalField());\n")
-    output("K<%s> := NumberField(%s);\n" % (name,pol))
+    output("K<%s> := NumberField(%s);\n" % (name, pol))
     output("OK := Integers(K);\n")
     output("Plist := [];\n")
     for P in Plist:
         Pgens = P.gens_reduced()
         Pmagma = "(%s)*OK" % Pgens[0]
-        if len(Pgens)>1:
-           Pmagma += "+(%s)*OK" % Pgens[1]
+        if len(Pgens) > 1:
+            Pmagma += "+(%s)*OK" % Pgens[1]
         output("Append(~Plist,%s);\n" % Pmagma)
-        #output("Append(~Plist,(%s)*OK);\n" % P.gens_reduced()[0])
+        # output("Append(~Plist,(%s)*OK);\n" % P.gens_reduced()[0])
     output('effort := 400;\n')
     # output definition of search function:
     output('ECSearch := procedure(class_label, N, aplist);\n')
@@ -310,6 +315,7 @@ def output_magma_field(field_label,K,Plist,outfilename=None, verbose=False):
     if outfilename:
         output("\n")
         outfile.close()
+
 
 def output_magma_curve_search(HMF, form, outfilename=None, verbose=False):
     r""" Outputs Magma script to search for an curve to match the newform
@@ -340,24 +346,25 @@ def output_magma_curve_search(HMF, form, outfilename=None, verbose=False):
         if verbose:
             sys.stdout.write(L)
     if outfilename:
-        outfile=file(outfilename, mode="a")
+        outfile = file(outfilename, mode="a")
 
     N = HMF.ideal(form['level_label'])
-    Plist = [P['ideal'] for P in HMF.primes_iter(30)];
-    goodP = [(i,P) for i,P in enumerate(Plist) if not P.divides(N)]
+    Plist = [P['ideal'] for P in HMF.primes_iter(30)]
+    goodP = [(i, P) for i, P in enumerate(Plist) if not P.divides(N)]
     label = form['short_label']
     if verbose:
         print("Missing curve %s" % label)
-    aplist = [int(form['hecke_eigenvalues'][i]) for i,P in goodP]
+    aplist = [int(form['hecke_eigenvalues'][i]) for i, P in goodP]
     Ngens = N.gens_reduced()
     Nmagma = "(%s)*OK" % Ngens[0]
-    if len(Ngens)>1:
+    if len(Ngens) > 1:
         Nmagma += "+(%s)*OK" % Ngens[1]
-    output("ECSearch(\"%s\",%s,%s);\n" % (label,Nmagma,aplist))
-    #output("ECSearch(\"%s\",(%s)*OK,%s);\n" % (label,N.gens_reduced()[0],aplist))
+    output("ECSearch(\"%s\",%s,%s);\n" % (label, Nmagma, aplist))
+    # output("ECSearch(\"%s\",(%s)*OK,%s);\n" % (label,N.gens_reduced()[0],aplist))
 
     if outfilename:
         outfile.close()
+
 
 def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilename=None, verbose=False):
     r""" Go through all Hilbert Modular Forms with the given field label,
@@ -369,13 +376,13 @@ def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilen
     fields = hmfs.fields
     query = {}
     query['field_label'] = field_label
-    if fields.count({'label':field_label})==0:
+    if fields.count({'label': field_label}) == 0:
         if verbose:
             print("No HMF data for field %s" % field_label)
         return None
 
-    query['dimension'] = 1 # only look at rational newforms
-    query['level_norm'] = {'$gte' : int(min_norm)}
+    query['dimension'] = 1  # only look at rational newforms
+    query['level_norm'] = {'$gte': int(min_norm)}
     if max_norm:
         query['level_norm']['$lte'] = int(max_norm)
     else:
@@ -387,7 +394,7 @@ def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilen
     missing_curves = []
     K = HilbertNumberField(field_label)
     primes = [P['ideal'] for P in K.primes_iter(100)]
-    curve_ap = {} # curve_ap[conductor_label] will be a dict iso -> ap
+    curve_ap = {}  # curve_ap[conductor_label] will be a dict iso -> ap
     form_ap = {}  # form_ap[conductor_label]  will be a dict iso -> ap
 
     # Step 1: look at all newforms, check that there is an elliptic
@@ -398,19 +405,19 @@ def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilen
 
     for f in cursor:
         curve_label = f['label']
-        ec = nfcurves.find_one({'field_label' : field_label, 'class_label' : curve_label, 'number' : 1})
+        ec = nfcurves.find_one({'field_label': field_label, 'class_label': curve_label, 'number': 1})
         if ec:
             if verbose:
                 print("curve with label %s found" % curve_label)
-            nfound +=1
+            nfound += 1
             ainvsK = [K.K()([QQ(str(c)) for c in ai]) for ai in ec['ainvs']]
             E = EllipticCurve(ainvsK)
             good_flags = [E.has_good_reduction(P) for P in primes]
-            good_primes = [P for (P,flag) in zip(primes,good_flags) if flag]
+            good_primes = [P for (P, flag) in zip(primes, good_flags) if flag]
             aplist = [E.reduction(P).trace_of_frobenius() for P in good_primes[:30]]
             f_aplist = [int(a) for a in f['hecke_eigenvalues'][:40]]
-            f_aplist = [ap for ap,flag in zip(f_aplist,good_flags) if flag][:30]
-            if aplist==f_aplist:
+            f_aplist = [ap for ap, flag in zip(f_aplist, good_flags) if flag][:30]
+            if aplist == f_aplist:
                 nok += 1
                 if verbose:
                     print("Curve %s and newform agree!" % ec['short_label'])
@@ -428,19 +435,19 @@ def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilen
             if verbose:
                 print("No curve with label %s found!" % curve_label)
             missing_curves.append(f['short_label'])
-            nnotfound +=1
+            nnotfound += 1
 
     # Report progress:
 
-    n = nfound+nnotfound
+    n = nfound + nnotfound
     if nnotfound:
-        print("Out of %s newforms, %s curves were found and %s were not found" % (n,nfound,nnotfound))
+        print("Out of %s newforms, %s curves were found and %s were not found" % (n, nfound, nnotfound))
     else:
-        print("Out of %s newforms, all %s had curves with the same label and ap" % (n,nfound))
-    if nfound==nok:
+        print("Out of %s newforms, all %s had curves with the same label and ap" % (n, nfound))
+    if nfound == nok:
         print("All curves agree with matching newforms")
     else:
-        print("%s curves agree with matching newforms, %s do not" % (nok,nfound-nok))
+        print("%s curves agree with matching newforms, %s do not" % (nok, nfound - nok))
     if nnotfound:
         print("Missing curves: %s" % missing_curves)
     else:
@@ -451,22 +458,23 @@ def find_curve_labels(field_label='2.2.5.1', min_norm=0, max_norm=None, outfilen
 
     # First output Magma code to define the field and primes:
     if outfilename:
-        output_magma_field(field_label,K.K(),primes,outfilename)
+        output_magma_field(field_label, K.K(), primes, outfilename)
         if verbose:
             print("...output definition of field and primes finished")
     if outfilename:
-        outfile=file(outfilename, mode="a")
+        outfile = file(outfilename, mode="a")
 
     for nf_label in missing_curves:
         if verbose:
             print("Curve %s is missing..." % nf_label)
-        form = forms.find_one({'field_label':field_label, 'short_label':nf_label})
+        form = forms.find_one({'field_label': field_label, 'short_label': nf_label})
         if not form:
             print("... form %s not found!" % nf_label)
         else:
             if verbose:
                 print("... found form, outputting Magma search code")
             output_magma_curve_search(K, form, outfilename, verbose=verbose)
+
 
 def magma_output_iter(infilename):
     r"""
@@ -502,6 +510,7 @@ def magma_output_iter(infilename):
 
     infile.close()
 
+
 def export_magma_output(infilename, outfilename=None, verbose=False):
     r"""
     Convert Magma search output to a curves file.
@@ -515,7 +524,7 @@ def export_magma_output(infilename, outfilename=None, verbose=False):
     - ``verbose`` (boolean, default ``False``) -- verbosity flag.
     """
     if outfilename:
-        outfile=file(outfilename, mode="w")
+        outfile = file(outfilename, mode="w")
 
     def output(L):
         if outfilename:
@@ -541,18 +550,19 @@ def export_magma_output(infilename, outfilename=None, verbose=False):
         ec['ainvs'] = [[str(c) for c in list(a)] for a in ai]
         ec['cm'] = '?'
         ec['base_change'] = []
-        output(make_curves_line(ec)+"\n")
+        output(make_curves_line(ec) + "\n")
+
 
 def is_fundamental_discriminant(d):
-    if d in [0,1]:
+    if d in [0, 1]:
         return False
     if d.is_squarefree():
-        return d%4==1
+        return d % 4 == 1
     else:
-        return d%16 in [8,12] and (d//4).is_squarefree()
+        return d % 16 in [8, 12] and (d // 4).is_squarefree()
 
-def rqf_iterator(d1,d2):
-    for d in srange(d1,d2+1):
+
+def rqf_iterator(d1, d2):
+    for d in srange(d1, d2 + 1):
         if is_fundamental_discriminant(d):
             yield d, '2.2.%s.1' % d
-

--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -71,7 +71,7 @@ from sage.rings.all import ZZ, QQ
 from sage.databases.cremona import cremona_to_lmfdb
 
 print "calling base._init()"
-dbport=37010
+dbport = 37010
 init(dbport, '')
 print "getting connection"
 conn = getDBConnection()
@@ -99,26 +99,28 @@ print "finished indices"
 # dict of label:field pairs:
 nf_lookup_table = {}
 
+
 def nf_lookup(label):
     r"""
     Returns a NumberField from its label, caching the result.
     """
-    #print "Looking up number field with label %s" % label
+    # print "Looking up number field with label %s" % label
     if label in nf_lookup_table:
-        #print "We already have it: %s" % nf_lookup_table[label]
+        # print "We already have it: %s" % nf_lookup_table[label]
         return nf_lookup_table[label]
-    #print "We do not have it yet, finding in database..."
+    # print "We do not have it yet, finding in database..."
     field = conn.numberfields.fields.find_one({'label': label})
     if not field:
         raise ValueError("Invalid field label: %s" % label)
-    #print "Found it!"
+    # print "Found it!"
     coeffs = [ZZ(c) for c in field['coeffs'].split(",")]
-    K = NumberField(PolynomialRing(QQ,'x')(coeffs),'a')
-    #print "The field with label %s is %s" % (label, K)
+    K = NumberField(PolynomialRing(QQ, 'x')(coeffs), 'a')
+    # print "The field with label %s is %s" % (label, K)
     nf_lookup_table[label] = K
     return K
 
-## HNF of an ideal I in a quadratic field
+# HNF of an ideal I in a quadratic field
+
 
 def ideal_HNF(I):
     r"""
@@ -130,11 +132,12 @@ def ideal_HNF(I):
     """
     N = I.norm()
     a, c, b, d = I.pari_hnf().python().list()
-    assert a>0 and d>0 and N==a*d and d.divides(a) and d.divides(b) and 0<=c<a
-    return [a,c,d]
+    assert a > 0 and d > 0 and N == a * d and d.divides(a) and d.divides(b) and 0 <= c < a
+    return [a, c, d]
 
-## Label of an ideal I in a quadratic field: string formed from the
-## Norm and HNF of the ideal
+# Label of an ideal I in a quadratic field: string formed from the
+# Norm and HNF of the ideal
+
 
 def ideal_label(I):
     r"""
@@ -142,17 +145,19 @@ def ideal_label(I):
     with integral basis [1,w].  This is the string '[N,c,d]' where
     [a,c,d] is the HNF form of I and N=a*d=Norm(I).
     """
-    a,c,d = ideal_HNF(I)
-    return "[%s,%s,%s]" % (a*d,c,d)
+    a, c, d = ideal_HNF(I)
+    return "[%s,%s,%s]" % (a * d, c, d)
 
-## Reconstruct an ideal in a quadratic field from its label.
+# Reconstruct an ideal in a quadratic field from its label.
 
-def ideal_from_label(K,lab):
+
+def ideal_from_label(K, lab):
     r"""Returns the ideal with label lab in the quadratic field K.
     """
     N, c, d = [ZZ(c) for c in lab[1:-1].split(",")]
-    a = N//d
-    return K.ideal(a,K([c,d]))
+    a = N // d
+    return K.ideal(a, K([c, d]))
+
 
 def parse_NFelt(K, s):
     r"""
@@ -160,11 +165,13 @@ def parse_NFelt(K, s):
     """
     return K([QQ(c) for c in s.split(",")])
 
+
 def NFelt(a):
     r"""
     Returns an NFelt string encoding the element a (in a number field K).
     """
     return ",".join([str(c) for c in list(a)])
+
 
 def QorZ_list(a):
     r"""
@@ -172,18 +179,21 @@ def QorZ_list(a):
     """
     return [int(a.numerator()), int(a.denominator())]
 
+
 def K_list(a):
     r"""
     Return the list representation of the number field element.
     """
-    #return [QorZ_list(c) for c in list(a)]  # old: [num,den]
+    # return [QorZ_list(c) for c in list(a)]  # old: [num,den]
     return [str(c) for c in list(a)]         # new: "num/den"
+
 
 def NFelt_list(a):
     r"""
     Return the list representation of the NFelt string.
     """
     return [QorZ_list(QQ(c)) for c in a.split(",")]
+
 
 def parse_point(E, s):
     r"""
@@ -193,32 +203,38 @@ def parse_point(E, s):
     cc = s[1:-1].split(":")
     return E([parse_NFelt(c) for c in cc])
 
+
 def point_string(P):
     r"""Return a string representation of a point on an elliptic curve
     """
-    return "["+":".join([NFelt(c) for c in list(P)])+"]"
+    return "[" + ":".join([NFelt(c) for c in list(P)]) + "]"
+
 
 def point_string_to_list(s):
     r"""Return a list representation of a point string
     """
     return s[1:-1].split(":")
 
+
 def point_list(P):
     r"""Return a list representation of a point on an elliptic curve
     """
     return [K_list(c) for c in list(P)]
+
 
 def field_data(s):
     r"""
     Returns full field data from field label.
     """
     deg, r1, abs_disc, n = [int(c) for c in s.split(".")]
-    sig = [r1, (deg-r1)//2]
+    sig = [r1, (deg - r1) // 2]
     return [s, deg, sig, abs_disc]
+
 
 @cached_function
 def get_cm_list(K):
     return cm_j_invariants_and_orders(K)
+
 
 def get_cm(j):
     r"""
@@ -226,15 +242,17 @@ def get_cm(j):
     """
     if not j.is_integral():
         return 0
-    for d,f,j1 in get_cm_list(j.parent()):
-        if j==j1:
-            return int(d*f*f)
+    for d, f, j1 in get_cm_list(j.parent()):
+        if j == j1:
+            return int(d * f * f)
     return 0
 
 whitespace = re.compile(r'\s+')
 
+
 def split(line):
     return whitespace.split(line.strip())
+
 
 def curves(line):
     r""" Parses one line from a curves file.  Returns the label and a dict
@@ -254,7 +272,7 @@ def curves(line):
     """
     # Parse the line and form the full label:
     data = split(line)
-    if len(data)!=13:
+    if len(data) != 13:
         print "line %s does not have 13 fields, skipping" % line
     field_label = data[0]       # string
     conductor_label = data[1]   # string
@@ -266,38 +284,38 @@ def curves(line):
     label = "%s-%s" % (field_label, short_label)
 
     conductor_ideal = data[4]     # string
-    conductor_norm = int(data[5]) # int
+    conductor_norm = int(data[5])  # int
     ainvs = data[6:11]            # list of 5 NFelt strings
     cm = data[11]                 # int or '?'
-    if cm!='?':
+    if cm != '?':
         cm = int(cm)
-    q_curve = (data[12]=='1')   # bool
+    q_curve = (data[12] == '1')   # bool
 
     # Create the field and curve to compute the j-invariant:
     dummy, deg, sig, abs_disc = field_data(field_label)
     K = nf_lookup(field_label)
-    ainvsK = [parse_NFelt(K,ai) for ai in ainvs] # list of K-elements
+    ainvsK = [parse_NFelt(K, ai) for ai in ainvs]  # list of K-elements
     ainvs = [[str(c) for c in ai] for ai in ainvsK]
     E = EllipticCurve(ainvsK)
     j = E.j_invariant()
     jinv = K_list(j)
-    if cm=='?':
+    if cm == '?':
         cm = get_cm(j)
         if cm:
-            print "cm=%s for j=%s" %(cm,j)
+            print "cm=%s for j=%s" % (cm, j)
 
     # Here we should check that the conductor of the constructed curve
     # agrees with the input conductor.  We just check the norm.
-    if E.conductor().norm()==conductor_norm:
+    if E.conductor().norm() == conductor_norm:
         pass
-        #print "Conductor norms agree: %s" % conductor_norm
+        # print "Conductor norms agree: %s" % conductor_norm
     else:
         raise RuntimeError("Wrong conductor for input line %s" % line)
 
     # get torsion order, structure and generators:
-    #print("E = %s over %s" % (ainvsK,K))
+    # print("E = %s over %s" % (ainvsK,K))
     torgroup = E.torsion_subgroup()
-    #print("torsion = %s" % torgroup)
+    # print("torsion = %s" % torgroup)
     ntors = int(torgroup.order())
     torstruct = [int(n) for n in list(torgroup.invariants())]
     torgens = [point_list(P.element()) for P in torgroup.gens()]
@@ -306,11 +324,11 @@ def curves(line):
     # subset of Q-curves)
 
     if q_curve:
-        #print "%s is a Q-curve, testing for base-change..." % label
+        # print "%s is a Q-curve, testing for base-change..." % label
         E1list = E.descend_to(QQ)
         if len(E1list):
             base_change = [cremona_to_lmfdb(E1.label()) for E1 in E1list]
-            print "%s is base change of %s" % (label,base_change)
+            print "%s is base change of %s" % (label, base_change)
         else:
             base_change = []
             print "%s is a Q-curve, but not base-change..." % label
@@ -318,7 +336,7 @@ def curves(line):
         base_change = []
 
     return label, {
-        'field_label' : field_label,
+        'field_label': field_label,
         'degree': deg,
         'signature': sig,
         'abs_disc': abs_disc,
@@ -339,7 +357,8 @@ def curves(line):
         'torsion_order': ntors,
         'torsion_structure': torstruct,
         'torsion_gens': torgens,
-        }
+    }
+
 
 def curve_data(line):
     r""" Parses one line from a curve_data file.  Returns the label and a dict
@@ -358,10 +377,10 @@ def curve_data(line):
     """
     # Parse the line and form the full label:
     data = split(line)
-    if len(data)<9:
+    if len(data) < 9:
         print "line %s does not have 9 fields (excluding gens), skipping" % line
     ngens = int(data[7])
-    if len(data)!=9+ngens:
+    if len(data) != 9 + ngens:
         print "line %s does not have 9 fields (excluding gens), skipping" % line
     field_label = data[0]       # string
     conductor_label = data[1]   # string
@@ -372,20 +391,21 @@ def curve_data(line):
 
     edata = {'label': label}
     r = data[4]
-    if r!="?":
+    if r != "?":
         edata['rank'] = int(r)
     rb = data[5]
-    if rb!="?":
+    if rb != "?":
         edata['rank_bounds'] = [int(c) for c in rb[1:-1].split(",")]
     ra = data[6]
-    if ra!="?":
+    if ra != "?":
         edata['analytic_rank'] = int(ra)
     ngens = int(data[7])
-    edata['gens'] = [point_string_to_list(g) for g in data[8:8+ngens]]
-    sha = data[8+ngens]
-    if sha!="?":
+    edata['gens'] = [point_string_to_list(g) for g in data[8:8 + ngens]]
+    sha = data[8 + ngens]
+    if sha != "?":
         edata['sha_an'] = int(sha)
     return label, edata
+
 
 def isoclass(line):
     r""" Parses one line from an isovlass file.  Returns the label and a dict
@@ -402,7 +422,7 @@ def isoclass(line):
     """
     # Parse the line and form the full label:
     data = split(line)
-    if len(data)<5:
+    if len(data) < 5:
         print "isoclass line %s does not have 5 fields (excluding gens), skipping" % line
     field_label = data[0]       # string
     conductor_label = data[1]   # string
@@ -419,7 +439,7 @@ def isoclass(line):
 
 filename_base_list = ['curves', 'curve_data']
 
-############################################################
+#
 
 
 def upload_to_db(base_path, filename_suffix):
@@ -439,7 +459,7 @@ def upload_to_db(base_path, filename_suffix):
             print "opened %s" % os.path.join(base_path, f)
         except IOError:
             print "No file %s exists" % os.path.join(base_path, f)
-            continue # in case not all prefixes exist
+            continue  # in case not all prefixes exist
 
         parse = globals()[f[:f.find('.')]]
 
@@ -447,9 +467,9 @@ def upload_to_db(base_path, filename_suffix):
         count = 0
         print "Starting to read lines from file %s" % f
         for line in h.readlines():
-            #if count==10: break # for testing
+            # if count==10: break # for testing
             label, data = parse(line)
-            if count%100==0:
+            if count % 100 == 0:
                 print "read %s from %s" % (label, f)
             count += 1
             if label not in data_to_insert:
@@ -458,7 +478,7 @@ def upload_to_db(base_path, filename_suffix):
             for key in data:
                 if key in curve:
                     if curve[key] != data[key]:
-                        raise RuntimeError("Inconsistent data for %s:\ncurve=%s\ndata=%s\nkey %s differs!" % (label,curve,data,key))
+                        raise RuntimeError("Inconsistent data for %s:\ncurve=%s\ndata=%s\nkey %s differs!" % (label, curve, data, key))
                 else:
                     curve[key] = data[key]
         print "finished reading %s lines from file %s" % (count, f)
@@ -466,18 +486,18 @@ def upload_to_db(base_path, filename_suffix):
     vals = data_to_insert.values()
     count = 0
     for val in vals:
-        #print val
+        # print val
         nfcurves.update({'label': val['label']}, {"$set": val}, upsert=True)
         count += 1
         if count % 100 == 0:
             print "inserted %s" % (val['label'])
 
-######################################################################
+#
 #
 # Code to download data from the database, (re)creating file curves.*,
 # curve_data.*, isoclass.*
 #
-######################################################################
+#
 
 
 def make_curves_line(ec):
@@ -499,8 +519,9 @@ def make_curves_line(ec):
                      ec['conductor_ideal'],
                      str(ec['conductor_norm'])
                      ] + [",".join(t) for t in ec['ainvs']
-                     ] + [str(ec['cm']),str(int(len(ec['base_change'])>0)) ]
+                          ] + [str(ec['cm']), str(int(len(ec['base_change']) > 0))]
     return " ".join(output_fields)
+
 
 def make_curve_data_line(ec):
     r""" for ec a curve object from the database, create a line of text to
@@ -521,14 +542,14 @@ def make_curve_data_line(ec):
         rk = str(ec['rank'])
     rk_bds = '?'
     if 'rank_bounds' in ec:
-        rk_bds = str(ec['rank_bounds']).replace(" ","")
+        rk_bds = str(ec['rank_bounds']).replace(" ", "")
     an_rk = '?'
     if 'analytic_rank' in ec:
         an_rk = str(ec['analytic_rank'])
     ngens = '0'
     gens_str = []
     if 'gens' in ec:
-        gens_str = ["["+":".join([c for c in P])+"]" for P in ec['gens']]
+        gens_str = ["[" + ":".join([c for c in P]) + "]" for P in ec['gens']]
         ngens = str(len(gens_str))
     sha = '?'
     if 'sha_an' in ec:
@@ -557,21 +578,21 @@ def make_isoclass_line(ec):
     """
     mat = ''
     if 'isogeny_matrix' in ec:
-        mat = str(ec['isogeny_matrix']).replace(' ','')
+        mat = str(ec['isogeny_matrix']).replace(' ', '')
     else:
         print("Making isogeny matrix for class %s" % ec['label'])
         from lmfdb.ecnf.isog_class import permute_mat
         from lmfdb.ecnf.WebEllipticCurve import FIELD
         K = FIELD(ec['field_label'])
-        curves = nfcurves.find({'field_label' : ec['field_label'],
-                                'conductor_label' : ec['conductor_label'],
-                                'iso_label' : ec['iso_label']}).sort('number')
+        curves = nfcurves.find({'field_label': ec['field_label'],
+                                'conductor_label': ec['conductor_label'],
+                                'iso_label': ec['iso_label']}).sort('number')
         Elist = [EllipticCurve([K.parse_NFelt(x) for x in c['ainvs']]) for c in curves]
         cl = Elist[0].isogeny_class()
-        perm = dict([(i,cl.index(E)) for i,E in enumerate(Elist)])
+        perm = dict([(i, cl.index(E)) for i, E in enumerate(Elist)])
         mat = permute_mat(cl.matrix(), perm, True)
         n = len(Elist)
-        mat = str([list(ri) for ri in mat.rows()]).replace(" ","")
+        mat = str([list(ri) for ri in mat.rows()]).replace(" ", "")
 
     output_fields = [ec['field_label'],
                      ec['conductor_label'],
@@ -588,7 +609,7 @@ def download_curve_data(field_label, base_path, min_norm=0, max_norm=None):
     """
     query = {}
     query['field_label'] = field_label
-    query['conductor_norm'] = {'$gte' : int(min_norm)}
+    query['conductor_norm'] = {'$gte': int(min_norm)}
     if max_norm:
         query['conductor_norm']['$lte'] = int(max_norm)
     else:
@@ -599,16 +620,16 @@ def download_curve_data(field_label, base_path, min_norm=0, max_norm=None):
 
     file = {}
     prefixes = ['curves', 'curve_data', 'isoclass']
-    suffix = ''.join([".",field_label,".",str(min_norm),"-",str(max_norm)])
+    suffix = ''.join([".", field_label, ".", str(min_norm), "-", str(max_norm)])
     for prefix in prefixes:
-        filename = os.path.join(base_path, ''.join([prefix,suffix]))
-        file[prefix] = open(filename,'w')
+        filename = os.path.join(base_path, ''.join([prefix, suffix]))
+        file[prefix] = open(filename, 'w')
 
     for ec in res:
-        file['curves'].write(make_curves_line(ec)+"\n")
-        file['curve_data'].write(make_curve_data_line(ec)+"\n")
+        file['curves'].write(make_curves_line(ec) + "\n")
+        file['curve_data'].write(make_curve_data_line(ec) + "\n")
         if ec['number'] == 1:
-            file['isoclass'].write(make_isoclass_line(ec)+"\n")
+            file['isoclass'].write(make_isoclass_line(ec) + "\n")
 
     for prefix in prefixes:
         file[prefix].close()

--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -38,7 +38,7 @@ field) and value types (with examples):
    - torsion_order            int
    - torsion_structure        list of 0, 1 or 2 ints
    - gens                     list of lists of 3 lists of d lists of 2 ints
-   - torsion_gens             list of lists of 3 lists of d lists of 2 ints
+   - torsion_gens             list of lists of 3 lists of d lists of strings
    - sha_an                   int
    - isogeny_matrix     *     list of list of ints (degrees)
 

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -17,16 +17,20 @@ logger = make_logger("ecnf")
 
 ecdb = None
 
+
 def db_ec():
     global ecdb
     if ecdb is None:
         ecdb = lmfdb.base.getDBConnection().elliptic_curves.nfcurves
     return ecdb
 
+
 class ECNF_isoclass(object):
+
     """
     Class for an isogeny class of elliptic curves over Q
     """
+
     def __init__(self, dbdata):
         """
         Arguments:
@@ -49,27 +53,27 @@ class ECNF_isoclass(object):
         print "label = %s" % label
         try:
             if label[-1].isdigit():
-                data = db_ec().find_one({"label" : label})
+                data = db_ec().find_one({"label": label})
             else:
-                data = db_ec().find_one({"label" : label+"1"})
+                data = db_ec().find_one({"label": label + "1"})
         except AttributeError:
-            return "Invalid label" # caller must catch this and raise an error
+            return "Invalid label"  # caller must catch this and raise an error
 
         if data:
             return ECNF_isoclass(data)
-        return "Class not found" # caller must catch this and raise an error
+        return "Class not found"  # caller must catch this and raise an error
 
     def make_class(self):
         self.ECNF = ECNF.by_label(self.label)
 
         # Create a list of the curves in the class from the database
         self.db_curves = [ECNF(c) for c in db_ec().find(
-            {'field_label' : self.field_label, 'conductor_label' :
-             self.conductor_label, 'iso_label' : self.iso_label}).sort('number')]
+            {'field_label': self.field_label, 'conductor_label':
+             self.conductor_label, 'iso_label': self.iso_label}).sort('number')]
         size = len(self.db_curves)
 
         # Extract the isogeny degree matrix from the database if possible, else create it
-        if hasattr(self,'isogeny_matrix'):
+        if hasattr(self, 'isogeny_matrix'):
             from sage.matrix.all import Matrix
             self.isogeny_matrix = Matrix(self.isogeny_matrix)
         else:
@@ -85,21 +89,20 @@ class ECNF_isoclass(object):
         self.curves = [[c.short_label, c.urls['curve'], c.latex_ainvs] for c in self.db_curves]
 
         self.urls = {}
-        self.urls['class'] = url_for(".show_ecnf_isoclass", nf = self.field_label, conductor_label=self.conductor_label, class_label = self.iso_label)
-        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf = self.field_label, conductor_label=self.conductor_label)
+        self.urls['class'] = url_for(".show_ecnf_isoclass", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label)
+        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=self.conductor_label)
         self.urls['field'] = url_for('.show_ecnf1', nf=self.ECNF.field_label)
         self.field = self.ECNF.field
         if self.field.is_real_quadratic():
-            self.hmf_label = "-".join([self.field.label,self.conductor_label,self.iso_label])
+            self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
 
         if self.field.is_imag_quadratic():
-            self.bmf_label = "-".join([self.field.label,self.conductor_label,self.iso_label])
-
+            self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
 
         self.friends = []
         if self.field.is_real_quadratic():
-            self.friends += [('Hilbert Modular Form '+self.hmf_label, self.urls['hmf'])]
+            self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
         if self.field.is_imag_quadratic():
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
 
@@ -121,7 +124,7 @@ def make_graph(M):
     """
     from sage.schemes.elliptic_curves.ell_curve_isogeny import fill_isogeny_matrix, unfill_isogeny_matrix
     from sage.graphs.graph import Graph
-    n = M.nrows() # = M.ncols()
+    n = M.nrows()  # = M.ncols()
     G = Graph(unfill_isogeny_matrix(M), format='weighted_adjacency_matrix')
     MM = fill_isogeny_matrix(M)
     # The maximum degree classifies the shape of the isogeny
@@ -134,79 +137,82 @@ def make_graph(M):
     elif n == 2:
         # one edge, two vertices.  We align horizontally and put
         # the lower number on the left vertex.
-        G.set_pos(pos={0:[-0.5,0],1:[0.5,0]})
+        G.set_pos(pos={0: [-0.5, 0], 1: [0.5, 0]})
     else:
         maxdegree = max(max(MM))
         if n == 3:
             # o--o--o
             centervert = [i for i in range(3) if max(MM.row(i)) < maxdegree][0]
             other = [i for i in range(3) if i != centervert]
-            G.set_pos(pos={centervert:[0,0],other[0]:[-1,0],other[1]:[1,0]})
+            G.set_pos(pos={centervert: [0, 0], other[0]: [-1, 0], other[1]: [1, 0]})
         elif maxdegree == 4:
             # o--o<8
             centervert = [i for i in range(4) if max(MM.row(i)) < maxdegree][0]
             other = [i for i in range(4) if i != centervert]
-            G.set_pos(pos={centervert:[0,0],other[0]:[0,1],other[1]:[-0.8660254,-0.5],other[2]:[0.8660254,-0.5]})
+            G.set_pos(pos={centervert: [0, 0], other[0]: [0, 1], other[1]: [-0.8660254, -0.5], other[2]: [0.8660254, -0.5]})
         elif maxdegree == 27:
             # o--o--o--o
             centers = [i for i in range(4) if list(MM.row(i)).count(3) == 2]
-            left = [j for j in range(4) if MM[centers[0],j] == 3 and j not in centers][0]
-            right = [j for j in range(4) if MM[centers[1],j] == 3 and j not in centers][0]
-            G.set_pos(pos={left:[-1.5,0],centers[0]:[-0.5,0],centers[1]:[0.5,0],right:[1.5,0]})
+            left = [j for j in range(4) if MM[centers[0], j] == 3 and j not in centers][0]
+            right = [j for j in range(4) if MM[centers[1], j] == 3 and j not in centers][0]
+            G.set_pos(pos={left: [-1.5, 0], centers[0]: [-0.5, 0], centers[1]: [0.5, 0], right: [1.5, 0]})
         elif n == 4:
             # square
-            opp = [i for i in range(1,4) if not MM[0,i].is_prime()][0]
-            other = [i for i in range(1,4) if i != opp]
-            G.set_pos(pos={0:[1,1],other[0]:[-1,1],opp:[-1,-1],other[1]:[1,-1]})
+            opp = [i for i in range(1, 4) if not MM[0, i].is_prime()][0]
+            other = [i for i in range(1, 4) if i != opp]
+            G.set_pos(pos={0: [1, 1], other[0]: [-1, 1], opp: [-1, -1], other[1]: [1, -1]})
         elif maxdegree == 8:
             # 8>o--o<8
             centers = [i for i in range(6) if list(MM.row(i)).count(2) == 3]
-            left = [j for j in range(6) if MM[centers[0],j] == 2 and j not in centers]
-            right = [j for j in range(6) if MM[centers[1],j] == 2 and j not in centers]
-            G.set_pos(pos={centers[0]:[-0.5,0],left[0]:[-1,0.8660254],left[1]:[-1,-0.8660254],centers[1]:[0.5,0],right[0]:[1,0.8660254],right[1]:[1,-0.8660254]})
+            left = [j for j in range(6) if MM[centers[0], j] == 2 and j not in centers]
+            right = [j for j in range(6) if MM[centers[1], j] == 2 and j not in centers]
+            G.set_pos(pos={centers[0]: [-0.5, 0], left[0]: [-1, 0.8660254], left[1]: [-1, -0.8660254], centers[1]: [0.5, 0], right[0]: [1, 0.8660254], right[1]: [1, -0.8660254]})
         elif maxdegree == 18:
             # two squares joined on an edge
             centers = [i for i in range(6) if list(MM.row(i)).count(3) == 2]
-            top = [j for j in range(6) if MM[centers[0],j] == 3]
-            bl = [j for j in range(6) if MM[top[0],j] == 2][0]
-            br = [j for j in range(6) if MM[top[1],j] == 2][0]
-            G.set_pos(pos={centers[0]:[0,0.5],centers[1]:[0,-0.5],top[0]:[-1,0.5],top[1]:[1,0.5],bl:[-1,-0.5],br:[1,-0.5]})
+            top = [j for j in range(6) if MM[centers[0], j] == 3]
+            bl = [j for j in range(6) if MM[top[0], j] == 2][0]
+            br = [j for j in range(6) if MM[top[1], j] == 2][0]
+            G.set_pos(pos={centers[0]: [0, 0.5], centers[1]: [0, -0.5], top[0]: [-1, 0.5], top[1]: [1, 0.5], bl: [-1, -0.5], br: [1, -0.5]})
         elif maxdegree == 16:
             # tree from bottom, 3 regular except for the leaves.
             centers = [i for i in range(8) if list(MM.row(i)).count(2) == 3]
-            center = [i for i in centers if len([j for j in centers if MM[i,j] == 2]) == 2][0]
+            center = [i for i in centers if len([j for j in centers if MM[i, j] == 2]) == 2][0]
             centers.remove(center)
-            bottom = [j for j in range(8) if MM[center,j] == 2 and j not in centers][0]
-            left = [j for j in range(8) if MM[centers[0],j] == 2 and j != center]
-            right = [j for j in range(8) if MM[centers[1],j] == 2 and j != center]
-            G.set_pos(pos={center:[0,0],bottom:[0,-1],centers[0]:[-0.8660254,0.5],centers[1]:[0.8660254,0.5],left[0]:[-0.8660254,1.5],right[0]:[0.8660254,1.5],left[1]:[-1.7320508,0],right[1]:[1.7320508,0]})
+            bottom = [j for j in range(8) if MM[center, j] == 2 and j not in centers][0]
+            left = [j for j in range(8) if MM[centers[0], j] == 2 and j != center]
+            right = [j for j in range(8) if MM[centers[1], j] == 2 and j != center]
+            G.set_pos(pos={center: [0, 0], bottom: [0, -1], centers[0]: [-0.8660254, 0.5], centers[1]: [0.8660254, 0.5], left[0]: [-0.8660254, 1.5], right[0]: [0.8660254, 1.5], left[1]: [-1.7320508, 0], right[1]: [1.7320508, 0]})
         elif maxdegree == 12:
             # tent
             centers = [i for i in range(8) if list(MM.row(i)).count(2) == 3]
-            left = [j for j in range(8) if MM[centers[0],j] == 2]
+            left = [j for j in range(8) if MM[centers[0], j] == 2]
             right = []
             for i in range(3):
-                right.append([j for j in range(8) if MM[centers[1],j] == 2 and MM[left[i],j] == 3][0])
-            G.set_pos(pos={centers[0]:[-0.3,0],centers[1]:[0.3,0],
-                           left[0]:[-0.14,0.15], right[0]:[0.14,0.15],
-                           left[1]:[-0.14,-0.15],right[1]:[0.14,-0.15],
-                           left[2]:[-0.14,-0.3],right[2]:[0.14,-0.3]})
+                right.append([j for j in range(8) if MM[centers[1], j] == 2 and MM[left[i], j] == 3][0])
+            G.set_pos(pos={centers[0]: [-0.3, 0], centers[1]: [0.3, 0],
+                           left[0]: [-0.14, 0.15], right[0]: [0.14, 0.15],
+                           left[1]: [-0.14, -0.15], right[1]: [0.14, -0.15],
+                           left[2]: [-0.14, -0.3], right[2]: [0.14, -0.3]})
 
-    G.relabel(range(1,n+1))
+    G.relabel(range(1, n + 1))
     return G
 
-def make_iso_matrix(clist): # clist is a list of ECNFs
+
+def make_iso_matrix(clist):  # clist is a list of ECNFs
     Elist = [E.E for E in clist]
     cl = Elist[0].isogeny_class()
-    perm = dict([(i,cl.index(E)) for i,E in enumerate(Elist)])
+    perm = dict([(i, cl.index(E)) for i, E in enumerate(Elist)])
     return permute_mat(cl.matrix(), perm, True)
+
 
 def invert_perm(perm):
     n = len(perm)
-    iperm = [0]*n # just to set the length
+    iperm = [0] * n  # just to set the length
     for i in range(n):
         iperm[perm[i]] = i
     return iperm
+
 
 def permute_mat(M, perm, inverse=False):
     """permute rows and columns of M according to perm.  M should be
@@ -216,4 +222,4 @@ def permute_mat(M, perm, inverse=False):
     iperm = [int(i) for i in perm]
     if inverse:
         iperm = invert_perm(iperm)
-    return M.matrix_from_rows_and_columns(iperm,iperm)
+    return M.matrix_from_rows_and_columns(iperm, iperm)

--- a/lmfdb/ecnf/kraus.py
+++ b/lmfdb/ecnf/kraus.py
@@ -9,8 +9,11 @@ from sage.schemes.elliptic_curves.all import EllipticCurve
 # 1. Number field functions:
 
 # Stopgap function waiting for Sage's divides() function to be happy with 0
-def divides(I,a):
+
+
+def divides(I, a):
     return a.is_zero() or I.divides(a)
+
 
 def CRT_nf(reslist, Ilist, check=True):
     r"""
@@ -29,32 +32,34 @@ def CRT_nf(reslist, Ilist, check=True):
     An integral element x such that x-reslist[i] is in Ilist[i] for all i.
     """
     n = len(reslist)
-    if n==0:
+    if n == 0:
         # we have no parent field so this is all we can do
         return 0
-    if n==1:
+    if n == 1:
         return reslist[0]
-    if n>2:
+    if n > 2:
         # use induction / recursion
-        x = CRT_nf([reslist[0],CRT_nf(reslist[1:],Ilist[1:])],
-                   [Ilist[0],prod(Ilist[1:])])
+        x = CRT_nf([reslist[0], CRT_nf(reslist[1:], Ilist[1:])],
+                   [Ilist[0], prod(Ilist[1:])])
         if check:
-            check_CRT_nf(reslist,Ilist,x)
+            check_CRT_nf(reslist, Ilist, x)
         return x
     # now n=2
     r = Ilist[0].element_1_mod(Ilist[1])
-    x = ((1-r)*reslist[0]+r*reslist[1]).mod(prod(Ilist))
+    x = ((1 - r) * reslist[0] + r * reslist[1]).mod(prod(Ilist))
     if check:
-        check_CRT_nf(reslist,Ilist,x)
+        check_CRT_nf(reslist, Ilist, x)
     return x
+
 
 def check_CRT_nf(reslist, Ilist, x):
     r"""
     Utility for checking CRT solutions.
     """
-    assert all([x-xi in Ii for xi,Ii in zip(reslist, Ilist)])
+    assert all([x - xi in Ii for xi, Ii in zip(reslist, Ilist)])
 
 # 2. elliptic curve functions concerning minimal models over number fields:
+
 
 def minimal_discriminant_ideal(E):
     r"""
@@ -70,8 +75,9 @@ def minimal_discriminant_ideal(E):
     local minimal model for E at P.
     """
     dat = E.local_data()
-    return prod([d.prime()**d.discriminant_valuation() for d in dat],
+    return prod([d.prime() ** d.discriminant_valuation() for d in dat],
                 E.base_field().ideal(1))
+
 
 def non_minimal_primes(E):
     r"""
@@ -91,6 +97,7 @@ def non_minimal_primes(E):
     D = E.discriminant()
     return [d.prime() for d in dat if D.valuation(d.prime()) > d.discriminant_valuation()]
 
+
 def is_global_minimal_model(E):
     r"""
     Returns whether this elliptic curve is a global minimal model.
@@ -107,6 +114,7 @@ def is_global_minimal_model(E):
     if not E.is_global_integral_model():
         return False
     return non_minimal_primes(E) == []
+
 
 def global_minimality_class(E):
     r"""
@@ -125,15 +133,16 @@ def global_minimality_class(E):
     """
     K = E.base_field()
     Cl = K.class_group()
-    if K.class_number()==1:
+    if K.class_number() == 1:
         return Cl(1)
     D = E.discriminant()
     dat = E.local_data()
     primes = [d.prime() for d in dat]
     vals = [d.discriminant_valuation() for d in dat]
-    I = prod([P**((D.valuation(P)-v)//12) for P,v in zip(primes,vals)],
+    I = prod([P ** ((D.valuation(P) - v) // 12) for P, v in zip(primes, vals)],
              E.base_field().ideal(1))
     return Cl(I)
+
 
 def has_global_minimal_model(E):
     r"""
@@ -157,7 +166,8 @@ def has_global_minimal_model(E):
 # model integral at P and with invariants c4, c6.  They are satisfied
 # globally if satisfied locally at all primes.
 
-def check_c4c6_nonsingular(c4,c6):
+
+def check_c4c6_nonsingular(c4, c6):
     r"""
     Check if c4, c6 are integral with valid associated discriminant.
 
@@ -172,13 +182,14 @@ def check_c4c6_nonsingular(c4,c6):
     """
     if not (c4.is_integral() and c6.is_integral()):
         return False
-    D = (c4**3-c6**2)/1728
+    D = (c4 ** 3 - c6 ** 2) / 1728
     return not D.is_zero() and D.is_integral()
 
 # Wrapper function for local Kraus check, outsources the real work to
 # other functions for primes dividing 2 or 3:
 
-def check_Kraus_local(c4,c6,P, assume_nonsingular=False):
+
+def check_Kraus_local(c4, c6, P, assume_nonsingular=False):
     r"""
     Check Kraus's condictions locally at a prime P.
 
@@ -197,15 +208,16 @@ def check_Kraus_local(c4,c6,P, assume_nonsingular=False):
     with invariants c4, c6.
     """
     if not assume_nonsingular:
-        if not check_c4c6_nonsingular(c4,c6):
+        if not check_c4c6_nonsingular(c4, c6):
             return False, None
     if P.divides(2):
-        return check_Kraus_local_2(c4,c6,P,True)
+        return check_Kraus_local_2(c4, c6, P, True)
     if P.divides(3):
-        return check_Kraus_local_3(c4,c6,P,True)
+        return check_Kraus_local_3(c4, c6, P, True)
     return True, 0
 
-def c4c6_model(c4,c6, assume_nonsingular=False):
+
+def c4c6_model(c4, c6, assume_nonsingular=False):
     r"""
     Return the elliptic curve [0,0,0,-c4/48,-c6/864] with given c-invariants.
 
@@ -224,13 +236,14 @@ def c4c6_model(c4,c6, assume_nonsingular=False):
     raises an ArithmeticError otherwise.
     """
     if not assume_nonsingular:
-        if not check_c4c6_nonsingular(c4,c6):
+        if not check_c4c6_nonsingular(c4, c6):
             return None
-    return EllipticCurve([0,0,0,-c4/48,-c6/864])
+    return EllipticCurve([0, 0, 0, -c4 / 48, -c6 / 864])
 
 # Kraus test and check for primes dividing 3:
 
-def red_mod(a,P):
+
+def red_mod(a, P):
     r"""
     Reduce a mod P assuming only that a is P-integral
     """
@@ -239,16 +252,18 @@ def red_mod(a,P):
     F = OK.residue_field(P)
     return OK(F(a))
 
-def make_integral(a,P,e):
+
+def make_integral(a, P, e):
     r"""
     Given a in O_{K,P} return b in O_K with P^e|(a-b)
     """
-    for b in (P**e).residues():
-        if (a-b).valuation(P) >= e:
+    for b in (P ** e).residues():
+        if (a - b).valuation(P) >= e:
             return b
-    raise ArithmeticError("Cannot lift %s to O_K mod (%s)^%s" % (a,P,e))
+    raise ArithmeticError("Cannot lift %s to O_K mod (%s)^%s" % (a, P, e))
 
-def test_b2_local(c4,c6,P,b2):
+
+def test_b2_local(c4, c6, P, b2):
     r"""
     Test if b2 is valid at a prime P dividing 3.
 
@@ -265,8 +280,8 @@ def test_b2_local(c4,c6,P,b2):
     The elliptic curve which is the (b2/12,0,0)-transform of
     [0,0,0,-c4/48,-c6/864] if this is integral at P, else False.
     """
-    E = c4c6_model(c4,c6).rst_transform(b2/12,0,0)
-    if not (c4,c6) == E.c_invariants():
+    E = c4c6_model(c4, c6).rst_transform(b2 / 12, 0, 0)
+    if not (c4, c6) == E.c_invariants():
         print("test_b2_local: wrong c-invariants at P=%s" % P)
         return False
     if not E.is_local_integral_model(P):
@@ -274,7 +289,8 @@ def test_b2_local(c4,c6,P,b2):
         return False
     return E
 
-def test_b2_global(c4,c6,b2):
+
+def test_b2_global(c4, c6, b2):
     r"""
     Test if b2 is valid at all primes P dividing 3.
 
@@ -290,8 +306,8 @@ def test_b2_global(c4,c6,b2):
     [0,0,0,-c4/48,-c6/864] if this is integral at all primes P
     dividing 3, else False.
     """
-    E = c4c6_model(c4,c6).rst_transform(b2/12,0,0)
-    if not (c4,c6) == E.c_invariants():
+    E = c4c6_model(c4, c6).rst_transform(b2 / 12, 0, 0)
+    if not (c4, c6) == E.c_invariants():
         print("test_b2_global: wrong c-invariants")
         return False
     if not all([E.is_local_integral_model(P) for P in c4.parent().primes_above(3)]):
@@ -299,7 +315,8 @@ def test_b2_global(c4,c6,b2):
         return False
     return E
 
-def check_Kraus_local_3(c4,c6,P, assume_nonsingular=False):
+
+def check_Kraus_local_3(c4, c6, P, assume_nonsingular=False):
     r"""
     Test if c4,c6 satisfy Kraus's conditions at a prime P dividing 3.
 
@@ -319,32 +336,33 @@ def check_Kraus_local_3(c4,c6,P, assume_nonsingular=False):
     (b2/12,0,0)-transform of [0,0,0,-c4/48,-c6/864] is integral at P.
     """
     if not assume_nonsingular:
-        if not check_c4c6_nonsingular(c4,c6):
+        if not check_c4c6_nonsingular(c4, c6):
             return False, 0
     e = P.ramification_index()
-    P3 = P**e
-    if c4.valuation(P)==0:
-        b2 = (-c6*c4.inverse_mod(P3)).mod(P3)
-        assert test_b2_local(c4,c6,P,b2)
+    P3 = P ** e
+    if c4.valuation(P) == 0:
+        b2 = (-c6 * c4.inverse_mod(P3)).mod(P3)
+        assert test_b2_local(c4, c6, P, b2)
         return True, b2
-    if c6.valuation(P)>=3*e:
+    if c6.valuation(P) >= 3 * e:
         b2 = c6.parent().zero()
-        assert test_b2_local(c4,c6,P,b2)
+        assert test_b2_local(c4, c6, P, b2)
         return True, b2
     # check for a solution x to x^3-3*x*c4-26=0 (27), such an x must
     # also satisfy x*c4+c6=0 (3) and x^2=c4 (3) and x^3=-c6 (9), and
     # if x is a solution then so is any x'=x (3).
-    P27 = P3**3
+    P27 = P3 ** 3
     for x in P3.residues():
-        if (x*c4+c6).valuation(P) >= e:
-            if (x*(x*x-3*c4)-2*c6).valuation(P) >= 3*e:
-                assert test_b2_local(c4,c6,P,x)
+        if (x * c4 + c6).valuation(P) >= e:
+            if (x * (x * x - 3 * c4) - 2 * c6).valuation(P) >= 3 * e:
+                assert test_b2_local(c4, c6, P, x)
                 return True, x
     return False, 0
 
 # Kraus test and check for primes dividing 2:
 
-def sqrt_mod_4(x,P):
+
+def sqrt_mod_4(x, P):
     r"""
     Returns a local square root mod 4, if it exists.
 
@@ -362,13 +380,14 @@ def sqrt_mod_4(x,P):
     """
     K = x.parent()
     e = P.ramification_index()
-    P2 = P**e
+    P2 = P ** e
     for r in P2.residues():
-        if (r*r-x).valuation(P) >= 2*e:
+        if (r * r - x).valuation(P) >= 2 * e:
             return True, r
     return False, 0
 
-def test_a1a3_local(c4,c6,P,a1,a3):
+
+def test_a1a3_local(c4, c6, P, a1, a3):
     r"""
     Test if a1,a3 are valid at a prime P dividing 2.
 
@@ -385,8 +404,8 @@ def test_a1a3_local(c4,c6,P,a1,a3):
     The elliptic curve which is the (a1^2/12,a1/2,a3/2)-transform of
     [0,0,0,-c4/48,-c6/864] if this is integral at P, else False.
     """
-    E = c4c6_model(c4,c6).rst_transform(a1**2/12,a1/2,a3/2)
-    if not (c4,c6) == E.c_invariants():
+    E = c4c6_model(c4, c6).rst_transform(a1 ** 2 / 12, a1 / 2, a3 / 2)
+    if not (c4, c6) == E.c_invariants():
         print("test_a1a3_local: wrong c-invariants at P=%s" % P)
         return False
     if not E.is_local_integral_model(P):
@@ -394,7 +413,8 @@ def test_a1a3_local(c4,c6,P,a1,a3):
         return False
     return E
 
-def test_a1a3_global(c4,c6,a1,a3):
+
+def test_a1a3_global(c4, c6, a1, a3):
     r"""
     Test if a1,a3 are valid at all primes P dividing 2.
 
@@ -410,8 +430,8 @@ def test_a1a3_global(c4,c6,a1,a3):
     [0,0,0,-c4/48,-c6/864] if this is integral at all primes P
     dividing 2, else False.
     """
-    E = c4c6_model(c4,c6).rst_transform(a1**2/12,a1/2,a3/2)
-    if not (c4,c6) == E.c_invariants():
+    E = c4c6_model(c4, c6).rst_transform(a1 ** 2 / 12, a1 / 2, a3 / 2)
+    if not (c4, c6) == E.c_invariants():
         print "wrong c-invariants"
         return False
     if not all([E.is_local_integral_model(P) for P in c4.parent().primes_above(2)]):
@@ -419,7 +439,8 @@ def test_a1a3_global(c4,c6,a1,a3):
         return False
     return E
 
-def test_rst_global(c4,c6,r,s,t):
+
+def test_rst_global(c4, c6, r, s, t):
     r"""
     Test if the (r,s,t)-transform of the standard c4,c6-model is integral.
 
@@ -435,8 +456,8 @@ def test_rst_global(c4,c6,r,s,t):
     [0,0,0,-c4/48,-c6/864] if this is integral at all primes P, else
     False.
     """
-    E = c4c6_model(c4,c6).rst_transform(r,s,t)
-    if not (c4,c6) == E.c_invariants():
+    E = c4c6_model(c4, c6).rst_transform(r, s, t)
+    if not (c4, c6) == E.c_invariants():
         print("test_rst_global: wrong c-invariants")
         return False
     if not E.is_global_integral_model():
@@ -445,7 +466,8 @@ def test_rst_global(c4,c6,r,s,t):
         return False
     return E
 
-def check_Kraus_local_2(c4,c6,P, assume_nonsingular=False):
+
+def check_Kraus_local_2(c4, c6, P, assume_nonsingular=False):
     r"""
     Test if c4,c6 satisfy Kraus's conditions at a prime P dividing 2.
 
@@ -466,40 +488,41 @@ def check_Kraus_local_2(c4,c6,P, assume_nonsingular=False):
     integral at P.
     """
     if not assume_nonsingular:
-        if not check_c4c6_nonsingular(c4,c6):
-            return False,0,0
+        if not check_c4c6_nonsingular(c4, c6):
+            return False, 0, 0
     e = P.ramification_index()
-    P2 = P**e
+    P2 = P ** e
     c4val = c4.valuation(P)
-    if c4val==0:
-        flag, t = sqrt_mod_4(-c6,P)
+    if c4val == 0:
+        flag, t = sqrt_mod_4(-c6, P)
         if not flag:
-            return False,0,0
+            return False, 0, 0
         # In the next 2 lines we are dividing by units at P,
         # but the results may not be globally integral
-        a1 = make_integral(c4/t,P,e)
-        a3 = make_integral((c6+a1**6)/(4*a1**3),P,e)
-        assert test_a1a3_local(c4,c6,P,a1,a3)
-        return True, a1,a3
-    if c4val >= 4*e:
-        flag, a3 = sqrt_mod_4(c6/8,P)
+        a1 = make_integral(c4 / t, P, e)
+        a3 = make_integral((c6 + a1 ** 6) / (4 * a1 ** 3), P, e)
+        assert test_a1a3_local(c4, c6, P, a1, a3)
+        return True, a1, a3
+    if c4val >= 4 * e:
+        flag, a3 = sqrt_mod_4(c6 / 8, P)
         if not flag:
-            return False,0,0
+            return False, 0, 0
         a1 = 0
-        assert test_a1a3_local(c4,c6,P,a1,a3)
-        return True, a1,a3
+        assert test_a1a3_local(c4, c6, P, a1, a3)
+        return True, a1, a3
     # general case, val(c4) strictly between 0 and 4e
     for a1 in P2.residues():
-        Px = -a1**6+3*a1**2*c4+2*c6
-        if Px.valuation(P)>=4*e:
-            Px16 = Px/16
-            flag, a3 = sqrt_mod_4(Px16,P)
-            if flag and (4*a1*a1*Px-(a1**4-c4)**2).valuation(P)>=8*e:
-                assert test_a1a3_local(c4,c6,P,a1,a3)
-                return True, a1,a3
-    return False,0,0
+        Px = -a1 ** 6 + 3 * a1 ** 2 * c4 + 2 * c6
+        if Px.valuation(P) >= 4 * e:
+            Px16 = Px / 16
+            flag, a3 = sqrt_mod_4(Px16, P)
+            if flag and (4 * a1 * a1 * Px - (a1 ** 4 - c4) ** 2).valuation(P) >= 8 * e:
+                assert test_a1a3_local(c4, c6, P, a1, a3)
+                return True, a1, a3
+    return False, 0, 0
 
-def check_Kraus_global(c4,c6, assume_nonsingular=False, debug=False):
+
+def check_Kraus_global(c4, c6, assume_nonsingular=False, debug=False):
     r"""
     Test if c4,c6 satisfy Kraus's conditions at all primes.
 
@@ -516,76 +539,78 @@ def check_Kraus_global(c4,c6, assume_nonsingular=False, debug=False):
     elliptic curve E which is integral and has c-invarinats c4,c6.
     """
     if not assume_nonsingular:
-        if not check_c4c6_nonsingular(c4,c6):
+        if not check_c4c6_nonsingular(c4, c6):
             return False
 
     # Check all primes dividing 3; for each get the value of b2
     K = c4.parent()
     three = K.ideal(3)
     Plist3 = K.primes_above(3)
-    dat = [check_Kraus_local_3(c4,c6,P,True) for P in Plist3]
+    dat = [check_Kraus_local_3(c4, c6, P, True) for P in Plist3]
     if not all([d[0] for d in dat]):
         if debug:
-            print("Local Kraus condition for (c4,c6)=(%s,%s) fails at some prime dividing 3" % (c4,c6))
+            print("Local Kraus condition for (c4,c6)=(%s,%s) fails at some prime dividing 3" % (c4, c6))
         return False
     if debug:
-        print("Local Kraus conditions for (c4,c6)=(%s,%s) pass at all primes dividing 3" % (c4,c6))
+        print("Local Kraus conditions for (c4,c6)=(%s,%s) pass at all primes dividing 3" % (c4, c6))
 
     # OK at all these primes; now use CRT to combine the b2 values to
     # get a single residue class for b2 mod 3:
     b2list = [d[1] for d in dat]
-    P3list = [P**three.valuation(P) for P in Plist3]
-    b2 = CRT_nf(b2list,P3list).mod(three)
+    P3list = [P ** three.valuation(P) for P in Plist3]
+    b2 = CRT_nf(b2list, P3list).mod(three)
 
     # test that this b2 value works at all P|3:
-    E = test_b2_global(c4,c6,b2)
+    E = test_b2_global(c4, c6, b2)
     if not E:
         raise RuntimeError("Error in check_Kraus_global at some prime dividing 3")
     else:
         if debug:
-            print("Using b2=%s gives a model integral at 3:\n%s" % (b2,E.ainvs()))
+            print("Using b2=%s gives a model integral at 3:\n%s" % (b2, E.ainvs()))
 
     # Check all primes dividing 2; for each get the value of a1,a3
     two = K.ideal(2)
     Plist2 = K.primes_above(2)
-    dat = [check_Kraus_local_2(c4,c6,P,True) for P in Plist2]
+    dat = [check_Kraus_local_2(c4, c6, P, True) for P in Plist2]
     if not all([d[0] for d in dat]):
         if debug:
-            print("Local Kraus condition for (c4,c6)=(%s,%s) fails at some prime dividing 2" % (c4,c6))
+            print("Local Kraus condition for (c4,c6)=(%s,%s) fails at some prime dividing 2" % (c4, c6))
         return False
     if debug:
-        print("Local Kraus conditions for (c4,c6)=(%s,%s) pass at all primes dividing 2" % (c4,c6))
+        print("Local Kraus conditions for (c4,c6)=(%s,%s) pass at all primes dividing 2" % (c4, c6))
 
     # OK at all these primes; now use CRT to combine the a1,a3 values
     # to get residue classes mod 2:
     a1list = [d[1] for d in dat]
     a3list = [d[2] for d in dat]
-    P2list = [P**two.valuation(P) for P in Plist2]
-    a1 = CRT_nf(a1list,P2list)
-    a3 = CRT_nf(a3list,P2list)
+    P2list = [P ** two.valuation(P) for P in Plist2]
+    a1 = CRT_nf(a1list, P2list)
+    a3 = CRT_nf(a3list, P2list)
     # These are integral at all primes dividing 2 but not necessarily
     # globally, yet we want to reduce them modulo 2!
+
     def is_2integral(a):
-        return all([a.valuation(P)>=0 for P in Plist2])
+        return all([a.valuation(P) >= 0 for P in Plist2])
+
     def red_mod2(a):
         for r in K.ideal(2).residues():
-            if is_2integral((a-r)/2):
+            if is_2integral((a - r) / 2):
                 return r
         raise ArithmeticError("%s cannot be reduced mod 2" % a)
     if debug:
-        print("Before reduction mod 2, (a1,a3)=(%s,%s)" % (a1,a3))
-    #a1 = red_mod2(a1)
-    #a3 = red_mod2(a3)
+        print("Before reduction mod 2, (a1,a3)=(%s,%s)" % (a1, a3))
+    # a1 = red_mod2(a1)
+    # a3 = red_mod2(a3)
     if debug:
-        print("After  reduction mod 2, (a1,a3)=(%s,%s)" % (a1,a3))
+        print("After  reduction mod 2, (a1,a3)=(%s,%s)" % (a1, a3))
 
     # test that these a1,a3 values work at all P|2:
-    E = test_a1a3_global(c4,c6,a1,a3)
+    E = test_a1a3_global(c4, c6, a1, a3)
     if not E:
         raise RuntimeError("Error in check_Kraus_global at some prime dividing 2")
     else:
         if debug:
-            print("Using (a1,a3)=(%s,%s) gives a model integral at 2:\n%s" % (a1,a3,E.ainvs()))
+            print("Using (a1,a3)=(%s,%s) gives a model integral at 2:\n%s" % (a1, a3, E.ainvs()))
 
     # Now we put together the 2-adic and 3-adic transforms to get a
     # global (r,s,t)-transform from [0,0,0,-c4/48,-c6/864] to a global
@@ -600,24 +625,25 @@ def check_Kraus_global(c4,c6, assume_nonsingular=False, debug=False):
     # 3-integral).  Since a1 was only determined mod 2 this can be
     # fixed first.
 
-    a1 = CRT_nf([0,a1],[K.ideal(three),K.ideal(two)])
-    r = b2/3 - a1**2/4
-    s = a1/2
-    t = s*(b2-a1**2)/3 + a3/2
+    a1 = CRT_nf([0, a1], [K.ideal(three), K.ideal(two)])
+    r = b2 / 3 - a1 ** 2 / 4
+    s = a1 / 2
+    t = s * (b2 - a1 ** 2) / 3 + a3 / 2
     if debug:
-        print("Using (r,s,t)=%s should give a global integral model..." % [r,s,t])
+        print("Using (r,s,t)=%s should give a global integral model..." % [r, s, t])
 
     # Final computation of the curve E:
-    E = test_rst_global(c4,c6,r,s,t)
+    E = test_rst_global(c4, c6, r, s, t)
     if not E:
-        E = c4c6_model(c4,c6).rst_transform(r,s,t)
-        for P in Plist2+Plist3:
+        E = c4c6_model(c4, c6).rst_transform(r, s, t)
+        for P in Plist2 + Plist3:
             if not E.is_local_integral_model(P):
                 print("Not integral at P=%s" % P)
         raise RuntimeError("Error in check_Kraus_global combining transforms at 2 and 3")
 
     # Success!
     return E
+
 
 def scale_by_units(E):
     r""" Return a model of E reduced with respect to scaling by units, then
@@ -637,35 +663,37 @@ def scale_by_units(E):
     real quadratic; unchanged otherwise.
     """
     K = E.base_field()
-    if not K.signature()==(2,0):
+    if not K.signature() == (2, 0):
         return E
 
-    embs = K.embeddings(RealField(1000)) # lower precision works badly!
+    embs = K.embeddings(RealField(1000))  # lower precision works badly!
     u = K.units()[0]
     uv = [e(u).abs().log() for e in embs]
 
     c4, c6 = E.c_invariants()
     c4s = [e(c4) for e in embs]
     c6s = [e(c6) for e in embs]
-    v = [(x4.abs()**(1/4)+x6.abs()**(1/6)).log() for x4,x6 in zip(c4s,c6s)]
-    kr = -(v[0]*uv[0]+v[1]*uv[1])/(uv[0]**2+uv[1]**2)
+    v = [(x4.abs() ** (1 / 4) + x6.abs() ** (1 / 6)).log() for x4, x6 in zip(c4s, c6s)]
+    kr = -(v[0] * uv[0] + v[1] * uv[1]) / (uv[0] ** 2 + uv[1] ** 2)
     k1 = kr.floor()
     k2 = kr.ceil()
-    nv1 = (v[0] + k1*uv[0])**2 + (v[1] + k1*uv[1])**2
-    nv2 = (v[0] + k2*uv[0])**2 + (v[1] + k2*uv[1])**2
+    nv1 = (v[0] + k1 * uv[0]) ** 2 + (v[1] + k1 * uv[1]) ** 2
+    nv2 = (v[0] + k2 * uv[0]) ** 2 + (v[1] + k2 * uv[1]) ** 2
     if nv1 < nv2:
-        k=k1
+        k = k1
     else:
-        k=k2
-    return E.scale_curve(u**k)
+        k = k2
+    return E.scale_curve(u ** k)
+
 
 def first_prime_in_class(c, norm_bound=1000):
-    Cl = c.parent() # the class group
+    Cl = c.parent()  # the class group
     K = Cl.number_field()
     for P in K.primes_of_bounded_norm_iter(RR(norm_bound)):
-        if Cl(P)==c:
+        if Cl(P) == c:
             return P
     raise RuntimeError("No prime of norm less than %s found in class %s" % (norm_bound, c))
+
 
 def semi_global_minimal_model(E, debug=False):
     r"""
@@ -690,15 +718,15 @@ def semi_global_minimal_model(E, debug=False):
         P = E.base_field().ideal(1)
     else:
         if debug:
-            print("No global minimal model, obstruction class = %s of order %s" % (c,c.order()))
+            print("No global minimal model, obstruction class = %s of order %s" % (c, c.order()))
         P = first_prime_in_class(c)
         if debug:
             print("Using a prime in that class: %s" % P)
-        I = I/P
+        I = I / P
     u = I.gens_reduced()[0]
-    rc4 = c4/u**4
-    rc6 = c6/u**6
-    Emin = check_Kraus_global(rc4,rc6,assume_nonsingular=True,debug=debug)
+    rc4 = c4 / u ** 4
+    rc6 = c6 / u ** 6
+    Emin = check_Kraus_global(rc4, rc6, assume_nonsingular=True, debug=debug)
     if Emin:
         Emin = scale_by_units(Emin)._reduce_model()
         return Emin, P
@@ -706,13 +734,14 @@ def semi_global_minimal_model(E, debug=False):
         raise RuntimeError("failed to compute global minimal model")
         return E, K.ideal(0)
 
+
 def test_run(fld):
     for E in read_curves("/home/jec/ecnf-data/RQF/curves.%s" % fld):
-        label = E[0]+"-"+E[2]+E[3]
+        label = E[0] + "-" + E[2] + E[3]
         E = E[4]
         print("%s: %s --> " % (label, E.ainvs()))
-        Emin,I = semi_global_minimal_model(E)
+        Emin, I = semi_global_minimal_model(E)
         if I.is_one():
             print("          %s (global minimal model)" % (Emin.ainvs(),))
         else:
-            print("          %s (minimal model away from %s)" % (Emin.ainvs(),I))
+            print("          %s (minimal model away from %s)" % (Emin.ainvs(), I))

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -18,6 +18,7 @@ from lmfdb.WebNumberField import nf_display_knowl, WebNumberField
 LIST_RE = re.compile(r'^(\d+|(\d+-(\d+)?))(,(\d+|(\d+-(\d+)?)))*$')
 TORS_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
 
+
 def split_full_label(lab):
     r""" Split a full curve label into 4 components
     (field_label,conductor_label,isoclass_label,curve_number)
@@ -25,9 +26,10 @@ def split_full_label(lab):
     data = lab.split("-")
     field_label = data[0]
     conductor_label = data[1]
-    isoclass_label = re.search("[a-z]+",data[2]).group()
-    curve_number = re.search("\d+",data[2]).group() # (a string)
-    return (field_label,conductor_label,isoclass_label,curve_number)
+    isoclass_label = re.search("[a-z]+", data[2]).group()
+    curve_number = re.search("\d+", data[2]).group()  # (a string)
+    return (field_label, conductor_label, isoclass_label, curve_number)
+
 
 def split_short_label(lab):
     r""" Split a short curve label into 3 components
@@ -35,9 +37,10 @@ def split_short_label(lab):
     """
     data = lab.split("-")
     conductor_label = data[0]
-    isoclass_label = re.search("[a-z]+",data[1]).group()
-    curve_number = re.search("\d+",data[1]).group() # (a string)
-    return (conductor_label,isoclass_label,curve_number)
+    isoclass_label = re.search("[a-z]+", data[1]).group()
+    curve_number = re.search("\d+", data[1]).group()  # (a string)
+    return (conductor_label, isoclass_label, curve_number)
+
 
 def split_class_label(lab):
     r""" Split a class label into 3 components
@@ -47,7 +50,8 @@ def split_class_label(lab):
     field_label = data[0]
     conductor_label = data[1]
     isoclass_label = data[2]
-    return (field_label,conductor_label,isoclass_label)
+    return (field_label, conductor_label, isoclass_label)
+
 
 def split_short_class_label(lab):
     r""" Split a short class label into 2 components
@@ -56,23 +60,26 @@ def split_short_class_label(lab):
     data = lab.split("-")
     conductor_label = data[0]
     isoclass_label = data[1]
-    return (conductor_label,isoclass_label)
+    return (conductor_label, isoclass_label)
 
 ecnf_credit = "John Cremona, Alyson Deines, Steve Donelly, Paul Gunnells, Warren Moore, Haluk Sengun, John Voight, Dan Yasaki"
+
 
 def get_bread(*breads):
     bc = [("Elliptic Curves", url_for(".index"))]
     map(bc.append, breads)
     return bc
 
+
 def web_ainvs(field_label, ainvs):
     return web_latex([make_field(field_label).parse_NFelt(x) for x in ainvs])
+
 
 @ecnf_page.route("/")
 def index():
 #    if 'jump' in request.args:
 #        return show_ecnf1(request.args['label'])
-    if len(request.args)>0:
+    if len(request.args) > 0:
         return elliptic_curve_search(data=request.args)
     bread = get_bread()
 
@@ -86,16 +93,16 @@ def index():
 
     data['fields'] = []
     # Rationals
-    data['fields'].append(['the rational field',(('1.1.1.1',[url_for('ec.rational_elliptic_curves'),'$\Q$']),)])
+    data['fields'].append(['the rational field', (('1.1.1.1', [url_for('ec.rational_elliptic_curves'), '$\Q$']),)])
     # Real quadratics (only a sample)
-    rqfs = ['2.2.%s.1' %str(d) for d in [5,89,229,497]]
-    data['fields'].append(['real quadratic fields',((nf,[url_for('.show_ecnf1',nf=nf),field_pretty(nf)]) for nf in rqfs)])
+    rqfs = ['2.2.%s.1' % str(d) for d in [5, 89, 229, 497]]
+    data['fields'].append(['real quadratic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in rqfs)])
     # Imaginary quadratics
-    iqfs = ['2.0.%s.1' %str(d) for d in [4,8,3,7,11]]
-    data['fields'].append(['imaginary quadratic fields',((nf,[url_for('.show_ecnf1',nf=nf),field_pretty(nf)]) for nf in iqfs)])
+    iqfs = ['2.0.%s.1' % str(d) for d in [4, 8, 3, 7, 11]]
+    data['fields'].append(['imaginary quadratic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in iqfs)])
     # Cubics
     cubics = ['3.1.23.1']
-    data['fields'].append(['cubic fields',((nf,[url_for('.show_ecnf1',nf=nf),field_pretty(nf)]) for nf in cubics)])
+    data['fields'].append(['cubic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in cubics)])
 
 # data['highlights'] holds data (URL and descriptive text) for a
 # sample of elliptic curves with interesting features:
@@ -123,21 +130,21 @@ def index():
     )
 
     return render_template("ecnf-index.html",
-        title="Elliptic Curves over Number Fields",
-        data=data,
-        bread=bread)
+                           title="Elliptic Curves over Number Fields",
+                           data=data,
+                           bread=bread)
 
 
 @ecnf_page.route("/<nf>/")
 def show_ecnf1(nf):
-    if nf=="1.1.1.1":
+    if nf == "1.1.1.1":
         return redirect(url_for("ec.rational_elliptic_curves", **request.args))
     if request.args:
         return elliptic_curve_search(data=request.args)
     start = 0
     count = 50
     nf_label = parse_field_string(nf)
-    query = {'field_label' : nf_label}
+    query = {'field_label': nf_label}
     cursor = db_ecnf().find(query)
     nres = cursor.count()
     if(start >= nres):
@@ -155,11 +162,11 @@ def show_ecnf1(nf):
     info = {}
     info['field'] = nf_label
     info['query'] = query
-    info['curves'] = res # [ECNF(e) for e in res]
+    info['curves'] = res  # [ECNF(e) for e in res]
     info['number'] = nres
     info['start'] = start
     info['count'] = count
-    info['more'] = int(start+count<nres)
+    info['more'] = int(start + count < nres)
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs
     if nres == 1:
@@ -172,10 +179,12 @@ def show_ecnf1(nf):
     t = 'Elliptic Curves over %s' % field_pretty(nf_label)
     return render_template("ecnf-search-results.html", info=info, credit=ecnf_credit, bread=bread, title=t)
 
+
 @ecnf_page.route("/<nf>/<conductor_label>/")
 def show_ecnf_conductor(nf, conductor_label):
     nf_label = parse_field_string(nf)
-    return elliptic_curve_search(data={'nf_label':nf_label, 'conductor_label':conductor_label}, **request.args)
+    return elliptic_curve_search(data={'nf_label': nf_label, 'conductor_label': conductor_label}, **request.args)
+
 
 @ecnf_page.route("/<nf>/<conductor_label>/<class_label>/")
 def show_ecnf_isoclass(nf, conductor_label, class_label):
@@ -185,48 +194,49 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     cl = ECNF_isoclass.by_label(label)
     title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.ECNF.field.field_pretty())
     bread = [("Elliptic Curves", url_for(".index"))]
-    bread.append((cl.ECNF.field.field_pretty(),url_for(".show_ecnf1", nf=nf_label)))
-    bread.append((conductor_label, url_for(".show_ecnf_conductor", nf = nf_label, conductor_label = conductor_label)))
-    bread.append((class_label, url_for(".show_ecnf_isoclass", nf = nf_label, conductor_label = conductor_label, class_label = class_label)))
+    bread.append((cl.ECNF.field.field_pretty(), url_for(".show_ecnf1", nf=nf_label)))
+    bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
+    bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=conductor_label, class_label=class_label)))
     info = {}
     return render_template("show-ecnf-isoclass.html",
-        credit=ecnf_credit,
-        title=title,
-        bread=bread,
-        cl=cl,
-        properties2 = cl.properties,
-        friends = cl.friends)
+                           credit=ecnf_credit,
+                           title=title,
+                           bread=bread,
+                           cl=cl,
+                           properties2=cl.properties,
+                           friends=cl.friends)
 
 
 @ecnf_page.route("/<nf>/<conductor_label>/<class_label>/<number>")
 def show_ecnf(nf, conductor_label, class_label, number):
     nf_label = parse_field_string(nf)
-    label = "".join(["-".join([nf_label, conductor_label, class_label]),number])
+    label = "".join(["-".join([nf_label, conductor_label, class_label]), number])
     ec = ECNF.by_label(label)
     bread = [("Elliptic Curves", url_for(".index"))]
     if not ec:
         info = {}
         info['query'] = {}
-        info['err'] = 'No elliptic curve in the database has label %s.' %label
-        return search_input_error(info,bread)
+        info['err'] = 'No elliptic curve in the database has label %s.' % label
+        return search_input_error(info, bread)
 
     title = "Elliptic Curve %s over Number Field %s" % (ec.short_label, ec.field.field_pretty())
     bread = [("Elliptic Curves", url_for(".index"))]
-    bread.append((ec.field.field_pretty(),ec.urls['field']))
+    bread.append((ec.field.field_pretty(), ec.urls['field']))
     bread.append((ec.conductor_label, ec.urls['conductor']))
     bread.append((ec.iso_label, ec.urls['class']))
     bread.append((ec.number, ec.urls['curve']))
     info = {}
 
     return render_template("show-ecnf.html",
-        credit=ecnf_credit,
-        title=title,
-        bread=bread,
-        ec=ec,
-#        properties = ec.properties,
-        properties2 = ec.properties,
-        friends = ec.friends,
-        info=info)
+                           credit=ecnf_credit,
+                           title=title,
+                           bread=bread,
+                           ec=ec,
+                           #        properties = ec.properties,
+                           properties2=ec.properties,
+                           friends=ec.friends,
+                           info=info)
+
 
 def elliptic_curve_search(**args):
     info = to_dict(args['data'])
@@ -235,15 +245,15 @@ def elliptic_curve_search(**args):
         # This label should be a full isogeny class label or a full
         # curve label (including the field_label component)
         try:
-            nf,cond_label,iso_label,number = split_full_label(label)
+            nf, cond_label, iso_label, number = split_full_label(label)
         except IndexError:
             if not 'query' in info:
                 info['query'] = {}
             bread = [("Elliptic Curves", url_for(".index"))]
-            info['err'] = 'No elliptic curve in the database has label %s.' %label
-            return search_input_error(info,bread)
+            info['err'] = 'No elliptic curve in the database has label %s.' % label
+            return search_input_error(info, bread)
 
-        return show_ecnf(nf,cond_label,iso_label,number)
+        return show_ecnf(nf, cond_label, iso_label, number)
 
     query = {}
     bread = [('Elliptic Curves', url_for(".index")),
@@ -346,11 +356,11 @@ def elliptic_curve_search(**args):
         e['numb'] = str(e['number'])
         e['field_knowl'] = nf_display_knowl(e['field_label'], getDBConnection(), e['field_label'])
 
-    info['curves'] = res # [ECNF(e) for e in res]
+    info['curves'] = res  # [ECNF(e) for e in res]
     info['number'] = nres
     info['start'] = start
     info['count'] = count
-    info['more'] = int(start+count<nres)
+    info['more'] = int(start + count < nres)
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs
     if nres == 1:
@@ -363,9 +373,9 @@ def elliptic_curve_search(**args):
     t = 'Elliptic Curve search results'
     return render_template("ecnf-search-results.html", info=info, credit=ecnf_credit, bread=bread, title=t)
 
+
 def search_input_error(info, bread):
     return render_template("ecnf-search-results.html", info=info, title='Elliptic Curve Search Input Error', bread=bread)
-
 
 
 # Harald wrote the following and it is not used -- JEC
@@ -379,4 +389,3 @@ def search():
         return "ERROR: we always do http get to explicitly display the search parameters"
     else:
         return redirect(404)
-

--- a/lmfdb/ecnf/point-find.py
+++ b/lmfdb/ecnf/point-find.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+r""" Functions to add ranks and generators to elliptic curves in the
+database by outputting a Magma script and parsing its output """
+
+import os.path
+import gzip
+import re
+import sys
+import time
+import os
+import random
+import glob
+import pymongo
+from lmfdb.base import _init as init
+from lmfdb.base import getDBConnection
+from sage.rings.all import ZZ, QQ
+from sage.databases.cremona import cremona_to_lmfdb
+from lmfdb.ecnf.hmf_check_find import (is_fundamental_discriminant, rqf_iterator)
+
+print "calling base._init()"
+dbport=37010
+init(dbport, '')
+print "getting connection"
+conn = getDBConnection()
+print "setting nfcurves, qcurves and fields"
+nfcurves = conn.elliptic_curves.nfcurves
+qcurves = conn.elliptic_curves.curves
+fields = conn.numberfields.fields
+
+############################################################
+#
+# Code to go through nfcurves database (for one field) to find curves
+# (grouped into isogeny classes) and output Magma code to process
+# these.
+#
+############################################################
+
+def output_magma_field(field_label, outfilename=None, verbose=False):
+    r"""
+    Writes Magma code to a file to define a number field.
+
+    INPUT:
+
+    - ``field_label`` (str) -- a number field label
+
+    - ``outfilename`` (string, default ``None``) -- name of file for output.
+
+    - ``verbose`` (boolean, default ``False``) -- verbosity flag.  If
+      True, all output written to stdout.
+
+    OUTPUT:
+
+    Output goes to file and/or screen, nothing is returned.  Outputs
+    Magma commands to define the field `K` with given label.
+    """
+    def output(L):
+        if outfilename:
+            outfile.write(L)
+        if verbose:
+            sys.stdout.write(L)
+
+    if outfilename:
+        outfile=file(outfilename, mode="w")
+
+    F = fields.find_one({'label':field_label})
+    if not F:
+        raise ValueError("%s is not a field in the database!" % field_label)
+
+    output("COEFFS := [%s];\n" % F['coeffs'])
+    output("K<a> := NumberField(PolynomialRing(Rationals())!COEFFS);\n")
+
+    if outfilename:
+        output("\n")
+        outfile.close()
+
+
+def output_magma_point_search(curves, outfilename=None, verbose=False):
+    r""" Outputs Magma script to search for an curve to match the newform
+    with given label.
+
+    INPUT:
+
+    - ``curves`` -- a list or iterator of database elliptic curve
+      objects (one complete isogeny class: the label will be taken
+      from the furst one)
+
+    - ``outfilename`` (string, default ``None``) -- name of output file
+
+    - ``verbose`` (boolean, default ``False``) -- verbosity flag.
+
+    OUTPUT:
+
+    Output goes to file and/or screen, nothing is returned. Outputs
+    Magma commands to compute the rank and generators of the curves in
+    the class.  The output will be appended to the file whose name is
+    provided, so that the field definition can be output there first
+    using the output_magma_field() function.
+    """
+    def output(L):
+        if outfilename:
+            outfile.write(L)
+        if verbose:
+            sys.stdout.write(L)
+    if outfilename:
+        outfile=file(outfilename, mode="a")
+
+    try:
+        curve1 = curves.next()
+        curves.rewind()
+    except AttributeError:  # it was a list, not an iterator
+        curve1 = curves[0]
+
+    all_ai = [[[int(c) for c in ai] for ai in e['ainvs']] for e in curves]
+    all_ai_str = str(all_ai).replace(" ","")
+    R = PolynomialRing(QQ,'a')
+    all_ai_pols = [[R(ai) for ai in c] for c in all_ai]
+
+    output('LABEL := ["%s","%s","%s"];\n' %
+           (curve1['field_label'],
+            curve1['conductor_label'],
+            curve1['iso_label']))
+    output("CURVES := %s;\n" % all_ai_str)
+    output("CURVES := %s;\n" % all_ai_pols)
+    output("PointSearch(LABEL,CURVES);\n")
+
+    if outfilename:
+        outfile.close()
+
+##########################################
+#
+# Functions below here not ready for use!
+#
+##########################################
+
+def magma_output_iter(infilename):
+    r"""
+    Read Magma search output
+
+    INPUT:
+
+    - ``infilename`` (string) -- name of file containing Magma output
+    """
+    infile = file(infilename)
+
+    while True:
+        try:
+            L = infile.next()
+        except StopIteration:
+            raise StopIteration
+
+        if 'Field' in L:
+            field_label = L.split()[1]
+            K = HilbertNumberField(field_label)
+            KK = K.K()
+            w = KK.gen()
+
+        if 'Isogeny class' in L:
+            class_label = L.split()[2]
+            cond_label, iso_label = class_label.split("-")
+            num = 0
+
+        if 'Curve' in L:
+            ai = [KK(a.encode()) for a in L[7:-2].split(",")]
+            num += 1
+            yield field_label, cond_label, iso_label, num, ai
+
+    infile.close()
+
+def export_magma_output(infilename, outfilename=None, verbose=False):
+    r"""
+    Convert Magma search output to a curve_data file.
+
+    INPUT:
+
+    - ``infilename`` (string) -- name of file containing Magma output
+
+    - ``outfilename`` (string, default ``None``) -- name of output file
+
+    - ``verbose`` (boolean, default ``False``) -- verbosity flag.
+    """
+    if outfilename:
+        outfile=file(outfilename, mode="w")
+
+    def output(L):
+        if outfilename:
+            outfile.write(L)
+        if verbose:
+            sys.stdout.write(L)
+
+    K = None
+
+    for field_label, cond_label, iso_label, num, ai in magma_output_iter(infilename):
+        ec = {}
+        ec['field_label'] = field_label
+        if not K:
+            K = HilbertNumberField(field_label)
+        ec['conductor_label'] = cond_label
+        ec['iso_label'] = iso_label
+        ec['number'] = num
+        N = K.ideal(cond_label)
+        norm = N.norm()
+        hnf = N.pari_hnf()
+        ec['conductor_ideal'] = "[%i,%s,%s]" % (norm, hnf[1][0], hnf[1][1])
+        ec['conductor_norm'] = norm
+        ec['ainvs'] = [[str(c) for c in list(a)] for a in ai]
+        ec['cm'] = '?'
+        ec['base_change'] = []
+        output(make_curves_line(ec)+"\n")

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -195,20 +195,29 @@ cellpadding="5";
 
 <div>
 <h2> {{ KNOWL('ec.mordell-weil', title="Mordell-Weil rank and generators") }} </h2>
-{% if ec.rk_bnds == 'not recorded' %}
-Not yet determined.
+{% if ec.rk == "?" %}
+{% if ec.rk_bnds != "not recorded" %}
+<b>Rank</b> \(r\) satisfies \({{ ec.rank_bounds[0] }} \le r \le {{ ec.rank_bounds[1] }}\)
 {% else %}
-{% if ec.rk == 'not recorded' %}
-\({{ ec.rank_bounds[0] }} \le r \le {{ ec.rank_bounds[1] }}\)
-{% else %}
-\( r = {{ ec.rank }} \)
+Rank not yet determined.
 {% endif %}
+{% else %}
+<b>Rank:</b> \( {{ ec.rank }} \)
+{% endif %}
+
 {% if ec.rank_bounds[0] %}
 {% if ec.gens == 'not recorded' %}
 <p>No generators recorded.</p>
 {% else %}
-<p>Generators: {{ ec.gens }}</p>
-{% endif %}
+<p><b>
+{% if ec.rank_bounds[0] == 1 %}
+Generator:
+{% else %}
+Generators:
+{% endif %}</b>
+{{ ec.gens }}
+</p>
+
 {% endif %}
 {% endif %}
 </div>

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -220,6 +220,10 @@ Generators:
 
 {% endif %}
 {% endif %}
+<p>
+<b>Regulator:</b>
+{{ ec.reg }}
+</p>
 </div>
 
 <div>

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -195,7 +195,22 @@ cellpadding="5";
 
 <div>
 <h2> {{ KNOWL('ec.mordell-weil', title="Mordell-Weil rank and generators") }} </h2>
+{% if ec.rk_bnds == 'not recorded' %}
 Not yet determined.
+{% else %}
+{% if ec.rk == 'not recorded' %}
+\({{ ec.rank_bounds[0] }} \le r \le {{ ec.rank_bounds[1] }}\)
+{% else %}
+\( r = {{ ec.rank }} \)
+{% endif %}
+{% if ec.rank_bounds[0] %}
+{% if ec.gens == 'not recorded' %}
+<p>No generators recorded.</p>
+{% else %}
+<p>Generators: {{ ec.gens }}</p>
+{% endif %}
+{% endif %}
+{% endif %}
 </div>
 
 <div>


### PR DESCRIPTION
The file point-find.py contains scripts to go through the curves already in the database and compute their ranks and generators.  This involved developing new code for Sage which is currently under review there, and it is not intended that reviewing this file is done before merging this pull request!

The code changes to be looked at are quite small: depending on whether the database has the rank, or only rank bounds, or neither, and whether it contains any generators, appropriate information is displayed on an individial curve home page: these are the only pages where anything looks different.  Useful examples are:

  - a curve of rank 0: http://localhost:37777/EllipticCurve/2.2.5.1/36.1/a/1
  - a curve of rank 1 with generator: http://localhost:37777/EllipticCurve/2.2.5.1/209.2/c/1
  - a curve of rank 2 with generators: http://localhost:37777/EllipticCurve/2.2.5.1/1831.2/c/1
  - rank bounds 0..2 and no generators: http://localhost:37777/EllipticCurve/2.2.5.1/2929.3/a/1
  - rank bounds 0..1 and no generator: http://localhost:37777/EllipticCurve/2.2.5.1/3599.4/a/1
  - no rank information yet: http://localhost:37777/EllipticCurve/2.2.24.1/10.1/a/1

I am still filling the database and these are the only possibilities currently in there.  As the last example shows, there is no need to wait until I have processed all the curves before merging this.  When all curves have rank or rank bounds in the database I will add rank to the search fields, but that is a separate task.