### PR TITLE
Fix bug in displaying many high degree artin representation pages, and limit display count

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -134,7 +134,7 @@ def artin_representation_search(**args):
     elif len(tmp_both) >= 2:
         query["$or"] = tmp_both
 
-    count_default = 50
+    count_default = 10
     if req.get('count'):
         try:
             count = int(req['count'])

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -105,7 +105,7 @@ Enter values into one or more boxes to restrict the search.
     </tr>
 
     <tr>
-        <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value='50' size='10'></td>
+        <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value='10' size='10'></td>
     </tr>
   </table>
   

--- a/lmfdb/math_classes.py
+++ b/lmfdb/math_classes.py
@@ -5,7 +5,7 @@ from utils import url_for, pol_to_html
 from databases.Dokchitser_databases import Dokchitser_ArtinRepresentation_Collection, Dokchitser_NumberFieldGaloisGroup_Collection
 from databases.standard_types import PolynomialAsSequenceInt
 from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField
-from lmfdb.transitive_group import group_display_knowl, group_display_short
+from lmfdb.transitive_group import group_display_knowl, group_display_short, tryknowl
 from WebNumberField import WebNumberField
 
 
@@ -148,8 +148,7 @@ class ArtinRepresentation(object):
         galnt = self.smallest_gal_t()
         if len(galnt)==1:
             return galnt[0]
-        C = getDBConnection()
-        return group_display_knowl(galnt[0],galnt[1],C)
+        return tryknowl(galnt[0],galnt[1])
 
     def is_ramified(self, p):
         return self.number_field_galois_group().discriminant() % p == 0


### PR DESCRIPTION
When searching for Artin representations, the old default was 50.  There is enough computation done in the search result page that it was timing out on the beta and prod in some cases.  This sets the default limit to 10 which should fix that.

Second, there was a bug in displaying an individual artin representation page when the smallest "containing" permutation representation had high degree, and this fixes the bug.  A case which would trigger it before is

  http://127.0.0.1:37777/ArtinRepresentation/10.2e20_3e20.30t176.1c1
and one which was a lower degree permutation representation, so was a knowl before and still is, is on

  http://127.0.0.1:37777/ArtinRepresentation/5.22291.6t16.1c1
