### PR TITLE
Fix issue 570, missing gamma factors in some L-functions.

### DIFF
--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -686,6 +686,8 @@ def lfuncFEtex(L, fmt):
                 curr_nu_exp += 1
             else:
                 old_nu = nu
+                if curr_nu_exp > 1:
+                    ans += "^{" + str(curr_nu_exp) + "}"
                 curr_nu_exp = 1
                 ans += "\Gamma_{\C}(s" + seriescoeff(nu, 0, "signed", "", -6, 5) + ")"
         if curr_nu_exp >= 2:

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -672,6 +672,8 @@ def lfuncFEtex(L, fmt):
                 curr_mu_exp += 1
             else:
                 old_mu = mu
+                if curr_mu_exp > 1:
+                    ans += "^{" + str(curr_mu_exp) + "}"
                 curr_mu_exp = 1
                 ans += "\Gamma_{\R}(s" + seriescoeff(mu, 0, "signed", "", -6, 5) + ")"
         if curr_mu_exp >= 2:


### PR DESCRIPTION
The bug was on the L-function side.  Any L-function with a mu_i of multiplicity bigger than 1 which is not the largest mu_i would not get an exponent on the corresponding gamma factor.  This happens a lot for higher degree Artin representations.  An example which is now fixed is

  http://localhost:37777/L/ArtinRepresentation/4/1609/1/
