### PR TITLE
fixing login after #352

### DIFF
--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -52,7 +52,7 @@ def get_username(uid):
 def ctx_proc_userdata():
     userdata = {}
     userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
-    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name()
+    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
     userdata['user_is_authenticated'] = current_user.is_authenticated()
     userdata['user_is_admin'] = current_user.is_admin()
     userdata['get_username'] = get_username # this is a function

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -52,10 +52,10 @@ def get_username(uid):
 def ctx_proc_userdata():
     userdata = {}
     userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
-    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
+    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name()
     userdata['user_is_authenticated'] = current_user.is_authenticated()
     userdata['user_is_admin'] = current_user.is_admin()
-    userdata['get_username'] = get_username
+    userdata['get_username'] = get_username # this is a function
     return userdata
 
 # blueprint specific definition of the body_class variable

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -127,13 +127,13 @@ class LmfdbUser(UserMixin):
     def id(self):
         return self._data['_id']
 
-    def is_authenticate(self):
+    def is_authenticated(self):
         """required by flask-login user class"""
         return self._authenticated
 
     def is_anonymous(self):
         """required by flask-login user class"""
-        return not self.is_authenticated()
+        return not self._authenticated
 
     def is_admin(self):
         """true, iff has attribute admin set to True"""

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -127,13 +127,13 @@ class LmfdbUser(UserMixin):
     def id(self):
         return self._data['_id']
 
-    def is_authenticated(self):
-        """required by flask-login user class"""
-        return self._authenticated
+    # def is_authenticated(self):
+    #     """required by flask-login user class"""
+    #     return self._authenticated
 
     def is_anonymous(self):
         """required by flask-login user class"""
-        return not self._authenticated
+        return not self.is_authenticated()
 
     def is_admin(self):
         """true, iff has attribute admin set to True"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
 flask-cache
-flask-login
+flask-login == 0.2.11
 flask-markdown
 pymongo
 pyyaml


### PR DESCRIPTION
The first two commits make and then undo some changes which do fix the observed problem, using version 0.2.11 of flask-login but _not_ using 0.3.0.  The last one changes requirements.txt to force version 0.2.11 which will stop things failing for new users.

To see which version _you_ are running:
```
sage -sh
pip freeze | grep Flask-Login
exit
```
If you have a later version, uninstall it and install this one:
```
sage -sh
pip uninstall flask-login
pip install flask-login=0.2.11
exit
```
Please test the above instructions!
