### PR TITLE
show that an external link is external

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -374,7 +374,7 @@ to this elliptic curve is surjective.
 <p>
 The image of the {{KNOWL('ec.galois_rep',title='2-adic representation')}} attached to this elliptic curve
 is the subgroup of $\GL(2,\Z_2)$ with {{KNOWL('ec.rouse_label', title='Rouse label')}}
- <a href="{{data.data.twoadic_rouse_url}}">{{data.twoadic_label}}</a>.
+ <a href="{{data.data.twoadic_rouse_url}}" target="_blank">{{data.twoadic_label}}</a>.
 </p>
 <p>
 This subgroup is the pull-back of the subgroup of


### PR DESCRIPTION
Trivial change -- see http://localhost:37777/EllipticCurve/Q/15a1 under Galois Representations.  When the 2-adic rep is not surjective its image has a code defined by Rouse and the code is a link to his web pages, e.g. http://users.wfu.edu/rouseja/2adic/X187d.html .   This is now an "external" link with a little symbol next to it and opens in a new window/tab.
I will merge this right away to avoid wasting people's time.