### PR TITLE
changes to sidebar

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -61,7 +61,7 @@
           status: beta
         - title: dummy
           status: future
-        - title: Local $\zeta$-functions
+        - title: Local L-functions
           status: future
           colspan: onecolumn
 

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -59,6 +59,11 @@
         - title: Operations
           url_for: "tensor_products.index"
           status: beta
+        - title: dummy
+          status: future
+        - title: Local $\zeta$-functions
+          status: future
+          colspan: onecolumn
 
 3ModForm:
    type: multilevel
@@ -79,6 +84,7 @@
            status: future
          - title: Half-integral
            status: future
+           colspan: onecolumn
          - title: Noncongruence
            status: future
            colspan: onecolumn
@@ -122,6 +128,7 @@
                colspan: onecolumn
              - title: $\Q$-curves
                status: future
+               colspan: onecolumn
            colspan: onecolumn
          - title: "Genus 2:"
            part3:
@@ -195,14 +202,13 @@
       url_for: "artin_representations.index"
     - title: Galois
       status: future
-    - title: dummy
-      status: future
+      colspan: onecolumn
     - title: Weil-Deligne
       status: future
-    - title: dummy
-      status: future
+      colspan: onecolumn
     - title: Automorphic
       status: future
+      colspan: onecolumn
 
 7Mot:
    type: simple
@@ -234,11 +240,13 @@
    parts:
     - title: Galois groups
       url_for: "galois_groups.index"
-    - title: dummy
+      colspan: onecolumn
+    - title: Sato-Tate groups
       status: future
+      colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"
-      status: future
+      status: beta
     - title: Subgroups of
       part2:
          - title: $\SL(2)$

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -182,6 +182,7 @@
       colspan: onecolumn
     - title: Function fields
       status: future
+      colspan: onecolumn
 
 6Repn:
    type: simple

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -18,7 +18,8 @@
   <tr>
   {% for item in value.secondpart.parts %}
      {% if not item.status or BETA %}
-    <td>{{item.url | safe}}</td>
+  {% if item.colspan == "onecolumn" %}<td colspan=2>{% else %}<td>{% endif %}
+      {{item.url | safe}}</td>
     {%- if loop.index is even -%}</tr><tr>{%- endif -%}
      {% endif %}
   {% endfor %}</tr>
@@ -45,7 +46,7 @@
         <table class="short2">
         <tr class="bor">
         {%- for pt2 in entry.part2 -%}
-          {%- if pt2.colspan == "onecolumn"%}
+          {%- if pt2.colspan == "onecolumn%" -%}
             {%- if loop.index is even -%}</tr><tr>{%- endif -%}
             <td colspan="2">
           {%- else -%}
@@ -165,39 +166,34 @@
       </tr><tr>
     {%- endif -%}{# if loop.index is even #}
   {%- endif -%}{# if entry.colspan == "onecolumn" #}
-  {%- if entry.status -%}
-    {%- if BETA -%}
-      <td scope="col" width="50%">{{entry.url | safe}}
-    {%- endif -%}
-  {%- else -%}
-    <td scope="col" width="50%">{{entry.url | safe}}
-  {%- endif -%}{# if entry.status #}
+  {%- if BETA or not entry.status -%}
+  {%- if entry.colspan == "onecolumn" -%}
+    <td colspan=2>
+      {%- else -%}
+    <td scope="col" width="20%">
+      {%- endif -%}
+      {{entry.url | safe}}
+  {%- endif -%}    {# if BETA or not entry.status #}
   {%- if entry.part2 -%}
-    <td scope="col" width="30%">
+    <td scope="col" width="40%">
     {%- for pt2 in entry.part2 -%}
-      {%- if pt2.status -%}
-        {%- if BETA -%}
+      {%- if BETA or not pt2.status -%}
           <span class="subtitle">{{ pt2.url | safe }}</span>
-        {%- endif -%}
-      {%- else -%}{# if pt2.status #}
-        <span class="subtitle">{{ pt2.url | safe }}</span>
       {%- endif -%}
       {%- if pt2.part3 -%}
         <div class="parts">
-        {%- for pt3 in pt2.part3 -%}
-          {%- if pt3.status == "future" -%}
-            {%- if BETA -%}
-              <span class="subitem">{{ pt3.url | safe}}</span>
+          {%- for pt3 in pt2.part3 -%}
+            {%- if BETA or not pt3.status -%}
+            {%- if pt3.status == "beta" -%}
+            <span class="beta", class="subitem">
+            {%- else -%}
+            <span class="subitem">
             {%- endif -%}
-          {%- elif pt3.status == "beta" -%}
-            {%- if BETA -%}
-              <span class="beta", class="subitem">{{ pt3.url | safe}}</span>
             {%- endif -%}
-          {%- else -%}
-            <span class="subitem">{{ pt3.url | safe}}</span>
-          {%- endif -%}{# if pt3.status == "future" #}
-        {%- endfor -%}{# for pt3 in pt2.part3 #}
-                      </div>
+            {{ pt3.url | safe}}
+            </span>
+          {%- endfor -%}{# for pt3 in pt2.part3 #}
+        </div>
       {%- endif -%} {# if pt2.part3 #}
     {%- endfor -%} {# for pt2 in entry.part2 #}
     </td>


### PR DESCRIPTION
Lattices now appear in the sidebar (under beta only).  Also added (tagged "future" so not visible except under beta):  Local zeta-functions (under L-functions), and Sato-Tate groups (under groups) and some small tidying up.

Not that the design was supposed to be that this sort of thing *only* required changing the sidebar.yaml file;  however it also always seems to also requre changes to the html template too, whose logic is quite baroque.