### PR TITLE
g2: add EC from splitting as friends

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -761,7 +761,7 @@ class WebG2C(object):
 
         # Curve
         set_code('curve',
-                 '|R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
+                 'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
                  % (self.data['min_eqn'][0],self.data['min_eqn'][1]),
                  pari_not_implemented, # pari code goes here
                  'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -709,7 +709,7 @@ class WebG2C(object):
             #   url_for(".index_Q",
             #       igusa_clebsch = str(self.igusa_clebsch)))  #doesn't work.
             #('Siegel modular form someday', '.')
-            ]
+            ] + [('Elliptic curve %s' % lab,url_for_ec(lab)) for lab in endodata['spl_facs_labels'] if lab != '']
         #self.downloads = [('Download all stored data', '.')]
 
         # Breadcrumbs
@@ -758,7 +758,7 @@ class WebG2C(object):
 
         # Curve
         set_code('curve',
-                 'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
+                 '|R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
                  % (self.data['min_eqn'][0],self.data['min_eqn'][1]),
                  pari_not_implemented, # pari code goes here
                  'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -709,7 +709,10 @@ class WebG2C(object):
             #   url_for(".index_Q",
             #       igusa_clebsch = str(self.igusa_clebsch)))  #doesn't work.
             #('Siegel modular form someday', '.')
-            ] + [('Elliptic curve %s' % lab,url_for_ec(lab)) for lab in endodata['spl_facs_labels'] if lab != '']
+            ]
+
+        if not endodata['is_simple_geom']:
+            self.friends += [('Elliptic curve %s' % lab,url_for_ec(lab)) for lab in endodata['spl_facs_labels'] if lab != '']
         #self.downloads = [('Download all stored data', '.')]
 
         # Breadcrumbs


### PR DESCRIPTION
Ticket #522 
When a genus 2 curves splits, the corresponding elliptic curve is now in the "related object" box.

Examples:
/Genus2Curve/Q/614656/a/614656/1
/Genus2Curve/Q/720/b/116640/1

Question: should the related object be the elliptic curve or the isogeny class of EC?