### PR TITLE
Dir chars of cond 1 no longer display vals on gens

### DIFF
--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -41,15 +41,16 @@
 
 
         {# Values on generators #}
-        <h2>
-            {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
-        </h2>
-        <div class = 'sage nodisplay code'>sage: chi_sage.values_on_gens()</div>
-        {{ addcode(codeval,'div') }}
-        <p>
-            {{ generators }} &rarr; {{ genvalues }}
-        </p>
-
+        {% if conductor>1 %}
+            <h2>
+                {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
+            </h2>
+            <div class = 'sage nodisplay code'>sage: chi_sage.values_on_gens()</div>
+            {{ addcode(codeval,'div') }}
+            <p>
+                {{ generators }} &rarr; {{ genvalues }}
+            </p>
+        {% endif %}
 
         {# Values #}
         


### PR DESCRIPTION
Dirichlet characters with modulus==2 and conductor==1 used to display a lonely arrow under "Values on generators", because (Z/1Z)* has 0 generators. This "values on generators" section is no longer displayed for characters with conductor==1.