### PR TITLE
issue #796: wrapping of large j-inv and equations

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -113,7 +113,7 @@ class ECNF(object):
         self.latex_ainvs = web_latex(self.ainvs)
         from sage.schemes.elliptic_curves.all import EllipticCurve
         self.E = E = EllipticCurve(self.ainvs)
-        self.equn = web_latex(E)
+        self.equn = web_latex(E).replace('=', '\) = \(\qquad')
         self.numb = str(self.number)
 
         # Conductor, discriminant, j-invariant
@@ -308,7 +308,8 @@ class ECNF(object):
         self.properties += [
             ('Conductor', self.cond),
             ('Conductor norm', self.cond_norm),
-            ('j-invariant', self.j),
+            # See issue #796 for why this is hidden
+            # ('j-invariant', self.j),
             ('CM', self.cm_bool)]
 
         if self.base_change:

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -97,6 +97,7 @@ cellpadding="5";
 
 <h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
+      <div style='overflow:auto'>
         <table id="invariants">
         <tr>
         <td>


### PR DESCRIPTION
This wraps large j, removes j from Properties, ad also wraps large Weierstrass equations at the = sign.
See EllipticCurve/4.4.2000.1/239.1/d/2 for an example.