### PR TITLE
Issue755

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -332,7 +332,7 @@ class WebEC(object):
             ('L-function', url_for("l_functions.l_function_ec_page", label=self.lmfdb_label)),
             ('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso)),
             ('Symmetric 4th power L-function', url_for("l_functions.l_function_ec_sym_page", power='4', label=self.lmfdb_iso)),
-            ('Modular form ' + self.lmfdb_iso.replace('.', '.2'), url_for("emf.render_elliptic_modular_forms", level=int(N), weight=2, character=0, label=iso))]
+            ('Modular form ' + self.lmfdb_iso.replace('.', '.2'), url_for("emf.render_elliptic_modular_forms", level=int(N), weight=2, character=1, label=iso))]
 
         self.downloads = [('Download coeffients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=100)),
                           ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label))]

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -121,7 +121,7 @@ def render_elliptic_modular_forms(level=None, weight=None, character=None, label
             return render_web_modform_space_gamma1(**info)
         return render_elliptic_modular_form_navigation_wp(**info)
         # Otherwise we go to the main navigation page
-    except IndexError as e: # catch everything here..
+    except IndexError as e: # catch everything here except KeyError below...
         emf_logger.debug("catching exceptions. info={0}".format(info))
         errst = str(e)
         ## Try to customise some of the error messages:
@@ -133,7 +133,12 @@ def render_elliptic_modular_forms(level=None, weight=None, character=None, label
             errst = "The space {0}.{1}.{2} is not in the database!".format(level,weight,character)
             flash(errst)
         return render_elliptic_modular_form_navigation_wp()
-            
+    except KeyError as e:
+        emf_logger.debug("catching exceptions. info={0}".format(info))
+        errst = "The space {0}.{1}.{2} is not in the database!".format(level,weight,character)
+        flash(errst)
+        return render_elliptic_modular_form_navigation_wp()
+
 
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_download_utils import download_web_modform,get_coefficients
 


### PR DESCRIPTION
This fixes Issue 755: 
   1.  The modular form URL in the related Objects list for an elliptic curve used the old-style numbering; now corrected
   2. if a complete and valid  URL for a classical modular form is given for which that form is not in the database, for example 
ModularForm/GL2/Q/holomorphic/201/2/1/b/
from
EllipticCurve/Q/201/b/1
then instead of crashing, a reasonable error message appears explaining why the modular form could not be displayed.