### PR TITLE
putting back the cause of the deprecation warning

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -15,7 +15,7 @@ import re
 
 import sage.all
 from sage.all import ZZ, QQ, PolynomialRing, NumberField, CyclotomicField, latex, AbelianGroup, euler_phi, pari, prod
-from sage.arith.all import primes
+from sage.rings.arith import primes
 
 from lmfdb.transitive_group import *
 


### PR DESCRIPTION
The deprecation warning will be be back again, but at least it still works with Sage 6.7.

We can switch it back again when we decide that everyone has to upgrade to Sage 7