### PR TITLE
no redirect of URLs for Cremona label curves

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -373,18 +373,21 @@ def by_ec_label(label):
                 return elliptic_curve_jump_error(label, {})
 
         # We permanently redirect to the lmfdb label
-        if number:
+        if number: # it's a curve
             data = db_ec().find_one({'label': label})
             if data is None:
                 return elliptic_curve_jump_error(label, {})
             ec_logger.debug(url_for(".by_ec_label", label=data['lmfdb_label']))
-            return redirect(url_for(".by_ec_label", label=data['lmfdb_label']), 301)
-        else:
+            #return redirect(url_for(".by_ec_label", label=data['lmfdb_label']), 301)
+            return render_curve_webpage_by_label(data['label'])
+        else: # it's an isogeny class
             data = db_ec().find_one({'iso': label})
             if data is None:
                 return elliptic_curve_jump_error(label, {})
             ec_logger.debug(url_for(".by_ec_label", label=data['lmfdb_label']))
-            return redirect(url_for(".by_ec_label", label=data['lmfdb_iso']), 301)
+            #return redirect(url_for(".by_ec_label", label=data['iso']), 301)
+            return render_isogeny_class(data['iso'])
+
     if number:
         return redirect(url_for(".by_triple_label", conductor=N, iso_label=iso, number=number))
     else:


### PR DESCRIPTION
When a Cremona label for an elliptic curve or isogeny class is entered as a URL we used to use redirect to display the curve / class with its LMFDB URL.  Now we do not.

Example: http://localhost:37777/EllipticCurve/Q/338a displays "Elliptic Curve Isogeny Class 338.c (Cremona label 338a)" without changing the URL.  Similarly, http://localhost:37777/EllipticCurve/Q/11a1 displays "Elliptic Curve 11.a2 (Cremona label 11a1)" without changing the URL.

I think this is what was greed at the meeting at ICERM today.