### PR TITLE
Labels

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -14,7 +14,7 @@ from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, web_latex_spli
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.ec_stats import get_stats
 from lmfdb.elliptic_curves.isog_class import ECisog_class
-from lmfdb.elliptic_curves.web_ec import WebEC, parse_points, match_lmfdb_label, match_lmfdb_iso_label, match_cremona_label, split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex
+from lmfdb.elliptic_curves.web_ec import WebEC, parse_points, match_lmfdb_label, match_lmfdb_iso_label, match_cremona_label, split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, class_cremona_label, curve_lmfdb_label, curve_cremona_label
 from lmfdb.search_parsing import split_list, parse_rational, parse_ints, parse_bracketed_posints, parse_primes, parse_count, parse_start
 
 import sage.all
@@ -285,12 +285,12 @@ def search_input_error(info, bread):
 
 @ec_page.route("/<int:conductor>/<iso_label>/")
 def by_double_iso_label(conductor,iso_label):
-    full_iso_label = str(conductor)+"."+iso_label
+    full_iso_label = class_lmfdb_label(conductor,iso_label)
     return render_isogeny_class(full_iso_label)
 
 @ec_page.route("/<int:conductor>/<iso_label>/<int:number>")
 def by_triple_label(conductor,iso_label,number):
-    full_label = str(conductor)+"."+iso_label+str(number)
+    full_label = curve_lmfdb_label(conductor,iso_label,number)
     return render_curve_webpage_by_label(full_label)
 
 # The following function determines whether the given label is in

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -8,6 +8,7 @@ import lmfdb.base
 from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label
+from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label
 
 import sage.all
 from sage.all import EllipticCurve, latex, matrix
@@ -129,7 +130,7 @@ class ECisog_class(object):
         N, iso, number = split_lmfdb_label(self.lmfdb_iso)
 
         self.newform = web_latex(self.E.q_eigenform(10))
-        self.newform_label = self.lmfdb_iso.replace('.', '.2')
+        self.newform_label = newform_label(N,2,1,iso)
         self.newform_link = url_for("emf.render_elliptic_modular_forms", level=N, weight=2, character=1, label=iso)
 
         self.lfunction_link = url_for("l_functions.l_function_ec_page", label=self.lmfdb_iso)

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -9,6 +9,7 @@ import lmfdb.base
 from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.search_parsing import split_list
 from lmfdb.elliptic_curves import ec_page, ec_logger
+from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label
 
 import sage.all
 from sage.all import EllipticCurve, latex, matrix, ZZ, QQ
@@ -324,7 +325,7 @@ class WebEC(object):
             ('L-function', url_for("l_functions.l_function_ec_page", label=self.lmfdb_label)),
             ('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso)),
             ('Symmetric 4th power L-function', url_for("l_functions.l_function_ec_sym_page", power='4', label=self.lmfdb_iso)),
-            ('Modular form ' + self.lmfdb_iso.replace('.', '.2.1'), url_for("emf.render_elliptic_modular_forms", level=int(N), weight=2, character=1, label=iso))]
+            ('Modular form ' + newform_label(cond,2,1,iso), url_for("emf.render_elliptic_modular_forms", level=int(N), weight=2, character=1, label=iso))]
 
         self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=100)),
                           ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label))]

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -41,6 +41,18 @@ def split_lmfdb_iso_label(lab):
 def split_cremona_label(lab):
     return cremona_label_regex.match(lab).groups()
 
+def curve_lmfdb_label(conductor, iso_class, number):
+    return "%s.%s%s" % (conductor, iso_class, number)
+
+def curve_cremona_label(conductor, iso_class, number):
+    return "%s%s%s" % (conductor, iso_class, number)
+
+def class_lmfdb_label(conductor, iso_class):
+    return "%s.%s" % (conductor, iso_class)
+
+def class_cremona_label(conductor, iso_class):
+    return "%s%s" % (conductor, iso_class)
+
 logger = make_logger("ec")
 
 ecdb = None


### PR DESCRIPTION
Classical modular forms provide a function for the construction of the label from weight, level, etc, which should be used everywhere for consistency.  Here we use it in constructing home pages for elliptic curves over Q, and isogeny classes,
In the reverse direction, the second commit adds new label-creating functions for elliptic curves and classes over Q.