### PR TITLE
change source link at foot of page to point to beta or prod branch la…

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -145,6 +145,10 @@ def is_debug_mode():
     from flask import current_app
     return current_app.debug
 
+branch = "prod"
+if os.getenv('BETA') is not None: # or is_debug_mode():
+    branch = "beta"
+
 @app.before_request
 def set_beta_state():
     g.BETA = os.getenv('BETA') is not None or is_debug_mode()
@@ -238,8 +242,8 @@ _current_source = '<a href="%s%s">%s</a>' % (_url_source, git_rev, "Source")
 """
 Creates link to the list of revisions on the master, where the most recent commit is on top.
 """
-_url_changeset = 'https://github.com/LMFDB/lmfdb/commit/'
-_latest_changeset = '<a href="%s%s">%s</a>' % (_url_changeset, git_rev, git_date)
+_url_changeset = 'https://github.com/LMFDB/lmfdb/commits/%s' % branch
+_latest_changeset = '<a href="%s">%s</a>' % (_url_changeset, git_date)
 
 
 @app.context_processor


### PR DESCRIPTION
…test commit list depending on environment BETA

(it used to point to the diffs of the latest commit on master, which was not at all helpful especially on the production server).

Ideally it would also point to beta when running locally in debug mode, but we (JJ & JC) could not get that to work.
