### PR TITLE
Switch to larger database in genus 2

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -31,16 +31,6 @@ def db_g2c():
         g2cdb = lmfdb.base.getDBConnection().genus2_curves
     return g2cdb
 
-# TODO: Remove database below when switched to use of genus2_curves only
-
-g2endodb = None
-
-def db_g2endo():
-    global endodb
-    if g2endodb is None:
-        g2endodb = lmfdb.base.getDBConnection().genus2_endomorphisms
-    return g2endodb
-
 ###############################################################################
 # List and dictionaries needed routing and searching
 ###############################################################################

--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -26,16 +26,6 @@ def db_g2c():
         g2cdb = getDBConnection().genus2_curves
     return g2cdb
 
-# TODO: Remove database below when switched to use of genus2_curves only
-
-g2endodb = None
-
-def db_g2endo():
-    global g2endodb
-    if g2endodb is None:
-        g2endodb = getDBConnection().genus2_endomorphisms
-    return g2endodb
-
 ###############################################################################
 # Pretty print functions
 ###############################################################################
@@ -244,9 +234,9 @@ class G2Cisog_class(object):
             self.is_gl2_type_name = 'no'
 
         # Endomorphism data
-        # TODO: Change lines here after database switch
         curve = db_g2c().curves.find_one({"class" : self.label})
-        endodata = db_g2endo().bycurve.find_one({"label" : curve['label']})
+        endodata = db_g2c().endomorphisms.find_one({"label" :
+            curve['label']})
         self.gl2_statement_base = \
             gl2_statement_base(endodata['factorsRR_base'], r'\(\Q\)')
         self.endo_statement_base = \

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -278,15 +278,15 @@ function show_invs(invstyle) {
 
 <h3 style="display: inline"> {{ KNOWL('g2c.jac_endomorphisms', title='Endomorphisms') }} </h3>
 
-<p>{{data.endodata.gl2_statement_base}}</p>
-
 <!-- Description over QQ: -->
+<p>{{data.endodata.gl2_statement_base}}</p>
 {{data.endodata.endo_statement_base|safe}}
 
 <!-- Description of field of definition: -->
 <p>{{data.endodata.fod_statement|safe}}</p>
 
 <!-- Description over QQbar: -->
+<p>{{data.endodata.gl2_statement_geom}}</p>
 {{data.endodata.endo_statement_geom|safe}}
 <!-- Excuse the upcoming dirty spacing hack, but putting paragraph tags around
 the previous statement ruins its table spacing.

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -74,7 +74,7 @@ Same for all other occasions of it.-->
 <!-- <p></p> -->
 
 <p>More complete information on endomorphism algebras and rings can be found on
-the webpages of the individual curves in the isogeny class.</p>
+the pages of the individual curves in the isogeny class.</p>
 
 <h2>{{ KNOWL('ag.isogeny', title='Isogenies') }}</h2>
 
@@ -95,5 +95,8 @@ the webpages of the individual curves in the isogeny class.</p>
 <A HREF="/NumberField/{{c.nf}}">{{c.nf}}</A>.</p>
 {% endfor %}
 {% endif %}
+
+<p>More complete information on the decomposition of the Jacobian found on the
+pages of the individual curves in the isogeny class.</p>
 
 {% endblock %}


### PR DESCRIPTION
Recently we switched to a larger database for genus 2 curves. A new curve is for example

Genus2Curve/Q/847/d/847/1

As you can see this works without any need for this pull request. This does the following:

(1) Most importantly, we switch to a new endomorphism collection, which is now in genus2_curves, not in genus2_endomorphisms. The old one will be axed should this pull request be accepted.
(2) Removed all extraneous references and dirty hacks needed to make the previous database work.
(3) Fixed 6 more curves in the new database for which a bug occurred; one of these is Genus2Curve/Q/900601/a/900601/1.
(4) Some small layout and wording fixes.