### PR TITLE
Newdq

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -162,24 +162,21 @@ def parse_field_string(F):  # parse Q, Qsqrt2, Qsqrt-4, Qzeta5, etc
 def NF_redirect():
     return redirect(url_for(".number_field_render_webpage", **request.args))
 
-# function copied from classical_modular_form.py
-# def set_sidebar(l):
-#        res=list()
-##       print "l=",l
-#        for ll in l:
-#                if(len(ll)>1):
-#                        content=list()
-#                        for n in range(1,len(ll)):
-#                                content.append(ll[n])
-#                        res.append([ll[0],content])
-#       print "res=",res
-#        return res
-
+@nf_page.route("/HowComputed")
+def how_computed_page():
+    info = {}
+    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), 
+        ('Galois group labels', url_for(".render_groups_page")), 
+        (Completename, url_for(".render_discriminants_page")) ]
+    t = 'How Number Field Data was Computed'
+    bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Galois group labels', ' ')]
+    return render_template("single.html", kid='dq.nf.howcomputed', 
+        credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
 
 @nf_page.route("/GaloisGroups")
 def render_groups_page():
     info = {}
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")) ]
     t = 'Galois group labels'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Galois group labels', ' ')]
     C = base.getDBConnection()
@@ -210,7 +207,7 @@ def render_class_group_data():
     #for k in info.keys():
     # nf_logger.info(str(k) + ' ---> ' + str(info[k]))
     #nf_logger.info('******************* ')
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page"))]
+    #info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page"))]
     t = 'Class Groups of Quadratic Imaginary Fields'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), (t, ' ')]
     info['message'] =  ''
@@ -241,11 +238,11 @@ def render_class_group_data():
             info['message'] = 'Invalid congruence requested'
             return class_group_request_error(info, bread)
 
-    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread, learnmore=info.pop('learnmore'))
+    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread)
 
 def class_group_request_error(info, bread):
     t = 'Class Groups of Quadratic Imaginary Fields'
-    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread, learnmore=info.pop('learnmore'))
+    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread)
 
 
 @nf_page.route("/")
@@ -413,7 +410,11 @@ def render_field_webpage(args):
                                                                [str(a) for a in dirichlet_chars]),
                                                            poly=info['polynomial'])))
     info['learnmore'] = [('Global number field labels', url_for(
-        ".render_labels_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+        ".render_labels_page")), 
+        (Completename, url_for(".render_discriminants_page")),
+        ('How data was computed', url_for(".how_computed_page"))]
+    if info['signature'] == [0,1]:
+        info['learnmore'].append(('Quadratic imaginary class groups', url_for(".render_class_group_data")))
     # With Galois group labels, probably not needed here
     # info['learnmore'] = [('Global number field labels',
     # url_for(".render_labels_page")), ('Galois group
@@ -874,10 +875,3 @@ def download_search(info, res):
                      attachment_filename=filename,
                      as_attachment=True)
 
-@nf_page.route("/HowComputed")
-def how_computed_page():
-    info = {}
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
-    t = 'How This Data Was Computed'
-    bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('How computed', ' ')]
-    return render_template("how_computed.html", info=info, credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -76,7 +76,12 @@ def ctx_galois_groups():
 
 @app.context_processor
 def ctx_number_fields():
-    return {'number_field_data': number_field_data}
+    return {'number_field_data': number_field_data,
+            'global_numberfield_summary': global_numberfield_summary}
+
+def global_numberfield_summary():
+    init_nf_count()
+    return r'This database contains %s <a title="global number fields" knowl="nf">global number fields</a> of <a title="degree" knowl="nf.degree">degree</a> $n\leq %d$.  In addition, extensive data on <a href="%s">class groups of quadratic imaginary fields</a> is available for download.' %(comma(nfields),max_deg,url_for('.render_class_group_data'))
 
 def group_display_shortC(C):
     def gds(nt):
@@ -265,8 +270,8 @@ def number_field_render_webpage():
         }
         t = 'Global Number Fields'
         bread = [('Global Number Fields', url_for(".number_field_render_webpage"))]
-        info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
-        return render_template("number_field_all.html", info=info, credit=NF_credit, title=t, bread=bread)  # , learnmore=info.pop('learnmore'))
+        info['learnmore'] = [(Completename, url_for(".render_discriminants_page")), ('How data was computed', url_for(".how_computed_page")), ('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+        return render_template("number_field_all.html", info=info, credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
     else:
         return number_field_search(**args)
 
@@ -868,3 +873,11 @@ def download_search(info, res):
     return send_file(strIO,
                      attachment_filename=filename,
                      as_attachment=True)
+
+@nf_page.route("/HowComputed")
+def how_computed_page():
+    info = {}
+    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+    t = 'How This Data Was Computed'
+    bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('How computed', ' ')]
+    return render_template("how_computed.html", info=info, credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))

--- a/lmfdb/number_fields/templates/class_group_data.html
+++ b/lmfdb/number_fields/templates/class_group_data.html
@@ -72,4 +72,3 @@ $k = $
 </div>
 
 {% endblock %}
-</html>

--- a/lmfdb/number_fields/templates/discriminant_ranges.html
+++ b/lmfdb/number_fields/templates/discriminant_ranges.html
@@ -162,4 +162,3 @@ The bound \(B\) is for the
 </p>
 
 {% endblock %}
-</html>

--- a/lmfdb/number_fields/templates/galois_groups.html
+++ b/lmfdb/number_fields/templates/galois_groups.html
@@ -23,4 +23,3 @@ below.
 </p>
 
 {% endblock %}
-</html>

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -2,18 +2,9 @@
 {% block content %}
 {# Offers options to browse and search #}
 
-<p>
-This database contains {{ info.nfields }}
-{{KNOWL('nf', title='global number fields')}} of
-{{KNOWL('nf.degree', title='degree')}} $n\leq {{ info.maxdeg }}$.  The data is
-complete in a variety of ways, see 
-<a href="Discriminants">completeness of global number field data</a>
-for details.
-In addition, extensive data on
-<a href="QuadraticImaginaryClassGroups">class groups of quadratic imaginary
-fields</a> is available for download.
-
-</p>
+<div>
+{{ KNOWL_INC('dq.nf.extent') }}
+</div>
 
 <h2> Browse {{KNOWL('nf', title='global number fields')}} </h2>
 

--- a/lmfdb/number_fields/templates/number_field_labels.html
+++ b/lmfdb/number_fields/templates/number_field_labels.html
@@ -19,4 +19,3 @@ discriminant equals \(a_1^{\epsilon_1}a_2^{\epsilon_2}\cdots a_k^{\epsilon_k}\).
 
 
 {% endblock %}
-</html>


### PR DESCRIPTION
Add dynamic data quality knowl for extent of data for global number fields.

Added data quality menu to home page of number fields.  Contents of "how computed" needs improvement, but that is inside a knowl.  This and the last are accessible from main number field page.

The learnmore entry only now appears on main number field page and pages for any quadratic imaginary field, but no where else.

Removed extaneous closing html tags from some templates -- no visible change.