### PR TITLE
fixed two bugs which resulted in slow ecnf search results and ...

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -8,7 +8,6 @@ from kraus import (non_minimal_primes, is_global_minimal_model, has_global_minim
 ecnf = None
 nfdb = None
 
-
 def db_ecnf():
     global ecnf
     if ecnf is None:
@@ -29,18 +28,20 @@ special_names = {'2.0.4.1': 'i',
 
 field_list = {}  # cached collection of enhanced WebNumberFields, keyed by label
 
-
 def FIELD(label):
     nf = WebNumberField(label, gen_name=special_names.get(label, 'a'))
     nf.parse_NFelt = lambda s: nf.K()([QQ(str(c)) for c in s])
     return nf
 
-
 def make_field(label):
-    if label in field_list:
-        return field_list[label]
-    return FIELD(label)
+    global field_list
+    if not label in field_list:
+        #print("Constructing field %s" % label)
+        field_list[label] = FIELD(label)
+    return field_list[label]
 
+def web_ainvs(field_label, ainvs):
+    return web_latex([make_field(field_label).parse_NFelt(x) for x in ainvs])
 
 def EC_R_plot(ainvs, xmin, xmax, ymin, ymax, colour, legend):
     x = var('x')

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -10,7 +10,7 @@ from flask import render_template, render_template_string, request, abort, Bluep
 from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input, parse_torsion_structure
 from sage.all import ZZ, var, PolynomialRing, QQ, GCD
 from lmfdb.ecnf import ecnf_page, logger
-from lmfdb.ecnf.WebEllipticCurve import ECNF, db_ecnf, make_field
+from lmfdb.ecnf.WebEllipticCurve import ECNF, db_ecnf, web_ainvs
 from lmfdb.ecnf.isog_class import ECNF_isoclass
 from lmfdb.number_fields.number_field import parse_list, parse_field_string, field_pretty
 from lmfdb.WebNumberField import nf_display_knowl, WebNumberField
@@ -69,11 +69,6 @@ def get_bread(*breads):
     bc = [("Elliptic Curves", url_for(".index"))]
     map(bc.append, breads)
     return bc
-
-
-def web_ainvs(field_label, ainvs):
-    return web_latex([make_field(field_label).parse_NFelt(x) for x in ainvs])
-
 
 @ecnf_page.route("/")
 def index():


### PR DESCRIPTION
& isogeny cllass pages.

Nicolas observed that ec/nf isogeny class pages loaded very slowly and I fixed that by doing two things, one of which also speeds up search results:  there was a cache of web number fields, used for displaying nice lists of Weierstrass coefficients, but nothing was ever put into the cache! so WebNumberFields were repeatedly being created for the same field.  Secondly,  when preparing the list of W. coeffs to display for the isogeny class, it was constructing the full ECNF object, and this is not necessary since all we need is the label and url and W.coeffs (constructed as for search result lists).