### PR TITLE
better prompt & example for emf browse/search by specific label@

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
@@ -202,11 +202,13 @@ table.ntdata thead th.spaceleft {
 
   <h1>Find a specific cusp form from the database</h1>
       <div>
-        Search by {{KNOWL('mf.elliptic.label',title="label")}} 
+        Search by {{KNOWL('mf.elliptic.label',title="label")}} of a
+        form, or of a space of forms
         <form name="search" method = "post" action="{{url_for('.render_elliptic_modular_forms')}}">	  
-          <input type="text" name="jump_to" value="" placeholder="1.12"> 
+          <input type="text" name="jump_to" value="" placeholder="1.12.1a"> 
 	  <button type="submit" value="Find">Find</button>
         </form>
+        <span class="formexample"> e.g. 1.12.1a or 11.6 </span>
       </div>
 
 {#


### PR DESCRIPTION
Follow-up to #371 after showing to John Voight.  The suggested example in the box does now lead to one modular form, and the alternative to lead to a space of forms is also mentioned.
