### PR TITLE
improved torsion search for elliptic and genus 2 curves

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -7,7 +7,7 @@ import pymongo
 ASC = pymongo.ASCENDING
 from lmfdb.base import app, getDBConnection
 from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response, redirect
-from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input
+from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input, parse_torsion_structure
 from sage.all import ZZ, var, PolynomialRing, QQ, GCD
 from lmfdb.ecnf import ecnf_page, logger
 from lmfdb.ecnf.WebEllipticCurve import ECNF, db_ecnf, make_field
@@ -300,11 +300,13 @@ def elliptic_curve_search(**args):
         query[tmp[0]] = tmp[1]
 
     if 'torsion_structure' in info and info['torsion_structure']:
-        info['torsion_structure'] = clean_input(info['torsion_structure'])
-        if not TORS_RE.match(info['torsion_structure']):
-            info['err'] = 'Error parsing input for the torsion structure.  It needs to be one or more integers in square brackets, such as [6], [2,2], or [2,4].  Moreover, each integer should be bigger than 1, and each divides the next.'
+        res = parse_torsion_structure(info['torsion_structure'],2)
+        if 'Error' in res:
+            info['err'] = res
             return search_input_error(info, bread)
-        query['torsion_structure'] = parse_list(info['torsion_structure'])
+        #update info for repeat searches
+        info['torsion_structure'] = str(res).replace(' ','')
+        query['torsion_structure'] = [int(r) for r in res]
 
     if 'include_isogenous' in info and info['include_isogenous'] == 'off':
         query['number'] = 1

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -10,7 +10,7 @@ import tempfile
 import os
 import StringIO
 
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, parse_range2, web_latex_split_on_pm, comma, clean_input
+from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, parse_range2, web_latex_split_on_pm, comma, clean_input, parse_torsion_structure
 from lmfdb.number_fields.number_field import parse_list
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.ec_stats import get_stats
@@ -56,38 +56,6 @@ def cmp_label(lab1, lab2):
     a, b, c = parse_cremona_label(lab2)
     id2 = int(a), class_to_int(b), int(c)
     return cmp(id1, id2)
-
-def parse_torsion_structure(L):
-    r"""
-    Parse a string entered into torsion structure search box
-    '[]' --> []
-    '[n]' --> [str(n)]
-    'n' --> [str(n)]
-    '[m,n]' or '[m n]' --> [str(m),str(n)]
-    'm,n' or 'm n' --> [str(m),str(n)]
-    """
-    # strip <whitespace> or <whitespace>[<whitespace> from the beginning:
-    L1 = re.sub(r'^\s*\[?\s*', '', str(L))
-    # strip <whitespace> or <whitespace>]<whitespace> from the beginning:
-    L1 = re.sub(r'\s*]?\s*$', '', L1)
-    # catch case where there is nothing left:
-    if not L1:
-        return []
-    # This matches a string of 1 or more digits at the start,
-    # optionally followed by nontrivial <ws> or <ws>,<ws> followed by
-    # 1 or more digits at the end:
-    TORS_RE = re.compile(r'^\d+((\s+|\s*,\s*)\d+)?$')
-    if TORS_RE.match(L1):
-        if ',' in L1:
-            # strip interior <ws> and use ',' as delimiter:
-            res = [int(a) for a in L1.replace(' ','').split(',')]
-        else:
-            # use whitespace as delimiter:
-            res = [int(a) for a in L1.split()]
-        n = len(res)
-        if (n==1 and res[0]>0) or (n==2 and res[0]>0 and res[1]>0 and res[1]%res[0]==0):
-            return res
-    return 'Error parsing input %s for the torsion structure.  It needs to be a list of 0, 1 or 2 integers, optionally in square brackets, such as [6], 6, [2,2], or [2,4].  Moreover, each integer should be bigger than 1, and each divides the next.' % L
 
 
 #########################
@@ -274,7 +242,7 @@ def elliptic_curve_search(**args):
         query['number'] = 1
 
     if 'torsion_structure' in info and info['torsion_structure']:
-        res = parse_torsion_structure(info['torsion_structure'])
+        res = parse_torsion_structure(info['torsion_structure'],2)
         if 'Error' in res:
             info['err'] = res
             return search_input_error(info, bread)

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -92,8 +92,8 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 </tr>
 <tr>
 <td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>  
-<td><input type='text' name='torsion' placeholder='[2, 4]' size=10>
-<td><span class="formexample"> e.g. [2, 4] </span></td>
+<td><input type='text' name='torsion' placeholder='[2,2,2]' size=10>
+<td><span class="formexample"> e.g. [2,2,2] </span></td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\overline{\Q}\)-automorphism group') }}</td>
 <td align = "center"><select name='geom_aut_grp' width="122" style="width: 122px">
         <option ></option>

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -21,7 +21,7 @@
 <td><input type='text' name='cond' placeholder='169' size=10 value="{{info.cond}}"></td>
 <td><input type='text' name='disc' placeholder='169' size=10 value="{{info.disc}}"></td>
 <td><input type='text' name='num_rat_wpts' placeholder='1' size=10 value="{{info.num_rat_wpts}}">
-<td><input type='text' name='torsion' placeholder='[2, 4]' size=10 value="{{info.torsion}}">
+<td><input type='text' name='torsion' placeholder='[2,2,2]' size=10 value="{{info.torsion}}">
 <td><input type='text' name='torsion_order' placeholder='2' size=10 value="{{info.torsion_order}}">
 <td><input type='text' name='two_selmer_rank' placeholder='1' size=10 value="{{info.two_selmer_rank}}">
 </tr>

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -481,6 +481,45 @@ def parse_range2(arg, key, parse_singleton=int):
     else:
         return [key, parse_singleton(arg)]
 
+# Function to parse search box input for finite abelian group
+# invariants, e.g. torsion structure for elliptic curves or genus 2
+# curves
+
+def parse_torsion_structure(L, maxrank=2):
+    r"""
+    Parse a string entered into torsion structure search box
+    '[]' --> []
+    '[n]' --> [str(n)]
+    'n' --> [str(n)]
+    '[m,n]' or '[m n]' --> [str(m),str(n)]
+    'm,n' or 'm n' --> [str(m),str(n)]
+    ... and similarly for up to maxrank factors
+    """
+    # strip <whitespace> or <whitespace>[<whitespace> from the beginning:
+    L1 = re.sub(r'^\s*\[?\s*', '', str(L))
+    # strip <whitespace> or <whitespace>]<whitespace> from the beginning:
+    L1 = re.sub(r'\s*]?\s*$', '', L1)
+    # catch case where there is nothing left:
+    if not L1:
+        return []
+    # This matches a string of 1 or more digits at the start,
+    # optionally followed by up to 3 times (nontrivial <ws> or <ws>,<ws> followed by
+    # 1 or more digits):
+    TORS_RE = re.compile(r'^\d+((\s+|\s*,\s*)\d+){0,%s}$' % (maxrank-1))
+    if TORS_RE.match(L1):
+        if ',' in L1:
+            # strip interior <ws> and use ',' as delimiter:
+            res = [int(a) for a in L1.replace(' ','').split(',')]
+        else:
+            # use whitespace as delimiter:
+            res = [int(a) for a in L1.split()]
+        n = len(res)
+        if all(x>0 for x in res) and all(res[i+1]%res[i]==0 for i in range(n-1)):
+            return res
+    return 'Error parsing input %s.  It needs to be a list of up to %s integers, optionally in square brackets, separated by spaces or a comma, such as [6], 6, [2,2], or [2,4].  Moreover, each integer should be bigger than 1, and each divides the next.' % (L,maxrank)
+
+
+
 
 def len_val_fn(value):
     """ This creates a SON pair of the type {len:len(value), val:value}, with the len first so lexicographic ordering works.


### PR DESCRIPTION
As suggested in the wiki:  genus 2 torsion structure search now allows more possible inputs, e.g. '29', '2 2 2', '[2,2,2]'.    Modelled on recent changes for elliptic curve torsion search, but allowing up to 4 factors.  The sample input is changed to [2,2,2] (from [2, 4]) to emphasize that the number of factors can be up to 4!
Try your luck at http://localhost:37777/Genus2Curve/Q/ but beware that this search page has no error handling yet.  In the case of torsion structure, if the input cannot be correctly parsed it is quietly ignored.  While if you put 'x' into the torsion order box you get a server error.  This also needs improving!
