### PR TITLE
EC over Q: fix Tamagawa number code for gp and magma

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -70,8 +70,8 @@ real_period:
 
 cp:
   sage:  E.tamagawa_numbers()
-  pari:  E.omega[1]
-  magma: RealPeriod(E);
+  pari:  gr=ellglobalred(E); [[gr[4][i,1],gr[5][i][4]] | i<-[1..#gr[4][,1]]]
+  magma: TamagawaNumbers(E);
 
 
 ntors:


### PR DESCRIPTION
Fix the gp and magma code for the Tamagawa numbers of elliptic curves over Q.

Example:
/EllipticCurve/Q/262080cv3