### PR TITLE
Modifying oldspace display for spaces of classical modular forms

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -146,7 +146,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
                     sname = "S^{{ new }}_{{ {k} }}(\\Gamma_0({N}),\\chi_{{ {N} }}({chi},\\cdot))".format(k=k,N=N,chi=chi)
                 else:
                     sname = "S^{{ new }}_{{ {k} }}(\\Gamma_0({N}))".format(k=k,N=N)
-                l.append("[{mult}]\\cdot \href{{ {url} }}{{ {sname} }}".format(sname=sname,mult=mult,url=url))
+                l.append("\href{{ {url} }}{{ {sname} }}^{{\oplus {mult} }}".format(sname=sname,mult=mult,url=url))
             if l != []:            
                 s = "\\oplus ".join(l)
                 info['oldspace_decomposition']=' $ {0} $'.format(s)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -70,7 +70,7 @@
     {% endif %}
       {% if oldspace_decomposition != '' and space.dimension_cusp_forms > space.dimension_new_cusp_forms %}
         <h2> Decomposition of {{old_name}} into {{ KNOWL('mf.elliptic.oldspace',title='lower level spaces')}}</h2>
-        {{ old_name}}  = {{ oldspace_decomposition | safe }} 
+        {{ old_name}}  \(\cong\) {{ oldspace_decomposition | safe }} 
       {% endif %}
         
     {{ test | safe }}


### PR DESCRIPTION
Adjusts the display of the decomposition of an old space of modular forms.  The changes are to put the multiplicity as an exponent with oplus instead of in front with square brackets, and changed the equals sign to an isomorphism symbol (it isn't equal unless you apply operators on the pieces to raise their levels).  See
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/10/12/1/
