### PR TITLE
commented out some lines

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -155,8 +155,8 @@ def render_curve_webpage_by_label(label):
                            data=data,
                            bread=data.bread,
                            title=data.title,
-                           friends=data.friends,
-                           downloads=data.downloads)
+                           friends=data.friends)
+                           #downloads=data.downloads)
 
 ###############################################################################
 # Isogeny class pages
@@ -176,8 +176,8 @@ def render_isogeny_class(iso_class):
                            credit=credit,
                            info=class_data,
                            title=class_data.title,
-                           friends=class_data.friends,
-                           downloads=class_data.downloads)
+                           friends=class_data.friends)
+                           #downloads=class_data.downloads)
 
 ################################################################################
 # Searching

--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -270,7 +270,7 @@ class G2Cisog_class(object):
         x = self.label.split('.')[1]
         self.friends = [('L-function',
             url_for("l_functions.l_function_genus2_page", cond=self.cond,x=x))]
-        self.downloads = [('Download Euler factors', ".")]
+        #self.downloads = [('Download Euler factors', ".")]
         #self.downloads = [
         #        ('Download Euler factors', "."),
         #            url_for(".download_g2c_eulerfactors", label=self.label)),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -710,7 +710,7 @@ class WebG2C(object):
             #       igusa_clebsch = str(self.igusa_clebsch)))  #doesn't work.
             #('Siegel modular form someday', '.')
             ]
-        self.downloads = [('Download all stored data', '.')]
+        #self.downloads = [('Download all stored data', '.')]
 
         # Breadcrumbs
         iso = self.label.split('.')[1]


### PR DESCRIPTION
To deal with issue #856, for now I've simply commented out the relevant lines in the folder genus2_curves so that no download link appears on the page of a genus 2 curve or of an isogeny class of genus 2 curves. This also affects the link for downloading Euler factors (see issue #428). Of course, downloading the data should really be possible at some point.