### PR TITLE
Make it so that "right clicking" on mathjax gives the mathjax menu, 

### DIFF
--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -64,9 +64,26 @@ MathJax.Hub.Config({
   },
   asciimath2jax: { delimiters: [['#(',')#'], ['#[',']#']] },
   "HTML-CSS": { scale: 85 },
-  menuSettings: { zscale: "150%", zoom: "Double-Click", context: "Browser" }
+  menuSettings: { zscale: "150%", zoom: "Double-Click" }
 
 });
+MathJax.Hub.Register.StartupHook("MathEvents Ready",function () { 
+  var EVENT = MathJax.Extension.MathEvents.Event, 
+      MENU = EVENT.Menu, 
+      HUB = MathJax.Hub; 
+  EVENT.Menu = function (event) { 
+    if (!HUB.getJaxFor(this).noContextualMenu) {return MENU.apply(this,arguments)} 
+        return true; 
+  } 
+}); 
+MathJax.Hub.Queue( 
+  function () { 
+    var jax = MathJax.Hub.getAllJax("sidebar"); 
+    for (var i = 0, m = jax.length; i < m; i++) { 
+      jax[i].noContextualMenu = true; 
+    } 
+  } 
+); 
 </script>
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 {#- <script type="text/javascript" src="http://www.lmfdb.org/MathJax/MathJax.js"></script> -#}


### PR DESCRIPTION
except in the sidebar where it will give the browser menu.

Go to a page with math, right-click (control click for macs) on a Q in the sidebar, and you should get the browser menu, but in the rest of the page you get the mathjax menu.

The code came from a forum post by mathjax author Davide Cervone.
