### PR TITLE
removed redundant explanations for e and o

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
@@ -146,7 +146,7 @@ $S_{ {{k}} }^{new}(\Gamma_0({{level}}), \chi)$</th>
   </tbody>
 </table>
 <small>The space is clickable whenever the Hecke orbits are stored for that space.
-The parity is listed as "e" for even, "o" for odd and "n/a" in case we do not have it
+The parity is listed as "n/a" in case we do not have it
 stored in the database.</small>
 
 {% endif %}


### PR DESCRIPTION
Fixes Issue #918 
e.g. ModularForm/GL2/Q/holomorphic/1/12/?group=1