### PR TITLE
Groupnames

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -252,7 +252,7 @@ def render_group_webpage(args):
             info['err'] = "Group " + label + " was not found in the database."
             info['label'] = label
             return search_input_error(info, bread)
-        title = 'Galois Group:' + label
+        title = 'Galois Group: ' + label
         wgg = WebGaloisGroup.from_data(data)
         n = data['n']
         t = data['t']
@@ -321,7 +321,8 @@ def render_group_webpage(args):
         ]
         pretty = group_display_pretty(n,t,C)
         if len(pretty)>0:
-            prop2.extend([('Name:', pretty)])
+            prop2.extend([('Group:', pretty)])
+            info['pretty_name'] = pretty
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
         info.update(data)

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -24,7 +24,7 @@ try:
 except:
     logger.fatal("It looks like the SPKGes gap_packages and database_gap are not installed on the server.  Please install them via 'sage -i ...' and try again.")
 
-from lmfdb.transitive_group import group_display_short, group_display_long, group_display_inertia, group_knowl_guts, galois_module_knowl_guts, subfield_display, otherrep_display, resolve_display, conjclasses, generators, chartable, aliastable, WebGaloisGroup, galois_module_knowl
+from lmfdb.transitive_group import group_display_short, group_display_pretty, group_display_long, group_display_inertia, group_knowl_guts, galois_module_knowl_guts, subfield_display, otherrep_display, resolve_display, conjclasses, generators, chartable, aliastable, WebGaloisGroup, galois_module_knowl
 
 from lmfdb.WebNumberField import modules2string
 
@@ -75,6 +75,11 @@ def ctx_galois_groups():
 def group_display_shortC(C):
     def gds(nt):
         return group_display_short(nt[0], nt[1], C)
+    return gds
+
+def group_display_prettyC(C):
+    def gds(nt):
+        return group_display_pretty(nt[0], nt[1], C)
     return gds
 
 LIST_RE = re.compile(r'^(\d+|(\d+-\d+))(,(\d+|(\d+-\d+)))*$')
@@ -211,7 +216,7 @@ def galois_group_search(**args):
         start = 0
 
     info['groups'] = res
-    info['group_display'] = group_display_shortC(C)
+    info['group_display'] = group_display_prettyC(C)
     info['report'] = "found %s groups" % nres
     info['yesno'] = yesno
     info['wgg'] = WebGaloisGroup.from_data
@@ -313,8 +318,12 @@ def render_group_webpage(args):
             ('Solvable:', yesno(data['solv'])),
             ('Primitive:', yesno(data['prim'])),
             ('$p$-group:', yesno(pgroup)),
-            ('Name:', group_display_short(n, t, C)),
         ]
+        pretty = group_display_pretty(n,t,C)
+        if len(pretty)>0:
+            prop2.extend([('Name:', pretty)])
+        data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
+        data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
         info.update(data)
 
         bread = get_bread([(label, ' ')])

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -15,8 +15,10 @@ table.reptable td, table.reptable th {
     <table>
       <tr><td>Degree $n$ :<td>&nbsp;&nbsp;<td>${{info.n}}$</tr>
       <tr><td>Transitive number $t$ :<td>&nbsp;&nbsp;<td>${{info.t}}$</tr>
-      <tr><td>{{KNOWL('gg.simple_name', title='Simple name')}} :<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
-      <tr><td>{{KNOWL('gg.conway_name', title='CHM name')}} :<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
+      {% if info.pretty_name %}
+      <tr><td>{{KNOWL('gg.simple_name', title='Group')}} :<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
+      {% endif %}
+      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}} :<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
       <tr><td>Parity:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>Primitive:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
       <tr><td>Generators:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -15,6 +15,8 @@ table.reptable td, table.reptable th {
     <table>
       <tr><td>Degree $n$ :<td>&nbsp;&nbsp;<td>${{info.n}}$</tr>
       <tr><td>Transitive number $t$ :<td>&nbsp;&nbsp;<td>${{info.t}}$</tr>
+      <tr><td>{{KNOWL('gg.simple_name', title='Simple name')}} :<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
+      <tr><td>{{KNOWL('gg.conway_name', title='CHM name')}} :<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
       <tr><td>Parity:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>Primitive:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
       <tr><td>Generators:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -129,8 +129,17 @@ def group_display_short(n, t, C):
     group = C.transitivegroups.groups.find_one({'label': label})
     if group['pretty']:
         return group['pretty']
-    return group['name']
+    name = group['name']
+    name = name.replace('=', ' = ')
+    return name
 
+# Returns the empty string if there is no pretty name
+def group_display_pretty(n, t, C):
+    label = base_label(n, t)
+    group = C.transitivegroups.groups.find_one({'label': label})
+    if group['pretty']:
+        return group['pretty']
+    return ""
 
 def group_display_knowl(n, t, C, name=None):
     if not name:
@@ -251,6 +260,8 @@ def group_cclasses_knowl_guts(n, t, C):
     gname = group['name']
     if group['pretty']:
         gname = group['pretty']
+    else:
+        gname = gname.replace('=', ' = ')
     rest = '<div>Conjugacy class representatives for '
     rest += gname
     rest += '<blockquote>'
@@ -263,6 +274,7 @@ def group_character_table_knowl_guts(n, t, C):
     label = base_label(n, t)
     group = C.transitivegroups.groups.find_one({'label': label})
     gname = group['name']
+    gname = gname.replace('=', ' = ')
     if group['pretty']:
         gname = group['pretty']
     inf = '<div>Character table for '

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -129,9 +129,10 @@ def group_display_short(n, t, C):
     group = C.transitivegroups.groups.find_one({'label': label})
     if group['pretty']:
         return group['pretty']
-    name = group['name']
-    name = name.replace('=', ' = ')
-    return name
+    return "%dT%d"%(n,t)
+    #name = group['name']
+    #name = name.replace('=', ' = ')
+    #return name
 
 # Returns the empty string if there is no pretty name
 def group_display_pretty(n, t, C):
@@ -233,8 +234,10 @@ def group_knowl_guts(n, t, C):
         inf += ", primitive"
     else:
         inf += ", imprimitive"
+    inf += '<div>'
+    inf += '<a title="%s [gg.conway_name]" knowl="gg.conway_name" kwarts="n=%s&t=%s">%s</a>: '%('CHM label',str(n),str(t),'CHM label')
+    inf += '%s</div>'%(group['name'])
 
-    inf = "&nbsp;&nbsp;&mdash;&nbsp;&nbsp;  " + inf + ""
     rest = '<div><h3>Generators</h3><blockquote>'
     rest += generators(n, t)
     rest += '</blockquote></div>'
@@ -250,8 +253,8 @@ def group_knowl_guts(n, t, C):
     rest += '</div>'
 
     if group['pretty']:
-        return group['pretty'] + inf + rest
-    return group['name'] + inf + rest
+        return group['pretty'] + "&nbsp;&nbsp;&mdash;&nbsp;&nbsp;  "+ inf + rest
+    return inf + rest
 
 
 def group_cclasses_knowl_guts(n, t, C):


### PR DESCRIPTION
Fixes the display of group names.

 - if you search for Galois groups, only display the "nice" name in the name column if we have one
 - on the page for an individual Galois group
    - if there is a nice name, show it in both properties and on the page
    - call the "gap" name the CHM label, and show it in the list of information
    - make knowls for the two naming conventions
  - when searching for number fields, local fields, or Artin representations, use the nice name for a Galois group if it exists, otherwise use the style nTt
  - in group display knowls, include the nice name if it exists, and always have a line for the CHM label
