### PR TITLE
Short char bc

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -14,7 +14,7 @@ from lmfdb.utils import to_dict, parse_range, make_logger
 from lmfdb.WebCharacter import *
 from lmfdb.characters import characters_page, logger
 import ListCharacters
-from lmfdb.WebNumberField import WebNumberField
+##from lmfdb.WebNumberField import WebNumberField
 
 try:
     from dirichlet_conrey import *

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -113,7 +113,7 @@ def render_Dirichletwebpage(modulus=None, number=None):
         m = info['modlabel']
         info['bread'] = [('Characters','/Character'),
                          ('Dirichlet','/Character/Dirichlet'),
-                         ('Modulus %s'%m, '/Character/Dirichlet/%s'%m)]
+                         ('Mod %s'%m, '/Character/Dirichlet/%s'%m)]
         #logger.info(info)
         return render_template('CharGroup.html', **info)
     else:
@@ -127,8 +127,8 @@ def render_Dirichletwebpage(modulus=None, number=None):
         m,n = info['modlabel'], info['numlabel']
         info['bread'] = [('Characters','/Character'),
                          ('Dirichlet','/Character/Dirichlet'),
-                         ('Modulus %s'%m, '/Character/Dirichlet/%s'%m),
-                         ('Character number %s'%n, '/Character/Dirichlet/%s/%s'%(m,n)) ]
+                         ('Mod %s'%m, '/Character/Dirichlet/%s'%m),
+                         ('# %s'%n, '/Character/Dirichlet/%s/%s'%(m,n)) ]
         #logger.info(info)
         # TODO fix navi field
         del info["navi"]

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -128,7 +128,7 @@ def render_Dirichletwebpage(modulus=None, number=None):
         info['bread'] = [('Characters','/Character'),
                          ('Dirichlet','/Character/Dirichlet'),
                          ('Mod %s'%m, '/Character/Dirichlet/%s'%m),
-                         ('# %s'%n, '/Character/Dirichlet/%s/%s'%(m,n)) ]
+                         ('#%s'%n, '/Character/Dirichlet/%s/%s'%(m,n)) ]
         #logger.info(info)
         # TODO fix navi field
         del info["navi"]
@@ -185,7 +185,7 @@ def render_Heckewebpage(number_field=None, modulus=None, number=None):
         info['bread'] = [('Characters','/Character'),
                          ('Hecke','/Character/Hecke'),
                          ('Number Field %s'%number_field,'/Character/Hecke/%s'%number_field),
-                         ('Modulus %s'%m, '/Character/Hecke/%s/%s'%(number_field,m))]
+                         ('Mod %s'%m, '/Character/Hecke/%s/%s'%(number_field,m))]
         #logger.info(info)
         return render_template('CharGroup.html', **info)
     else:
@@ -195,8 +195,8 @@ def render_Heckewebpage(number_field=None, modulus=None, number=None):
         info['bread'] = [('Characters','/Character'),
                          ('Hecke','/Character/Hecke'),
                          ('Number Field %s'%number_field,'/Character/Hecke/%s'%number_field),
-                         ('Modulus %s'%m, '/Character/Hecke/%s/%s'%(number_field,m)),
-                         ('Character number %s'%n, '/Character/Hecke/%s/%s/%s'%(number_field,m,n))]
+                         ('Mod %s'%m, '/Character/Hecke/%s/%s'%(number_field,m)),
+                         ('#%s'%n, '/Character/Hecke/%s/%s/%s'%(number_field,m,n))]
         #logger.info(info)
         # TODO fix navi field
         del info["navi"]

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -14,6 +14,7 @@ from lmfdb.utils import to_dict, parse_range, make_logger
 from lmfdb.WebCharacter import *
 from lmfdb.characters import characters_page, logger
 import ListCharacters
+from lmfdb.WebNumberField import WebNumberField
 
 try:
     from dirichlet_conrey import *
@@ -189,14 +190,15 @@ def render_Heckewebpage(number_field=None, modulus=None, number=None):
         #logger.info(info)
         return render_template('CharGroup.html', **info)
     else:
-        info = WebHeckeCharacter(**args).to_dict()
+        X = WebHeckeCharacter(**args)
+        info = X.to_dict()
         info['navi'] = navi([info['previous'],info['next']])
         m,n = info['modlabel'], info['number']
         info['bread'] = [('Characters','/Character'),
                          ('Hecke','/Character/Hecke'),
                          ('Number Field %s'%number_field,'/Character/Hecke/%s'%number_field),
-                         ('Mod %s'%m, '/Character/Hecke/%s/%s'%(number_field,m)),
-                         ('#%s'%n, '/Character/Hecke/%s/%s/%s'%(number_field,m,n))]
+                         ('Mod %s'%X.modulus, '/Character/Hecke/%s/%s'%(number_field,m)),
+                         ('#%s'%X.number, '/Character/Hecke/%s/%s/%s'%(number_field,m,n))]
         #logger.info(info)
         # TODO fix navi field
         del info["navi"]

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -14,7 +14,6 @@ from lmfdb.utils import to_dict, parse_range, make_logger
 from lmfdb.WebCharacter import *
 from lmfdb.characters import characters_page, logger
 import ListCharacters
-##from lmfdb.WebNumberField import WebNumberField
 
 try:
     from dirichlet_conrey import *


### PR DESCRIPTION
Fix to ticket Dirichlet character breadcrumbs #410. Also changed breadcrumbs for Hecke character since they are even longer, cf. Character/Hecke/3.1.44.1/61.-22a0+1a1/1.

This request is a new copy of #487, I had to remove the branch corresponding to #487 due to a problem with github.