### PR TITLE
added search for WebObject without construction of objects, also  spe…

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
@@ -241,6 +241,17 @@ class WebObject(object):
         C = cls.connect_to_db()
         return gridfs.GridFS(C,coll)
 
+    @classmethod
+    def _find_document_in_db_collection(cls,search={},**kwds):
+        r"""
+        Searches the database for fields matching values in a dict containing
+        values for the keys (or using keywords) in self._key without constructing the object. 
+        """
+        coll = cls.connect_to_db(cls._collection_name)
+        search_pattern = { key : search[key] for key in search.keys() if key in cls._key }
+        search_pattern.update(kwds) ## add keywords
+        return coll.find(search_pattern) 
+    
     def __init__(self,
                  use_separate_db = True,
                  use_gridfs = True,


### PR DESCRIPTION
I added search for WebObject without construction of objects, also  special routines for checking if a WebNewForm or WebModFormSpace is in the database without constructing the forms or spaces. 
The utility functions each take a valid newform or space label as input and return True or False if an object (with current emf_version) exists in the database. 
Example:
sage: lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils.is_newform_in_db("200.2.1a")
True
sage: lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils.is_newform_in_db("200.4.1a")
False
sage: lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils.is_modformspace_in_db("200.4.1")
False
sage: lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils.is_modformspace_in_db("200.2.1")
True
sage: