### PR TITLE
Debugging of genus 2 endomorphism functionality

### DIFF
--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -258,6 +258,14 @@ function show_invs(invstyle) {
 
 <br>
 
+<h3 style="display: inline"> Decomposition </h3>
+
+<!-- Description of a splitting field of minimal degree: -->
+<p>{{data.endodata.spl_fod_statement|safe}}</p>
+
+<!-- Description of the splittings themselves. -->
+<p>{{data.endodata.spl_statement|safe}}</p>
+
 <h3 style="display: inline"> {{ KNOWL('g2c.jac_endomorphisms', title='Endomorphisms') }} </h3>
 
 <p>{{data.endodata.gl2_statement_base}}</p>
@@ -275,13 +283,5 @@ function show_invs(invstyle) {
 <h3 style="display: inline">{{data.endodata.lattice_statement_preamble}}</h3>
 
 {{data.endodata.lattice_statement|safe}}
-
-<h3 style="display: inline"> Decomposition </h3>
-
-<!-- Description of a splitting field of minimal degree: -->
-<p>{{data.endodata.spl_fod_statement|safe}}</p>
-
-<!-- Description of the splittings themselves. -->
-<p>{{data.endodata.spl_statement|safe}}</p>
 
 {% endblock %}

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -486,7 +486,7 @@ def spl_statement(coeffss, labels, condnorms):
         statement = """The Jacobian admits two distinct elliptic curve factors
         up to isogeny</p>\
         <p>Elliptic curves that represent these factors and admit small
-        isogenies are:<br>"""
+        isogenies are:"""
     for n in range(len(coeffss)):
         # Use labels when possible:
         label = labels[n]
@@ -494,15 +494,15 @@ def spl_statement(coeffss, labels, condnorms):
             # TODO: Next statement can be removed by a database update
             if not '-' in label:
                 label = cremona_to_lmfdb(label)
-            statement += """Elliptic curve with label <a href=%s>%s</a><br>"""\
+            statement += """<br>Elliptic curve with label <a href=%s>%s</a>"""\
             % (url_for_ec(label), label)
         # Otherwise give defining equation:
         else:
-            statement += """\(4 y^2 = x^3 - (g_4 / 48) x - (g_6 / 864)\),
+            statement += """<br>\(4 y^2 = x^3 - (g_4 / 48) x - (g_6 / 864)\),
             with<br>\
             \(g_4 = %s\)<br>\
             \(g_6 = %s\)<br>\
-            Conductor norm: %s<br>""" % \
+            Conductor norm: %s""" % \
             (strlist_to_nfelt(coeffss[n][0], 'b'),
             strlist_to_nfelt(coeffss[n][1], 'b'),
             condnorms[n])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -481,7 +481,7 @@ def spl_statement(coeffss, labels, condnorms):
     if len(coeffss) == 1:
         statement = """The Jacobian decomposes up to isogeny as the square of
         an elliptic curve</p>\
-        <p>Elliptic curve that admits a small isogeny:<br>"""
+        <p>Elliptic curve that admits a small isogeny:"""
     else:
         statement = """The Jacobian admits two distinct elliptic curve factors
         up to isogeny</p>\


### PR DESCRIPTION
Fixed three small issues:

(1) Monomials of high degree were represented incorrectly as "x^{1}0" instead of "x^{10}", fixed by using latex() instead of str();
(2) Cases with endomorphism ring tensor RR isomorphic to CC x CC were for some reason not accounted for and resulted in a debug statement, so this possibility has been added now;
(3) Cremona and LMFDB labels were confused since my database did not take into account that the "label" field in the LMFDB database for a rational elliptic curve is in fact the Cremona label, not the LMFDB label. Accounted for by an imported conversion function, and will update the database later.