### PR TITLE
better sorting of elliptic curve search results

### DIFF
--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -24,6 +24,7 @@ field) and value types (with examples):
    - short_label        *     string
    - conductor_label    *     string
    - iso_label          *     string (letter code of isogeny class)
+   - iso_nlabel         *     int (numerical code of isogeny class)
    - conductor_ideal    *     string
    - conductor_norm     *     int
    - number             *     int    (number of curve in isogeny class, from 1)
@@ -231,7 +232,7 @@ def field_data(s):
     return [s, deg, sig, abs_disc]
 
 
-@cached_function
+#@cached_function
 def get_cm_list(K):
     return cm_j_invariants_and_orders(K)
 
@@ -253,12 +254,18 @@ whitespace = re.compile(r'\s+')
 def split(line):
     return whitespace.split(line.strip())
 
+def numerify_iso_label(lab):
+    from sage.databases.cremona import class_to_int
+    if 'CM' in lab:
+        return -1 - class_to_int(lab[2:])
+    else:
+        return class_to_int(lab.lower())
 
 def curves(line):
     r""" Parses one line from a curves file.  Returns the label and a dict
     containing fields with keys 'field_label', 'degree', 'signature',
     'abs_disc', 'label', 'short_label', conductor_label',
-    'conductor_ideal', 'conductor_norm', 'iso_label', 'number',
+    'conductor_ideal', 'conductor_norm', 'iso_label', 'iso_nlabel', 'number',
     'ainvs', 'jinv', 'cm', 'q_curve', 'base_change',
     'torsion_order', 'torsion_structure', 'torsion_gens'.
 
@@ -277,6 +284,7 @@ def curves(line):
     field_label = data[0]       # string
     conductor_label = data[1]   # string
     iso_label = data[2]         # string
+    iso_nlabel = numerify_iso_label(iso_label)         # int
     number = int(data[3])       # int
     short_class_label = "%s-%s" % (conductor_label, iso_label)
     short_label = "%s%s" % (short_class_label, str(number))
@@ -348,6 +356,7 @@ def curves(line):
         'conductor_ideal': conductor_ideal,
         'conductor_norm': conductor_norm,
         'iso_label': iso_label,
+        'iso_nlabel': iso_nlabel,
         'number': number,
         'ainvs': ainvs,
         'jinv': jinv,
@@ -385,6 +394,7 @@ def curve_data(line):
     field_label = data[0]       # string
     conductor_label = data[1]   # string
     iso_label = data[2]         # string
+    iso_nlabel = numerify_iso_label(iso_label)         # int
     number = int(data[3])       # int
     short_label = "%s-%s%s" % (conductor_label, iso_label, str(number))
     label = "%s-%s" % (field_label, short_label)
@@ -427,6 +437,7 @@ def isoclass(line):
     field_label = data[0]       # string
     conductor_label = data[1]   # string
     iso_label = data[2]         # string
+    iso_nlabel = numerify_iso_label(iso_label)         # int
     number = int(data[3])       # int
     short_label = "%s-%s%s" % (conductor_label, iso_label, str(number))
     label = "%s-%s" % (field_label, short_label)
@@ -616,7 +627,7 @@ def download_curve_data(field_label, base_path, min_norm=0, max_norm=None):
         max_norm = 'infinity'
     cursor = nfcurves.find(query)
     ASC = pymongo.ASCENDING
-    res = cursor.sort([('conductor_norm', ASC), ('conductor_label', ASC), ('iso_label', ASC), ('number', ASC)])
+    res = cursor.sort([('conductor_norm', ASC), ('conductor_label', ASC), ('iso_nlabel', ASC), ('number', ASC)])
 
     file = {}
     prefixes = ['curves', 'curve_data', 'isoclass']

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -146,7 +146,7 @@ def show_ecnf1(nf):
         start -= (1 + (start - nres) / count) * count
     if(start < 0):
         start = 0
-    res = cursor.sort([('field_label', ASC), ('conductor_norm', ASC), ('conductor_label', ASC), ('iso_label', ASC), ('number', ASC)]).skip(start).limit(count)
+    res = cursor.sort([('field_label', ASC), ('conductor_norm', ASC), ('conductor_label', ASC), ('iso_nlabel', ASC), ('number', ASC)]).skip(start).limit(count)
 
     bread = [('Elliptic Curves', url_for(".index")),
              (nf_label, url_for('.show_ecnf1', nf=nf_label))]
@@ -346,7 +346,7 @@ def elliptic_curve_search(**args):
         start -= (1 + (start - nres) / count) * count
     if(start < 0):
         start = 0
-    res = cursor.sort([('field_label', ASC), ('conductor_norm', ASC), ('conductor_label', ASC), ('iso_label', ASC), ('number', ASC)]).skip(start).limit(count)
+    res = cursor.sort([('field_label', ASC), ('conductor_norm', ASC), ('conductor_label', ASC), ('iso_nlabel', ASC), ('number', ASC)]).skip(start).limit(count)
 
     res = list(res)
     for e in res:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -282,7 +282,7 @@ def elliptic_curve_search(**args):
             return search_input_error(info, bread)
 
     if 'download' in info and info['download'] != '0':
-        res = db_ec().find(query).sort([ ('conductor', ASCENDING), ('lmfdb_iso', ASCENDING), ('lmfdb_number', ASCENDING) ])
+        res = db_ec().find(query).sort([ ('conductor', ASCENDING), ('iso_nlabel', ASCENDING), ('lmfdb_number', ASCENDING) ])
         return download_search(info, res)
     
     count_default = 100
@@ -312,7 +312,7 @@ def elliptic_curve_search(**args):
         start -= (1 + (start - nres) / count) * count
     if(start < 0):
         start = 0
-    res = cursor.sort([('conductor', ASCENDING), ('lmfdb_iso', ASCENDING), ('lmfdb_number', ASCENDING)
+    res = cursor.sort([('conductor', ASCENDING), ('iso_nlabel', ASCENDING), ('lmfdb_number', ASCENDING)
                        ]).skip(start).limit(count)
     info['curves'] = res
     info['format_ainvs'] = format_ainvs
@@ -320,6 +320,8 @@ def elliptic_curve_search(**args):
     info['iso_url'] = lambda dbc: url_for(".by_double_iso_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1])
     info['number'] = nres
     info['start'] = start
+    info['count'] = count
+    info['more'] = int(start + count < nres)
     if nres == 1:
         info['report'] = 'unique match'
     elif nres == 2:
@@ -329,6 +331,7 @@ def elliptic_curve_search(**args):
             info['report'] = 'displaying matches %s-%s of %s' % (start + 1, min(nres, start + count), nres)
         else:
             info['report'] = 'displaying all %s matches' % nres
+
     credit = 'John Cremona'
     if 'non-surjective_primes' in query:
         credit += 'and Andrew Sutherland'

--- a/lmfdb/elliptic_curves/import_ec_data.py
+++ b/lmfdb/elliptic_curves/import_ec_data.py
@@ -19,6 +19,7 @@ The documents in the collection 'curves' in the database 'elliptic_curves' have 
    - 'conductor': (int) conductor, e.g. 1225
    - 'iso': (string) Cremona isogeny class code, e.g. '11a'
    - 'lmfdb_iso': (string) LMFDB isogeny class code, e.g. '11.a'
+   - 'iso_nlabel': (int) numerical version of the (lmfdb) isogeny class label
    - 'number': (int) Cremona curve number within its class, e.g. 2
    - 'lmfdb_number': (int) LMFDB curve number within its class, e.g. 2
    - 'ainvs': (list of strings) list of a-invariants, e.g. ['0', '1', '1', '10617', '75394']
@@ -79,19 +80,19 @@ print "setting curves"
 # curves = conn.elliptic_curves.test
 curves = conn.elliptic_curves.curves
 
-# The following ensure_index command checks if there is an index on
+# The following create_index command checks if there is an index on
 # label, conductor, rank and torsion. If there is no index it creates
 # one.  Need: once torsion structure is computed, we should have an
 # index on that too.
 
-curves.ensure_index('label')
-curves.ensure_index('conductor')
-curves.ensure_index('rank')
-curves.ensure_index('torsion')
-curves.ensure_index('degree')
-curves.ensure_index('jinv')
-curves.ensure_index('sha')
-curves.ensure_index('cm')
+curves.create_index('label')
+curves.create_index('conductor')
+curves.create_index('rank')
+curves.create_index('torsion')
+curves.create_index('degree')
+curves.create_index('jinv')
+curves.create_index('sha')
+curves.create_index('cm')
 
 print "finished indices"
 
@@ -116,6 +117,10 @@ def parse_ainvs(s):
 
 # def parse_gens(s):
  #   return [int(a) for a in s[1:-1].split(':')]
+
+def numerical_iso_label(lmfdb_iso):
+    from lmfdb.ecnf.import_ecnf_data import numerify_iso_label
+    return numerify_iso_label(lmfdb_iso.split('.')[1])
 
 whitespace = re.compile(r'\s+')
 
@@ -337,8 +342,8 @@ def alldegphi(line):
 
 def alllabels(line):
     r""" Parses one line from an alllabels file.  Returns the label
-    and a dict containing six fields, 'conductor', 'iso', 'number',
-    'lmfdb_label', 'lmfdb_iso', 'lmfdb_number', being strings or ints.
+    and a dict containing seven fields, 'conductor', 'iso', 'number',
+    'lmfdb_label', 'lmfdb_iso', 'iso_nlabel', 'lmfdb_number', being strings or ints.
 
     Input line fields:
 
@@ -360,6 +365,7 @@ def alllabels(line):
         'number': int(data[2]),
         'lmfdb_label': lmfdb_label,
         'lmfdb_iso': data[3] + '.' + data[4],
+        'iso_nlabel': numerical_iso_label(C['lmfdb_iso']),
         'lmfdb_number': data[5]
     }
 
@@ -531,3 +537,23 @@ def add_sha_tor_primes(N1,N2):
         data['sha_primes'] = [int(p) for p in sha_primes]
         data['torsion_primes'] = [int(p) for p in torsion_primes]
         curves.update({'lmfdb_label': label}, {"$set": data}, upsert=True)
+
+# one-off script to add numerical conversion of the isogeny class letter code, for sorting purposes
+def add_numerical_iso_codes(N1,N2):
+    """
+    Add the 'iso_nlabel' field to every
+    curve in the database whose conductor is between N1 and N2
+    inclusive.
+    """
+    query = {}
+    query['conductor'] = { '$gte': int(N1), '$lte': int(N2) }
+    res = curves.find(query)
+    res = res.sort([('conductor', pymongo.ASCENDING)])
+    n = 0
+    for C in res:
+        label = C['lmfdb_label']
+        n += 1
+        if n%1000==0: print label
+        data = {}
+        data['iso_nlabel'] = numerical_iso_label(C['lmfdb_iso'])
+        curves.update_one({'_id': C['_id']}, {"$set": data}, upsert=True)

--- a/lmfdb/elliptic_curves/templates/search_results.html
+++ b/lmfdb/elliptic_curves/templates/search_results.html
@@ -99,7 +99,16 @@ table td.params {
 
 {% if info.number %}
 
-<h2> Results ({{info.report}})</h2>
+<h2> Results ({{info.report}})
+{% if info.start > 0 %}
+<a href="#" class="navlink"
+   onclick="decrease_start_by_count_and_submit_form('re-search');return
+            false">Previous</A>
+{% endif %}
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
+{% endif %}
+</h2>
 <table>
 <tr>
   <th class="center">{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
@@ -128,20 +137,18 @@ table td.params {
 </table>
 
 <hr>
-<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
-<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A></td>
-
-
-{% else %}
-<h2> No matches</h2>
+{% if info.start > 0 %}
+<a href="#" class="navlink"
+   onclick="decrease_start_by_count_and_submit_form('re-search');return
+            false">Previous</A>
 {% endif %}
-
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
 {% endif %}
-
 
 
 <form>
-Download all search results for 
+Download all search results for
 <input type="submit" name="Submit" value="gp">
 <input type="submit" name="Submit" value="sage">
 <input type="submit" name="Submit" value="magma">
@@ -153,6 +160,15 @@ Download all search results for
 <input type="hidden" name="torsion_structure" value="{{info.torsion_structure}}"/>
 <input type="hidden" name="sha" value="{{info.sha}}"/>
 </form>
+
+
+{% else %}
+<h2> No matches</h2>
+{% endif %}
+
+{% endif %}
+
+
 
 
 {#


### PR DESCRIPTION
I added numerical version of the letter codes labelling isogeny classes which allows for a more sensible sorting of these when there are more than 26 for one conductor.  e.g. search on field 2.2.12.1 and conductor norm 3072 with include-isogenous-curves "no".  You will see that no longer are the labels ba...bz between b and c.

Field 2.0.4.1 and conductor norm 1-100 shows that it works OK even when the isogeny class labels have "CM" prepended (something which does need documenting somehere -- these are curves over imaginary quadratic fields with no associated Bianchi newform).

Field 3.1.23.1 and 2400-2600 shows that I handled the upper case letters used by Gunnells & Yasaki (which I do want to change at some point for consistency).

I did the same for elliptic curves over Q since first making the pull request.  Search on conductor 187200 with Optimal Only set to Yes to see the problem; or to see the record, N=235200.