### PR TITLE
Old space

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -204,7 +204,7 @@ class WebModFormSpace(WebObject, CachedRepresentation):
             WebInt('sturm_bound'),
             WebHeckeOrbits('hecke_orbits', level, weight,
                            character, self,include_in_update=update_hecke_orbits),
-            WebDict('oldspace_decomposition', required=False),
+            WebList('oldspace_decomposition', required=False),
             WebInt('bitprec', value=bitprec),
             WebFloat('version', value=float(emf_version), save_to_fs=True),
             WebList('zeta_orders',value=[],save_to_db=True),

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
@@ -307,10 +307,10 @@ class WebObject(object):
         if update_from_db:
             #emf_logger.debug('Update requested for {0}'.format(self.__dict__))
             emf_logger.debug('Update requested')
-            #try:
-            self.update_from_db()
-            #except Exception as e:
-            #    raise RuntimeError(str(e))
+            try:
+                self.update_from_db()
+            except Exception as e:
+                raise RuntimeError(str(e))
         #emf_logger.debug('init_dynamic_properties will be called for {0}'.format(self.__dict__))
         if init_dynamic_properties:
             emf_logger.debug('init_dynamic_properties will be called')

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -132,7 +132,26 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
         #        WMFS.hecke_orbits.append(F)
         info['space'] = WMFS
 #    info['old_decomposition'] = WMFS.oldspace_decomposition()
-
+    info['oldspace_decomposition']=''
+    try: 
+        emf_logger.debug("Oldspace = {0}".format(WMFS.oldspace_decomposition))
+        if WMFS.oldspace_decomposition != []:
+            emf_logger.debug("oldspace={0}".format(WMFS.oldspace_decomposition))
+            l = []
+            for t in WMFS.oldspace_decomposition:
+                emf_logger.debug("t={0}".format(t))
+                N,k,chi,mult,d = t
+                url = url_for('emf.render_elliptic_modular_forms', level=N, weight=k, character=chi)
+                if chi != 1:
+                    sname = "S^{{ new }}_{{ {k} }}(\\Gamma_0({N}),\\chi_{{ {N} }}({chi},\\cdot))".format(k=k,N=N,chi=chi)
+                else:
+                    sname = "S^{{ new }}_{{ {k} }}(\\Gamma_0({N}))".format(k=k,N=N)
+                l.append("[{mult}]\\cdot \href{{ {url} }}{{ {sname} }}".format(sname=sname,mult=mult,url=url))
+            if l != []:            
+                s = "\\oplus ".join(l)
+                info['oldspace_decomposition']=' $ {0} $'.format(s)
+    except Exception as e:
+        emf_logger.critical("Oldspace decomposition failed. Error:{0}".format(e))
     ## For side-bar
     lifts = list()
     lifts.append(('Half-Integral Weight Forms', '/ModularForm/Mp2/Q'))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -36,7 +36,7 @@
    {% if space.weight % 2 != 0 and space.character.value(-1) == 1 %}
      The weight is odd and the character is even.
    {% endif %}
-    {% else %}
+ {% else %}
 
       {% if extra_info is defined %}
         <span style="font-size:50%">({{ extra_info | safe }})</span>
@@ -67,13 +67,12 @@
       {% else %}
         {{ name_new }} {{ nontrivial_new_info }}
       {% endif %}
-      HERE
-      {% if space.oldspace_decomposition != {} and space.dimension_cusp_forms > space.dimension_new_cusp_forms %}
+    {% endif %}
+      {% if oldspace_decomposition != '' and space.dimension_cusp_forms > space.dimension_new_cusp_forms %}
         <h2> Decomposition of {{old_name}} into {{ KNOWL('mf.elliptic.oldspace',title='lower level spaces')}}</h2>
-        {{ space.oldspace_decomposition | safe }}
+        {{ old_name}}  = {{ oldspace_decomposition | safe }} 
       {% endif %}
         
-    {% endif %}
     {{ test | safe }}
   {% endif %}
 {% endif %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -67,7 +67,7 @@
       {% else %}
         {{ name_new }} {{ nontrivial_new_info }}
       {% endif %}
-
+      HERE
       {% if space.oldspace_decomposition != {} and space.dimension_cusp_forms > space.dimension_new_cusp_forms %}
         <h2> Decomposition of {{old_name}} into {{ KNOWL('mf.elliptic.oldspace',title='lower level spaces')}}</h2>
         {{ space.oldspace_decomposition | safe }}


### PR DESCRIPTION
Adds display of decomposition into old spaces as per issue #673  in the cases when this has been computed. 
See e.g. 
ModularForm/GL2/Q/holomorphic/2/12/1/  
(which only has an oldspace) and 
ModularForm/GL2/Q/holomorphic/10/10/9/
ModularForm/GL2/Q/holomorphic/10/12/1/

See in particular the last example for a sum with more components. Feel free to improve the display, in particular of how the multiplicities of each component is displayed. At the moment I simply wrote the mutiplicity in brackets in front of the component.
 
