### PR TITLE
Nf url

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -146,7 +146,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
         # catch the url being None or set to '':
         if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label:
             friends.append(('Number field ' + f.base_ring.lmfdb_pretty, f.base_ring.lmfdb_url))
-        if hasattr(f.coefficient_field, "lmfdb_url") and f.coefficient_field.lmfdb_url is not None:
+        if hasattr(f.coefficient_field, "lmfdb_url") and f.coefficient_field.lmfdb_url:
             friends.append(('Number field ' + f.coefficient_field.lmfdb_pretty, f.coefficient_field.lmfdb_url))
     friends.append(("Dirichlet character \(" + WMFS.character.latex_name + "\)", WMFS.character.url()))
     friends = uniq(friends)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -143,9 +143,10 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
     friends = list()
     for label in WMFS.hecke_orbits:
         f = WMFS.hecke_orbits[label]
-        if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label is not None:
+        # catch the url being None or set to '':
+        if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label:
             friends.append(('Number field ' + f.base_ring.lmfdb_pretty, f.base_ring.lmfdb_url))
-        if hasattr(f.coefficient_field, "lmfdb_label") and f.coefficient_field.lmfdb_label is not None:
+        if hasattr(f.coefficient_field, "lmfdb_url") and f.coefficient_field.lmfdb_url is not None:
             friends.append(('Number field ' + f.coefficient_field.lmfdb_pretty, f.coefficient_field.lmfdb_url))
     friends.append(("Dirichlet character \(" + WMFS.character.latex_name + "\)", WMFS.character.url()))
     friends = uniq(friends)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -144,7 +144,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
     for label in WMFS.hecke_orbits:
         f = WMFS.hecke_orbits[label]
         # catch the url being None or set to '':
-        if hasattr(f.base_ring, "lmfdb_label") and f.base_ring.lmfdb_label:
+        if hasattr(f.base_ring, "lmfdb_url") and f.base_ring.lmfdb_url:
             friends.append(('Number field ' + f.base_ring.lmfdb_pretty, f.base_ring.lmfdb_url))
         if hasattr(f.coefficient_field, "lmfdb_url") and f.coefficient_field.lmfdb_url:
             friends.append(('Number field ' + f.coefficient_field.lmfdb_pretty, f.coefficient_field.lmfdb_url))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -153,7 +153,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
             c_pol_ltx_x = web_latex_poly(p1, 'x')
             z1 = p1.base_ring().gens()[0].multiplicative_order()
             info['coeff_field'] = [ web_latex_split_on_pm(WNF.coefficient_field.absolute_polynomial_latex('x')), web_latex_split_on_pm(c_pol_ltx_x), z1]
-            if hasattr(WNF.coefficient_field, "lmfdb_label") and not WNF.coefficient_field.lmfdb_label is None:
+            if hasattr(WNF.coefficient_field, "lmfdb_url") and WNF.coefficient_field.lmfdb_url:
                 info['coeff_field_pretty'] = [ WNF.coefficient_field.lmfdb_url, WNF.coefficient_field.lmfdb_pretty, WNF.coefficient_field.lmfdb_label]
             if z1==4:
                 info['polynomial_st'] = 'where \({0}=0\) and \(\zeta_4=i\).'.format(c_pol_ltx)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -94,9 +94,9 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     friends = list()
     space_url = url_for('emf.render_elliptic_modular_forms',level=level, weight=weight, character=character)
     friends.append(('\( S_{%s}(%s, %s)\)'%(WNF.weight, WNF.level, WNF.character.latex_name), space_url))
-    if hasattr(WNF.base_ring, "lmfdb_label") and not WNF.base_ring.lmfdb_label is None:
+    if hasattr(WNF.base_ring, "lmfdb_url") and WNF.base_ring.lmfdb_url:
         friends.append(('Number field ' + WNF.base_ring.lmfdb_pretty, WNF.base_ring.lmfdb_url))
-    if hasattr(WNF.coefficient_field, "lmfdb_label") and not WNF.coefficient_field.lmfdb_label is None:
+    if hasattr(WNF.coefficient_field, "lmfdb_url") and WNF.coefficient_field.lmfdb_label:
         friends.append(('Number field ' + WNF.coefficient_field.lmfdb_pretty, WNF.coefficient_field.lmfdb_url))
     friends = uniq(friends)
     friends.append(("Dirichlet character \(" + WNF.character.latex_name + "\)", WNF.character.url()))
@@ -139,7 +139,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
 #           b_pol_ltx = web_latex_poly(p2, latex(zeta)) #this is not used anymore
             z1 = zeta.multiplicative_order() 
             info['coeff_field'] = [ web_latex_split_on_pm(WNF.coefficient_field.absolute_polynomial_latex('x')),web_latex_split_on_pm(c_pol_ltx_x), z1]
-            if hasattr(WNF.coefficient_field, "lmfdb_label") and not WNF.coefficient_field.lmfdb_label is None:
+            if hasattr(WNF.coefficient_field, "lmfdb_url") and WNF.coefficient_field.url:
                 info['coeff_field_pretty'] = [ WNF.coefficient_field.lmfdb_url, WNF.coefficient_field.lmfdb_pretty, WNF.coefficient_field.lmfdb_label]
             if z1==4:
                 info['polynomial_st'] = 'where \({0}=0\) and \(\zeta_4=i\).</div><br/>'.format(c_pol_ltx)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -139,7 +139,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
 #           b_pol_ltx = web_latex_poly(p2, latex(zeta)) #this is not used anymore
             z1 = zeta.multiplicative_order() 
             info['coeff_field'] = [ web_latex_split_on_pm(WNF.coefficient_field.absolute_polynomial_latex('x')),web_latex_split_on_pm(c_pol_ltx_x), z1]
-            if hasattr(WNF.coefficient_field, "lmfdb_url") and WNF.coefficient_field.url:
+            if hasattr(WNF.coefficient_field, "lmfdb_url") and WNF.coefficient_field.lmfdb_url:
                 info['coeff_field_pretty'] = [ WNF.coefficient_field.lmfdb_url, WNF.coefficient_field.lmfdb_pretty, WNF.coefficient_field.lmfdb_label]
             if z1==4:
                 info['polynomial_st'] = 'where \({0}=0\) and \(\zeta_4=i\).</div><br/>'.format(c_pol_ltx)


### PR DESCRIPTION
It is embarrassing but this is the 4th in a row -- and this time surely the last -- making sure that the attribute lmfdb_url is not accessed when it has not been set, or is set to an empty string, for the 'friends' section of modular form and modular forms space web pages.

It may be that this just addresses a symptom rather than the root cause -- why are the urls not being set when the lmfdb_label is?
