### PR TITLE
more efficient code for ecnf isogeny classes

### DIFF
--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -10,7 +10,7 @@ from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.isog_class import make_graph
 from lmfdb.ecnf.WebEllipticCurve import ECNF, web_ainvs
-from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.number_fields.number_field import field_pretty, nf_display_knowl
 
 import sage.all
 from sage.all import EllipticCurve, latex, matrix
@@ -66,7 +66,6 @@ class ECNF_isoclass(object):
         return "Class not found"  # caller must catch this and raise an error
 
     def make_class(self):
-        self.ECNF = ECNF.by_label(self.label)
 
         # Create a list of the curves in the class from the database
         self.db_curves = [c for c in db_ec().find(
@@ -88,8 +87,8 @@ class ECNF_isoclass(object):
         self.graph_link = '<img src="%s" width="200" height="150"/>' % self.graph_img
         self.isogeny_matrix_str = latex(matrix(self.isogeny_matrix))
 
-        def latex_ainvs(c):
-            return web_latex([self.field.parse_NFelt(x) for x in c['ainvs']])
+        self.field = field_pretty(self.field_label)
+        self.field_knowl = nf_display_knowl(self.field_label, lmfdb.base.getDBConnection(), self.field)
         def curve_url(c):
             return url_for(".show_ecnf",
                            nf=c['field_label'],
@@ -102,31 +101,32 @@ class ECNF_isoclass(object):
         self.urls = {}
         self.urls['class'] = url_for(".show_ecnf_isoclass", nf=self.field_label, conductor_label=self.conductor_label, class_label=self.iso_label)
         self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=self.conductor_label)
-        self.urls['field'] = url_for('.show_ecnf1', nf=self.ECNF.field_label)
-        self.field = self.ECNF.field
-        if self.field.is_real_quadratic():
-            self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
-            self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
+        self.urls['field'] = url_for('.show_ecnf1', nf=self.field_label)
+        real_quadratic = self.signature == [2,0]
+        imag_quadratic = self.signature == [0,1]
+        if real_quadratic:
+            self.hmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
+            self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field_label, label=self.hmf_label)
 
-        if self.field.is_imag_quadratic():
-            self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
+        if imag_quadratic:
+            self.bmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
 
         self.friends = []
-        if self.field.is_real_quadratic():
+        if real_quadratic:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
-        if self.field.is_imag_quadratic():
+        if imag_quadratic:
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
 
-        self.properties = [('Base field', self.ECNF.field.field_pretty()),
-                           ('Label', self.ECNF.class_label),
+        self.properties = [('Base field', self.field),
+                           ('Label', self.class_label),
                            (None, self.graph_link),
-                           ('Conductor', '%s' % self.ECNF.cond)
+                           ('Conductor', '%s' % self.conductor_label)
                            ]
 
         self.bread = [('Elliptic Curves ', url_for(".index")),
-                      (self.ECNF.field_label, self.urls['field']),
-                      (self.ECNF.conductor_label, self.urls['conductor']),
-                      ('isogeny class %s' % self.ECNF.short_label, self.urls['class'])]
+                      (self.field_label, self.urls['field']),
+                      (self.conductor_label, self.urls['conductor']),
+                      ('isogeny class %s' % self.short_label, self.urls['class'])]
 
 
 def make_graph(M):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -203,9 +203,9 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     label = "-".join([nf_label, conductor_label, class_label])
     full_class_label = "-".join([conductor_label, class_label])
     cl = ECNF_isoclass.by_label(label)
-    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.ECNF.field.field_pretty())
+    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field)
     bread = [("Elliptic Curves", url_for(".index"))]
-    bread.append((cl.ECNF.field.field_pretty(), url_for(".show_ecnf1", nf=nf_label)))
+    bread.append((cl.field, url_for(".show_ecnf1", nf=nf_label)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
     info = {}

--- a/lmfdb/ecnf/templates/show-ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/show-ecnf-isoclass.html
@@ -30,7 +30,7 @@ function show_code(system) {
 -->
 
 
-<h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.ECNF.field.knowl()|safe }}</h2>
+<h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.field_knowl|safe }}</h2>
 <table>
 <tr>
 <th>{{ KNOWL('ec.curve_label',title = "Curve label") }}</th>


### PR DESCRIPTION
This fixes issue #793: no number fields or elliptic curves need to be constructed in displaying an isogeny class.
