### PR TITLE
HMF improve search results

### DIFF
--- a/lmfdb/hilbert_modular_forms/check_conjugates.py
+++ b/lmfdb/hilbert_modular_forms/check_conjugates.py
@@ -45,6 +45,9 @@ def get_Fdata(label):
         Fdata[label] = fields.find_one({'label':label})
     return Fdata[label]
 
+def nautos(label):
+    return len(get_WNF(label, 'a').K().automorphisms())
+
 def fldlabel2conjdata(label):
     data = {}
     Fdata = get_Fdata(label)
@@ -65,6 +68,13 @@ def fldlabel2conjdata(label):
     data['primes'] = primes
     cprimes = conjideals(primes, auts)
     data['conjprimes'] = cprimes
+    #old code for comparison
+    primes = [prm[2] for prm in primes]
+    old_cprimes = [[primes.index(cideals[(prm,ig)]) for prm in primes] for ig in range(len(auts))]
+    if cprimes!=old_cprimes:
+        print("Field %s: new cprimes labels do NOT agree with old" % label)
+    else:
+        print("Field %s: new cprimes labels DO agree with old" % label)
     return data
 
 def conjstringideal(F,stridl,g):

--- a/lmfdb/hilbert_modular_forms/check_conjugates.py
+++ b/lmfdb/hilbert_modular_forms/check_conjugates.py
@@ -68,13 +68,6 @@ def fldlabel2conjdata(label):
     data['primes'] = primes
     cprimes = conjideals(primes, auts)
     data['conjprimes'] = cprimes
-    #old code for comparison
-    primes = [prm[2] for prm in primes]
-    old_cprimes = [[primes.index(cideals[(prm,ig)]) for prm in primes] for ig in range(len(auts))]
-    if cprimes!=old_cprimes:
-        print("Field %s: new cprimes labels do NOT agree with old" % label)
-    else:
-        print("Field %s: new cprimes labels DO agree with old" % label)
     return data
 
 def conjstringideal(F,stridl,g):

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -92,9 +92,9 @@ def hilbert_modular_form_search(**args):
             elif field == 'field_label':
                 query[field] = parse_field_string(info[field])
             elif field == 'field_degree':
-                query[field] = parse_range(info[field])
+                query['deg'] = parse_range(info[field])
             elif field == 'field_disc':
-                query[field] = parse_range(info[field])
+                query['disc'] = parse_range(info[field])
             elif field == 'label':
                 query[field] = info[field]
             elif field == 'dimension':
@@ -104,32 +104,53 @@ def hilbert_modular_form_search(**args):
             else:
                 query[field] = info[field]
 
+    count_default = 100
     if info.get('count'):
         try:
             count = int(info['count'])
         except:
-            count = 100
+            count = count_default
     else:
-        info['count'] = 100
-        count = 100
+        info['count'] = count_default
+        count = count_default
+
+    start_default = 0
+    if info.get('start'):
+        try:
+            start = int(info['start'])
+            if(start < 0):
+                start += (1 - (start + 1) / count) * count
+        except:
+            start = start_default
+    else:
+        start = start_default
 
     info['query'] = dict(query)
     res = C.hmfs.forms.find(
-        query).sort([('level_norm', pymongo.ASCENDING), ('label', pymongo.ASCENDING)]).limit(count)
+        query).sort([('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)]).skip(start).limit(count)
     nres = res.count()
+    if(start >= nres):
+        start -= (1 + (start - nres) / count) * count
+    if(start < 0):
+        start = 0
 
     if nres > 0:
         info['field_pretty_name'] = field_pretty(res[0]['field_label'])
     else:
         info['field_pretty_name'] = ''
     info['number'] = nres
+    info['start'] = start
+    info['more'] = int(start + count < nres)
     if nres == 1:
         info['report'] = 'unique match'
     else:
-        if nres > count:
-            info['report'] = 'displaying first %s of %s matches' % (count, nres)
+        if nres == 0:
+            info['report'] = 'no matches'
         else:
-            info['report'] = 'displaying all %s matches' % nres
+            if nres > count or start != 0:
+                info['report'] = 'displaying matches %s-%s of %s' % (start + 1, min(nres, start + count), nres)
+            else:
+                info['report'] = 'displaying all %s matches' % nres
 
     res_clean = []
     for v in res:

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -127,7 +127,7 @@ def hilbert_modular_form_search(**args):
 
     info['query'] = dict(query)
     res = C.hmfs.forms.find(
-        query).sort([('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)]).skip(start).limit(count)
+        query).sort([('deg', pymongo.ASCENDING), ('disc', pymongo.ASCENDING), ('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)]).skip(start).limit(count)
     nres = res.count()
     if(start >= nres):
         start -= (1 + (start - nres) / count) * count

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -23,6 +23,9 @@ from lmfdb.number_fields.number_field import parse_list, parse_field_string
 
 from lmfdb.WebNumberField import *
 
+hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
+
+
 @hmf_page.route("/random")
 def random_hmf():    # Random Hilbert modular form
     from sage.misc.prandom import randint
@@ -62,12 +65,11 @@ def hilbert_modular_form_render_webpage():
     args = request.args
     if len(args) == 0:
         info = {}
-        credit = 'John Cremona, Lassina Dembele, Steve Donnelly and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
         t = 'Hilbert Modular Forms'
         bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage"))]
         info['learnmore'] = []
         info['counts'] = get_stats().counts()
-        return render_template("hilbert_modular_form_all.html", info=info, credit=credit, title=t, bread=bread)
+        return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=bread)
     else:
         return hilbert_modular_form_search(**args)
 
@@ -169,7 +171,7 @@ def hilbert_modular_form_search(**args):
     bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")), (
         'Search results', ' ')]
     properties = []
-    return render_template("hilbert_modular_form_search.html", info=info, title=t, properties=properties, bread=bread)
+    return render_template("hilbert_modular_form_search.html", info=info, title=t, credit=hmf_credit, properties=properties, bread=bread)
 
 
 @hmf_page.route('/<field_label>/holomorphic/<label>/download/<download_type>')
@@ -331,7 +333,6 @@ def render_hmf_webpage(**args):
                                                                                          'label'], ' ')]
 
     t = "Hilbert Cusp Form %s" % info['label']
-    credit = 'John Cremona, Lassina Dembele, Steve Donnelly and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
 
     forms_space = C.hmfs.forms.find(
         {'field_label': data['field_label'], 'level_ideal': data['level_ideal']})
@@ -412,4 +413,4 @@ def render_hmf_webpage(**args):
                    ('Base Change', is_base_change)
                    ]
 
-    return render_template("hilbert_modular_form.html", downloads=info["downloads"], info=info, properties2=properties2, credit=credit, title=t, bread=bread, friends=info['friends'])
+    return render_template("hilbert_modular_form.html", downloads=info["downloads"], info=info, properties2=properties2, credit=hmf_credit, title=t, bread=bread, friends=info['friends'])

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
@@ -1,7 +1,51 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<h2> Results ({{info.report}})</h2>
+<h2> Further refine search </h2>
+
+<form id='re-search'>
+<input type="hidden" name="start" value="{{info.start}}"/>
+<table border="0">
+<tr>
+<td>{{ KNOWL('nf', title='field') }}</td>
+<td><input type='text' name='field_label' value={{info.field_label}}>
+<td>field {{ KNOWL('nf.degree', title='degree') }}</td>
+<td><input type='text' name='field_degree' value={{info.field_degree}}>
+<td>field {{ KNOWL('nf.discriminant', title='discriminant') }}</td>
+<td><input type='text' name='field_disc' value={{info.field_disc}}>
+</tr>
+<tr>
+<td>{{ KNOWL('mf.hilbert.weight_vector', title='weight') }}</td>
+<td><input type='text' name='weight' value={{info.weight}}>
+<td>{{ KNOWL('mf.hilbert.level_norm', title='level norm') }}</td>
+<td><input type='text' name='level_norm' value={{info.level_norm}}>
+<td>{{ KNOWL('mf.hilbert.dimension', title='dimension') }}</td>
+<td><input type='text' name='dimension' value={{info.dimension}}>
+</tr>
+<tr>
+<td>Maximum number</td>
+<td><input type='text' name='count' value={{info.count}}></td>
+</tr>
+<tr>
+<td colspan=3><button type='submit' value='Search'>Refine of change search</button>
+</td>
+</tr>
+</table>
+</form>
+
+<h2> Results: {{info.report}}</h2>
+
+{% if info.number > 0 %}
+
+<hr>
+{% if info.start > 0 %}
+<a href="#" class="navlink"
+   onclick="decrease_start_by_count_and_submit_form('re-search');return
+            false">Previous</a>
+{% endif %}
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</a></td>
+{% endif %}
 
 <table class="ntdata">
 <tr>
@@ -21,7 +65,16 @@
 {% endfor %}
 </table>
 
+<hr>
+{% if info.start > 0 %}
+<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
+{% endif %}
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A></td>
+{% endif %}
 <br>
+{% endif %}
+
 <!--
    <p class="tex2jax_ignore">
    Results for database query {{ info.query }}


### PR DESCRIPTION
1. Added a "Further refine search" section at top.  (Test with any search from http://localhost:37777/ModularForm/GL2/TotallyReal/)
2. Added Previous / Next buttons which appear when relevant, and enhanced the heading e.g. "Displaying matches 101-200 of 350 matches"
3. Added to the database the numerical equivalent of the letter label_suffix field (e.g. 26 for ba) which enables better sorting of output.  e.g. search on level norm 3072 and see the corrrect order from 'a' to 'cd'.  This needs to be done also for elliptic curves. 
4. Added Aurel Page to credit, and added credit line to search results page.