### PR TITLE
add gp code for ecnf

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -349,12 +349,13 @@ class ECNF(object):
         # Fill in placeholders for this specific curve:
 
         gen = self.field.generator_name().replace("\\","") # phi not \phi
-        for lang in ['sage', 'magma']:
+        for lang in ['sage', 'magma', 'pari']:
             self.code['field'][lang] = self.code['field'][lang] % self.field.poly()
             if gen != 'a':
                 self.code['field'][lang] = self.code['field'][lang].replace("<a>","<%s>" % gen)
+                self.code['field'][lang] = self.code['field'][lang].replace("a=","%s=" % gen)
 
-        for lang in ['sage', 'magma']:
+        for lang in ['sage', 'magma', 'pari']:
             self.code['curve'][lang] = self.code['curve'][lang] % self.ainvs
 
         for k in self.code:

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -1,6 +1,6 @@
 prompt:
   sage:   'sage:'
-  pari:   'gp:'
+  pari:   'gp (2.8):'
   magma:  'magma:'
 
 logo:
@@ -18,11 +18,14 @@ not-implemented:
 
 field:
   sage:  K.<a> = NumberField(%s)
+  pari: K = nfinit(%s); a=x
   magma: K<a> := NumberField(%s);
 
 curve:
   sage: |
     E = EllipticCurve(%s)
+  pari: |
+    E = ellinit(%s)
   magma: |
     E := EllipticCurve(%s);
 
@@ -40,14 +43,17 @@ cond_norm:
 
 disc:
   sage:  E.discriminant()
+  pari:  E.disc
   magma: Discriminant(E);
 
 disc_norm:
   sage:  E.discriminant().norm()
+  pari:  norm(E.disc)
   magma: Norm(Discriminant(E));
 
 jinv:
   sage:  E.j_invariant()
+  pari:  E.j
   magma: jInvariant(E);
 
 cm:
@@ -68,25 +74,20 @@ gens:
 
 tors:
   sage:  E.torsion_subgroup().gens()
+  pari:  elltors(E)[2]
   magma: TorsionSubgroup(E);
 
 torgens:
   sage:  E.torsion_subgroup().gens()
+  pari:  elltors(E)[3]
   magma: |
     [f(P): P in Generators(T)] where T,f:=TorsionSubgroup(E);
 
 ntors:
   sage:  E.torsion_order()
+  pari:  elltors(E)[1]
   magma: Order(TorsionSubgroup(E));
 
-cp:
-  sage:  E.tamagawa_numbers()
-  pari:  E.omega[1]
-  magma: RealPeriod(E);
-
-sha:
-  sage:  E.sha().an_numerical()
-  magma: MordellWeilShaInformation(E);
 
 localdata:
   sage:

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -58,6 +58,7 @@ function show_code(system) {
     <div align ="right">
       Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
        {# <a onclick="show_code('pari'); return false" href='#'>pari</a>, #}
+        <a onclick="show_code('pari'); return false" href='#'>gp</a>,
         <a onclick="show_code('magma'); return false" href='#'>magma</a>
     </div>
 
@@ -143,7 +144,7 @@ cellpadding="5";
         {% endif %}
         </tr>
 
-          <tr><td colspan=5> {{ code(ec.code,'disc_norm') }}</td></tr>
+          <tr><td colspan=5> {{ code(ec.code,'disc') }}</td></tr>
         <tr>
         <td>
           {% if ec.is_minimal %}
@@ -157,7 +158,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
         </tr>
-        <tr><td colspan=5> {{ code(ec.code,'disc') }}</td></tr>
+        <tr><td colspan=5> {{ code(ec.code,'disc_norm') }}</td></tr>
 
 {% if not ec.is_minimal %}
         <tr>


### PR DESCRIPTION
Ticket #777 
Add gp code for elliptic curves over number fields. Also correct discriminant / discriminant norm codes.
Note: the gp code only works with pari/gp 2.8 (development version)

Examples:
/EllipticCurve/2.2.229.1/1.1/a/1
/EllipticCurve/2.2.5.1/31.1/a/1