### PR TITLE
issue 165: quote ecnf labels over imag quad field, and fix 2 isogeny …

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,4 +1,5 @@
 from flask import url_for
+from urllib import quote
 from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RealField, rainbow, implicit_plot, plot, text, Infinity
 from lmfdb.base import app, getDBConnection
 from lmfdb.utils import image_src, web_latex, web_latex_ideal_fact, encode_plot
@@ -272,11 +273,11 @@ class ECNF(object):
         self.urls = {}
         # It's useful to be able to use this class out of context, when calling url_for will fail:
         try:
-            self.urls['curve'] = url_for(".show_ecnf", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label, number=self.number)
+            self.urls['curve'] = url_for(".show_ecnf", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number)
         except RuntimeError:
             return
-        self.urls['class'] = url_for(".show_ecnf_isoclass", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label)
-        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=self.conductor_label)
+        self.urls['class'] = url_for(".show_ecnf_isoclass", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label)
+        self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=quote(self.conductor_label))
         self.urls['field'] = url_for(".show_ecnf1", nf=self.field_label)
 
         if self.field.is_real_quadratic():

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -4,6 +4,7 @@ import tempfile
 import os
 from pymongo import ASCENDING, DESCENDING
 from flask import url_for, make_response
+from urllib import quote
 import lmfdb.base
 from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.elliptic_curves import ec_page, ec_logger
@@ -161,7 +162,7 @@ def make_graph(M):
             centervert = [i for i in range(4) if max(MM.row(i)) < maxdegree][0]
             other = [i for i in range(4) if i != centervert]
             G.set_pos(pos={centervert: [0, 0], other[0]: [0, 1], other[1]: [-0.8660254, -0.5], other[2]: [0.8660254, -0.5]})
-        elif maxdegree == 27:
+        elif maxdegree == 27 and n==4:
             # o--o--o--o
             centers = [i for i in range(4) if list(MM.row(i)).count(3) == 2]
             left = [j for j in range(4) if MM[centers[0], j] == 3 and j not in centers][0]
@@ -185,7 +186,7 @@ def make_graph(M):
             bl = [j for j in range(6) if MM[top[0], j] == 2][0]
             br = [j for j in range(6) if MM[top[1], j] == 2][0]
             G.set_pos(pos={centers[0]: [0, 0.5], centers[1]: [0, -0.5], top[0]: [-1, 0.5], top[1]: [1, 0.5], bl: [-1, -0.5], br: [1, -0.5]})
-        elif maxdegree == 16:
+        elif maxdegree == 16 and n==8:
             # tree from bottom, 3 regular except for the leaves.
             centers = [i for i in range(8) if list(MM.row(i)).count(2) == 3]
             center = [i for i in centers if len([j for j in centers if MM[i, j] == 2]) == 2][0]

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -179,7 +179,7 @@ def make_graph(M):
             left = [j for j in range(6) if MM[centers[0], j] == 2 and j not in centers]
             right = [j for j in range(6) if MM[centers[1], j] == 2 and j not in centers]
             G.set_pos(pos={centers[0]: [-0.5, 0], left[0]: [-1, 0.8660254], left[1]: [-1, -0.8660254], centers[1]: [0.5, 0], right[0]: [1, 0.8660254], right[1]: [1, -0.8660254]})
-        elif maxdegree == 18:
+        elif maxdegree == 18 and n==6:
             # two squares joined on an edge
             centers = [i for i in range(6) if list(MM.row(i)).count(3) == 2]
             top = [j for j in range(6) if MM[centers[0], j] == 3]

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -5,6 +5,7 @@
 import re
 import pymongo
 ASC = pymongo.ASCENDING
+from urllib import quote, unquote
 from lmfdb.base import app, getDBConnection
 from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response, redirect
 from lmfdb.utils import image_src, web_latex, to_dict, parse_range, parse_range2, coeff_to_poly, pol_to_html, make_logger, clean_input, parse_torsion_structure
@@ -192,12 +193,13 @@ def show_ecnf1(nf):
 @ecnf_page.route("/<nf>/<conductor_label>/")
 def show_ecnf_conductor(nf, conductor_label):
     nf_label = parse_field_string(nf)
-    return elliptic_curve_search(data={'nf_label': nf_label, 'conductor_label': conductor_label}, **request.args)
+    return elliptic_curve_search(data={'nf_label': nf_label, 'conductor_label': quote(conductor_label)}, **request.args)
 
 
 @ecnf_page.route("/<nf>/<conductor_label>/<class_label>/")
 def show_ecnf_isoclass(nf, conductor_label, class_label):
     nf_label = parse_field_string(nf)
+    conductor_label = unquote(conductor_label)
     label = "-".join([nf_label, conductor_label, class_label])
     full_class_label = "-".join([conductor_label, class_label])
     cl = ECNF_isoclass.by_label(label)
@@ -205,7 +207,7 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     bread = [("Elliptic Curves", url_for(".index"))]
     bread.append((cl.ECNF.field.field_pretty(), url_for(".show_ecnf1", nf=nf_label)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
-    bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=conductor_label, class_label=class_label)))
+    bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
     info = {}
     return render_template("show-ecnf-isoclass.html",
                            credit=ecnf_credit,


### PR DESCRIPTION
…graphs

Fixes for issue #790 -- it uses urllib.quote/unquote on conductor labels, and also fixes an isogeny graph over Q(i) which crashed (it's a graph shape which can only occur over a field containsing 4th roots of unity).

The test suite passes.

Test URL:  EllipticCurve/2.0.4.1/%255B225%252C0%252C15%255D/a/  and also the ones in the Issue ticket.