### PR TITLE
Fix value fields of Dirichlet characters

### DIFF
--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -738,7 +738,8 @@ class WebChar(WebCharObject):
                                     number_field=self.nflabel,
                                     modulus=self.modlabel,
                                     number=self.numlabel) ) )
-        f.append( ("Value Field", '/NumberField/' + self.vflabel) )
+        if len(self.vflabel)>0:
+            f.append( ("Value Field", '/NumberField/' + self.vflabel) )
         return f
 
 #############################################################################

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -171,7 +171,7 @@ class WebNumberField:
     # For cyclotomic fields
     @classmethod
     def from_cyclo(cls, n):
-        if euler_phi(n) > 15:
+        if euler_phi(n) > 23:
             return cls('none')  # Forced to fail
         pol = pari.polcyclo(n)
         R = PolynomialRing(QQ, 'x')


### PR DESCRIPTION
On the page

  http://127.0.0.1:37777/Character/Dirichlet/101/25

the value field friend link will now work (did not before), and on

http://127.0.0.1:37777/Character/Dirichlet/59/7

the friend link to the Value Field is suppressed, because we don't have the field.
