### PR TITLE
Further polishing of genus 2 endomorphism display

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -17,7 +17,7 @@ from lmfdb.genus2_curves.web_g2c import WebG2C, list_to_min_eqn, isog_label, st_
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
 #q = ZZ['x'].gen()
-credit_string = "Andrew Booker, Andrew Sutherland, John Voight, and Dan Yasaki"
+credit_string = "Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight, and Dan Yasaki"
 
 ###############################################################################
 # Database connection
@@ -30,6 +30,8 @@ def db_g2c():
     if g2cdb is None:
         g2cdb = lmfdb.base.getDBConnection().genus2_curves
     return g2cdb
+
+# TODO: Remove database below when switched to use of genus2_curves only
 
 g2endodb = None
 

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -1,6 +1,12 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<!--New table class to avoid spacing in LaTeX-links -->
+<style type="text/css">
+table.g2 a {
+  padding: 0;
+}
+
 <style>
 /* seems to be unused?
 <div.ip>span { white-space: nowrap; font-family: serif; }
@@ -275,17 +281,23 @@ function show_invs(invstyle) {
 <p>{{data.endodata.gl2_statement_base}}</p>
 
 <!-- Description over QQ: -->
-<p>{{data.endodata.endo_statement_base|safe}}</p>
+{{data.endodata.endo_statement_base|safe}}
 
 <!-- Description of field of definition: -->
 <p>{{data.endodata.fod_statement|safe}}</p>
 
 <!-- Description over QQbar: -->
-<p>{{data.endodata.endo_statement_geom|safe}}</p>
+{{data.endodata.endo_statement_geom|safe}}
+<!-- Excuse the upcoming dirty spacing hack, but putting paragraph tags around
+the previous statement ruins its table spacing.
+Same for all other occasions of it.-->
+<p></p>
 
 <!-- Remainder of the lattice: -->
 <h3 style="display: inline">{{data.endodata.lattice_statement_preamble}}</h3>
 
+<p></p>
 {{data.endodata.lattice_statement|safe}}
+<p></p>
 
 {% endblock %}

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -1,6 +1,12 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<!--New table class to avoid spacing in LaTeX-links -->
+<style type="text/css">
+table.g2 a {
+  padding: 0;
+}
+
 <style type="text/css">
 #isogeny_class_table th, #isogeny_class_table td {
 padding : 4px;
@@ -55,13 +61,17 @@ text-align: center;
 <p>{{info.gl2_statement_base}}</p>
 
 <!-- Description over QQ: -->
-<p>{{info.endo_statement_base|safe}}</p>
+{{info.endo_statement_base|safe}}
 
 <!-- Description of field of definition: -->
 <p>{{info.fod_statement|safe}}</p>
 
 <!-- Description over QQbar: -->
-<p>{{info.endo_statement_geom|safe}}</p>
+{{info.endo_statement_geom|safe}}
+<!-- Excuse the upcoming dirty spacing hack, but putting paragraph tags around
+the previous statement ruins its table spacing.
+Same for all other occasions of it.-->
+<!-- <p></p> -->
 
 <p>More complete information on endomorphism algebras and rings can be found on
 the webpages of the individual curves in the isogeny class.</p>

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -6,20 +6,35 @@ import unittest2
 class Genus2Test(LmfdbTest):
 
     # All tests should pass
-    #
-    def test_by_full_label(self):
-        L = self.tc.get('/Genus2Curve/Q/277/a/277/1')
-        assert '277' in L.data
-
-    def test_by_double_iso_label(self):
-        L = self.tc.get('/Genus2Curve/Q/336/a/')
-        assert '336.a.172032.1' in L.data
-
-    def test_by_g2c_label(self):
-        L = self.tc.get('/Genus2Curve/Q/169.a.169.1')
-        assert '13' in L.data
 
     def test_Cond_search(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=100-200&count=100')
         assert '196.a.21952.1' in L.data
 
+    def test_by_double_iso_label(self):
+        L = self.tc.get('/Genus2Curve/Q/336/a/')
+        assert '336.a.172032.1' in L.data
+
+    def test_by_full_label(self):
+        # Two elliptic curve factors and decomposing endomorphism algebra:
+        L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
+        assert '32.a1' in L.data and '34.a3' in L.data
+        # RM case, should we ever want this:
+        #L = self.tc.get('/Genus2Curve/Q/17689/e/866761/1')
+        #assert '17689' in L.data
+        # QM curve:
+        L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
+        assert 'quaternion algebra' in L.data
+        L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
+        # Square over a quadratic extension that is CM over one extension and
+        # multiplication by a quaternion algebra ramifying at infinity over
+        # another:
+        assert 'square of an elliptic curve' in L.data and '2.2.8.1-64.1-a3'\
+            in L.data and r'\mathbf{H}' in L.data and '(CM)' in L.data
+
+    def test_by_g2c_label(self):
+        # This curve also decomposes as a square, this time of a curve without
+        # a label:
+        L = self.tc.get('/Genus2Curve/Q/169.a.169.1')
+        assert 'square of an elliptic curve' in L.data and '\Z/{19}\Z'\
+            in L.data

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 #                                 $ easy_install -U coverage
 #                                 $ easy_install -U unittest2
 # Second, call it in two ways, either $ ./test.sh for coverage to test all
-# or to test only a part of LMFDB:    $ ./test lmfdb/knowledge
+# or to test only a part of LMFDB:    $ ./test.sh lmfdb/knowledge
 
 cd `dirname "$0"`
 


### PR DESCRIPTION
Main changes:

(1) Added some more bells and whistles to the display of endomorphism algebras
and rings.

(2) Fixed a bug where maximal orders in quaternion algebras were displayed as ZZ.

(3) Fixed a bug where the subgroup lattice was displayed incorrectly.

(4) Added more tests in genus 2.

(5) Added name to genus 2 credits.

(6) Corrected a typo in the main test.sh file.

Some good places to observe these modifications are

Genus2Curve/Q/169/a/169/1
Genus2Curve/Q/1088/b/2176/1
Genus2Curve/Q/4096/b/65536/1
Genus2Curve/Q/262144/d/524288/1