### PR TITLE
Changed q-exp knowl ref

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
@@ -14,7 +14,7 @@ info in this page is set by set_info_for_web_newform in emf_render_web_newform.p
       <th>{{ KNOWL('mf.elliptic.label',title='Label')}}</th>
       <th>{{ KNOWL('mf.elliptic.dimension_galois_orbit',title='Dimension')}}</th>
       <th>{{ KNOWL('mf.elliptic.coefficient_field',title='Field')}}</th>
-      <th align="left">{{ KNOWL('mf.elliptic.q-expansion-of-eigenform',title='$q$-expansion of eigenform')}}</th>
+      <th align="left">{{ KNOWL('mf.elliptic.q-expansion',title='$q$-expansion of eigenform')}}</th>
     </tr>
     </thead>
   <tbody>


### PR DESCRIPTION
On pages such as ModularForm/GL2/Q/holomorphic/8/4/5/, the q-expansion knowl pointed to "q-expansion of an eigen form", which does not exist as a knowl. This knowl now points to "q-expansion", which does exist.