### PR TITLE
fix typesetting of base nf defining poly

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -31,6 +31,7 @@ field_list = {}  # cached collection of enhanced WebNumberFields, keyed by label
 def FIELD(label):
     nf = WebNumberField(label, gen_name=special_names.get(label, 'a'))
     nf.parse_NFelt = lambda s: nf.K()([QQ(str(c)) for c in s])
+    nf.latex_poly = web_latex(nf.poly())
     return nf
 
 def make_field(label):

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -61,7 +61,7 @@ function show_code(system) {
  {{ KNOWL('nf.generator', 'Generator') }} \({{
  ec.field.generator_name() }}\), with {{
  KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
- \({{ec.field.poly()}}\); {{ KNOWL('nf.class_number', 'class number')
+ {{ec.field.latex_poly}}; {{ KNOWL('nf.class_number', 'class number')
  }} \({{ec.field.class_number()}}\).
 </p>
 </div>


### PR DESCRIPTION
See http://beta.lmfdb.org/EllipticCurve/3.3.404.1/2.1/a/1 where the base field's defining poly looks bad since it not been properly latexed (see the visible * symbol).  Bug reported by Henri Cohen. This little patch fixes that.