### PR TITLE
issue 756: special L-value approximately equal, not equal

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -316,7 +316,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
       <h3> {{KNOWL('ec.q.special_value', title='Special L-value', special_value = data.special_value)}} attached to the curve </h3>
     {{ code(data.code,'L1') }}
     <p>
-        \( {{ data.bsd.lder_name }} = {{ data.bsd.lder }} \)
+        \( {{ data.bsd.lder_name }} \) &approx; \( {{ data.bsd.lder }} \)
     </p>
 
     <h2> Local data </h2>


### PR DESCRIPTION
This just changes = to &approx; in a template, e.g. 
EllipticCurve/Q/11/a/1
in the section  Special L-value attached to the curve
