### PR TITLE
Fix bug in searching for artin rep'ns with a particular root number

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -72,6 +72,7 @@ def artin_representation_search(**args):
 
     title = 'Artin representation search results'
     bread = [('Artin representation', url_for(".index")), ('Search results', ' ')]
+    sign_code = 0
     query = {'Hide': 0}
     if req.get("ramified", "") != "":
         tmp = req["ramified"].split(",")
@@ -87,7 +88,8 @@ def artin_representation_search(**args):
             assert req["root_number"] in ["1", "-1"]
         except:
             raise AssertionError("The root number can only be 1 or -1")
-        query["GaloisConjugates.Sign"] = int(req["root_number"])
+        sign_code= int(req["root_number"])
+        query["GaloisConjugates.Sign"] = sign_code
 
     if req.get("frobenius_schur_indicator", "") != "":
         try:
@@ -178,7 +180,7 @@ def artin_representation_search(**args):
 
     initfunc = ArtinRepresentation
 
-    return render_template("artin-representation-search.html", req=req, data=data, title=title, bread=bread, query=query, start=start, report=report, nres=nres, initfunc=initfunc)
+    return render_template("artin-representation-search.html", req=req, data=data, title=title, bread=bread, query=query, start=start, report=report, nres=nres, initfunc=initfunc, sign_code=sign_code)
 
 
 # Obsolete

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -87,7 +87,7 @@ def artin_representation_search(**args):
             assert req["root_number"] in ["1", "-1"]
         except:
             raise AssertionError("The root number can only be 1 or -1")
-        query["Sign"] = int(req["root_number"])
+        query["GaloisConjugates.Sign"] = int(req["root_number"])
 
     if req.get("frobenius_schur_indicator", "") != "":
         try:

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -108,7 +108,9 @@
           <tr><td>
           {% for cnt in range(galccsize) %}
         {% set artx = initfunc(artin['Baselabel'],cnt+1) %}
+        {% if sign_code == 0 or sign_code == art.sign() %}
             <a href = "{{artx.url_for()}}">{{art.baselabel()}}c{{cnt+1}}</a>
+        {% endif %}
           {% endfor %}
             </td>
             <td>${{art.dimension()}}$</td>

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -13,8 +13,7 @@ class ArtinRepTest(LmfdbTest):
 		assert '41' in L.data # Only 1 result at the time this test was written, which has conductor 2009 = 7^2.41
 
     def test_search_gal_ram_rn_fn(self):
-		#L = self.tc.get('/ArtinRepresentation/?dimension=&conductor=&group=11T5&ramified=43&unramified=&root_number=1&frobenius_schur_indicator=1&count=15')
-		L = self.tc.get('/ArtinRepresentation/?dimension=&conductor=&group=11T5&ramified=43&unramified=&root_number=&frobenius_schur_indicator=1&count=15')
+		L = self.tc.get('/ArtinRepresentation/?dimension=&conductor=&group=11T5&ramified=43&unramified=&root_number=1&frobenius_schur_indicator=1&count=15')
 		assert '2898947' in L.data # prime divisor of one of the conductors in the result
 
     def test_display_page(self):


### PR DESCRIPTION
This should fix the bug found by the tests

http://127.0.0.1:37777/ArtinRepresentation/?start=0&paging=0&dimension=&conductor=&group=11T5&ramified=43&unramified=&root_number=1&frobenius_schur_indicator=1&count=50