### PR TITLE
ecnf isog & curve pages link to HMFs & show ranks

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -280,19 +280,26 @@ class ECNF(object):
         self.urls['conductor'] = url_for(".show_ecnf_conductor", nf=self.field_label, conductor_label=quote(self.conductor_label))
         self.urls['field'] = url_for(".show_ecnf1", nf=self.field_label)
 
-        if self.field.is_real_quadratic():
+        sig = self.signature
+        real_quadratic = sig == [2,0]
+        totally_real = sig[1] == 0
+        imag_quadratic = sig == [0,1]
+
+        if totally_real:
             self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
+            self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
 
-        if self.field.is_imag_quadratic():
+        if imag_quadratic:
             self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
 
         self.friends = []
         self.friends += [('Isogeny class ' + self.short_class_label, self.urls['class'])]
         self.friends += [('Twists', url_for('ecnf.index', field_label=self.field_label, jinv=self.jinv))]
-        if self.field.is_real_quadratic():
+        if totally_real:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
-        if self.field.is_imag_quadratic():
+            self.friends += [('L-function', self.urls['Lfunction'])]
+        if imag_quadratic:
             self.friends += [('Bianchi Modular Form %s not yet available' % self.bmf_label, '')]
 
         self.properties = [

--- a/lmfdb/ecnf/templates/show-ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/show-ecnf-isoclass.html
@@ -44,6 +44,17 @@ function show_code(system) {
 {% endfor %}
 </table>
 
+<h2>{{ KNOWL('ec.rank',title='Rank') }}</h2>
+
+{% if cl.rk == "?" %}
+{% if cl.rk_bnds != "not recorded" %}
+<b>Rank</b> \(r\) satisfies \({{ cl.rank_bounds[0] }} \le r \le {{ cl.rank_bounds[1] }}\)
+{% else %}
+Rank not yet determined.
+{% endif %}
+{% else %}
+<b>Rank:</b> \( {{ cl.rank }} \)
+{% endif %}
 
 
 <h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>


### PR DESCRIPTION
More information show on isogeny class and curve pages for elliptic curves over number fields: when totally real (not just real quadratic) give link to the Hilbert MF and also directly to the L-function.  Also added rank info to isogeny class pages (since it's a class invariant).