### PR TITLE
fixed bug in classical m.f. jump to label

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
@@ -144,7 +144,7 @@ def extract_data_from_jump_to(s):
     args['level'] = int(level)
     args['weight'] = int(weight) 
     args['character'] = int(character)
-    args['label'] = label
+    if label: args['label'] = label
     return args
 
 


### PR DESCRIPTION
Go to http://localhost:37777/ModularForm/GL2/Q/holomorphic/ and put 1.12 in the bottom search box.  It fails before this change, now it succeeds,  It also works if you put 1.12a in the box.

The fault was that when there was no final label, the label '' (empty string) was being put in the URL and this is invalid.
