### PR TITLE
Fix Galois groups for L-polynomials for curves of genus 2

### DIFF
--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -70,6 +70,11 @@ def list_to_factored_poly_otherorder(s, galois=False):
         if v[1] > 1:
             outstr += '^{' + str(v[1]) + '}'        
     if galois:
+        if galois and len(sfacts_fc)==2:
+            if sfacts[0][0].degree()==2 and sfacts[1][0].degree()==2:
+                troubletest = sfacts[0][0].disc()*sfacts[1][0].disc()
+                if troubletest.is_square():
+                    gal_list=[[2,1]]
         return [outstr, gal_list]
     return outstr
 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -504,7 +504,10 @@ def lfuncEPhtml(L,fmt):
             eptable += "<td>" 
        #     eptable += group_display_knowl(4,thispolygal[1][0],C) 
             this_gal_group = thispolygal[1]
-            eptable += group_display_knowl(this_gal_group[0][0],this_gal_group[0][1],C) 
+            if this_gal_group[0]==[1,1]:
+                eptable += group_display_knowl(this_gal_group[0][0],this_gal_group[0][1],C,'$C_1$') 
+            else:
+                eptable += group_display_knowl(this_gal_group[0][0],this_gal_group[0][1],C) 
             for j in range(1,len(thispolygal[1])):
                 eptable += "$\\times$"
                 eptable += group_display_knowl(this_gal_group[j][0],this_gal_group[j][1],C)


### PR DESCRIPTION
The page

  http://127.0.0.1:37777/L/Genus2Curve/Q/93820/a

has reducible local factors where both quadratic factors give the same field.  This now displays the Galois group as just C_2 instead of C_2 X C_2.

Also, implemented request that the trivial group be given by C_1 instead of "Trivial" on this page.