### PR TITLE
added canonical heights of generators for e.c./Q

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -102,9 +102,22 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     Trivial {%endif%}  {%endif%} </div>
 
     {% if data.mw.rank!=0 %}
-    <p><h3> Infinite order Mordell-Weil generators </h3>
+    {% if data.mw.rank==1 %}
+    <p><h3> Infinite order Mordell-Weil generator and height</h3>
+    {% else %}
+    <p><h3> Infinite order Mordell-Weil generators and heights</h3>
+    {% endif %}
       {{ code(data.code,'gens') }}
-      <div style='overflow:auto'><p> {{ data.mw.generators }} </p></div>
+      <div style='overflow:auto'><p>
+      <table>
+        <tr><td>\(P\)</td>
+          {% for pt in data.mw.generators %}<td>{{pt}}</td>{% endfor %}
+          </tr>
+        <tr><td>\(\hat{h}(P)\)</td>
+          {% for ht in data.mw.heights %}<td>{{ht}}</td>{% endfor %}
+          </tr>
+        </table>
+      </p></div>
     </p>
     {%endif %}
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -226,9 +226,12 @@ class WebEC(object):
 
         mw['rank'] = self.rank
         try:
-            mw['generators'] = ', '.join(web_latex(self.E(g).xy()) for g in parse_points(self.gens))
+            self.generators = [self.E(g) for g in parse_points(self.gens)]
+            mw['generators'] = [web_latex(P.xy()) for P in self.generators]
+            mw['heights'] = [P.height() for P in self.generators]
         except AttributeError:
             mw['generators'] = ''
+            mw['heights'] = []
 
         # Torsion subgroup: order, structure, generators
 


### PR DESCRIPTION
As suggested by Silverman, canonical heights are now displayed for generators (of infinite order) for elliptic curves over Q.
Example of rank 1 with large generator to show scrolling still ok:  http://localhost:37777/EllipticCurve/Q/151704bj1
Rank 1, more normal: http://localhost:37777/EllipticCurve/Q/110005/b/2
Rank 2: http://localhost:37777/EllipticCurve/Q/110001/a/2
Rank 3: http://localhost:37777/EllipticCurve/Q/215890/a/1
Rank 4 (points small but with 4 of them scrolling still required): http://localhost:37777/EllipticCurve/Q/234446/a/1

Not yet done: same for curves over number fields.