### PR TITLE
G2 database task separation

### DIFF
--- a/lmfdb/genus2_curves/__init__.py
+++ b/lmfdb/genus2_curves/__init__.py
@@ -3,10 +3,10 @@ from lmfdb.base import app
 from lmfdb.utils import make_logger
 from flask import Blueprint
 
-g2c_page = Blueprint("g2c", __name__, template_folder='templates', static_folder="static")
+g2c_page = Blueprint("g2c", __name__, template_folder='templates',
+        static_folder="static")
 g2c_logger = make_logger(g2c_page)
 g2c_logger.info("Initializing genus 2 curves blueprint")
-
 
 @g2c_page.context_processor
 def body_class():

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -20,7 +20,7 @@ from sage.all import ZZ, QQ, latex, matrix, srange
 credit_string = "Andrew Booker, Andrew Sutherland, John Voight, and Dan Yasaki"
 
 ###############################################################################
-#   Database connection
+# Database connection
 ###############################################################################
 
 g2cdb = None
@@ -40,7 +40,7 @@ def db_g2endo():
     return g2endodb
 
 ###############################################################################
-# List and dictionaries needed for routing and searching
+# List and dictionaries needed routing and searching
 ###############################################################################
 
 # lists determine display order in drop down lists, dictionary key is the
@@ -52,8 +52,9 @@ st_group_list = ['J(C_2)', 'J(C_4)', 'J(C_6)', 'J(D_2)', 'J(D_3)', 'J(D_4)',
         'F_{a,b}', 'F_{ac}', 'N(G_{1,3})', 'G_{3,3}', 'N(G_{3,3})', 'USp(4)']
 st_group_dict = {a:a for a in st_group_list}
 
+# End_QQbar tensored with RR determines ST0 (which is the search parameter):
 real_geom_end_alg_list = ['M_2(C)', 'M_2(R)', 'C x C', 'C x R', 'R x R', 'R']
-real_geom_end_alg_dict = {
+real_geom_end_alg_to_ST0_dict = {
         'M_2(C)':'U(1)',
         'M_2(R)':'SU(2)',
         'C x C':'U(1) x U(1)',
@@ -113,7 +114,7 @@ def index_Q():
     info["st_group_list"] = st_group_list
     info["st_group_dict"] = st_group_dict
     info["real_geom_end_alg_list"] = real_geom_end_alg_list
-    info["real_geom_end_alg_dict"] = real_geom_end_alg_dict
+    info["real_geom_end_alg_to_ST0_dict"] = real_geom_end_alg_to_ST0_dict
     info["aut_grp_list"] = aut_grp_list
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list
@@ -195,7 +196,7 @@ def genus2_curve_search(**args):
     info["st_group_list"] = st_group_list
     info["st_group_dict"] = st_group_dict
     info["real_geom_end_alg_list"] = real_geom_end_alg_list
-    info["real_geom_end_alg_dict"] = real_geom_end_alg_dict
+    info["real_geom_end_alg_to_ST0_dict"] = real_geom_end_alg_to_ST0_dict
     info["aut_grp_list"] = aut_grp_list
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -16,44 +16,12 @@ from lmfdb.genus2_curves.web_g2c import WebG2C, list_to_min_eqn, isog_label, st_
 
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
-q = ZZ['x'].gen()
+#q = ZZ['x'].gen()
 credit_string = "Andrew Booker, Andrew Sutherland, John Voight, and Dan Yasaki"
 
-# lists determine display order in drop down lists, dictionary key is the database entry, dictionary value is the display value
-st_group_list = ['J(C_2)','J(C_4)','J(C_6)','J(D_2)', 'J(D_3)','J(D_4)','J(D_6)', 'J(T)', 'J(O)','C{2,1}','C_{6,1}','D_{2,1}','D_{3,2}','D_{4,1}','D_{4,2}','D_{6,1}','D_{6,2}','O_1','E_1','E_2','E_3','E_4','E_6','J(E_1)','J(E_2)','J(E_3)','J(E_4)','J(E_6)','F_{a,b}','F_{ac}','N(G_{1,3})','G_{3,3}','N(G_{3,3})','USp(4)']
-st_group_dict = {a:a for a in st_group_list}
-real_geom_end_alg_list = ['M_2(C)','M_2(R)','C x C', 'C x R', 'R x R', 'R']
-real_geom_end_alg_dict = {
-        'M_2(C)':'U(1)',
-        'M_2(R)':'SU(2)',
-        'C x C':'U(1) x U(1)',
-        'C x R':'U(1) x SU(2)',
-        'R x R':'SU(2) x SU(2)',
-        'R':'USp(4)'
-        }
-aut_grp_list = ['[2, 1]', '[4, 1]','[4, 2]','[6, 2]','[8, 3]','[12, 4]']
-aut_grp_dict = {
-        '[2, 1]':'C_2',
-        '[4, 1]':'C_4',                   
-        '[4, 2]':'V_4',
-        '[6, 2]':'C_6',                   
-        '[8, 3]':'D_8',                   
-        '[12, 4]':'D_{12}'
-        }
-geom_aut_grp_list = ['[2, 1]', '[4, 2]','[8, 3]','[10, 2]','[12, 4]','[24, 8]','[48, 29]']
-geom_aut_grp_dict = {
-        '[2, 1]':'C_2',
-        '[4, 2]':'V_4',
-        '[8, 3]':'D_8',
-        '[10, 2]':'C_{10}',
-        '[12, 4]':'D_{12}',
-        '[24, 8]':'2D_{12}',
-        '[48, 29]':'tilde{S}_4'}
-
-
-#########################
+###############################################################################
 #   Database connection
-#########################
+###############################################################################
 
 g2cdb = None
 
@@ -71,17 +39,57 @@ def db_g2endo():
         g2endodb = lmfdb.base.getDBConnection().genus2_endomorphisms
     return g2endodb
 
-#########################
-#    Top level
-#########################
+###############################################################################
+# List and dictionaries needed for routing and searching
+###############################################################################
+
+# lists determine display order in drop down lists, dictionary key is the
+# database entry, dictionary value is the display value
+st_group_list = ['J(C_2)', 'J(C_4)', 'J(C_6)', 'J(D_2)', 'J(D_3)', 'J(D_4)',
+        'J(D_6)', 'J(T)', 'J(O)', 'C{2,1}', 'C_{6,1}', 'D_{2,1}', 'D_{3,2}',
+        'D_{4,1}', 'D_{4,2}', 'D_{6,1}', 'D_{6,2}', 'O_1', 'E_1', 'E_2', 'E_3',
+        'E_4', 'E_6', 'J(E_1)', 'J(E_2)', 'J(E_3)', 'J(E_4)', 'J(E_6)',
+        'F_{a,b}', 'F_{ac}', 'N(G_{1,3})', 'G_{3,3}', 'N(G_{3,3})', 'USp(4)']
+st_group_dict = {a:a for a in st_group_list}
+
+real_geom_end_alg_list = ['M_2(C)', 'M_2(R)', 'C x C', 'C x R', 'R x R', 'R']
+real_geom_end_alg_dict = {
+        'M_2(C)':'U(1)',
+        'M_2(R)':'SU(2)',
+        'C x C':'U(1) x U(1)',
+        'C x R':'U(1) x SU(2)',
+        'R x R':'SU(2) x SU(2)',
+        'R':'USp(4)'
+        }
+
+aut_grp_list = ['[2, 1]', '[4, 1]', '[4, 2]', '[6, 2]', '[8, 3]', '[12, 4]']
+aut_grp_dict = {
+        '[2, 1]':'C_2',
+        '[4, 1]':'C_4',
+        '[4, 2]':'V_4',
+        '[6, 2]':'C_6',
+        '[8, 3]':'D_8',
+        '[12, 4]':'D_{12}'
+        }
+
+geom_aut_grp_list = ['[2, 1]', '[4, 2]', '[8, 3]', '[10, 2]', '[12, 4]',
+        '[24, 8]', '[48, 29]']
+geom_aut_grp_dict = {
+        '[2, 1]':'C_2',
+        '[4, 2]':'V_4',
+        '[8, 3]':'D_8',
+        '[10, 2]':'C_{10}',
+        '[12, 4]':'D_{12}',
+        '[24, 8]':'2D_{12}',
+        '[48, 29]':'tilde{S}_4'}
+
+###############################################################################
+# Routing for top level, random curves and by conductor:
+###############################################################################
 
 @app.route("/G2C")
 def G2C_redirect():
     return redirect(url_for(".index", **request.args))
-
-#########################
-#  Search/navigate
-#########################
 
 @g2c_page.route("/")
 def index():
@@ -130,11 +138,57 @@ def random_curve():
     # This version uses the curve's own URL:
     return redirect(url_for(".by_g2c_label", label=label), 301)
 
+###############################################################################
+# Curve pages
+###############################################################################
 
+@g2c_page.route("/Q/<int:conductor>/<iso_label>/<int:disc>/<int:number>")
+def by_full_label(conductor,iso_label, disc,number):
+    full_label = str(conductor)+"."+iso_label+"."+str(disc)+"."+str(number)
+    g2c_logger.debug(full_label)
+    return render_curve_webpage_by_label(full_label)
 
-def split_label(label_string):
-    L = label_string.split(".")
-    return L
+@g2c_page.route("/Q/<label>")
+def by_g2c_label(label):
+    g2c_logger.debug(label)
+    return render_curve_webpage_by_label(label)
+
+def render_curve_webpage_by_label(label):
+    credit = credit_string
+    data = WebG2C.by_label(label)
+    return render_template("curve_g2.html",
+                           properties2=data.properties,
+                           credit=credit,
+                           data=data,
+                           bread=data.bread,
+                           title=data.title,
+                           friends=data.friends,
+                           downloads=data.downloads)
+
+###############################################################################
+# Isogeny class pages
+###############################################################################
+
+@g2c_page.route("/Q/<int:conductor>/<iso_label>/")
+def by_double_iso_label(conductor, iso_label):
+    full_iso_label = str(conductor)+"."+iso_label
+    return render_isogeny_class(full_iso_label)
+
+def render_isogeny_class(iso_class):
+    credit = credit_string
+    class_data = G2Cisog_class.by_label(iso_class)
+    return render_template("isogeny_class_g2.html",
+                           properties2=class_data.properties,
+                           bread=class_data.bread,
+                           credit=credit,
+                           info=class_data,
+                           title=class_data.title,
+                           friends=class_data.friends,
+                           downloads=class_data.downloads)
+
+################################################################################
+# Searching
+################################################################################
 
 def genus2_curve_search(**args):
     info = to_dict(args)
@@ -181,7 +235,7 @@ def genus2_curve_search(**args):
                 newors.extend(oldors)
             tmp[1] = newors
         query[tmp[0]] = tmp[1]
-        
+
     if info.get("is_gl2_type"):
         if info['is_gl2_type'] == "True":
             query['is_gl2_type']= True
@@ -207,8 +261,8 @@ def genus2_curve_search(**args):
             query['torsion'] = [int(r) for r in res]
 
     if info.get('ic0'):
-        query['igusa_clebsch']=[info['ic0'], info['ic1'], info['ic2'], info['ic3'] ]
-        
+        query['igusa_clebsch']=[info['ic0'], info['ic1'], info['ic2'],
+                info['ic3'] ]
 
     for fld in ["cond", "num_rat_wpts", "torsion_order", "two_selmer_rank"]:
         if info.get(fld):
@@ -260,25 +314,26 @@ def genus2_curve_search(**args):
         start = 0
 
     res = cursor.sort([("cond", pymongo.ASCENDING),
-                                            ("class", pymongo.ASCENDING),
-                                            ("disc_key", pymongo.ASCENDING),
-                                            ("label", pymongo.ASCENDING)]).skip(start).limit(count)
+                       ("class", pymongo.ASCENDING),
+                       ("disc_key", pymongo.ASCENDING),
+                       ("label", pymongo.ASCENDING)]).skip(start).limit(count)
     nres = res.count()
     if nres == 1:
         info["report"] = "unique match"
     else:
         if nres > count or start != 0:
-            info['report'] = 'displaying matches %s-%s of %s' % (start + 1, min(nres, start + count), nres)
+            info['report'] = 'displaying matches %s-%s of %s' % (start + 1,
+                    min(nres, start + count), nres)
         else:
             info['report'] = 'displaying all %s matches' % nres
     res_clean = []
-    
-    
+
     for v in res:
         v_clean = {}
         v_clean["label"] = v["label"]
         v_clean["isog_label"] = v["class"]
-        isogeny_class = db_g2c().isogeny_classes.find_one({'label' : isog_label(v["label"])})
+        isogeny_class = db_g2c().isogeny_classes.find_one({'label' :
+            isog_label(v["label"])})
         v_clean["is_gl2_type"] = isogeny_class["is_gl2_type"]
         if isogeny_class["is_gl2_type"] == True:
             v_clean["is_gl2_type_display"] = '&#10004;' #checkmark
@@ -297,7 +352,8 @@ def genus2_curve_search(**args):
     info["more"] = int(start+count<nres)
     credit = credit_string
     title = 'Genus 2 Curves search results'
-    return render_template("search_results_g2.html", info=info, credit=credit, bread=bread, title=title)
+    return render_template("search_results_g2.html", info=info, credit=credit,
+            bread=bread, title=title)
 
 def g2_list_to_query(dlist):
     # if there is only one part, we don't need an $or
@@ -327,50 +383,3 @@ def g2_list_to_query(dlist):
             s0, d0 = make_disc_key(x)
             ans.append({'disc_key': d0})
     return [['$or', ans]]
-
-##########################
-#  Specific curve pages
-##########################
-
-@g2c_page.route("/Q/<int:conductor>/<iso_label>/")
-def by_double_iso_label(conductor,iso_label):
-    full_iso_label = str(conductor)+"."+iso_label
-    return render_isogeny_class(full_iso_label)
-
-@g2c_page.route("/Q/<int:conductor>/<iso_label>/<int:disc>/<int:number>")
-def by_full_label(conductor,iso_label,disc,number):
-    full_label = str(conductor)+"."+iso_label+"."+str(disc)+"."+str(number)
-    g2c_logger.debug(full_label)
-    return render_curve_webpage_by_label(full_label)
-
-
-@g2c_page.route("/Q/<label>")
-def by_g2c_label(label):
-    g2c_logger.debug(label)
-    return render_curve_webpage_by_label(label)
-
-def render_isogeny_class(iso_class):
-    credit = credit_string
-    class_data = G2Cisog_class.by_label(iso_class)
-
-    return render_template("isogeny_class_g2.html",
-                           properties2=class_data.properties,
-                           bread=class_data.bread,
-                           credit=credit,
-                           info=class_data,
-                           title=class_data.title,
-                           friends=class_data.friends,
-                           downloads=class_data.downloads)
-
-
-def render_curve_webpage_by_label(label):
-    credit = credit_string
-    data = WebG2C.by_label(label)
-    
-    return render_template("curve_g2.html",
-                           properties2=data.properties,
-                           credit=credit,
-                           data=data,
-                           bread=data.bread, title=data.title,
-                           friends=data.friends,
-                           downloads=data.downloads)

--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -6,7 +6,7 @@ from pymongo import ASCENDING, DESCENDING
 from flask import url_for, make_response
 import lmfdb.base
 from lmfdb.utils import comma, make_logger, web_latex, encode_plot
-from lmfdb.genus2_curves.web_g2c import g2c_page, g2c_logger, list_to_min_eqn, end_alg_name, st_group_name, st0_group_name, get_end_data
+from lmfdb.genus2_curves.web_g2c import g2c_page, g2c_logger, list_to_min_eqn, end_alg_name, st_group_name, st0_group_name
 from sage.all import QQ, PolynomialRing, factor,ZZ, NumberField, expand, var
 from lmfdb.WebNumberField import field_pretty
 
@@ -160,32 +160,17 @@ class G2Cisog_class(object):
         self.bad_lfactors = [ [c[0], list_to_factored_poly_otherorder(c[1])]
                 for c in self.bad_lfactors]
 
-        # Endomorphisms begin
-        # duplication of get_end_alg.  need to clean up!
-        end_alg_title_dict = {'end_ring': r'\End(J)',
-                              'rat_end_alg': r'\End(J) \otimes \Q',
-                              'real_end_alg': r'\End(J) \otimes \R',
-                              'geom_end_ring': r'\End(J_{\overline{\Q}})',
-                              'rat_geom_end_alg': r'\End(J_{\overline{\Q}}) \otimes \Q',
-                              'real_geom_end_alg':'\End(J_{\overline{\Q}}) \otimes \R'}
-        for endalgtype in ['end_ring', 'rat_end_alg', 'real_end_alg', 'geom_end_ring', 'rat_geom_end_alg', 'real_geom_end_alg']:
-            if hasattr(self, endalgtype):
-                setattr(self,endalgtype + '_name',[end_alg_title_dict[endalgtype],end_alg_name(getattr(self,endalgtype))])
-            else:
-                setattr(self,endalgtype + '_name',[end_alg_title_dict[endalgtype],''])
-
-        if hasattr(self, 'geom_end_field') and self.geom_end_field != '':
-            self.geom_end_field_name = field_pretty(self.geom_end_field)
-        else:
-            self.geom_end_field_name = ''
+        # Data derived from Sato-Tate group
         self.st_group_name = st_group_name(self.st_group)
         self.st0_group_name = st0_group_name(self.real_geom_end_alg)
+        self.real_geom_end_alg_name = [r'\End(J_{\overline{\Q}}) \otimes \R',
+                end_alg_name(self.real_geom_end_alg)]
         if self.is_gl2_type:
             self.is_gl2_type_name = 'yes'
-            gl2_statement = 'of \(\GL_2\)-type'
         else:
             self.is_gl2_type_name = 'no'
-            gl2_statement = 'not of \(\GL_2\)-type'
+
+        # TODO: Replace this with curve data until end of paragraph
         if hasattr(self, 'is_simple') and hasattr(self, 'is_geom_simple'):
             if self.is_geom_simple:
                 simple_statement = "simple over \(\overline{\Q}\), "
@@ -195,20 +180,22 @@ class G2Cisog_class(object):
                 simple_statement = "not simple over \(\Q\), "
         else:
             simple_statement = ""  # leave empty since not computed.
+        gl2_statement = "kabonka"
         self.endomorphism_statement = simple_statement + gl2_statement
-        # Endomorphisms end
 
         # Title
         self.title = "Genus 2 Isogeny Class %s" % (self.label)
 
         # Lady Gaga box
-        self.properties = [('Label', self.label),
-                           ('Number of curves', str(self.ncurves)),
-                           ('Conductor','%s' % self.cond),
-                           ('Sato-Tate group', '\(%s\)' % self.st_group_name),
-                           ('\(%s\)' % self.real_geom_end_alg_name[0],
-                            '\(%s\)' % self.real_geom_end_alg_name[1]),
-                           ('\(\mathrm{GL}_2\)-type','%s' % self.is_gl2_type_name)]
+        self.properties = [
+                ('Label', self.label),
+                ('Number of curves', str(self.ncurves)),
+                ('Conductor','%s' % self.cond),
+                ('Sato-Tate group', '\(%s\)' % self.st_group_name),
+                ('\(%s\)' % self.real_geom_end_alg_name[0],
+                 '\(%s\)' % self.real_geom_end_alg_name[1]),
+                ('\(\mathrm{GL}_2\)-type','%s' % self.is_gl2_type_name)
+                ]
         x = self.label.split('.')[1]
         self.friends = [('L-function',
             url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x))]
@@ -227,7 +214,6 @@ class G2Cisog_class(object):
                        ('%s' % self.cond, url_for(".by_conductor", conductor=self.cond)),
                        ('%s' % self.label, ' ')
                      ]
-
 
         # More friends (to be improved)
         self.ecproduct_wurl = []

--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -12,6 +12,10 @@ from lmfdb.WebNumberField import field_pretty
 
 logger = make_logger("g2c")
 
+###############################################################################
+# Database connection
+###############################################################################
+
 g2cdb = None
 
 def db_g2c():
@@ -19,6 +23,10 @@ def db_g2c():
     if g2cdb is None:
         g2cdb = lmfdb.base.getDBConnection().genus2_curves
     return g2cdb
+
+###############################################################################
+# Pretty print functions
+###############################################################################
 
 def list_to_poly(s):
     return str(PolynomialRing(QQ, 'x')(s)).replace('*','')
@@ -46,7 +54,7 @@ def list_to_factored_poly_otherorder(s, galois=False):
     for v in sfacts_fc:
         this_poly = v[0]
         # if the factor is -1+T^2, replace it by 1-T^2
-        # this should happen an even number of times, mod powers 
+        # this should happen an even number of times, mod powers
         if this_poly.substitute(T=0) == -1:
             this_poly = -1*this_poly
             v[0] = this_poly
@@ -81,7 +89,7 @@ def list_to_factored_poly_otherorder(s, galois=False):
         if len(sfacts) > 1 or v[1] > 1:
             outstr += ')'
         if v[1] > 1:
-            outstr += '^{' + str(v[1]) + '}'        
+            outstr += '^{' + str(v[1]) + '}'
     if galois:
         if galois and len(sfacts_fc)==2:
             if sfacts[0][0].degree()==2 and sfacts[1][0].degree()==2:
@@ -94,13 +102,18 @@ def list_to_factored_poly_otherorder(s, galois=False):
 def url_for_label(label):
     # returns the url for label
     L = label.split(".")
-    return url_for(".by_full_label", conductor=L[0], iso_label=L[1], disc=L[2], number=L[3])
+    return url_for(".by_full_label", conductor=L[0], iso_label=L[1], disc=L[2],
+            number=L[3])
 
 def isog_url_for_label(label):
     # returns the isogeny class url for curve label
-    # TODO FIX: replace by full label line by approporiate
+    # TODO FIX: replace by full label line by appropriate
     L = label.split(".")
     return url_for(".by_double_iso_label", conductor=L[0], iso_label=L[1])
+
+###############################################################################
+# The actual class definition
+###############################################################################
 
 class G2Cisog_class(object):
     """
@@ -131,16 +144,28 @@ class G2Cisog_class(object):
             return G2Cisog_class(data)
         return "Class not found" # caller must catch this and raise an error
 
+    ###########################################################################
+    # Main data creation for individual isogeny classes
+    ###########################################################################
+
     def make_class(self):
-        curves_data = db_g2c().curves.find({"class" : self.label}).sort([("disc_key", pymongo.ASCENDING), ("label", pymongo.ASCENDING)])
-        self.curves = [ {"label" : c['label'], "equation_formatted" : list_to_min_eqn(c['min_eqn']), "url": url_for_label(c['label'])} for c in curves_data ]
+        # Data
+        curves_data = db_g2c().curves.find({"class" :
+            self.label}).sort([("disc_key", pymongo.ASCENDING),
+                               ("label", pymongo.ASCENDING)])
+        self.curves = [ {"label" : c['label'], "equation_formatted" :
+            list_to_min_eqn(c['min_eqn']), "url": url_for_label(c['label'])}
+            for c in curves_data ]
         self.ncurves = curves_data.count()
-        self.bad_lfactors = [ [c[0], list_to_factored_poly_otherorder(c[1])] for c in self.bad_lfactors]
-        ## duplication of get_end_alg.  need to clean up!
-        end_alg_title_dict = {'end_ring': r'\End(J)', 
+        self.bad_lfactors = [ [c[0], list_to_factored_poly_otherorder(c[1])]
+                for c in self.bad_lfactors]
+
+        # Endomorphisms begin
+        # duplication of get_end_alg.  need to clean up!
+        end_alg_title_dict = {'end_ring': r'\End(J)',
                               'rat_end_alg': r'\End(J) \otimes \Q',
                               'real_end_alg': r'\End(J) \otimes \R',
-                              'geom_end_ring': r'\End(J_{\overline{\Q}})', 
+                              'geom_end_ring': r'\End(J_{\overline{\Q}})',
                               'rat_geom_end_alg': r'\End(J_{\overline{\Q}}) \otimes \Q',
                               'real_geom_end_alg':'\End(J_{\overline{\Q}}) \otimes \R'}
         for endalgtype in ['end_ring', 'rat_end_alg', 'real_end_alg', 'geom_end_ring', 'rat_geom_end_alg', 'real_geom_end_alg']:
@@ -148,7 +173,7 @@ class G2Cisog_class(object):
                 setattr(self,endalgtype + '_name',[end_alg_title_dict[endalgtype],end_alg_name(getattr(self,endalgtype))])
             else:
                 setattr(self,endalgtype + '_name',[end_alg_title_dict[endalgtype],''])
-        
+
         if hasattr(self, 'geom_end_field') and self.geom_end_field != '':
             self.geom_end_field_name = field_pretty(self.geom_end_field)
         else:
@@ -171,28 +196,61 @@ class G2Cisog_class(object):
         else:
             simple_statement = ""  # leave empty since not computed.
         self.endomorphism_statement = simple_statement + gl2_statement
+        # Endomorphisms end
 
+        # Title
+        self.title = "Genus 2 Isogeny Class %s" % (self.label)
+
+        # Lady Gaga box
+        self.properties = [('Label', self.label),
+                           ('Number of curves', str(self.ncurves)),
+                           ('Conductor','%s' % self.cond),
+                           ('Sato-Tate group', '\(%s\)' % self.st_group_name),
+                           ('\(%s\)' % self.real_geom_end_alg_name[0],
+                            '\(%s\)' % self.real_geom_end_alg_name[1]),
+                           ('\(\mathrm{GL}_2\)-type','%s' % self.is_gl2_type_name)]
         x = self.label.split('.')[1]
-        
-        self.friends = [('L-function', url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x))]
+        self.friends = [('L-function',
+            url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x))]
+        self.downloads = [('Download Euler factors', ".")]
+        #self.downloads = [
+        #        ('Download Euler factors', "."),
+        #            url_for(".download_g2c_eulerfactors", label=self.label)),
+        #        ('Download stored data for all curves',
+        #            url_for(".download_g2c_all", label=self.label))
+        #        ]
 
+        # Breadcrumbs
+        self.bread = [
+                       ('Genus 2 Curves', url_for(".index")),
+                       ('$\Q$', url_for(".index_Q")),
+                       ('%s' % self.cond, url_for(".by_conductor", conductor=self.cond)),
+                       ('%s' % self.label, ' ')
+                     ]
+
+
+        # More friends (to be improved)
         self.ecproduct_wurl = []
         if hasattr(self, 'ecproduct'):
             for i in range(2):
                 curve_label = self.ecproduct[i]
                 crv_url = url_for("ec.by_ec_label", label=curve_label)
                 if i == 1 or len(set(self.ecproduct)) != 1:
-                    self.friends.append(('Elliptic curve ' + curve_label, crv_url))
-                self.ecproduct_wurl.append({'label' : curve_label, 'url' : crv_url})
+                    self.friends.append(('Elliptic curve ' + curve_label,
+                        crv_url))
+                self.ecproduct_wurl.append({'label' : curve_label, 'url' :
+                    crv_url})
 
         self.ecquadratic_wurl = []
         if hasattr(self, 'ecquadratic'):
             for i in range(len(self.ecquadratic)):
                 curve_label = self.ecquadratic[i]
                 crv_spl = curve_label.split('-')
-                crv_url = url_for("ecnf.show_ecnf_isoclass", nf = crv_spl[0], conductor_label = crv_spl[1], class_label = crv_spl[2])
+                crv_url = url_for("ecnf.show_ecnf_isoclass", nf = crv_spl[0],
+                        conductor_label = crv_spl[1], class_label = crv_spl[2])
                 self.friends.append(('Elliptic curve ' + curve_label, crv_url))
-                self.ecquadratic_wurl.append({'label' : curve_label, 'url' : crv_url, 'nf' : crv_spl[0]})
+                self.ecquadratic_wurl.append({'label' : curve_label, 'url' :
+                    crv_url, 'nf' : crv_spl[0]})
 
         if hasattr(self, 'mfproduct'):
             for i in range(len(self.mfproduct)):
@@ -200,31 +258,15 @@ class G2Cisog_class(object):
                 mf_spl = mf_label.split('.')
                 mf_spl.append(mf_spl[2][-1])
                 mf_spl[2] = mf_spl[2][:-1] # Need a splitting function
-                mf_url = url_for("emf.render_elliptic_modular_forms", level=mf_spl[0], weight=mf_spl[1], character=mf_spl[2], label=mf_spl[3])
+                mf_url = url_for("emf.render_elliptic_modular_forms",
+                        level=mf_spl[0], weight=mf_spl[1], character=mf_spl[2],
+                        label=mf_spl[3])
                 self.friends.append(('Modular form ' + mf_label, mf_url))
 
         if hasattr(self, 'mfhilbert'):
             for i in range(len(self.mfhilbert)):
                 mf_label = self.mfhilbert[i]
                 mf_spl = mf_label.split('-')
-                mf_url = url_for("hmf.render_hmf_webpage", field_label=mf_spl[0], label=mf_label)
+                mf_url = url_for("hmf.render_hmf_webpage",
+                        field_label=mf_spl[0], label=mf_label)
                 self.friends.append(('Hilbert modular form ' + mf_label, mf_url))
-
-        self.properties = [('Label', self.label),
-                           ('Number of curves', str(self.ncurves)),
-                           ('Conductor','%s' % self.cond),
-                           ('Sato-Tate group', '\(%s\)' % self.st_group_name),
-                           ('\(%s\)' % self.real_geom_end_alg_name[0],'\(%s\)' % self.real_geom_end_alg_name[1]),
-                           ('\(\mathrm{GL}_2\)-type','%s' % self.is_gl2_type_name)]
-
-        self.title = "Genus 2 Isogeny Class %s" % (self.label)
-        self.downloads = [
-                          ('Download Euler factors', ".")] # url_for(".download_g2c_eulerfactors", label=self.label)),
-#                          ('Download stored data for all curves', url_for(".download_g2c_all", label=self.label))]
-        
-        self.bread = [
-                       ('Genus 2 Curves', url_for(".index")),
-                       ('$\Q$', url_for(".index_Q")),
-                       ('%s' % self.cond, url_for(".by_conductor", conductor=self.cond)),
-                       ('%s' % self.label, ' ')
-                     ]

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -74,7 +74,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td><select name='real_geom_end_alg' width="122" style="width: 122px">
         <option ></option>
     {% for G in info.real_geom_end_alg_list %}
-        <option value='{{G}}'>{{info.real_geom_end_alg_dict[G]}}</option>
+        <option value='{{G}}'>{{info.real_geom_end_alg_to_ST0_dict[G]}}</option>
     {% endfor %}
 </select></td>
 </tr>

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -3,7 +3,7 @@
 
 <p>
 The database currently contains {{info.count}} genus 2 curves
-over the rational numbers. 
+over the rational numbers.
 </p>
 
 <h2> Browse {{ KNOWL('g2c.g2curve', title='genus 2 curves over $\Q$') }} </h2>
@@ -23,7 +23,7 @@ By {{ KNOWL('g2c.abs_discriminant', title='absolute discriminant')}}:
 <p>
 Some of our favorite curves:
 {% for curve in info.browse_curves: %}
- <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a>  
+ <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a>
 {% endfor %}
 </p>
 <p>
@@ -44,7 +44,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <table>
 <tr>Please enter a value or leave blank:</tr>
 <tr>
-<td>{{ KNOWL('ag.conductor', title='conductor') }}</td>  
+<td>{{ KNOWL('ag.conductor', title='conductor') }}</td>
 <td><input type='text' name='cond' placeholder='169' size=10>
 <td><span class="formexample"> e.g. 169, 100-1000 </span></td>
 <td>{{ KNOWL('g2c.gl2type', title='$\GL_2$-type') }}</td>
@@ -67,7 +67,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 </select></td>
 </tr>
 <tr>
-<td>{{ KNOWL('g2c.num_rat_wpts', title='rational Weierstrass points') }}</td>  
+<td>{{ KNOWL('g2c.num_rat_wpts', title='rational Weierstrass points') }}</td>
 <td><input type='text' name='num_rat_wpts' placeholder='1' size=10>
 <td><span class="formexample"> e.g. 1, 0-6 </span></td>
 <td>{{KNOWL('g2c.st_group_identity_component',title='Sato-Tate identity component')}}</td>
@@ -79,7 +79,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 </select></td>
 </tr>
 <tr>
-<td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>  
+<td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>
 <td><input type='text' name='torsion_order' placeholder='2' size=10>
 <td><span class="formexample"> e.g. 2 </span></td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\Q\)-automorphism group') }}</td>
@@ -91,7 +91,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 </select></td>
 </tr>
 <tr>
-<td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>  
+<td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>
 <td><input type='text' name='torsion' placeholder='[2,2,2]' size=10>
 <td><span class="formexample"> e.g. [2,2,2] </span></td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\overline{\Q}\)-automorphism group') }}</td>
@@ -103,7 +103,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 </select></td>
 </tr>
 <!--<tr>
-<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>  
+<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>
 <td><input type='text' name='two_selmer_rank' placeholder='1' size=10>
 <td><span class="formexample"> e.g. 1 </span></td>
 </tr>-->

--- a/lmfdb/genus2_curves/templates/browse_search_g2_nf.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2_nf.html
@@ -23,12 +23,12 @@ The database currently contains many (but not all) genus 2 curves over number fi
 <form>
 <table>
 <tr>
-<td>Field</td>  
+<td>Field</td>
 <td><input type='text' name='field' placeholder='Q' size=10>
 <td><span class="formexample"> e.g. Q </span></td>
 </tr>
 <tr>
-<td>Conductor norm</td>  
+<td>Conductor norm</td>
 <td><input type='text' name='cond_norm' placeholder='169' size=10>
 <td><span class="formexample"> e.g. 169 </span></td>
 </tr>

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -1,5 +1,6 @@
 {% extends 'homepage.html' %}
 {% block content %}
+
 <style>
 /* seems to be unused?
 <div.ip>span { white-space: nowrap; font-family: serif; }
@@ -8,6 +9,7 @@
 div.properties-body table tr td.label { vertical-align: top; }
 #content > h2.subhead { color:black;}
 </style>
+
 {% macro code(codes, languages, item) %}
 {% for L in languages %}
 <div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">
@@ -52,7 +54,9 @@ function show_invs(invstyle) {
 #}
 {% set KNOWL_ID = "g2c.%s"|format(data['label']) %}
 
-<!--<h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>-->
+<!--
+<h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
+-->
 
 <div align ="center">
     Show commands using:  

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -59,7 +59,7 @@ function show_invs(invstyle) {
 -->
 
 <div align ="center">
-    Show commands using:  
+    Show commands using:
     <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
     <!-- No pari/gp commands yet!
     <a onclick="show_code('pari'); return false" href='#'>pari/gp</a>,

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -51,11 +51,24 @@ text-align: center;
 </p>
 
 <h2> {{ KNOWL('g2c.jac_endomorphisms', title='Endomorphisms of the Jacobian') }} </h2>
-<!-- TODO: Add results -->
+
+<p>{{info.gl2_statement_base}}</p>
+
+<!-- Description over QQ: -->
+<p>{{info.endo_statement_base|safe}}</p>
+
+<!-- Description of field of definition: -->
+<p>{{info.fod_statement|safe}}</p>
+
+<!-- Description over QQbar: -->
+<p>{{info.endo_statement_geom|safe}}</p>
+
+<p>More complete information on endomorphism algebras and rings can be found on
+the webpages of the individual curves in the isogeny class.</p>
 
 <h2>{{ KNOWL('ag.isogeny', title='Isogenies') }}</h2>
 
-<!-- TODO: Replace by new results from endomorphism algebra -->
+<!-- TODO: Replace and complete with new results from endomorphism algebra -->
 
 {% if info.ecproduct_wurl == [] and info.ecquadratic_wurl == [] %}
 <p>None currently known.</p>

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -51,20 +51,11 @@ text-align: center;
 </p>
 
 <h2> {{ KNOWL('g2c.jac_endomorphisms', title='Endomorphisms of the Jacobian') }} </h2>
-<p>{{info.endomorphism_statement}}</p>
-<table>
-{% for endalgtype in ['end_ring_name', 'rat_end_alg_name', 'real_end_alg_name', 'geom_end_ring_name', 'rat_geom_end_alg_name', 'real_geom_end_alg_name'] %}
-{% if info[endalgtype][1] != '' %}
-<tr>  <td> \({{info[endalgtype][0]}}\)</td><td>\(\simeq\)</td><td>\({{info[endalgtype][1]}}\)</td></tr>
-{% endif %}
-{% endfor %}
-</table>
-{% if info.geom_end_field_name != '' %}
-<p>Field over which all endomorphisms are defined:
-<a href="/NumberField/{{info.geom_end_field}}">{{info.geom_end_field_name}}</a></p>
-{% endif %}
+<!-- TODO: Add results -->
 
 <h2>{{ KNOWL('ag.isogeny', title='Isogenies') }}</h2>
+
+<!-- TODO: Replace by new results from endomorphism algebra -->
 
 {% if info.ecproduct_wurl == [] and info.ecquadratic_wurl == [] %}
 <p>None currently known.</p>

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -27,7 +27,7 @@ text-align: center;
 <!-- Someone please redo this table with css.-->
 <table>
     <tr><td> {{KNOWL('lfunction.sign', title='Root number')}}:<td> \({{ info.root_number }}\)</tr>
-    <tr><td>&nbsp;</td></tr> 
+    <tr><td>&nbsp;</td></tr>
     <tr><td valign=top> {{ KNOWL('g2c.bad_lfactors', title='Bad L-factors') }}:<td>
         <table id = "bad_lfactors_table">
         <tr>
@@ -60,7 +60,7 @@ text-align: center;
 {% endfor %}
 </table>
 {% if info.geom_end_field_name != '' %}
-<p>Field over which all endomorphisms are defined: 
+<p>Field over which all endomorphisms are defined:
 <a href="/NumberField/{{info.geom_end_field}}">{{info.geom_end_field_name}}</a></p>
 {% endif %}
 
@@ -77,7 +77,7 @@ text-align: center;
 
 {% if info.ecquadratic_wurl != [] %}
 {% for c in info.ecquadratic_wurl %}
-<p>\(J\) is isogenous over \(\Q\) to \(\mathrm{Res}_{F/\Q}(\)<a href="{{c.url}}">{{c.label}}</a>\()\), where \(F=\) 
+<p>\(J\) is isogenous over \(\Q\) to \(\mathrm{Res}_{F/\Q}(\)<a href="{{c.url}}">{{c.label}}</a>\()\), where \(F=\)
 <A HREF="/NumberField/{{c.nf}}">{{c.nf}}</A>.</p>
 {% endfor %}
 {% endif %}

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -1,5 +1,4 @@
 {% extends 'homepage.html' %}
-
 {% block content %}
 
 <style type="text/css">
@@ -27,22 +26,20 @@ text-align: center;
 <p>
 <!-- Someone please redo this table with css.-->
 <table>
-<tr><td> {{KNOWL('lfunction.sign', title='Root number')}}:<td> \({{ info.root_number }}\) </tr>
-<tr> <td>&nbsp;</td> </tr> 
-<tr><td valign=top> {{ KNOWL('g2c.bad_lfactors', title='Bad L-factors') }}:<td>
-<table id = "bad_lfactors_table">
-<tr>
-<th>Prime</th>
-<th>L-Factor</th>
-</tr>
-{% for c in info.bad_lfactors %}
-<tr><td class="center">\({{ c[0] }}\)</a></td><td align="center">\( {{ c[1] }}\)</td></tr>
-{% endfor %}
+    <tr><td> {{KNOWL('lfunction.sign', title='Root number')}}:<td> \({{ info.root_number }}\)</tr>
+    <tr><td>&nbsp;</td></tr> 
+    <tr><td valign=top> {{ KNOWL('g2c.bad_lfactors', title='Bad L-factors') }}:<td>
+        <table id = "bad_lfactors_table">
+        <tr>
+            <th>Prime</th>
+            <th>L-Factor</th>
+        </tr>
+        {% for c in info.bad_lfactors %}
+        <tr><td class="center">\({{ c[0] }}\)</a></td><td align="center">\( {{ c[1] }}\)</td></tr>
+        {% endfor %}
+        </table>
+    </tr>
 </table>
-
-</table>
-
-<p>
 
 <h2>{{ KNOWL('g2c.st_group', title='Sato-Tate group')}}</h2>
 <p>
@@ -86,5 +83,3 @@ text-align: center;
 {% endif %}
 
 {% endblock %}
-
-

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -16,7 +16,7 @@
 <td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>  
 <td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>  
 </tr>
-<tr>
+
 <tr>
 <td><input type='text' name='cond' placeholder='169' size=10 value="{{info.cond}}"></td>
 <td><input type='text' name='disc' placeholder='169' size=10 value="{{info.disc}}"></td>
@@ -25,6 +25,7 @@
 <td><input type='text' name='torsion_order' placeholder='2' size=10 value="{{info.torsion_order}}">
 <td><input type='text' name='two_selmer_rank' placeholder='1' size=10 value="{{info.two_selmer_rank}}">
 </tr>
+
 <tr>
 <td>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</td>
 <td>{{ KNOWL('g2c.st_group', title='\(\mathrm{ST}\)') }}</td>
@@ -70,7 +71,7 @@
     {% endfor %}
 </select></td>
 
-<td ><select name='aut_grp' width="122" style="width: 122px">
+<td><select name='aut_grp' width="122" style="width: 122px">
     <option ></option>
     {% for G in info.aut_grp_list %}
         {% if G == info.aut_grp %}
@@ -81,7 +82,7 @@
     {% endfor %}
 </select></td>
 
-<td ><select name='geom_aut_grp' width="122" style="width: 122px">
+<td><select name='geom_aut_grp' width="122" style="width: 122px">
     <option ></option>
     {% for G in info.geom_aut_grp_list %}
         {% if G == info.geom_aut_grp %}
@@ -100,48 +101,45 @@
 
 <h2> Results ({{info.report}})
 {% if info.start > 0 %}
-<a href="#" class="navlink"
-   onclick="decrease_start_by_count_and_submit_form('re-search');return
-            false">Previous</A>
+<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
 {% endif %}
 {% if info.more > 0 %}
 <a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
 {% endif %}
 </h2>
+
 <table class="ntdata">
 <tr>
-<th>{{ KNOWL('g2c.label', title='Label') }}</th>
-<th>{{ KNOWL('g2c.isogeny_class', title='Isogeny class') }}</th>
-<th>{{ KNOWL('g2c.equation', title='Equation') }}</th>
-<th>{{ KNOWL('g2c.st_group', title='Sato Tate group') }}</th>
-<th>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</th>
+    <th>{{ KNOWL('g2c.label', title='Label') }}</th>
+    <th>{{ KNOWL('g2c.isogeny_class', title='Isogeny class') }}</th>
+    <th>{{ KNOWL('g2c.equation', title='Equation') }}</th>
+    <th>{{ KNOWL('g2c.st_group', title='Sato Tate group') }}</th>
+    <th>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</th>
 </tr>
 {% for curve in info.curves: %}
 <tr>
-  <td> <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a> </td>
-  <td> <a href = "{{info.isog_url(curve)}}"> {{curve.isog_label}} </a> </td>
-  <td> \({{curve.equation_formatted}}\) </td>
-  <td align=center> \({{curve.st_group_name}}\) </td>
-  <td align=center> {{curve.is_gl2_type_display | safe}} </td>
+    <td> <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a> </td>
+    <td> <a href = "{{info.isog_url(curve)}}"> {{curve.isog_label}} </a> </td>
+    <td> \({{curve.equation_formatted}}\) </td>
+    <td align=center> \({{curve.st_group_name}}\) </td>
+    <td align=center> {{curve.is_gl2_type_display | safe}} </td>
 </tr>
 {% endfor %}
 </table>
 
 <hr>
 {% if info.start > 0 %}
-<a href="#" class="navlink"
-   onclick="decrease_start_by_count_and_submit_form('re-search');return
-            false">Previous</A>
+<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
 {% endif %}
 {% if info.more > 0 %}
 <a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
 {% endif %}
 
-<br>
 <!--
-   <p class="tex2jax_ignore">
-   Results for database query {{ info.query }}
-   </p>
+    <br>
+    <p class="tex2jax_ignore">
+    Results for database query {{ info.query }}
+    </p>
 -->
 
 {% endblock %}

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -64,9 +64,9 @@
     <option ></option>
     {% for G in info.real_geom_end_alg_list %}
         {% if G == info.real_geom_end_alg %}
-            <option value='{{G}}' selected>{{info.real_geom_end_alg_dict[G]}}</option>
+            <option value='{{G}}' selected>{{info.real_geom_end_alg_to_ST0_dict[G]}}</option>
         {% else %}
-            <option value='{{G}}'>{{info.real_geom_end_alg_dict[G]}}</option>
+            <option value='{{G}}'>{{info.real_geom_end_alg_to_ST0_dict[G]}}</option>
         {% endif %}
     {% endfor %}
 </select></td>

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -9,12 +9,12 @@
 
 <table>
 <tr>
-<td>{{ KNOWL('ag.conductor', title='conductor') }}</td>  
+<td>{{ KNOWL('ag.conductor', title='conductor') }}</td>
 <td>{{ KNOWL('g2c.abs_discriminant', title='absolute discriminant')}}</td>
-<td>{{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}</td>  
-<td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>  
-<td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>  
-<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>  
+<td>{{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}</td>
+<td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>
+<td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>
+<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>
 </tr>
 
 <tr>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -17,7 +17,7 @@ from flask import url_for, make_response
 logger = make_logger("g2c")
 
 ###############################################################################
-#   Database connection
+# Database connection
 ###############################################################################
 
 g2cdb = None
@@ -49,13 +49,12 @@ def db_ecQQ():
 ###############################################################################
 
 def isog_label(label):
-    #get isog label from full label
     L = label.split(".")
     return L[0]+ "." + L[1]
 
 ###############################################################################
-# Conversion of eliptic curve labels (database stores Cremona labels
-# but we want to display LMFDB labels -- see Issue #635)
+# Conversion of eliptic curve labels (database stores Cremona labels but we
+# want to display LMFDB labels -- see Issue #635)
 ###############################################################################
 
 def cremona_to_lmfdb(label):
@@ -177,7 +176,7 @@ def eqn_list_to_curve_plot(L):
         plotzones)
 
 ###############################################################################
-# Invariant conversions on the fly
+# Invariant conversion
 ###############################################################################
 
 def igusa_clebsch_to_igusa(I):
@@ -241,7 +240,7 @@ def normalize_invariants(I,W):
 def end_alg_name(name):
     name_dict = {
         "Z":"\\Z",
-        "Q":"\\Q",      
+        "Q":"\\Q",
         "Q x Qsqrt-4":"\\Q \\times \\Q(\\sqrt{-1})",
         "Q x Qsqrt-7":"\\Q \\times \\Q(\\sqrt{-7})",
         "Q x Qsqrt-11":"\\Q \\times \\Q(\\sqrt{-11})",
@@ -290,10 +289,10 @@ def st_group_name(name):
 
 def get_end_data(isogeny_class):
     data = {}
-    end_alg_title_dict = {'end_ring': r'\End(J)', 
+    end_alg_title_dict = {'end_ring': r'\End(J)',
                           'rat_end_alg': r'\End(J) \otimes \Q',
                           'real_end_alg': r'\End(J) \otimes \R',
-                          'geom_end_ring': r'\End(J_{\overline{\Q}})', 
+                          'geom_end_ring': r'\End(J_{\overline{\Q}})',
                           'rat_geom_end_alg': r'\End(J_{\overline{\Q}}) \otimes \Q',
                           'real_geom_end_alg':'\End(J_{\overline{\Q}}) \otimes \R'}
     for endalgtype in ['end_ring', 'rat_end_alg', 'real_end_alg', 'geom_end_ring', 'rat_geom_end_alg', 'real_geom_end_alg']:
@@ -301,12 +300,12 @@ def get_end_data(isogeny_class):
             data[endalgtype + '_name'] = [end_alg_title_dict[endalgtype],end_alg_name(isogeny_class[endalgtype])]
         else:
             data[endalgtype + '_name'] = [end_alg_title_dict[endalgtype],'']
-        
+
     data['geom_end_field'] = isogeny_class['geom_end_field']
     if data['geom_end_field'] != '':
         data['geom_end_field_name'] = field_pretty(data['geom_end_field'])
     else:
-        data['geom_end_field_name'] = ''        
+        data['geom_end_field_name'] = ''
 
     data['st0_group_name'] = st0_group_name(isogeny_class['real_geom_end_alg'])
     data['st_group_name'] = st_group_name(isogeny_class['st_group'])
@@ -338,15 +337,15 @@ def get_end_data(isogeny_class):
 
 def gl2_statement(factorsRR, base):
     if factorsRR in [['RR', 'RR'], ['CC']]:
-        return "The Jacobian is of \(\GL_2\)-type" + " over " + base
-    return "The Jacobian is not of \(\GL_2\)-type" + " over " + base
+        return "The Jacobian is of \(\GL_2\)-type over " + base
+    return "The Jacobian is not of \(\GL_2\)-type over " + base
 
 def endo_statement(factorsQQ, factorsRR, ring, fieldstring):
     statement = """<table>"""
     # First row: description of endomorphism algebra factors
     statement += """<tr><td>\(\End (J_{%s}) \otimes \Q\
     \)</td><td>\(\simeq\)</td><td>""" % fieldstring
-    factorsQQ_number = len(factorsQQ) 
+    factorsQQ_number = len(factorsQQ)
     factorsQQ_pretty = [ field_pretty(fac[0]) for fac in factorsQQ if
             fac[0] ]
     # In the case of only one factor we either get a number field or a
@@ -539,7 +538,7 @@ class WebG2C(object):
             print label
             data = db_g2c().curves.find_one({"label" : label})
             endodata = db_g2endo().bycurve.find_one({"label" : label})
-            
+
         except AttributeError:
             return "Invalid label" # caller must catch this and raise an error
 
@@ -550,21 +549,21 @@ class WebG2C(object):
                 return "Endomorphism data for curve not found"
         return "Data for curve not found" # caller must catch this and raise an error
 
-###############################################################################
-# Main data manipulation for individual curve
-###############################################################################
+    ###########################################################################
+    # Main data creation for individual curves
+    ###########################################################################
 
     def make_curve(self):
         # To start with the data fields of self are just those from the
         # databases.  We reformat these, while computing some further (easy)
         # data about the curve on the fly.
 
-        # Get data from databases:
+        # Initialize data:
         data = self.data = {}
         endodata = self.endodata = {}
 
         # Polish data from database before putting it into the data dictionary:
-        disc = ZZ(self.disc_sign) * ZZ(self.disc_key[3:]) 
+        disc = ZZ(self.disc_sign) * ZZ(self.disc_key[3:])
         # to deal with disc_key, uncomment line above and comment line below
         #disc = ZZ(self.disc_sign) * ZZ(self.abs_disc)
         data['disc'] = disc
@@ -604,11 +603,11 @@ class WebG2C(object):
         # GL_2 statement over the base field
         endodata['gl2_statement_base'] = gl2_statement(self.factorsRR_base,
                 r'\(\Q\)')
-        
+
         # NOTE: In what follows there is some copying of code and data that is
         # stupid from the point of view of efficiency but likely better from
         # that of maintenance.
-        
+
         # Endomorphism data over QQ:
         endodata['factorsQQ_base'] = self.factorsQQ_base
         endodata['factorsRR_base'] = self.factorsRR_base
@@ -649,7 +648,7 @@ class WebG2C(object):
         endodata['spl_fod_statement'] = \
         spl_fod_statement(endodata['is_simple_geom'],
                 endodata['spl_fod_label'], endodata['spl_fod_poly'])
-        
+
         # Isogeny factors:
         if not endodata['is_simple_geom']:
             endodata['spl_facs_coeffs'] = self.spl_facs_coeffs
@@ -665,37 +664,58 @@ class WebG2C(object):
                     endodata['spl_facs_labels'],
                     endodata['spl_facs_condnorms'])
 
-        x = self.label.split('.')[1]
-        self.make_code_snippets()
-        self.friends = [
-            ('Isogeny class %s' % isog_label(self.label), url_for(".by_double_iso_label", conductor = self.cond, iso_label = x)),
-            ('L-function', url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x)),
-            
-            ('Twists',url_for(".index_Q", ic0 = self.igusa_clebsch[0], ic1 = self.igusa_clebsch[1],ic2 = self.igusa_clebsch[2],ic3 = self.igusa_clebsch[3])),
-            #('Twists2',url_for(".index_Q", igusa_clebsch = str(self.igusa_clebsch)))  #doesn't work.
-            #('Siegel modular form someday', '.')
-            ]
-        self.downloads = [
-             ('Download all stored data', '.')]
-        iso = self.label.split('.')[1]
-        num = '.'.join(self.label.split('.')[2:4])
+        # Title
+        self.title = "Genus 2 Curve %s" % (self.label)
+
+        # Lady Gaga box
         self.plot = encode_plot(eqn_list_to_curve_plot(self.min_eqn))
         self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
-        self.properties = [('Label', self.label),
-                           (None, self.plot_link),
-                           ('Conductor','%s' % self.cond),
-                           ('Discriminant', '%s' % data['disc']),
-                           ('Invariants', '%s </br> %s </br> %s </br> %s'% tuple(data['ic_norm'])), 
-                           ('Sato-Tate group', '\(%s\)' % data['st_group_name']), 
-                           ('\(%s\)' % data['real_geom_end_alg_name'][0],'\(%s\)' % data['real_geom_end_alg_name'][1]),
-                           ('\(\mathrm{GL}_2\)-type','%s' % data['is_gl2_type_name'])]
-        self.title = "Genus 2 Curve %s" % (self.label)
+        self.properties = [
+                ('Label', self.label),
+               (None, self.plot_link),
+               ('Conductor','%s' % self.cond),
+               ('Discriminant', '%s' % data['disc']),
+               ('Invariants', '%s </br> %s </br> %s </br> %s' % tuple(data['ic_norm'])),
+               ('Sato-Tate group', '\(%s\)' % data['st_group_name']),
+               ('\(%s\)' % data['real_geom_end_alg_name'][0],'\(%s\)' % data['real_geom_end_alg_name'][1]),
+               ('\(\mathrm{GL}_2\)-type','%s' % data['is_gl2_type_name'])]
+        x = self.label.split('.')[1]
+        self.friends = [
+            ('Isogeny class %s' % isog_label(self.label),
+                url_for(".by_double_iso_label",
+                    conductor = self.cond,
+                    iso_label = x)),
+            ('L-function',
+                url_for("l_functions.l_function_genus2_page",
+                    cond=self.cond,x=x)),
+            ('Twists',
+                url_for(".index_Q",
+                    ic0 = self.igusa_clebsch[0],
+                    ic1 = self.igusa_clebsch[1],
+                    ic2 = self.igusa_clebsch[2],
+                    ic3 = self.igusa_clebsch[3])),
+            #('Twists2',
+            #   url_for(".index_Q",
+            #       igusa_clebsch = str(self.igusa_clebsch)))  #doesn't work.
+            #('Siegel modular form someday', '.')
+            ]
+        self.downloads = [('Download all stored data', '.')]
+
+        # Breadcrumbs
+        iso = self.label.split('.')[1]
+        num = '.'.join(self.label.split('.')[2:4])
         self.bread = [
              ('Genus 2 Curves', url_for(".index")),
              ('$\Q$', url_for(".index_Q")),
              ('%s' % self.cond, url_for(".by_conductor", conductor=self.cond)),
-             ('%s' % iso, url_for(".by_double_iso_label", conductor=self.cond, iso_label=iso)),
-             ('Genus 2 curve %s' % num, url_for(".by_g2c_label", label=self.label))]
+             ('%s' % iso, url_for(".by_double_iso_label", conductor=self.cond,
+                 iso_label=iso)),
+             ('Genus 2 curve %s' % num, url_for(".by_g2c_label",
+                 label=self.label))
+             ]
+
+        # Make code that is used on the page:
+        self.make_code_snippets()
 
     def make_code_snippets(self):
         sagecode = dict()
@@ -703,7 +723,6 @@ class WebG2C(object):
         magmacode = dict()
 
         #utility function to save typing!
-
         def set_code(key, s, g, m):
             sagecode[key] = s
             gpcode[key] = g
@@ -728,9 +747,11 @@ class WebG2C(object):
 
         # curve
         set_code('curve',
-                 'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'   % (self.data['min_eqn'][0],self.data['min_eqn'][1]),
+                 'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
+                 % (self.data['min_eqn'][0],self.data['min_eqn'][1]),
                  pari_not_implemented, # pari code goes here
-                 'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'   % (self.data['min_eqn'][0],self.data['min_eqn'][1]) 
+                 'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'
+                 % (self.data['min_eqn'][0],self.data['min_eqn'][1])
                  )
         if self.data['disc'] % 4096 == 0:
             ind2 = [a[0] for a in self.data['isogeny_class']['bad_lfactors']].index(2)
@@ -741,7 +762,8 @@ class WebG2C(object):
         set_code('cond',
                  sage_not_implemented, # sage code goes here
                  pari_not_implemented, # pari code goes here
-                 'Conductor(LSeries(C%s)); Factorization($1);' % magma_cond_option
+                 'Conductor(LSeries(C%s)); Factorization($1);'
+                 % magma_cond_option
                  )
         set_code('disc',
                  sage_not_implemented, # sage code goes here


### PR DESCRIPTION
This series of commits eliminates the old endomorphism functionality and replaces it with the new one. The old functionality is now nowhere in the code, improving its consistency and enabling Andrew Sutherland to get rid of the corresponding database entries.

The Sato-Tate group, from which the previous information was taken, is still used, as it contains provable information that is moreover used in searches. However, the determination of the more fine-grained detail concerning the endomorphism rings has now all been relegated to the new functionality, and with it to the parallel database genus2_endomorphisms (with the rest of the curve data coming from genus2_curves).

These commits also add some endomorphism display to the isogeny class pages. This is less complete than on the individual pages since that somehow seemed more natural to me. More should be added on the isogeny pages, such as information about isogenies and splittings, but that will follow at another occasion.

Some further cosmetic changes have also been made, including the usual quasi-obsessive-compulsive tinkering with the code layout.