### PR TITLE
Elliptic curves over number fields -- data source & extent knowls added

### DIFF
--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+import re
+from pymongo import ASCENDING, DESCENDING
+import lmfdb.base
+from lmfdb.base import app
+from lmfdb.utils import comma, make_logger
+from flask import url_for
+
+def format_percentage(num, denom):
+    return "%10.2f"%((100.0*num)/denom)
+
+logger = make_logger("ecnf")
+
+the_ECNFstats = None
+
+def get_stats():
+    global the_ECNFstats
+    if the_ECNFstats is None:
+        the_ECNFstats = ECNFstats()
+    return the_ECNFstats
+
+def ecnf_summary():
+    counts = get_stats().counts()
+    #ecnfstaturl = url_for('ecnf.statistics')
+    return r'The database currently contains %s elliptic curves in %s isogeny classes, over %s number fields (not including $\mathbb{Q}$) of degrees up to %s.' % (counts['ncurves_c'], counts['nclasses_c'], counts['nfields'], counts['maxdeg'])
+
+
+@app.context_processor
+def ctx_ecnf_summary():
+    return {'ecnf_summary': ecnf_summary}
+
+class ECNFstats(object):
+    """
+    Class for creating and displaying statistics for elliptic curves over number fields other than Q
+    """
+
+    def __init__(self):
+        logger.debug("Constructing an instance of ECstats")
+        self.ecdb = lmfdb.base.getDBConnection().elliptic_curves.nfcurves
+        self._counts = {}
+        self._stats = {}
+
+    def counts(self):
+        self.init_ecnfdb_count()
+        return self._counts
+
+    def stats(self):
+        self.init_ecdb_count()
+        self.init_ecdb_stats()
+        return self._stats
+
+    def init_ecnfdb_count(self):
+        if self._counts:
+            return
+        logger.debug("Computing elliptic curve (nf) counts...")
+        ecdb = self.ecdb
+        counts = {}
+        fields = ecdb.distinct('field_label')
+        counts['nfields'] = len(fields)
+        degrees = ecdb.distinct('degree')
+        counts['maxdeg'] = max(degrees)
+        counts['ncurves_by_degree'] = dict([(d,ecdb.find({'degree':d}).count()) for d in degrees])
+        ncurves = ecdb.count()
+        counts['ncurves']  = ncurves
+        counts['ncurves_c'] = comma(ncurves)
+        nclasses = ecdb.find({'number': 1}).count()
+        counts['nclasses'] = nclasses
+        counts['nclasses_c'] = comma(nclasses)
+        self._counts  = counts
+        logger.debug("... finished computing elliptic curve (nf) counts.")
+
+    def init_ecdb_stats(self):
+        if self._stats:
+            return
+        logger.debug("Computing elliptic curve stats...")
+        ecdb = self.ecdb
+        counts = self._counts
+        stats = {}
+        rank_counts = []
+        for r in range(counts['max_rank']+1):
+            ncu = ecdb.find({'rank': r}).count()
+            ncl = ecdb.find({'rank': r, 'number': 1}).count()
+            prop = format_percentage(ncl,counts['nclasses'])
+            rank_counts.append({'r': r, 'ncurves': ncu, 'nclasses': ncl, 'prop': prop})
+        stats['rank_counts'] = rank_counts
+        tor_counts = []
+        tor_counts2 = []
+        ncurves = counts['ncurves']
+        for t in  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16]:
+            ncu = ecdb.find({'torsion': t}).count()
+            if t in [4,8,12]: # two possible structures
+                ncyc = ecdb.find({'torsion_structure': [str(t)]}).count()
+                gp = "\(C_{%s}\)"%t
+                prop = format_percentage(ncyc,ncurves)
+                tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncyc, 'prop': prop})
+                nncyc = ncu-ncyc
+                gp = "\(C_{2}\\times C_{%s}\)"%(t//2)
+                prop = format_percentage(nncyc,ncurves)
+                tor_counts2.append({'t': t, 'gp': gp, 'ncurves': nncyc, 'prop': prop})
+            elif t==16: # all C_2 x C_8
+                gp = "\(C_{2}\\times C_{8}\)"
+                prop = format_percentage(ncu,ncurves)
+                tor_counts2.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
+            else: # all cyclic
+                gp = "\(C_{%s}\)"%t
+                prop = format_percentage(ncu,ncurves)
+                tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
+        stats['tor_counts'] = tor_counts+tor_counts2
+        stats['max_sha'] = ecdb.find().sort('sha', DESCENDING).limit(1)[0]['sha']
+        sha_counts = []
+        from sage.misc.functional import isqrt
+        for s in range(1,1+isqrt(stats['max_sha'])):
+            s2 = s*s
+            nc = ecdb.find({'sha': s2}).count()
+            if nc:
+                sha_counts.append({'s': s, 'ncurves': nc})
+        stats['sha_counts'] = sha_counts
+        self._stats = stats
+        logger.debug("... finished computing elliptic curve stats.")
+        #logger.debug("%s" % self._stats)
+

--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -70,6 +70,7 @@ from lmfdb.base import _init as init
 from lmfdb.base import getDBConnection
 from sage.rings.all import ZZ, QQ
 from sage.databases.cremona import cremona_to_lmfdb
+from lmfdb.ecnf.ecnf_stats import field_data
 
 from lmfdb.website import DEFAULT_DB_PORT as dbport
 from pymongo.mongo_client import MongoClient
@@ -99,6 +100,9 @@ nfcurves.ensure_index('conductor_norm')
 nfcurves.ensure_index('rank')
 nfcurves.ensure_index('torsion')
 nfcurves.ensure_index('jinv')
+nfcurves.ensure_index('number')
+nfcurves.ensure_index('degree')
+nfcurves.ensure_index('field_label')
 
 print "finished indices"
 
@@ -106,7 +110,6 @@ print "finished indices"
 # but only want to do this once for each label, so we will maintain a
 # dict of label:field pairs:
 nf_lookup_table = {}
-
 
 def nf_lookup(label):
     r"""
@@ -229,14 +232,6 @@ def point_list(P):
     """
     return [K_list(c) for c in list(P)]
 
-
-def field_data(s):
-    r"""
-    Returns full field data from field label.
-    """
-    deg, r1, abs_disc, n = [int(c) for c in s.split(".")]
-    sig = [r1, (deg - r1) // 2]
-    return [s, deg, sig, abs_disc]
 
 
 #@cached_function

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -112,8 +112,14 @@ def index():
     iqfs = ['2.0.%s.1' % str(d) for d in [4, 8, 3, 7, 11]]
     data['fields'].append(['imaginary quadratic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in iqfs)])
     # Cubics
-    cubics = ['3.1.23.1']
+    cubics = ['3.1.23.1'] + ['3.3.%s.1' % str(d) for d in [49,148,1957]]
     data['fields'].append(['cubic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in cubics)])
+    # Quartics
+    quartics = ['4.4.%s.1' % str(d) for d in [725,2777,9909,19821]]
+    data['fields'].append(['totally real quartic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quartics)])
+    # Quintics
+    quintics = ['5.5.%s.1' % str(d) for d in [14641]]
+    data['fields'].append(['a totally real quintic field', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quintics)])
 
 # data['highlights'] holds data (URL and descriptive text) for a
 # sample of elliptic curves with interesting features:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -12,6 +12,7 @@ from lmfdb.utils import image_src, web_latex, to_dict, coeff_to_poly, pol_to_htm
 from lmfdb.search_parsing import clean_input, parse_range, parse_range2, parse_bracketed_posints
 from sage.all import ZZ, var, PolynomialRing, QQ, GCD
 from lmfdb.ecnf import ecnf_page, logger
+from lmfdb.ecnf.ecnf_stats import get_stats
 from lmfdb.ecnf.WebEllipticCurve import ECNF, db_ecnf, web_ainvs
 from lmfdb.ecnf.isog_class import ECNF_isoclass
 from lmfdb.number_fields.number_field import parse_list, parse_field_string, field_pretty

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -87,6 +87,44 @@ def get_bread(*breads):
     map(bc.append, breads)
     return bc
 
+def learnmore_list():
+    return [('Completeness of the data', url_for(".completeness_page")),
+            ('Source of the data', url_for(".how_computed_page")),
+            ('Elliptic Curve labels', url_for(".labels_page"))]
+
+# Return the learnmore list with the matchstring entry removed
+def learnmore_list_remove(matchstring):
+    return filter(lambda t:t[0].find(matchstring) <0, learnmore_list())
+
+@ecnf_page.route("/Completeness")
+def completeness_page():
+    t = 'Completeness of the elliptic curve data over number fields'
+    bread = [('Elliptic Curves', url_for("ecnf.index")),
+             ('Completeness', '')]
+    credit = 'John Cremona'
+    return render_template("single.html", kid='dq.ecnf.extent',
+                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+
+
+@ecnf_page.route("/Source")
+def how_computed_page():
+    t = 'Source of the elliptic curve data over number fields'
+    bread = [('Elliptic Curves', url_for("ecnf.index")),
+             ('Source', '')]
+    credit = 'John Cremona'
+    return render_template("single.html", kid='dq.ecnf.source',
+                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
+@ecnf_page.route("/Labels")
+def labels_page():
+    t = 'Labels for elliptic curves over number fields'
+    bread = [('Elliptic Curves', url_for("ecnf.index")),
+             ('Labels', '')]
+    credit = 'John Cremona'
+    return render_template("single.html", kid='ec.curve_label',
+                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+
+
 @ecnf_page.route("/")
 def index():
 #    if 'jump' in request.args:
@@ -103,24 +141,32 @@ def index():
 # data['fields'] holds data for a sample of number fields of different
 # signatures for a general browse:
 
+    counts = get_stats().counts()
     data['fields'] = []
     # Rationals
     data['fields'].append(['the rational field', (('1.1.1.1', [url_for('ec.rational_elliptic_curves'), '$\Q$']),)])
     # Real quadratics (only a sample)
     rqfs = ['2.2.%s.1' % str(d) for d in [5, 89, 229, 497]]
-    data['fields'].append(['real quadratic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in rqfs)])
+    nquadratics = counts['nfields_by_degree'][2]
+    niqfs = 5
+    nrqfs = nquadratics - niqfs
+    data['fields'].append(['%s real quadratic fields, including' % nrqfs, ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in rqfs)])
     # Imaginary quadratics
     iqfs = ['2.0.%s.1' % str(d) for d in [4, 8, 3, 7, 11]]
-    data['fields'].append(['imaginary quadratic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in iqfs)])
+    data['fields'].append(['%s imaginary quadratic fields' % niqfs, ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in iqfs)])
     # Cubics
     cubics = ['3.1.23.1'] + ['3.3.%s.1' % str(d) for d in [49,148,1957]]
-    data['fields'].append(['cubic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in cubics)])
+    ncubics = counts['nfields_by_degree'][3]
+    data['fields'].append(['%s cubic fields, including' % ncubics, ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in cubics)])
     # Quartics
     quartics = ['4.4.%s.1' % str(d) for d in [725,2777,9909,19821]]
-    data['fields'].append(['totally real quartic fields', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quartics)])
+    nquartics = counts['nfields_by_degree'][4]
+    data['fields'].append(['%s totally real quartic fields, including' % nquartics,
+                           ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quartics)])
     # Quintics
     quintics = ['5.5.%s.1' % str(d) for d in [14641]]
-    data['fields'].append(['a totally real quintic field', ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quintics)])
+    nquintics = counts['nfields_by_degree'][5]
+    data['fields'].append(['%s totally real quintic field' % nquintics, ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)]) for nf in quintics)])
 
 # data['highlights'] holds data (URL and descriptive text) for a
 # sample of elliptic curves with interesting features:
@@ -150,7 +196,7 @@ def index():
     return render_template("ecnf-index.html",
                            title="Elliptic Curves over Number Fields",
                            data=data,
-                           bread=bread)
+                           bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 
 @ecnf_page.route("/<nf>/")
@@ -420,3 +466,15 @@ def search():
         return "ERROR: we always do http get to explicitly display the search parameters"
     else:
         return redirect(404)
+
+@ecnf_page.route("/stats")
+def statistics():
+    info = {
+        'counts': get_stats().counts(),
+        'stats': get_stats().stats(),
+    }
+    credit = 'John Cremona'
+    t = 'Elliptic curves over number fields: statistics'
+    bread = [('Elliptic Curves', url_for("ecnf.index")),
+             ('statistics', ' ')]
+    return render_template("stats.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -3,8 +3,8 @@
 {% block content %}
 
 <div>
-The database currently contains elliptic curves over a few number
-fields other than $\Q$, mostly quadratic fields.
+The database currently contains elliptic curves over several number
+fields of degree up to 6, mostly totally real fields.
 </div>
 
 <h2> Browse {{ KNOWL('ec',title='elliptic curves')}} over {{
@@ -16,7 +16,7 @@ KNOWL('nf',title = "number fields")}}</h2>
 <li>
 curves defined over {{types[0]}}:
 {% for label,f in types[1] %}
-{% if types[0]=='real quadratic fields' %}
+{% if types[0]!='imaginary quadratic fields' %}
 {% if loop.index0 %},...,{% endif %}
 {% else %}
 {% if loop.index0 %},{% endif %}

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -13,7 +13,7 @@ KNOWL('nf',title = "number fields")}}</h2>
 <ul>
 {% for types in data.fields %}
 <li>
-curves defined over {{types[0]}}:
+over {{types[0]}}:
 {% for label,f in types[1] %}
 {% if types[0]!='imaginary quadratic fields' %}
 {% if loop.index0 %},...,{% endif %}

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -3,8 +3,7 @@
 {% block content %}
 
 <div>
-The database currently contains elliptic curves over several number
-fields of degree up to 6, mostly totally real fields.
+{{ KNOWL_INC('dq.ecnf.extent') }}
 </div>
 
 <h2> Browse {{ KNOWL('ec',title='elliptic curves')}} over {{

--- a/lmfdb/ecnf/templates/stats.html
+++ b/lmfdb/ecnf/templates/stats.html
@@ -1,0 +1,21 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<div>
+{{ KNOWL_INC('dq.ecnf.extent') }}
+</div>
+
+<h2>Fields, number of curves and maximum conductor norm</h2>
+{% for d in info.stats.ncurves %}
+<h3> Degree {{d}} </h3>
+<table>
+<tr><th> Field <th> Number of curves <th> Number of isogeny classes <th> Maximum conductor norm </tr>
+{% for F in info.counts.fields_by_degree[d] %}
+<tr><td> {{F}} <td> {{info.stats.ncurves[d][F]}} <td> {{info.stats.nclasses[d][F]}} <td> {{info.stats.maxnorm[d][F]}} </tr>
+{% endfor %}
+</table>
+
+{% endfor %}
+
+{% endblock %}
+</html>


### PR DESCRIPTION
I also started work on a more details page which can be seen at EllipticCurve/stats but there are not links to that yet and it is work in progress (should not delay merging this though).

See teh main EllipticCurve/ gome page to see the dynamic knowl (dq.ecnf.extent) as well as two others in the Learn More About box.  The Source one has a lot in it which can obviously be edited later.