### PR TITLE
New artin representation code

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -454,7 +454,7 @@ class WebNumberField:
             else:
                 if "nfgg" not in self._data:
                     from math_classes import NumberFieldGaloisGroup
-                    nfgg = NumberFieldGaloisGroup.find_one({"label": self.label})
+                    nfgg = NumberFieldGaloisGroup(self._data['coeffs'])
                     self._data["nfgg"] = nfgg
                 else:
                     nfgg = self._data["nfgg"]
@@ -465,18 +465,19 @@ class WebNumberField:
             ccns = [int(x.size()) for x in cc]
             ccreps = [x.cycle_string() for x in ccreps]
             ccgen = '['+','.join(ccreps)+']'
-            ar = nfgg.ArtinReps() # list of artin reps from db
+            ar = nfgg.artin_representations() # list of artin reps from db
+            arfull = nfgg.artin_representations_full_characters() # list of artin reps from db
             gap.set('fixed', 'function(a,b) if a*b=a then return 1; else return 0; fi; end;');
             g = gap.Group(ccgen)
             h = g.Stabilizer('1')
             rc = g.RightCosets(h)
             # Permutation character for our field
             permchar = [gap.Sum(rc, 'j->fixed(j,'+x+')') for x in ccreps]
-            charcoefs = [0 for x in ar]
+            charcoefs = [0 for x in arfull]
             # list of lists (inner are giving char values
-            ar2 = [x['Character'] for x in ar]
+            ar2 = [x[0] for x in arfull]
             for j in range(len(ar)):
-                fieldchar = int(ar[j]['CharacterField'])
+                fieldchar = int(arfull[j][1])
                 zet = CyclotomicField(fieldchar).gen()
                 ar2[j] = [psum(zet, x) for x in ar2[j]]
             for j in range(len(ar)):

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This Blueprint is about Artin representations
-# Author: Paul-Olivier Dehaye
+# Author: Paul-Olivier Dehaye, John Jones
 
 import pymongo
 ASC = pymongo.ASCENDING
@@ -17,18 +17,24 @@ from lmfdb.WebNumberField import *
 
 def initialize_indices():
     try:
-        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor_plus", ASC),("galorbit", ASC)])
-        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor", ASC)])
-        ArtinRepresentation.collection().ensure_index([("Conductor", ASC), ("Dim", ASC)])
+#        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor_plus", ASC),("galorbit", ASC)])
+#        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor", ASC)])
+#        ArtinRepresentation.collection().ensure_index([("Conductor", ASC), ("Dim", ASC)])
+	pass
     except pymongo.errors.OperationFailure:
         pass
-
 
 def get_bread(breads=[]):
     bc = [("Artin Representations", url_for(".index"))]
     for b in breads:
         bc.append(b)
     return bc
+
+def make_cond_key(D):
+    D1=ZZ(D)
+    if D1<1: D1=ZZ(1)
+    D1 = int(D1.log(10))
+    return '%04d%s'%(D1,str(D))
 
 
 @artin_representations_page.route("/")
@@ -59,9 +65,14 @@ def parse_compound(query, fn=lambda x: x):
 
 def artin_representation_search(**args):
     req = to_dict(args)
-    title = 'Artin representations search results'
-    bread = [('Artin representations', url_for(".index")), ('Search results', ' ')]
-    query = {}
+    if 'natural' in req:
+        label = req['natural']
+        # test if it is ok
+        return render_artin_representation_webpage(label)
+
+    title = 'Artin representation search results'
+    bread = [('Artin representation', url_for(".index")), ('Search results', ' ')]
+    query = {'Hide': 0}
     if req.get("ramified", "") != "":
         tmp = req["ramified"].split(",")
         query["BadPrimes"] = {"$all": [str(x) for x in tmp]}
@@ -89,7 +100,6 @@ def artin_representation_search(**args):
             gcs = complete_group_codes(req['group'])
             if len(gcs) == 1:
                 query['Galois_nt'] = gcs[0]
-# list(gcs[0])
             if len(gcs) > 1:
                 query['Galois_nt'] = {'$in': [x for x in gcs]}
         except NameError as code:
@@ -100,8 +110,7 @@ def artin_representation_search(**args):
 
     tmp_conductor = []
     if req.get("conductor", "") != "":
-        from lmfdb.utils import len_val_fn
-        tmp_conductor = parse_compound(req["conductor"], fn=len_val_fn)
+        tmp_conductor = parse_compound(req["conductor"], fn=make_cond_key)
     # examples of tmp_conductor: [],
     # [{"len":2,"val":"44"},{"len":3,"val":"444"},{"$gte":{"len":2,"val":"44"},
     # "$lte":{"len":5,"val";"44444"}}]
@@ -109,50 +118,67 @@ def artin_representation_search(**args):
     if req.get("dimension", "") != "":
         tmp_dimension = parse_compound(req["dimension"], fn=int)
     # examples of tmp_dimension: [], [17], [5,7,{"$gte":4, "$lte":10}]
-    tmp_both = [{"Conductor_plus": c, "Dim": d} for c in tmp_conductor for d in tmp_dimension]
+    tmp_both = [{"Conductor_key": c, "Dim": d} for c in tmp_conductor for d in tmp_dimension]
     if len(tmp_conductor) == 0:
         tmp_both += [{"Dim": d} for d in tmp_dimension]
     if len(tmp_dimension) == 0:
-        tmp_both += [{"Conductor_plus": c} for c in tmp_conductor]
+        tmp_both += [{"Conductor_key": c} for c in tmp_conductor]
     if len(tmp_both) == 1:
         query.update(tmp_both[0])
     elif len(tmp_both) >= 2:
         query["$or"] = tmp_both
 
-    # Only show 1 polynomial per representation
-    query["Show"] = 1
-    count_default = 20
+    count_default = 50
     if req.get('count'):
         try:
             count = int(req['count'])
         except:
             count = count_default
-            req['count'] = count
     else:
-        req['count'] = count_default
         count = count_default
+    req['count'] = count
 
-    #results = ArtinRepresentation.collection().find(query).sort([("Dim", ASC), ("Conductor_plus", ASC), ("galorbit", ASC)]).limit(count)
-    results = ArtinRepresentation.collection().find(query).sort([("Dim", ASC), ("Conductor_plus", ASC), ("galorbit", ASC)])
-    # We step through the data so we can collect Galois conjugate rep'ns
-    data = []
-    galclass = []
-    curclass = '0'
-    for x in results:
-        ar = ArtinRepresentation(data=x)
-        if ar.galois_orbit_label() == curclass:
-            galclass.append(ar)
+    start_default = 0
+    if req.get('start'):
+        try:
+            start = int(req['start'])
+            if(start < 0):
+                start += (1 - (start + 1) / count) * count
+        except:
+            start = start_default
+    else:
+        start = start_default
+    if req.get('paging'):
+        try:
+            paging = int(req['paging'])
+            if paging == 0:
+                start = 0
+        except:
+            pass
+
+
+    data = ArtinRepresentation.collection().find(query).sort([("Dim", ASC), ("Conductor_key", ASC)])
+    nres = data.count()
+    data = data.skip(start).limit(count)
+
+    if(start >= nres):
+        start -= (1 + (start - nres) / count) * count
+    if(start < 0):
+        start = 0
+    if nres == 1:
+        report = 'unique match'
+    else:
+        if nres > count or start != 0:
+            report = 'displaying matches %s-%s of %s' % (start + 1, min(nres, start + count), nres)
         else:
-            if curclass != '0':
-                data.append(galclass)
-            curclass = ar.galois_orbit_label()
-            galclass = [ar]
-        if len(data) >= count:
-            break
-    if len(data) < count and len(galclass)>0:
-        data.append(galclass)
+            report = 'displaying all %s matches' % nres
+    if nres == 0:
+        report = 'no matches'
 
-    return render_template("artin-representation-search.html", req=req, data=data, data_count=len(data), title=title, bread=bread, query=query)
+
+    initfunc = ArtinRepresentation
+
+    return render_template("artin-representation-search.html", req=req, data=data, title=title, bread=bread, query=query, start=start, report=report, nres=nres, initfunc=initfunc)
 
 
 # Obsolete
@@ -166,20 +192,14 @@ def artin_representation_search(**args):
 #    return "ERROR: we always do http get to explicitly display the search parameters"
 #  else:
 #    return flask.redirect(404)
-@artin_representations_page.route("/<dim>/<conductor>/<index>")
-def by_data_no_slash(dim, conductor, index):
-    return flask.redirect(url_for(".by_data", dim=dim, conductor=conductor, index=index), code=301)
+#
+#@artin_representations_page.route("/<label>/")
+#def by_label_with_slash(label):
+#    print "here"
+#    return flask.redirect(url_for(".render_artin_representation_webpage", label=label), code=301)
 
 def search_input_error(info, bread):
     return render_template("artin-representation-search.html", req=info, title='Artin Representation Search Error', bread=bread)
-
-
-@artin_representations_page.route("/<dim>/<conductor>/<index>/")
-def by_data(dim, conductor, index):
-    artin_logger.debug("Asked for the Artin representation with parameters dim: %s conductor: %s index: %s" %
-                       (dim, conductor, index))
-    return render_artin_representation_webpage(dim, conductor, index)
-
 
 @artin_representations_page.route("/<dim>/<conductor>/")
 def by_partial_data(dim, conductor):
@@ -189,30 +209,31 @@ def by_partial_data(dim, conductor):
 
 
 # credit information should be moved to the databases themselves, not at the display level. that's too late.
-tim_credit = "Tim Dokchitser on Magma"
+tim_credit = "Tim Dokchitser, John Jones, and David Roberts"
 support_credit = "Support by Paul-Olivier Dehaye."
 
 
-def render_artin_representation_webpage(dim, conductor, index):
-    the_rep = ArtinRepresentation.find_one(
-        {'Dim': int(dim), "Conductor": str(conductor), "DBIndex": int(index)})
+@artin_representations_page.route("/<label>")
+def render_artin_representation_webpage(label):
+    # label=dim.cond.nTt.indexcj, c is literal, j is index in conj class
+    # Should we have a big try around this to catch bad labels?
+    the_rep = ArtinRepresentation(label)
 
-    extra_data = {}
-    C = base.getDBConnection()
-    extra_data['galois_knowl'] = group_display_knowl(5,3,C)
+    extra_data = {} # for testing?
+    C = getDBConnection()
+    extra_data['galois_knowl'] = group_display_knowl(5,3,C) # for testing?
     artin_logger.info("Found %s" % (the_rep._data))
 
-    bread = get_bread([(str("Dimension %s, conductor %s, index %s" % (the_rep.dimension(),
-                      the_rep.conductor(), the_rep.index())), ' ')])
+    bread = get_bread([(label, ' ')])
 
-    title = the_rep.title()
+    title = "Artin representation %s" % label
     the_nf = the_rep.number_field_galois_group()
     from lmfdb.number_field_galois_groups import nfgg_page
     from lmfdb.number_field_galois_groups.main import by_data
-    if the_rep.root_number() == 0:
-        processed_root_number = "unknown"
+    if the_rep.sign() == 0:
+        processed_root_number = "not computed"
     else:
-        processed_root_number = str(the_rep.root_number())
+        processed_root_number = str(the_rep.sign())
     properties = [("Dimension", str(the_rep.dimension())),
                   ("Group", the_rep.group()),
                   #("Conductor", str(the_rep.conductor())),
@@ -225,17 +246,18 @@ def render_artin_representation_webpage(dim, conductor, index):
     friends = []
     nf_url = the_nf.url_for()
     if nf_url:
-        friends.append(("Artin Field", nf_url))
+    	friends.append(("Artin Field", nf_url))
 
     friends.append(("L-function", url_for("l_functions.l_function_artin_page",
-                                          dimension=the_rep.dimension(),
-                                          conductor=the_rep.conductor(),
-                                          tim_index=the_rep.index())))
-              #[
-              #("Same degree and conductor", url_for(".by_partial_data", dim = the_rep.dimension(), conductor = the_rep.conductor())),\
-              #("L-function", url_for("l_functions.l_function_artin_page",  dimension = the_rep.dimension(), conductor = the_rep.conductor(), tim_index = the_rep.index()))
-              #]
-    return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, properties2=properties, extra_data=extra_data)
+                                          label=the_rep.label())))
+    info={}
+    #info['pol2']=str(the_rep.central_char(2))
+    #info['pol3']=str(the_rep.central_char(3))
+    #info['pol5']=str(the_rep.central_char(5))
+    #info['pol7']=str(the_rep.central_char(7))
+    #info['pol11']=str(the_rep.central_char(11))
+
+    return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, properties2=properties, extra_data=extra_data, info=info)
 
 
 def render_artin_representation_set_webpage(dim, conductor):

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -42,8 +42,26 @@ By {{ KNOWL('artin.gg_quotient',title="group") }}:
 <a href="?group=A7">$A_7$</a>,
 <a href="?group=S7">$S_7$</a>
 
+<h2>Go to a specific Artin representation by {{KNOWL('artin.label',title='label')}}
+
+<form>
+<table border=0 cellpadding=5>
+<tr>
+<td>Artin representation:&nbsp;&nbsp;</td>
+<td ><input type='text' name='natural' size=60 example='3.2e3_7e5.7t3.1c1'> </td>
+<td><button type='submit' name='search' value='Go'>label</button></td>
+</tr>
+<tr>
+<td colspan="3" rowspan="2"><span class="formexample"> e.g.,
+3.2e3_7e5.7t3.1c1
+</span></td>
+</tr>
+</table>
+</form>
+
+
 <h2> Search for an Artin representation </h2>
-Please enter a value or leave blank:
+Enter values into one or more boxes to restrict the search.
 <p></p>
 <form>
   <table>
@@ -89,31 +107,8 @@ Please enter a value or leave blank:
         <td><span class="formexample"> +1 for orthogonal, -1 for symplectic, 0 for non-real character </span></td>
     </tr>
 
-    {#
     <tr>
-        <td>Transitive degree</td>
-        <td><input type='text' name='transitive_degree' placeholder="2" size=15></td>
-        <td><span class="formexample"> e.g. 2, 2-5 </span></td>
-    </tr>
-    #}
-    
-    {#
-    <tr>
-        <td>{{ KNOWL('gg.galois_group',title="Galois group") }}</td>
-        <td><input type='text' name='galois_group' placeholder="S3" size=15></td>
-        <td><span class="formexample"> e.g. S3, C5 </span></td>
-    </tr>
-    #}
-    {#
-    <tr>
-        <td>Galois group size</td>
-        <td><input type='text' name='group_size' placeholder="10" size=15></td>
-        <td><span class="formexample"> e.g. 10 </span></td>
-    </tr>
-    #}
-
-    <tr>
-        <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value=15 size=10></td>
+        <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value='50' size='10'></td>
     </tr>
   </table>
   

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -48,7 +48,7 @@ By {{ KNOWL('artin.gg_quotient',title="group") }}:
 <table border=0 cellpadding=5>
 <tr>
 <td>Artin representation:&nbsp;&nbsp;</td>
-<td ><input type='text' name='natural' size=60 example='3.2e3_7e5.7t3.1c1'> </td>
+<td ><input type='text' name='natural' size='30' example='3.2e3_7e5.7t3.1c1'> </td>
 <td><button type='submit' name='search' value='Go'>label</button></td>
 </tr>
 <tr>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -2,7 +2,9 @@
 {% block content %}
 {# Refine search page #}
 
-<form>
+<form id="re-search">
+<input type="hidden" name="start" value="{{start}}"/>
+<input type="hidden" name="paging" value="0"/>
   <table>
     <tr>
       <td>{{ KNOWL('artin.dimension',title="Dimension") }}</td>
@@ -80,11 +82,10 @@
 
 
 
-<h2> Results: showing {{data_count}} results </h2>
-{% if data_count > 0 %}
+<h2> Results: {{report}} </h2>
+{% if nres > 0 %}
 <div>
-  Galois conjugate representations are grouped into single lines.  Some representations may be
-  listed more than once if they are presented in terms of different defining polynomials.
+  Galois conjugate representations are grouped into single lines.  
 </div>
 
 <div>
@@ -101,27 +102,35 @@
 	</tr></thead>
 	<tbody>
 
-        {% for galclass in data%}
-        {% set outer_loop = loop %}
+        {% for artin in data%}
+        {% set art = initfunc(artin['Baselabel'],1) %}
+        {% set galccsize = art.galois_conjugacy_size() %}
           <tr><td>
-          {% for artin in galclass %}
-            <a href = "{{artin.url_for()}}">{{outer_loop.index}}.{{loop.index}}</a>
+          {% for cnt in range(galccsize) %}
+        {% set artx = initfunc(artin['Baselabel'],cnt+1) %}
+            <a href = "{{artx.url_for()}}">{{art.baselabel()}}c{{cnt+1}}</a>
           {% endfor %}
-          {% set artin = galclass[0] %}
             </td>
-            <td>${{artin.dimension()}}$</td>
-          <td>${{artin.factored_conductor_latex()}}$</td>
-          <td>{{ artin.field_knowl()|safe }}</td>
+            <td>${{art.dimension()}}$</td>
+          <td>${{art.factored_conductor_latex()}}$</td>
+          <td>{{ art.field_knowl()|safe }}</td>
 
 	  {# <td align="center">{{artin.number_field_galois_group().G_name()}}</td> #}
-	  <td align="center">{{artin.pretty_galois_knowl() | safe }} </td>
+	  <td align="center">{{art.pretty_galois_knowl() | safe }} </td>
 {#	  <td>${{artin.processed_root_number()}}$</td> #}
-	  <td> ${{artin.indicator()}}$</td>
-	  <td>${{artin.trace_complex_conjugation()}}$</td>
+	  <td> ${{artin.Indicator}}$</td>
+	  <td>${{art.trace_complex_conjugation()}}$</td>
 	  </tr>
         {% endfor %}
 	</tbody>
 	</table>
+     {% if start > 0 %}
+         <a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
+      {% endif %}
+       {% if start +req.count  < nres %}
+   <a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A></td>
+    {% endif %}
+
   {% endif %}
 {% endif %}
 

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -8,7 +8,9 @@
         <tr><td>{{ KNOWL('artin.gg_quotient', title='Group') }}:<td>{{ object.pretty_galois_knowl() | safe }}</td>
         <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>${{ object.conductor_equation() }} $</tr>
         <tr><td> {{ KNOWL('artin.number_field', title='Artin number field') }}: <td>Splitting field of
-                $f={{ object.number_field_galois_group().polynomial().latex()}}$ over $\Q$.</tr>
+                $f={{ object.number_field_galois_group().polynomial().latex()}}$ over $\Q$</tr>
+        <tr><td> Size of {{ KNOWL('artin.galois_orbit', title='Galois orbit') }}: <td> {{object.galois_conjugacy_size()}}
+        <tr><td> Smallest {{ KNOWL('artin.permutation_container', title='containing permutation representation') }}: <td> {{object.smallest_gal_t_format()|safe}}
         <tr><td> {{ KNOWL('artin.parity', title='Parity') }} <td> {{ object.parity()}} </tr>
     </table>
 
@@ -44,7 +46,7 @@
         \end{aligned}\]
     </div>
     
-    <h3>Generators of the action on the roots $r_1 \cdots r_{{object.number_field_galois_group().degree()}}$</h3>
+    <h3>Generators of the action on the roots $r_1, \ldots, r_{{object.number_field_galois_group().degree()}}$</h3>
     <div>
     <center>
     <table class="ntdata">
@@ -77,7 +79,16 @@
       </center>
        The blue line marks the conjugacy class containing complex conjugation.
     </div>
-    
+ {# For testing in progress
+ <div>
+ <br>
+ {{ info.pol2 }} <br>
+ {{ info.pol3 }} <br>
+ {{ info.pol5 }} <br>
+ {{ info.pol7 }} <br>
+ {{ info.pol11 }} <br>
+ </div>
+ #}
    
 {% endblock %}
 

--- a/lmfdb/databases/Dokchitser_databases.py
+++ b/lmfdb/databases/Dokchitser_databases.py
@@ -1,5 +1,5 @@
-artin_location = ("limbo", "artrep20130914")
-galois_group_location = ("limbo", "nfgal20130914")
+artin_location = ("artin", "representations")
+galois_group_location = ("artin", "field_data")
 
 from type_generation import String, Array, Dict, Int, Anything, Float
 
@@ -43,25 +43,30 @@ LenPair = Dict({
     "val": TooLargeInt
 })
 
+Galois_Conjugate = Dict(
+    {
+    	"LocalFactors": FiniteSequence(Anything),
+    	"Character": Anything,
+    	"Sign": Int,
+    	"HardFactors": FiniteSequence(IndexAt1),
+    	"GalOrbIndex": Int
+    })
+
+
 Dokchitser_ArtinRepresentation = Dict({
     "_id": Anything,
+    "Baselabel": String,
     "Dim": Int,
     "Indicator": Int,
     "Conductor": TooLargeInt,
-    "HardFactors": FiniteSequence(IndexAt1),
     "HardPrimes": FiniteSequence(TooLargeInt),
     "BadPrimes": FiniteSequence(TooLargeInt),
-    "LocalFactors": FiniteSequence(Anything),
-    "DBIndex": IndexAt1,        # Starting at 1 
-    "NFGal": FiniteSequence(Anything),
-    "Character": Anything,
-    "Sign": Int,
+    "NFGal": LabelString,
     "CharacterField": Int,
-    "Conductor_plus": LenPair,                             # Added after Tim, by inject_conductor_len.py
-    "Galois_nt": Array(Int,Int),                           # Added after Tim by jj
-    # Next is whether or not to show this in a search page because of redundancies
-    "Show": Int,                                           # Added after Tim by jj
-    "galorbit": Anything,                                  # Added after Tim by jj
+    "Conductor_key": String,
+    "Galois_nt": Array(Int,Int),                          
+    "Hide": Int,                                           
+    "GaloisConjugates": FiniteSequence(Galois_Conjugate)
 })
 
 
@@ -76,11 +81,10 @@ Dokchitser_FrobResolvent = Dict(
         "Classes": Anything
     })
 
-Dokchitser_ArtinRepresentation_Short = Dict(
+ArtinRepresentation_Short = Dict(
     {
-        "Dim": Int,
-        "Conductor": TooLargeInt,
-        "DBIndex": IndexAt1,        # Starting at 1
+        "Baselabel": String,
+        "GalConj": Int,
         "CharacterField": Int,
         "Character": Dokchitser_Character
     })
@@ -95,22 +99,20 @@ Dokchitser_ConjugacyClass = Dict(
 
 Dokchitser_NumberFieldGaloisGroup = Dict({
     "_id": Anything,
-    "ArtinReps": FiniteSequence(Dokchitser_ArtinRepresentation_Short),
+    "ArtinReps": FiniteSequence(ArtinRepresentation_Short),
     "ComplexConjugation": Int,
     "ConjClasses": FiniteSequence(Dokchitser_ConjugacyClass),
-    "DBIndex": IndexAt1,                    # Starting at 1
     "FrobResolvents": Array(Dokchitser_FrobResolvent),
     "Frobs": PrimeIndexedSequence(Int),
     "G-Gens": FiniteSet(PermutationAsList),
     "G-Name": Custom_GroupLabel,
-    "Polynomial": PolynomialAsSequenceTooLargeInt,
+    "Polynomial": String, #PolynomialAsSequenceTooLargeInt,
     "QpRts": FiniteSequence(PolynomialAsSequenceTooLargeInt),
     "QpRts-minpoly": PolynomialAsSequenceInt,
     "QpRts-p": Int,
     "QpRts-prec": Int,
     "Size": TooLargeInt,
-    "TransitiveDegree": Int,
-    "label": LabelString                 # Added after Tim, by link_tim_other.py script
+    "TransitiveDegree": Int
 })
 
 

--- a/lmfdb/import_scripts/artin_representations/import_art_nf.py
+++ b/lmfdb/import_scripts/artin_representations/import_art_nf.py
@@ -1,0 +1,117 @@
+import sys, time
+import bson
+import sage.all
+import re
+import json
+from sage.all import *
+
+#pw_filename = "../../../xyzzy"
+#password = open(pw_filename, "r").readlines()[0].strip()
+
+# find lmfdb and the top of the tree
+mypath = os.path.realpath(__file__)
+while os.path.basename(mypath) != 'lmfdb':
+    mypath = os.path.dirname(mypath)
+    # now move up one more time...
+mypath = os.path.dirname(mypath)
+sys.path.append(mypath)
+
+# load the password file
+import yaml
+pw_dict = yaml.load(open(os.path.join(mypath, "passwords.yaml")))
+username = pw_dict['data']['username']
+password = pw_dict['data']['password']
+
+# fire it up
+#from lmfdb import base
+#C= base.getDBConnection()
+from pymongo.mongo_client import MongoClient
+C= MongoClient(port=37010)
+
+C['artin'].authenticate(username, password)
+
+art=C.artin
+rep=art.representations
+nfgal=art.field_data
+
+count = 0
+old = 0
+
+#utilities
+
+# turn poly coefs into a string
+def makels(li):
+  li2 = [str(x) for x in li]
+  return ','.join(li2)
+
+# turn a conductor into a sortable string
+# this uses length 4 prefix
+def make_cond_key(D):
+  D1 = int(D.log(10))
+  return '%04d%s'%(D1,str(D))
+
+
+# Main programs
+
+def artrepload(l):
+  global count
+  global old
+  ar1 = rep.find_one({'Baselabel': l['Baselabel']})
+  if ar1 is not None:
+    #print "Old representation"
+    old += 1
+    if (count+old) % 100==0:
+      print "%s new, %s old" %(str(count),str(old))
+    return
+  cond_key = make_cond_key(ZZ(l['Conductor']))
+  l['Conductor_key'] = cond_key
+  l['NFGal'] = makels(l['NFGal'])
+  rep.save(l)
+  count +=1
+  if (count+old) % 100==0:
+    print "%s new, %s old" %(str(count),str(old))
+  return
+
+def nfgalload(l):
+  global count
+  global old
+  polstr = makels(l['Polynomial'])
+  ff = nfgal.find_one({'Polynomial': polstr})
+  if ff is not None:
+    # print "Old field"
+    old += 1
+    if (count+old) % 100==0:
+      print "%s new, %s old" %(str(count),str(old))
+    return 
+  l['Polynomial']=polstr
+  artreps=l['ArtinReps']
+  artreps=[{'Baselabel': z[0][0], 'GalConj': z[0][1], 'CharacterField': z[1],
+    'Character': z[2]} for z in artreps]
+  l['ArtinReps']=artreps
+  nfgal.save(l)
+  count +=1
+  if (count+old) % 100==0:
+    print "%s new, %s old" %(str(count),str(old))
+  return
+
+
+# processing file names
+for path in sys.argv[1:]:
+    print path
+    count = 0
+    filename = os.path.basename(path)
+    fn = gzip.open(path) if filename[-3:] == '.gz' else open(path)
+    if re.match(r'^nfgal', filename):
+      case = 'nfgal'
+    if re.match(r'^art', filename):
+      case = 'art rep'
+    for line in fn.readlines():
+        line.strip()
+        if re.match(r'\S',line):
+            l = json.loads(line)
+	    if case == 'nfgal':
+	      nfgalload(l)
+	    if case == 'art rep':
+	      artrepload(l)
+
+

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -997,19 +997,15 @@ class DedekindZeta(Lfunction):   # added by DK
                     if nfgg[j]>0:
                         the_rep = ar[j]
                         if (the_rep.dimension()>1 or
-                                  str(the_rep.conductor())!=str(1) or
-                                  the_rep.index()>1):
+                                  str(the_rep.conductor())!=str(1)):
                             ar_url = url_for("l_functions.l_function_artin_page",
-                                             dimension=the_rep.dimension(),
-                                             conductor=the_rep.conductor(),
-                                             tim_index=the_rep.index())
+                                             label=the_rep.label())
                             right = (r'\({}^{%d}\)' % (nfgg[j])
                                      if nfgg[j]>1 else r'')
                             self.factorization += r'\(\;\cdot\)' 
-                            self.factorization += (r'<a href="%s">\(L(s, \rho_{%d,%s,%d})\)</a>' % (ar_url,
-                                            the_rep.dimension(),
-                                            str(the_rep.conductor()),
-                                            the_rep.index()))
+                            tex_label = the_rep.label()
+                            tex_label = tex_label.replace('_',r'\_')
+                            self.factorization += (r'<a href="%s">\(L(s, \rho_{%s})\)</a>' % (ar_url, tex_label))
                             self.factorization += right
 
         self.poles = [1, 0]  # poles of the Lambda(s) function
@@ -1139,22 +1135,16 @@ class ArtinLfunction(Lfunction):
     """
     def __init__(self, **args):
         constructor_logger(self, args)
-        if not ('dimension' in args.keys() and 'conductor' in args.keys() and 'tim_index' in args.keys()):
-            raise KeyError("You have to supply dimension, conductor and " +
-                           "tim_index for an Artin L-function")    
+        if not ('label' in args.keys()):
+            raise KeyError("You have to supply a label for an Artin L-function")    
 
         self._Ltype = "artin"
         
         from lmfdb.math_classes import ArtinRepresentation
-        self.dimension = args["dimension"]
-        self.conductor = args["conductor"]
-        self.tim_index = args["tim_index"]
-        self.artin = ArtinRepresentation(self.dimension,
-                                         self.conductor, self.tim_index)
+        self.label = args["label"]
+        self.artin = ArtinRepresentation(self.label)
 
-        self.title = ("L function for an Artin representation of dimension "
-                      + str(self.dimension)
-                      + ", conductor " + str(self.conductor))
+        self.title = ("L function for Artin representation " + str(self.label))
 
         self.motivic_weight = 0
         self.algebraic = True
@@ -1171,8 +1161,6 @@ class ArtinLfunction(Lfunction):
                 upperbound=1000)
         
         
-
-        
         self.sign = self.artin.root_number()
         self.poles_L = self.artin.poles()
         self.residues_L = self.artin.residues()
@@ -1186,7 +1174,7 @@ class ArtinLfunction(Lfunction):
         self.nu_fe = self.artin.nu_fe()
         
         
-        self.Q_fe = self.Q_fe = float(sqrt(Integer(self.conductor))/2.**len(self.nu_fe)/pi**(len(self.mu_fe)/2.+len(self.nu_fe)))
+        self.Q_fe = self.Q_fe = float(sqrt(Integer(self.artin.conductor()))/2.**len(self.nu_fe)/pi**(len(self.mu_fe)/2.+len(self.nu_fe)))
         self.kappa_fe = [.5 for m in self.mu_fe] + [1. for n in self.nu_fe] 
         self.lambda_fe = [m/2. for m in self.mu_fe] + [n for n in self.nu_fe]
         
@@ -1197,7 +1185,7 @@ class ArtinLfunction(Lfunction):
         self.citation = ''
         self.support = "Support by Paul-Olivier Dehaye"
 
-        self.texname = "L(s)"  
+        self.texname = "L(s,\\rho)"  
         self.texnamecompleteds = "\\Lambda(s)"  
         if self.selfdual:
             self.texnamecompleted1ms = "\\Lambda(1-s)" 
@@ -1207,8 +1195,7 @@ class ArtinLfunction(Lfunction):
         generateSageLfunction(self)
 
     def Lkey(self):
-        return {"dimension": self.dimension, "conductor": self.conductor,
-                "tim_index": self.tim_index}
+        return {"label": self.label}
 
 #############################################################################
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1130,7 +1130,7 @@ class HypergeometricMotiveLfunction(Lfunction):
 class ArtinLfunction(Lfunction):
     """Class representing the Artin L-function
 
-    Compulsory parameters: dimension, conductor, tim_index
+    Compulsory parameters: label
 
     """
     def __init__(self, **args):
@@ -1144,7 +1144,7 @@ class ArtinLfunction(Lfunction):
         self.label = args["label"]
         self.artin = ArtinRepresentation(self.label)
 
-        self.title = ("L function for Artin representation " + str(self.label))
+        self.title = ("L-function for Artin representation " + str(self.label))
 
         self.motivic_weight = 0
         self.algebraic = True

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -335,11 +335,9 @@ def l_function_nf_page(label):
 
 
 # L-function of Artin representation    ########################################
-@l_function_page.route("/ArtinRepresentation/<dimension>/<conductor>/<tim_index>/")
-def l_function_artin_page(dimension, conductor, tim_index):
-    args = {'dimension': dimension, 'conductor': conductor,
-            'tim_index': tim_index}
-    return render_single_Lfunction(ArtinLfunction, args, request)
+@l_function_page.route("/ArtinRepresentation/<label>/")
+def l_function_artin_page(label):
+    return render_single_Lfunction(ArtinLfunction, {'label': label}, request)
 
 # L-function of hypergeometric motive   ########################################
 @l_function_page.route("/Motive/Hypergeometric/Q/<label>/<t>")
@@ -960,7 +958,7 @@ def generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg
         return DedekindZeta(label=str(arg2))
 
     elif arg1 == "ArtinRepresentation":
-        return ArtinLfunction(dimension=arg2, conductor=arg3, tim_index=arg4)
+        return ArtinLfunction(label=str(arg2))
 
     elif arg1 == "SymmetricPower":
         return SymmetricPowerLfunction(power=arg2, underlying_type=arg3, field=arg4, label=arg5)

--- a/lmfdb/number_field_galois_groups/main.py
+++ b/lmfdb/number_field_galois_groups/main.py
@@ -13,10 +13,11 @@ from lmfdb.math_classes import *
 
 def initialize_indices():
     try:
-        NumberFieldGaloisGroup.collection().ensure_index([("label", ASC)])
-        NumberFieldGaloisGroup.collection().ensure_index([("Size", ASC)])
-        NumberFieldGaloisGroup.collection(
-        ).ensure_index([("Transitive_degree", ASC), ("Size", ASC), ("DBIndex", ASC)])
+##        NumberFieldGaloisGroup.collection().ensure_index([("label", ASC)])
+#        NumberFieldGaloisGroup.collection().ensure_index([("Size", ASC)])
+#        NumberFieldGaloisGroup.collection(
+#        ).ensure_index([("Transitive_degree", ASC), ("Size", ASC), ("DBIndex", ASC)])
+	pass
     except pymongo.errors.OperationFailure:
         pass
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -437,9 +437,14 @@ def render_field_webpage(args):
                    ]
     from lmfdb.math_classes import NumberFieldGaloisGroup
     try:
-        info["tim_number_field"] = NumberFieldGaloisGroup.find_one({"label": label})
+        info["tim_number_field"] = NumberFieldGaloisGroup(nf._data['coeffs'])
         v = nf.factor_perm_repn(info["tim_number_field"])
-        info["mydecomp"] = ['*' if x>0 else '' for x in v]
+        def dopow(m):
+            if m==0: return ''
+            if m==1: return '*'
+            return '*<sup>%d</sup>'% m
+
+        info["mydecomp"] = [dopow(x) for x in v]
     except AttributeError:
         pass
 #    del info['_id']
@@ -464,7 +469,7 @@ def format_coeffs(coeffs):
 
 def split_label(label):
     """
-      Parses number field labels. Allows for 3.1.4e1t11e1.1
+      Parses number field labels. Allows for 3.1.2e2_11.1
     """
     tmp = label.split(".")
     tmp[2] = parse_product(tmp[2])
@@ -472,7 +477,7 @@ def split_label(label):
 
 
 def parse_product(symbol):
-    tmp = symbol.split("t")
+    tmp = symbol.split("_")
     return str(prod(parse_power(pair) for pair in tmp))
 
 

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -208,7 +208,9 @@ function show_code(system) {
 	<center>
 	<table>
 
-	<thead><tr><th></th>
+	<thead><tr>
+    <th></th>
+    <th>Label</th>
 	<th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
 	<th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
 	<th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
@@ -219,8 +221,9 @@ function show_code(system) {
 	</tr></thead>
 	<tbody>
         {% for artin in info["tim_number_field"].artin_representations()%}
-          <tr> <td align="right">
-              {{info.mydecomp[loop.index-1]}}<a href = "{{artin.url_for()}}">{{loop.index}}</a></td><td align="center">${{artin.dimension()}}$</td>
+          <tr> <td align="left">
+              {{info.mydecomp[loop.index-1]|safe}}
+              <td align="left"><a href = "{{artin.url_for()}}">{{artin.label()}}</a></td><td align="center">${{artin.dimension()}}$</td>
 {#	  <td align="center">${{artin.conductor_equation()}}$</td> #}
 	  <td align="center">${{artin.factored_conductor_latex()}}$</td>
 	  {% if artin.number_field_galois_group().url_for() %}
@@ -242,8 +245,11 @@ function show_code(system) {
         <br />
         <div>
         Data is given for all irreducible 
-        representations of the Galois group.  Those marked with 
-        * are associated with this field.
+        representations of the Galois group for the Galois closure
+        of this field.  Those marked with * are summands in the
+        permutation representation coming from this field.  Representations
+        which appear with multiplicity greater than one are indicated
+        by exponents on the *.
 	</div>
 	{% endif %}
 


### PR DESCRIPTION
Sorry for the big commit, but there did not seem to be a good way to do this piecemeal.

There are still improvements which can be made, but I don't think there are any regressions.

New features are
 * artin rep'ns now have labels
 * on the page of an artin rep'n, we give the size of the Galois conj class
 * on the page of an artin rep'n, we give the "first" permutation representation containing it.  First means smallest degree, and then smallest t-number.
 * artin rep'n search results have paging

Some things to check (if you want):
 * search for an artin rep by label, like 3.3e4_19e2.12t33.1c2
 * search for degree 2 artin rep'ns and page back and forth
 * go to http://127.0.0.1:37777/NumberField/4.0.592.1 , click on the lines at the bottom for the two 3-dimensional representations and notice that they have different "smallest permutation representations", the one which has the star on the number field page will be a degree 4 version of S_4, and the other will be a degree 6 version

 

