### PR TITLE
Fix highlighting of positive zeros on l-function pages

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -883,7 +883,7 @@ def render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ar
     if len(positiveZeros) > 2 and len(negativeZeros) > 2:  # Add comma and empty space between negative and positive
         negativeZeros = negativeZeros.replace("]", ", ]")
 
-    return "<span class='redhighlight'>{0}</span><span class='bluehighlight'>{1}</span>".format(
+    return "<span class='redhighlight'>{0}</span><span class='nohighlight'>{1}</span>".format(
         negativeZeros[1:len(negativeZeros) - 1], positiveZeros[1:len(positiveZeros) - 1])
 
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -883,7 +883,7 @@ def render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ar
     if len(positiveZeros) > 2 and len(negativeZeros) > 2:  # Add comma and empty space between negative and positive
         negativeZeros = negativeZeros.replace("]", ", ]")
 
-    return "<span class='redhighlight'>{0}</span><span class='nohighlight'>{1}</span>".format(
+    return "<span class='redhighlight'>{0}</span><span class='positivezero'>{1}</span>".format(
         negativeZeros[1:len(negativeZeros) - 1], positiveZeros[1:len(positiveZeros) - 1])
 
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -683,6 +683,9 @@ div.literature {
   color: blue;
 }
 
+.nohighlight {
+  color: black;
+}
 
 
 .highlight {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -683,7 +683,7 @@ div.literature {
   color: blue;
 }
 
-.nohighlight {
+.positivezero {
   color: black;
 }
 


### PR DESCRIPTION
Previously, bluehighlight was being used on l-function pages (for positive zeros).  Since we just made bluehighlight use blue text, this fixes the l-function pages to give them a class for coloring the positive zeros, and restore it to black.