### PR TITLE
Make blue highlight class blue again

### DIFF
--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -680,7 +680,7 @@ div.literature {
 }
 
 .bluehighlight {
-  color: black;
+  color: blue;
 }
 
 


### PR DESCRIPTION
On the page of an Artin representation, such as ArtinRepresentation/5/287296/3/ , at the bottom are the character values for the conjugacy classes.  It says that the class containing complex conjugation is blue, but it has been black because the corresponding css class was changed.  This sets it back to being blue.