### PR TITLE
moved 4 sidebar entries back to beta status

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -45,6 +45,7 @@
           url_for: "l_functions.l_function_degree_page"
           url_args:
             degree: 'degree4'
+          status: beta
         - title: "5+"
           status: future
    secondpart:
@@ -52,10 +53,12 @@
        parts:
         - title: First zeros
           url_for: "first L-function zeros.firstzeros"
+          status: beta
         - title: $\zeta$&nbsp;zeros
           url_for: "zeta zeros.zetazeros"
         - title: Operations
           url_for: "tensor_products.index"
+          status: beta
 
 3ModForm:
    type: multilevel
@@ -183,6 +186,7 @@
            url_for:  "characters.render_Dirichletwebpage"
          - title: Hecke
            url_for:  "characters.render_Heckewebpage"
+           status: beta
       colspan: onecolumn
     - title: Artin
       url_for: "artin_representations.index"

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -9,7 +9,7 @@
 	<div class="L">
 	<span class="heading">{{value.firstpart.heading}}</span>
 	{% for item in value.firstpart.entries %}
-		{% if item.status != "future" or BETA %}
+		{% if not item.status or BETA %}
 			<span class="L">{{item.url | safe}}</span>
 		{% endif %}
 	{% endfor %}
@@ -17,8 +17,10 @@
 	<table class="short">
 	<tr>
 	{% for item in value.secondpart.parts %}
+	    {% if not item.status or BETA %}
 		<td>{{item.url | safe}}</td>
 		{% if loop.index is even -%}</tr><tr>{%- endif %}
+	    {% endif %}
 	{% endfor %}</tr>
 	</table>
 


### PR DESCRIPTION
As agreed at the meeting: 4 sidebar entries moved to beta.  This should have only requied adding the 4 lines "status:beta" in the sidebar.yaml file, but a bug in the logic of sidebar.html was revealed which needed to be fixed.

To test: run locally as usual with --debug and you'll see now in purple "Operations", "First Zeros", "4" (all in L-functions) and "Hecke" (in Representations / characters).  This is what will appear on beta.lmfdb.org  Then run without the --debug and those 4 entries disappear completely, as will appear on www.lmfdb.org.