### PR TITLE
Do not display values on gens when (Z/NZ)* is trivial

### DIFF
--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -41,7 +41,7 @@
 
 
         {# Values on generators #}
-        {% if conductor>1 %}
+        {% if modulus>2 %}
             <h2>
                 {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
             </h2>

--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -41,15 +41,16 @@
 
 
         {# Values on generators #}
-        <h2>
-            {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
-        </h2>
-        <div class = 'sage nodisplay code'>sage: chi_sage.values_on_gens()</div>
-        {{ addcode(codeval,'div') }}
-        <p>
-            {{ generators }} &rarr; {{ genvalues }}
-        </p>
-
+        {% if conductor>1 %}
+            <h2>
+                {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
+            </h2>
+            <div class = 'sage nodisplay code'>sage: chi_sage.values_on_gens()</div>
+            {{ addcode(codeval,'div') }}
+            <p>
+                {{ generators }} &rarr; {{ genvalues }}
+            </p>
+        {% endif %}
 
         {# Values #}
         


### PR DESCRIPTION
When N<=2, (Z/NZ)* has 0 generators, and so for Dirichlet characters with modulus N the "Values on generators" section does not look good (just a lonely arrow). This pull request prevents the section from being displayed when N<=2.