### PR TITLE
Issue 757: use lmfdb_label for bottom knowls

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -478,7 +478,7 @@ $(function() {
 });
 </script>
 
-    {% set KNOWL_ID = "ec.q.%s"|format(data['label']) %}
+    {% set KNOWL_ID = "ec.q.%s"|format(data['lmfdb_label']) %}
     <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>
 
 {% if DEBUG %}


### PR DESCRIPTION
Previous pull request fixed top knowls but forgot bottom knowls.