### PR TITLE
Hilbert modular forms search by label and single form display

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -30,7 +30,7 @@ def split_full_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form <NFlabel>-<Condlabel>-<Isoglabel><CurveId> (separated by dashes), such as 2.2.5.1-31.1-a1" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form (number field label) - (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 2.2.5.1-31.1-a1" % lab), "error")
         raise ValueError
     field_label = data[0]
     conductor_label = data[1]
@@ -38,7 +38,7 @@ def split_full_label(lab):
         isoclass_label = re.search("(CM)?[a-z]+", data[2]).group()
         curve_number = re.search("\d+", data[2]).group()  # (a string)
     except AttributeError:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of lower case letters), followed by a curve id (an integer), such as a1" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of lower case letters), followed by a curve id (an integer), such as a1" % lab), "error")
         raise ValueError
     return (field_label, conductor_label, isoclass_label, curve_number)
 
@@ -49,14 +49,14 @@ def split_short_label(lab):
     """
     data = lab.split("-")
     if len(data) != 2:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form <Condlabel>-<Isoglabel><CurveId> (separated by dashes), such as 31.1-a1" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 31.1-a1" % lab), "error")
         raise ValueError
     conductor_label = data[0]
     try:
         isoclass_label = re.search("[a-z]+", data[1]).group()
         curve_number = re.search("\d+", data[1]).group()  # (a string)
     except AttributeError:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of lower case letters), followed by a curve id (an integer), such as a1" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of lower case letters), followed by a curve id (an integer), such as a1" % lab), "error")
         raise ValueError
     return (conductor_label, isoclass_label, curve_number)
 
@@ -67,7 +67,7 @@ def split_class_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid isogeny class label. It must be of the form <NFlabel>-<Condlabel>-<Isoglabel> (separated by dashes), such as 2.2.5.1-31.1-a" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid isogeny class label. It must be of the form (number field label) - (conductor label) - (isogeny class label) (separated by dashes), such as 2.2.5.1-31.1-a" % lab), "error")
         raise ValueError
     field_label = data[0]
     conductor_label = data[1]
@@ -81,7 +81,7 @@ def split_short_class_label(lab):
     """
     data = lab.split("-")
     if len(data) != 2:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid isogeny class label. It must be of the form <Condlabel>-<Isoglabel> (separated by dashes), such as 31.1-a" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid isogeny class label. It must be of the form (conductor label) - (isogeny class label) (separated by dashes), such as 31.1-a" % lab), "error")
         raise ValueError
     conductor_label = data[0]
     isoclass_label = data[1]

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -22,7 +22,7 @@ from flask import render_template, render_template_string, request, abort, Bluep
 
 from markupsafe import Markup
 
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html
+from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, web_latex_split_on_pm
 from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, parse_count, parse_start
 
 from lmfdb.WebNumberField import *
@@ -74,7 +74,7 @@ def hilbert_modular_form_render_webpage():
                  ('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage"))]
         info['learnmore'] = []
         info['counts'] = get_stats().counts()
-        return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=bread)
+        return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list())
     else:
         return hilbert_modular_form_search(**args)
 
@@ -170,7 +170,7 @@ def hilbert_modular_form_search(**args):
     bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")), (
         'Search results', ' ')]
     properties = []
-    return render_template("hilbert_modular_form_search.html", info=info, title=t, credit=hmf_credit, properties=properties, bread=bread)
+    return render_template("hilbert_modular_form_search.html", info=info, title=t, credit=hmf_credit, properties=properties, bread=bread, learnmore=learnmore_list())
 
 def search_input_error(info = None, bread = None):
     if info is None: info = {'err':''}
@@ -418,4 +418,44 @@ def render_hmf_webpage(**args):
                    ('Base Change', is_base_change)
                    ]
 
-    return render_template("hilbert_modular_form.html", downloads=info["downloads"], info=info, properties2=properties2, credit=hmf_credit, title=t, bread=bread, friends=info['friends'])
+    return render_template("hilbert_modular_form.html", downloads=info["downloads"], info=info, properties2=properties2, credit=hmf_credit, title=t, bread=bread, friends=info['friends'], learnmore=learnmore_list())
+
+
+
+# Learn more box
+
+def learnmore_list():
+    return [('Completeness of the data', url_for(".completeness_page")),
+            ('Source of the data', url_for(".how_computed_page")),
+            ('Labels for Hilbert Modular Forms', url_for(".labels_page"))]
+
+# Return the learnmore list with the matchstring entry removed
+def learnmore_list_remove(matchstring):
+    return filter(lambda t:t[0].find(matchstring) <0, learnmore_list())
+
+
+
+#data quality pages
+@hmf_page.route("/Completeness")
+def completeness_page():
+    t = 'Completeness of the Hilbert Modular Forms data'
+    bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
+             ('Completeness', '')]
+    return render_template("single.html", kid='dq.mf.hilbert.extent',
+                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+
+@hmf_page.route("/Source")
+def how_computed_page():
+    t = 'Source of the Hilbert Modular Forms data'
+    bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
+             ('Source', '')]
+    return render_template("single.html", kid='dq.mf.hilbert.source',
+                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
+@hmf_page.route("/Labels")
+def labels_page():
+    t = 'Label of an Hilbert Modular Form'
+    bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
+             ('Labels', '')]
+    return render_template("single.html", kid='mf.hilbert.label',
+                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Labels'))

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -107,9 +107,8 @@ def hilbert_modular_form_search(**args):
 #    C.hmfs.forms.ensure_index([('level_norm', pymongo.ASCENDING), ('label', pymongo.ASCENDING)])
 
     info = to_dict(args)  # what has been entered in the search boxes
-    if 'label' in info and info.get('label'):
-        lab=info.get('label').strip()
-        info['label']=str(lab)
+    if 'label' in info and info['label']:
+        lab=info['label'].strip()
         try:
             split_full_label(lab)
             return hilbert_modular_form_by_label(lab, C)

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -86,7 +86,7 @@ def split_full_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span syle='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form <NFlabel>-<Condlabel>-<OrbitId> (separated by dashes), such as 2.2.5.1-31.1-a" % lab), "error")
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a" % lab), "error")
         raise ValueError
     field_label = data[0]
     level_label = data[1]
@@ -108,12 +108,14 @@ def hilbert_modular_form_search(**args):
 
     info = to_dict(args)  # what has been entered in the search boxes
     if 'label' in info and info.get('label'):
-        lab=info.get('label').replace(" ", "")
+        lab=info.get('label').strip()
+        info['label']=str(lab)
         try:
             split_full_label(lab)
+            return hilbert_modular_form_by_label(lab, C)
         except ValueError:
             return search_input_error()
-        return hilbert_modular_form_by_label(lab, C)
+
     query = {}
     try:
         parse_nf_string(info,query,'field_label',name="Field")

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -113,7 +113,7 @@ def hilbert_modular_form_search(**args):
             split_full_label(lab)
         except ValueError:
             return search_input_error()
-        return hilbert_modular_form_by_label(info.get('label'), C)
+        return hilbert_modular_form_by_label(lab, C)
     query = {}
     try:
         parse_nf_string(info,query,'field_label',name="Field")

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -95,11 +95,10 @@ def split_full_label(lab):
 
 def hilbert_modular_form_by_label(lab, C):
     if C.hmfs.forms.find({'label': lab}).limit(1).count() > 0:
-        return render_hmf_webpage(label=lab)
+        return redirect(url_for(".render_hmf_webpage", field_label=split_full_label(lab)[0], label=lab))
     else:
         flash(Markup("No Hilbert modular form in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
-    return redirect(url_for(".hilbert_modular_form_render_webpage"))
-
+        return redirect(url_for(".hilbert_modular_form_render_webpage"))
 
 
 def hilbert_modular_form_search(**args):
@@ -109,11 +108,12 @@ def hilbert_modular_form_search(**args):
     info = to_dict(args)  # what has been entered in the search boxes
     if 'label' in info and info['label']:
         lab=info['label'].strip()
+        info['label']=lab
         try:
             split_full_label(lab)
             return hilbert_modular_form_by_label(lab, C)
         except ValueError:
-            return search_input_error()
+            return redirect(url_for(".hilbert_modular_form_render_webpage"))
 
     query = {}
     try:

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -36,6 +36,10 @@
 {% if info.dimension > 1 %}
 <div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
 <div style='overflow-x:auto; overflow-y:hidden'>${{ info.hecke_polynomial }}$ </div>
+
+{% else %}
+<div>The Hecke eigenvalue field is <a knowl= "nf.field.data" kwargs="label=1.1.1.1">$\Q$</a>.</div>
+
 {% endif %}
  
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Print full eigenvalues</a>
@@ -43,7 +47,6 @@
 
 <style type="text/css">
 div.scrollable {
-    width: 100%;
     height: 100%;
     margin: 10;
     padding: 10;
@@ -52,17 +55,19 @@ div.scrollable {
 }
 </style>
 
-<table class="ntdata" cellpadding=10 style="width:80%; table-layout:fixed">
+<table class="ntdata" cellpadding=10 style="width:70%; table-layout:fixed">
 <tr>
-<th style="width:5%;">Norm</th>
-<th style="width:15%;">{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
+<th>Norm</th>
+<th>{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
+<th></th>
 <th>Eigenvalue</th>
 </tr>
 {% for entry in info.eigs: %}
 <tr>
 <td>{{entry.prime_norm}}</td>
 <td>${{entry.prime_ideal}}$</td>
-<td><div class=scrollable>${{entry.eigenvalue}}$</div></td>
+<td></td>
+<td colspan=6><div class=scrollable>${{entry.eigenvalue}}$</div></td>
 </tr>
 {% endfor %}
 </table>
@@ -80,7 +85,7 @@ div.scrollable {
 </table>
 </form>
 
-  <h2>  Atkin-Lehner eigenvalues  </h2>
+<h2>  Atkin-Lehner eigenvalues  </h2>
 
 {% if info.AL_eigs_count %} 
 <p>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -58,15 +58,15 @@ div.scrollable {
 <table class="ntdata" cellpadding=10 style="width:70%; table-layout:fixed">
 <tr>
 <th>Norm</th>
-<th>{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
-<th></th>
-<th>Eigenvalue</th>
+<th colspan=3>{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
+<th colspan=2></th>
+<th colspan=6>Eigenvalue</th>
 </tr>
 {% for entry in info.eigs: %}
 <tr>
 <td>{{entry.prime_norm}}</td>
-<td>${{entry.prime_ideal}}$</td>
-<td></td>
+<td colspan=3>${{entry.prime_ideal}}$</td>
+<td colspan=2></td>
 <td colspan=6><div class=scrollable>${{entry.eigenvalue}}$</div></td>
 </tr>
 {% endfor %}

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -34,27 +34,35 @@
   <h2>  Hecke eigenvalues ({{ KNOWL('mf.hilbert.q_expansion', title='$q$-expansion') }}) </h2>
 
 {% if info.dimension > 1 %}
-<p>
-<table>
-<tr><td> $e$ is a root of the defining polynomial <td> ${{ info.hecke_polynomial }}$ </tr>
-</table>
-</p>
+<div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
+<div style='overflow-x:auto; overflow-y:hidden'>${{ info.hecke_polynomial }}$ </div>
 {% endif %}
-
+ 
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Print full eigenvalues</a>
 &nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>
 
-<table class="ntdata" cellpadding=5>
+<style type="text/css">
+div.scrollable {
+    width: 100%;
+    height: 100%;
+    margin: 10;
+    padding: 10;
+    overflow-x: auto;
+    overflow-y:hidden
+}
+</style>
+
+<table class="ntdata" cellpadding=10 style="width:80%; table-layout:fixed">
 <tr>
-<th>Norm</th>
-<th>{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
+<th style="width:5%;">Norm</th>
+<th style="width:15%;">{{ KNOWL('nf.ideal.label.hmf', title='Prime') }} </th>
 <th>Eigenvalue</th>
 </tr>
 {% for entry in info.eigs: %}
 <tr>
 <td>{{entry.prime_norm}}</td>
 <td>${{entry.prime_ideal}}$</td>
-<td align=right>${{entry.eigenvalue}}$</td>
+<td><div class=scrollable>${{entry.eigenvalue}}$</div></td>
 </tr>
 {% endfor %}
 </table>

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -15,7 +15,7 @@ from sage.all import Integer, ZZ, QQ, PolynomialRing, NumberField, CyclotomicFie
 
 from lmfdb.lattice import lattice_page, lattice_logger
 from lmfdb.lattice.lattice_stats import get_stats
-from lmfdb.search_parsing import parse_ints, parse_list
+from lmfdb.search_parsing import parse_ints, parse_list, parse_count, parse_start
 
 from markupsafe import Markup
 
@@ -131,29 +131,32 @@ def lattice_search(**args):
         info['err'] = str(err)
         return search_input_error(info)
 
-    count_default = 50
-    if info.get('count'):
-        try:
-            count = int(info['count'])
-        except:
-            err = "Error: <span style='color:black'>%s</span> is not a valid input. It needs to be a positive integer." % info['count']
-            flash(Markup("Error: <span style='color:black'>%s</span> is not a valid input. It needs to be a positive integer." % info['count']), "error")
-            info['err'] = str(err)
-            return search_input_error(info)
-    else:
-        info['count'] = count_default
-        count = count_default
+    count = parse_count(info,50)
+    start = parse_start(info)
 
-    start_default = 0
-    if info.get('start'):
-        try:
-            start = int(info['start'])
-            if(start < 0):
-                start += (1 - (start + 1) / count) * count
-        except:
-            start = start_default
-    else:
-        start = start_default
+#    count_default = 50
+#    if info.get('count'):
+#        try:
+#            count = int(info['count'])
+#        except:
+#            err = "Error: <span style='color:black'>%s</span> is not a valid input. It needs to be a positive integer." % info['count']
+#            flash(Markup("Error: <span style='color:black'>%s</span> is not a valid input. It needs to be a positive integer." % info['count']), "error")
+#            info['err'] = str(err)
+#            return search_input_error(info)
+#    else:
+#        info['count'] = count_default
+#        count = count_default
+
+#    start_default = 0
+#    if info.get('start'):
+#        try:
+#            start = int(info['start'])
+#            if(start < 0):
+#                start += (1 - (start + 1) / count) * count
+#        except:
+#            start = start_default
+#    else:
+#        start = start_default
 
     info['query'] = dict(query)
     res = C.Lattices.lat.find(query).sort([('dim', ASC), ('det', ASC), ('label', ASC)]).skip(start).limit(count)
@@ -344,7 +347,7 @@ def completeness_page():
 
 @lattice_page.route("/Source")
 def how_computed_page():
-    t = 'Source of integral lattice data'
+    t = 'Source of the integral lattice data'
     bread = [('Lattice', url_for(".lattice_render_webpage")),
              ('Source', '')]
     credit = lattice_credit


### PR DESCRIPTION
In this pull request is addressed the search by label of HMF.
The data quality knowls and learn more boxes are added.
At the same time some display issues are corrected for the single hmfs pages: for example

http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a
http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-1889.2-c?display_eigs=True
http://localhost:37777/ModularForm/GL2/TotallyReal/4.4.3600.1/holomorphic/4.4.3600.1-484.9-m?numeigs=400

some minor changes to lattices (how to handle count) and typos for ecnf are corrected to