### PR TITLE
Further polishing of genus 2 endomorphism display

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -17,7 +17,7 @@ from lmfdb.genus2_curves.web_g2c import WebG2C, list_to_min_eqn, isog_label, st_
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
 #q = ZZ['x'].gen()
-credit_string = "Andrew Booker, Andrew Sutherland, John Voight, and Dan Yasaki"
+credit_string = "Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight, and Dan Yasaki"
 
 ###############################################################################
 # Database connection
@@ -30,6 +30,8 @@ def db_g2c():
     if g2cdb is None:
         g2cdb = lmfdb.base.getDBConnection().genus2_curves
     return g2cdb
+
+# TODO: Remove database below when switched to use of genus2_curves only
 
 g2endodb = None
 

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -1,6 +1,15 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<!--New table class to avoid spacing in LaTeX-links -->
+<style type="text/css">
+table.g2 a {
+  padding: 0;
+}
+table.g2 table, th, td, tr {
+  margin-top: 0;
+}
+
 <style>
 /* seems to be unused?
 <div.ip>span { white-space: nowrap; font-family: serif; }
@@ -275,17 +284,23 @@ function show_invs(invstyle) {
 <p>{{data.endodata.gl2_statement_base}}</p>
 
 <!-- Description over QQ: -->
-<p>{{data.endodata.endo_statement_base|safe}}</p>
+{{data.endodata.endo_statement_base|safe}}
 
 <!-- Description of field of definition: -->
 <p>{{data.endodata.fod_statement|safe}}</p>
 
 <!-- Description over QQbar: -->
-<p>{{data.endodata.endo_statement_geom|safe}}</p>
+{{data.endodata.endo_statement_geom|safe}}
+<!-- Excuse the upcoming dirty spacing hack, but putting paragraph tags around
+the previous statement ruins its table spacing.
+Same for all other occasions of it.-->
+<p></p>
 
 <!-- Remainder of the lattice: -->
 <h3 style="display: inline">{{data.endodata.lattice_statement_preamble}}</h3>
 
+<p></p>
 {{data.endodata.lattice_statement|safe}}
+<p></p>
 
 {% endblock %}

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -6,9 +6,6 @@
 table.g2 a {
   padding: 0;
 }
-table.g2 table, th, td, tr {
-  margin-top: 0;
-}
 
 <style>
 /* seems to be unused?

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -1,6 +1,15 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<!--New table class to avoid spacing in LaTeX-links -->
+<style type="text/css">
+table.g2 a {
+  padding: 0;
+}
+table.g2 table, th, td, tr {
+  margin-top: 0;
+}
+
 <style type="text/css">
 #isogeny_class_table th, #isogeny_class_table td {
 padding : 4px;
@@ -55,13 +64,17 @@ text-align: center;
 <p>{{info.gl2_statement_base}}</p>
 
 <!-- Description over QQ: -->
-<p>{{info.endo_statement_base|safe}}</p>
+{{info.endo_statement_base|safe}}
 
 <!-- Description of field of definition: -->
 <p>{{info.fod_statement|safe}}</p>
 
 <!-- Description over QQbar: -->
-<p>{{info.endo_statement_geom|safe}}</p>
+{{info.endo_statement_geom|safe}}
+<!-- Excuse the upcoming dirty spacing hack, but putting paragraph tags around
+the previous statement ruins its table spacing.
+Same for all other occasions of it.-->
+<!-- <p></p> -->
 
 <p>More complete information on endomorphism algebras and rings can be found on
 the webpages of the individual curves in the isogeny class.</p>

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -6,9 +6,6 @@
 table.g2 a {
   padding: 0;
 }
-table.g2 table, th, td, tr {
-  margin-top: 0;
-}
 
 <style type="text/css">
 #isogeny_class_table th, #isogeny_class_table td {

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -6,20 +6,32 @@ import unittest2
 class Genus2Test(LmfdbTest):
 
     # All tests should pass
-    #
-    def test_by_full_label(self):
-        L = self.tc.get('/Genus2Curve/Q/277/a/277/1')
-        assert '277' in L.data
-
-    def test_by_double_iso_label(self):
-        L = self.tc.get('/Genus2Curve/Q/336/a/')
-        assert '336.a.172032.1' in L.data
-
-    def test_by_g2c_label(self):
-        L = self.tc.get('/Genus2Curve/Q/169.a.169.1')
-        assert '13' in L.data
 
     def test_Cond_search(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=100-200&count=100')
         assert '196.a.21952.1' in L.data
 
+    def test_by_double_iso_label(self):
+        L = self.tc.get('/Genus2Curve/Q/336/a/')
+        assert '336.a.172032.1' in L.data
+
+    def test_by_full_label(self):
+        # Two elliptic curve factors and decomposing endomorphism algebra:
+        L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
+        assert '32.a1' in L.data and '34.a3' in L.data
+        # QM curve:
+        L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
+        assert 'quaternion algebra' in L.data
+        L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
+        # Square over a quadratic extension that is CM over one extension and
+        # multiplication by a quaternion algebra ramifying at infinity over
+        # another:
+        assert 'square of an elliptic curve' in L.data and '2.2.8.1-64.1-a3'\
+            in L.data and r'\mathbf{H}' in L.data and '(CM)' in L.data
+
+    def test_by_g2c_label(self):
+        # This curve also decomposes as a square, this time of a curve without
+        # a label:
+        L = self.tc.get('/Genus2Curve/Q/169.a.169.1')
+        assert 'square of an elliptic curve' in L.data and '\Z/{19}\Z'\
+            in L.data

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -28,14 +28,6 @@ def db_g2c():
         g2cdb = getDBConnection().genus2_curves
     return g2cdb
 
-g2endodb = None
-
-def db_g2endo():
-    global g2endodb
-    if g2endodb is None:
-        g2endodb = getDBConnection().genus2_endomorphisms
-    return g2endodb
-
 ecdbQQ = None
 
 def db_ecQQ():
@@ -43,6 +35,16 @@ def db_ecQQ():
     if ecdbQQ is None:
         ecdbQQ = getDBConnection().elliptic_curves.curves
     return ecdbQQ
+
+# TODO: Remove database below when switched to use of genus2_curves only
+
+g2endodb = None
+
+def db_g2endo():
+    global g2endodb
+    if g2endodb is None:
+        g2endodb = getDBConnection().genus2_endomorphisms
+    return g2endodb
 
 ###############################################################################
 # Recovering the isogeny class
@@ -52,6 +54,7 @@ def isog_label(label):
     L = label.split(".")
     return L[0]+ "." + L[1]
 
+# TODO: Remove after database conversion
 ###############################################################################
 # Conversion of eliptic curve labels (database stores Cremona labels but we
 # want to display LMFDB labels -- see Issue #635)
@@ -118,6 +121,17 @@ def factorsRR_raw_to_pretty(factorsRR):
 
 def zfactor(n):
     return factor(n) if n != 0 else 0
+
+def ring_pretty(L):
+    # Only usable for at most quadratic fields
+    # TODO: Generalize
+    if len(L) == 2:
+        return r'\Z'
+    c,b,a = L
+    D = b**2 - 4*a*c
+    if D % 4 == 0:
+        return r'\Z [\sqrt{' + str(D//4) + r'}]'
+    return r'\Z [\frac{1 + \sqrt{' + str(D) + r'}}{2}]'
 
 ###############################################################################
 # Plot functions
@@ -258,7 +272,7 @@ def end_alg_name(name):
         "C x C":"\\C \\times \\C",
         "M_2(R)":"\\mathrm{M}_2(\\R)",
         "M_2(C)":"\\mathrm{M}_2(\\C)"
-    }
+        }
     if name in name_dict.keys():
         return name_dict[name]
     else:
@@ -296,7 +310,7 @@ def get_st_data(isogeny_class):
     data['st0_group_name'] = st0_group_name(isogeny_class['real_geom_end_alg'])
     # Later used in Lady Gaga box:
     data['real_geom_end_alg_disp'] = [ r'\End(J_{\overline{\Q}}) \otimes \R',
-                end_alg_name(isogeny_class['real_geom_end_alg']) ]
+        end_alg_name(isogeny_class['real_geom_end_alg']) ]
     # Adding data that show in sidebar respectively search results:
     if isogeny_class['is_gl2_type']:
         data['is_gl2_type_name'] = 'yes'
@@ -310,89 +324,125 @@ def get_st_data(isogeny_class):
 # Statement functions for endomorphism functionality
 ###############################################################################
 
-def gl2_statement(factorsRR, base):
+def gl2_statement_base(factorsRR, base):
     if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
-        return "The Jacobian is of \(\GL_2\)-type over " + base
-    return "The Jacobian is not of \(\GL_2\)-type over " + base
+        return "of \(\GL_2\)-type over " + base
+    return "not of \(\GL_2\)-type over " + base
+
+def gl2_simple_statement(factorsQQ, factorsRR):
+    if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
+        gl2 = "of \(\GL_2\)-type"
+    else:
+        gl2 = "not of \(\GL_2\)-type"
+    if len(factorsQQ) == 1 and factorsQQ[0][2] != 1:
+        simple = "simple"
+    else:
+        simple = "not simple"
+    return gl2 + ", " + simple
 
 def endo_statement(factorsQQ, factorsRR, ring, fieldstring):
-    statement = """<table>"""
-    # First row: description of endomorphism algebra factors
-    statement += """<tr><td>\(\End (J_{%s}) \otimes \Q\
-    \)</td><td>\(\simeq\)</td><td>""" % fieldstring
+    statement = """<table class="g2">"""
     factorsQQ_number = len(factorsQQ)
     factorsQQ_pretty = [ field_pretty(fac[0]) for fac in factorsQQ if
-            fac[0] ]
-    # In the case of only one factor we either get a number field or a
-    # quaternion algebra:
-    if factorsQQ_number == 1:
-        # First we deal with the number field case:
-        if factorsQQ[0][2] == -1:
-            # Prettify if labels available, otherwise return defining polynomial:
-            if factorsQQ_pretty:
-                statement += """<a href=%s>%s</a>""" % \
-                (url_for("number_fields.by_label", label=factorsQQ[0][0]),
-                factorsQQ_pretty[0])
-            else:
-                statement += """number field with defining polynomial \
-                \(%s\)""" % intlist_to_poly(factorsQQ[0][1])
-            if len(factorsQQ[0][1]) == 5:
-                statement += """(CM)"""
-        # Up next is the case of a matrix ring, with labels and full
-        # prettification always available:
-        elif factorsQQ[0][2] == 1:
-            statement += """\(\mathrm{M}_2(\)<a href=%s>%s</a>\()\)""" % \
-            (url_for("number_fields.by_label", label=factorsQQ[0][0]),
-            factorsQQ_pretty[0])
-        # And finally we deal with quaternion algebras over the rationals:
-        else:
-            statement += """quaternion algebra over <a href=%s>%s</a> of \
-            discriminant %s""" % \
-            (url_for("number_fields.by_label", label=factorsQQ[0][0]),
-            factorsQQ_pretty[0], factorsQQ[0][2])
-    # If there are two factors, then we get two at most quadratic fields:
-    else:
-        statement += """<a href=%s>%s</a> \(\\times\) <a href=%s>%s</a>""" % \
-        (url_for("number_fields.by_label", label=factorsQQ[0][0]),
-        factorsQQ_pretty[0],
-        url_for("number_fields.by_label", label=factorsQQ[1][0]),
-        factorsQQ_pretty[1])
-    # End of first row:
-    statement += """</td></tr>"""
-    # Second row: description of algebra tensored with RR
-    statement += """<tr><td>\(\End (J_{%s}) \otimes\
-    \R\)</td><td>\(\simeq\)</td> <td>\(%s\)</td></tr>""" % \
-    (fieldstring, factorsRR_raw_to_pretty(factorsRR))
-    # Third row: description of the endomorphism ring as an order in the
+        fac[0] ]
+
+    # First row: description of the endomorphism ring as an order in the
     # endomorphism algebra
-    statement += """<tr><td>\(\End (J_{%s})\)</td><td>\(\simeq\)</td><td>""" \
-            % fieldstring
+    statement += """<tr><td>\(\End (J_{%s})\)</td><td>\(\simeq\)</td><td>"""\
+        % fieldstring
     # First the case of a maximal order:
     if ring[0] == 1:
-        if factorsQQ[0][0] == '1.1.1.1':
-            statement += """\(\Z\)"""
+        # Single factor:
+        if factorsQQ_number == 1:
+            # Number field or not:
+            if factorsQQ[0][2] == -1:
+                # Use pretty if available:
+                if len(factorsQQ[0][1]) in [2, 3]:
+                    statement += """\(%s\)""" % ring_pretty(factorsQQ[0][1])
+                else:
+                    statement += """the maximal order of \(\End (J_{%s}) \otimes \Q\)"""\
+                        % fieldstring
+            else:
+                # Use M_2 over integers if this applies:
+                if factorsQQ[0][2] == 1:
+                    statement += """\(\mathrm{M}_2 (%s)\)"""\
+                        % ring_pretty(factorsQQ[0][1])
+                else:
+                    statement += """a maximal order of \(\End (J_{%s}) \otimes \Q\)"""\
+                        % fieldstring
+        # If there are two factors, then they are both at most quadratic
+        # and we can prettify them
         else:
-            statement += """a maximal order in \(\End (J_{%s}) \otimes \Q\)"""\
-            % fieldstring
+            statement += r'\(' + ' \\times '.join([ ring_pretty(factorQQ) for
+                factorQQ in factorsQQ ]) + r'\)'
     # Then the case where there is still a single factor:
     elif factorsQQ_number == 1:
         # Number field case:
         if factorsQQ[0][2] == -1:
-            statement += """an order of conductor of norm \(%s\) in \(\End\
-            (J_{%s}) \otimes \Q\)""" % (ring[0], fieldstring)
+            statement += """an order of conductor of norm \(%s\) in \(\End (J_{%s}) \otimes \Q\)"""\
+                % (ring[0], fieldstring)
         # Otherwise mention whether the order is Eichler:
         elif ring[1] == 1:
-            statement += """an Eichler order of index \(%s\) in \(\End\
-            (J_{%s}) \otimes \Q\)""" % (ring[0], fieldstring)
+            statement += """an Eichler order of index \(%s\) in \(\End (J_{%s}) \otimes \Q\)"""\
+                % (ring[0], fieldstring)
         else:
-            statement += """a non-Eichler order of index \(%s\) in \(\End\
-            (J_{%s}) \otimes \Q\)""" % (ring[0], fieldstring)
+            statement += """a non-Eichler order of index \(%s\) in \(\End (J_{%s}) \otimes \Q\)"""\
+                % (ring[0], fieldstring)
     # Finally the most generic case:
     else:
-        statement += "an order of index \(%s\) in \(\End (J_{%s}) \otimes \
-        \Q\)""" % (ring[0], fieldstring)
-    # End of third row, and with it, of the statement:
+        statement += "an order of index \(%s\) in \(\End (J_{%s}) \otimes \Q\)"""\
+            % (ring[0], fieldstring)
+    # End of first row:
     statement += """</td></tr>"""
+
+    # Second row: description of endomorphism algebra factors
+    statement += """<tr><td>\(\End (J_{%s}) \otimes \Q \)</td><td>\(\simeq\)</td><td>"""\
+        % fieldstring
+    # In the case of only one factor we either get a number field or a
+    # quaternion algebra:
+    if factorsQQ_number == 1:
+        # First we deal with the number field case,
+        # in which we have set the discriminant to be -1
+        if factorsQQ[0][2] == -1:
+            # Prettify if labels available, otherwise return defining polynomial:
+            if factorsQQ_pretty:
+                statement += """<a href=%s>%s</a>"""\
+                    % (url_for("number_fields.by_label",
+                       label=factorsQQ[0][0]), factorsQQ_pretty[0])
+            else:
+                statement += """number field with defining polynomial \(%s\)"""\
+                    % intlist_to_poly(factorsQQ[0][1])
+            # Detect CM by presence of a quartic polynomial:
+            if len(factorsQQ[0][1]) == 5:
+                statement += """ (CM)"""
+                # TODO: Get the following line to work instead of the cop-out
+                # above:
+                #statement += """ ({{ KNOWL('ag.complex_multiplication', title='CM') }})"""
+        # Up next is the case of a matrix ring (trivial disciminant), with
+        # labels and full prettification always available:
+        elif factorsQQ[0][2] == 1:
+            statement += """\(\mathrm{M}_2(\)<a href=%s>%s</a>\()\)"""\
+                % (url_for("number_fields.by_label", label=factorsQQ[0][0]),
+                    factorsQQ_pretty[0])
+        # And finally we deal with quaternion algebras over the rationals:
+        else:
+            statement += """quaternion algebra over <a href=%s>%s</a> of discriminant %s"""\
+                % (url_for("number_fields.by_label", label=factorsQQ[0][0]),
+                    factorsQQ_pretty[0], factorsQQ[0][2])
+    # If there are two factors, then we get two at most quadratic fields:
+    else:
+        statement += """<a href=%s>%s</a> \(\\times\) <a href=%s>%s</a>"""\
+            % (url_for("number_fields.by_label", label=factorsQQ[0][0]),
+                factorsQQ_pretty[0], url_for("number_fields.by_label",
+                label=factorsQQ[1][0]), factorsQQ_pretty[1])
+    # End of second row:
+    statement += """</td></tr>"""
+
+    # Third row: description of algebra tensored with RR
+    statement += """<tr><td>\(\End (J_{%s}) \otimes \R\)</td><td>\(\simeq\)</td> <td>\(%s\)</td></tr>"""\
+        % (fieldstring, factorsRR_raw_to_pretty(factorsRR))
+
+    # End of statement:
     statement += """</table>"""
     return statement
 
@@ -403,15 +453,15 @@ def fod_statement(fod_label, fod_poly):
         fod_pretty = field_pretty(fod_label)
         fod_url = url_for("number_fields.by_label", label=fod_label)
         return """Smallest field over which all endomorphisms are defined:<br>
-        Galois number field \(L = \Q (a)\) with defining polynomial \(%s\) (<a\
-        href=%s">%s)</a>""" % (fod_poly, fod_url, fod_pretty)
+        Galois number field \(K = \Q (a) \cong \) <a href=%s">%s</a> with defining polynomial \(%s\)"""\
+            % (fod_url, fod_pretty, fod_poly)
     else:
         return """Smallest field over which all endomorphisms are defined:<br>
-        Galois number field \(L = \Q (a)\) with defining polynomial \(%s\)"""\
-        % fod_poly
+        Galois number field \(K = \Q (a)\) with defining polynomial \(%s\)"""\
+            % fod_poly
 
-def st_group_statement(group, fieldstring):
-    return """Sato-Tate group over \(%s\): \(%s\)""" % (fieldstring, group)
+def st_group_statement(group):
+    return """Sato-Tate group: \(%s\)""" % group
 
 def lattice_statement_preamble():
     return """Remainder of the endomorphism lattice by subfield"""
@@ -419,67 +469,64 @@ def lattice_statement_preamble():
 def lattice_statement(lattice):
     statement = ''
     for ED in lattice:
-        statement += """<p>"""
-        statement += """Over subfield \(K\) with generator \(%s\) with \
-        minimal polynomial \(%s\)""" % \
-        (strlist_to_nfelt(ED[0][2], 'a'), intlist_to_poly(ED[0][1]))
-        # Add link and prettify if available:
         if ED[0][0]:
-            statement += """ (<a href=%s>%s</a>)""" % \
-            (url_for("number_fields.by_label", label=ED[0][0]),
-            field_pretty(ED[0][0]))
+            # Add link and prettify if available:
+            statement += """Over subfield \(F \cong\) <a href=%s>%s</a> with generator \(%s\) with minimal polynomial \(%s\)"""\
+                % (url_for("number_fields.by_label", label=ED[0][0]),
+                   field_pretty(ED[0][0]), strlist_to_nfelt(ED[0][2], 'a'),
+                   intlist_to_poly(ED[0][1]))
+        else:
+            statement += """Over subfield \(F\) with generator \(%s\) with minimal polynomial \(%s\)"""\
+                % (strlist_to_nfelt(ED[0][2], 'a'), intlist_to_poly(ED[0][1]))
         statement += """:<br>"""
-        statement += endo_statement(ED[1], ED[2], ED[3], r'K')
-        #statement += """<br>"""
-        statement += st_group_statement(ED[4], r'K')
-        statement += """</p>"""
+        statement += endo_statement(ED[1], ED[2], ED[3], r'F')
+        statement += st_group_statement(ED[4])
+        statement += """<br>"""
+        statement += gl2_simple_statement(ED[1], ED[2])
+        statement += """<p></p>"""
     return statement
 
 def spl_fod_statement(is_simple_geom, spl_fod_label, spl_fod_poly):
     if is_simple_geom:
-        return """The Jacobian is simple over \(\overline{\Q}\)"""
+        return """simple over \(\overline{\Q}\)"""
     elif spl_fod_label == '1.1.1.1':
-        return """The Jacobian splits over \(\Q\)"""
+        return """splits over \(\Q\)"""
     elif spl_fod_label != '':
         spl_fod_pretty =  field_pretty(spl_fod_label)
         spl_fod_url = url_for("number_fields.by_label", label=spl_fod_label)
-        return """Field of minimal degree over which the Jacobian splits:<br>\
-        number field \(M = \Q (b)\) with defining polynomial \(%s\) \
-        (<a href=%s>%s)</a>""" % (spl_fod_poly, spl_fod_url, spl_fod_pretty)
+        return """Field of minimal degree over which decomposition occurs:<br>\
+        number field \(\Q (b) \cong \) <a href=%s>%s</a> with defining polynomial \(%s\)"""\
+            % (spl_fod_url, spl_fod_pretty, spl_fod_poly)
     else:
-        return """Field of minimal degree over which the Jacobian splits:<br>\
-        number field \(M = \Q (b)\) with defining polynomial %s""" % \
-        spl_fod_poly
+        return """Field of minimal degree over which decomposition occurs:<br>\
+        number field \(\Q (b)\) with defining polynomial %s"""\
+            % spl_fod_poly
 
 def spl_statement(coeffss, lmfdb_labels, condnorms):
     if len(coeffss) == 1:
-        statement = """The Jacobian decomposes up to isogeny as the square of
-        an elliptic curve</p>\
+        statement = """Decomposes up to isogeny as the square of an elliptic curve</p>\
         <p>Elliptic curve that admits a small isogeny:"""
     else:
-        statement = """The Jacobian admits two distinct elliptic curve factors
-        up to isogeny</p>\
-        <p>Elliptic curves that represent these factors and admit small
-        isogenies are:"""
+        statement = """Decomposes up to isogeny into two distinct elliptic curve isogeny classes</p>\
+        <p>Elliptic curves that represent these classes and admit small isogenies:"""
     for n in range(len(coeffss)):
         # Use labels when possible:
         lmfdb_label = lmfdb_labels[n]
         if lmfdb_label:
-            # TODO: Next statement should be removed by a database update
+            # TODO: Next statement can be removed after database update
             if not '-' in lmfdb_label:
                lmfdb_label = cremona_to_lmfdb(lmfdb_label)
             statement += """<br>Elliptic curve with label <a href=%s>%s</a>"""\
-            % (url_for_ec(lmfdb_label), lmfdb_label)
+                % (url_for_ec(lmfdb_label), lmfdb_label)
         # Otherwise give defining equation:
         else:
-            statement += """<br>\(4 y^2 = x^3 - (g_4 / 48) x - (g_6 / 864)\),
-            with<br>\
+            statement += """<br>\(4 y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with<br>\
             \(g_4 = %s\)<br>\
             \(g_6 = %s\)<br>\
-            Conductor norm: %s""" % \
-            (strlist_to_nfelt(coeffss[n][0], 'b'),
-            strlist_to_nfelt(coeffss[n][1], 'b'),
-            condnorms[n])
+            Conductor norm: %s"""\
+                % (strlist_to_nfelt(coeffss[n][0], 'b'),
+                   strlist_to_nfelt(coeffss[n][1], 'b'),
+                   condnorms[n])
     return statement
 
 ###############################################################################
@@ -550,14 +597,18 @@ class WebG2C(object):
         data['igusa_clebsch'] = [ZZ(a) for a in self.igusa_clebsch]
         data['igusa'] = [ZZ(a) for a in self.igusa]
         data['g2'] = self.g2inv
-        data['ic_norm'] = normalize_invariants(data['igusa_clebsch'], [2, 4, 6,
-            10])
-        data['igusa_norm'] = normalize_invariants(data['igusa'], [2, 4, 6, 8,
-            10])
+        data['ic_norm'] = data['igusa_clebsch']
+        data['igusa_norm'] = data['igusa']
+        # Should we ever want to normalize the invariants further, then
+        # uncomment the following lines:
+        #data['ic_norm'] = normalize_invariants(data['igusa_clebsch'], [2, 4, 6,
+        #    10])
+        #data['igusa_norm'] = normalize_invariants(data['igusa'], [2, 4, 6, 8,
+        #    10])
         data['ic_norm_factor_latex'] = [web_latex(zfactor(i)) for i in
-                data['ic_norm']]
+            data['ic_norm']]
         data['igusa_norm_factor_latex'] = [ web_latex(zfactor(j)) for j in
-                data['igusa_norm'] ]
+            data['igusa_norm'] ]
         data['num_rat_wpts'] = ZZ(self.num_rat_wpts)
         data['two_selmer_rank'] = ZZ(self.two_selmer_rank)
         if len(self.torsion) == 0:
@@ -575,8 +626,8 @@ class WebG2C(object):
             data[key] = st_data[key]
 
         # GL_2 statement over the base field
-        endodata['gl2_statement_base'] = gl2_statement(self.factorsRR_base,
-                r'\(\Q\)')
+        endodata['gl2_statement_base'] = \
+            gl2_statement_base(self.factorsRR_base, r'\(\Q\)')
 
         # NOTE: In what follows there is some copying of code and data that is
         # stupid from the point of view of efficiency but likely better from
@@ -587,32 +638,34 @@ class WebG2C(object):
         endodata['factorsRR_base'] = self.factorsRR_base
         endodata['ring_base'] = self.ring_base
         endodata['endo_statement_base'] = \
-        """Endomorphism ring over \(\Q\):<br>""" + \
-        endo_statement(endodata['factorsQQ_base'], endodata['factorsRR_base'],
-                endodata['ring_base'], r'')
+            """Endomorphism ring over \(\Q\):""" + \
+            endo_statement(endodata['factorsQQ_base'],
+                endodata['factorsRR_base'], endodata['ring_base'], r'')
         # Field of definition data:
         endodata['fod_label'] = self.fod_label
         endodata['fod_poly'] = intlist_to_poly(self.fod_coeffs)
         endodata['fod_statement'] = fod_statement(endodata['fod_label'],
-                endodata['fod_poly'])
+            endodata['fod_poly'])
         # Endomorphism data over QQbar:
         endodata['factorsQQ_geom'] = self.factorsQQ_geom
         endodata['factorsRR_geom'] = self.factorsRR_geom
         endodata['ring_geom'] = self.ring_geom
         if self.fod_label != '1.1.1.1':
             endodata['endo_statement_geom'] = \
-            """Endomorphism ring over \(\overline{\Q}\):<br>""" + \
+            """Endomorphism ring over \(\overline{\Q}\):""" + \
             endo_statement(endodata['factorsQQ_geom'],
-                    endodata['factorsRR_geom'], endodata['ring_geom'],
-                    r'\overline{\Q}')
+                endodata['factorsRR_geom'], endodata['ring_geom'],
+                r'\overline{\Q}')
 
         # Full endomorphism lattice:
-        endodata['lattice'] = self.lattice[1:len(self.lattice) - 1]
+        # TODO: Remove this sort once endomorphism database is updated
+        endodata['lattice'] = \
+            sorted(self.lattice, key = lambda t : len(t[0][1]))[1:-1]
         if endodata['lattice']:
             endodata['lattice_statement_preamble'] = \
-            lattice_statement_preamble()
+                lattice_statement_preamble()
             endodata['lattice_statement'] = \
-            lattice_statement(endodata['lattice'])
+                lattice_statement(endodata['lattice'])
 
         # Splitting field description:
         #endodata['is_simple_base'] = self.is_simple_base
@@ -620,7 +673,7 @@ class WebG2C(object):
         endodata['spl_fod_label'] = self.spl_fod_label
         endodata['spl_fod_poly'] = intlist_to_poly(self.spl_fod_coeffs)
         endodata['spl_fod_statement'] = \
-        spl_fod_statement(endodata['is_simple_geom'],
+            spl_fod_statement(endodata['is_simple_geom'],
                 endodata['spl_fod_label'], endodata['spl_fod_poly'])
 
         # Isogeny factors:
@@ -631,10 +684,10 @@ class WebG2C(object):
                 endodata['spl_facs_labels'] = self.spl_facs_labels
             else:
                 endodata['spl_facs_labels'] = ['' for coeffs in
-                        self.spl_facs_coeffs]
+                    self.spl_facs_coeffs]
             endodata['spl_facs_condnorms'] = self.spl_facs_condnorms
             endodata['spl_statement'] = \
-            spl_statement(endodata['spl_facs_coeffs'],
+                spl_statement(endodata['spl_facs_coeffs'],
                     endodata['spl_facs_labels'],
                     endodata['spl_facs_condnorms'])
 

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 #                                 $ easy_install -U coverage
 #                                 $ easy_install -U unittest2
 # Second, call it in two ways, either $ ./test.sh for coverage to test all
-# or to test only a part of LMFDB:    $ ./test lmfdb/knowledge
+# or to test only a part of LMFDB:    $ ./test.sh lmfdb/knowledge
 
 cd `dirname "$0"`
 


### PR DESCRIPTION
Main changes:

(1) Added some more bells and whistles to the display of endomorphism algebras
and rings.

(2) Fixed a bug where maximal orders in quaternion algebras were displayed as ZZ.

(3) Fixed a bug where the subgroup lattice was displayed incorrectly.

(4) Added more tests in genus 2.

(5) Added name to genus 2 credits.

(6) Corrected a typo in the main test.sh file.

Some good places to observe these modifications are

Genus2Curve/Q/169/a/169/1
Genus2Curve/Q/1088/b/2176/1
Genus2Curve/Q/4096/b/65536/1
Genus2Curve/Q/262144/d/524288/1