### PR TITLE
More adjustments to degree3 and degree4 L-functions, to make sure links work

### DIFF
--- a/lmfdb/lfunctions/templates/Degree3.html
+++ b/lmfdb/lfunctions/templates/Degree3.html
@@ -64,6 +64,8 @@ text-align: center;
 </style>
 
 
+
+
 <table border=1 cellpadding=5> 
 <tbody>
 <tr align="center">
@@ -81,14 +83,14 @@ text-align: center;
 </tr>
 <tr align="center"><td><a href="/L/ModularForm/GL3/Q/Maass/GL3Maass_1_16.4031_0.17112/">6.42223</a></td><td>$\SL(3,\Z)$ Maass form</td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td></td><td></td><td>0,0,0</td><td>16.40312, 0.17112</td><td>1</td><tr>
 <tr align="center"><td><a href="/L/NumberField/3.1.23.1/">5.11568</a></td><td><a href="/NumberField/3.1.23.1">global number field</a></td><td>23</td><td>$\left(\frac{-23}{\cdot}\right)$</td><td>&#x25CF;</td><td>&#x25CF;</td><td>$0$,0</td><td>0</td><td></td><td></td><td>1</td><tr>
-<tr align="center"><td><a href="/L/SymmetricPower/2/EllipticCurve/Q/11.a/">3.89928</a></td><td>$\Sym^2$ of rank 0 elliptic curve <a href="EllipticCurve/Q/11.a1">11.a1</a></td><td>121</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td>$0$,1</td><td>0</td><td></td><td></td><td>1</td><tr>
+<tr align="center"><td><a href="/L/SymmetricPower/2/EllipticCurve/Q/11.a/">3.89928</a></td><td>$\Sym^2$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11/a/2">11.a2</a></td><td>121</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td>$0$,1</td><td>0</td><td></td><td></td><td>1</td><tr>
 <tr align="center"><td><a href="/L/ArtinRepresentation/3.229.4t5.1c1">3.19363</a></td><td><a href="/ArtinRepresentation/3.229.4t5.1c1">Artin representation</a></td><td>229</td><td>$\left(\frac{229}{\cdot}\right)$</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td></td><td>0,1,1</td><td>0, 0</td><td>1</td><tr>
 <tr align="center"><td><a href="/L/ModularForm/GL3/Q/Maass/GL3Maass_4_8.23979_2.64122/">2.65766</a></td><td>$\GL(3)$ Maass form</td><td>4</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td></td><td></td><td>0,0,0</td><td>8.23979, 2.64122</td><td>1</td><tr>
 <tr align="center"><td><a href="/L/ModularForm/GL3/Q/Maass/GL3Maass_4_9.63244_1.37406/">2.53210</a></td><td>$\GL(3)$ Maass form</td><td>4</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td></td><td></td><td>0,0,0</td><td>9.63244, 1.37406</td><td>$e(1/3)$</td><tr>
 <tr align="center"><td><a href="/L/SymmetricPower/2/EllipticCurve/Q/37.a/">2.15869</a></td><td>$\Sym^2$ of rank 1 elliptic curve <a href="/EllipticCurve/Q/37.a1">37.a1</a></td><td>1369</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td>$0$,1</td><td>0</td><td></td><td></td><td>1</td><tr>
-<tr align="center"><td><a href="/TensorProducts/">1.36848</a></td><td>tensor product of an <a href="/ArtinRepresentation/3.229.4t5.1c1">Artin representation</a> and a <a href="/Character/Dirichlet/5/2">Dirichlet character</a></td><td>28625</td><td>$\chi_{1145}(228,\cdot)$</td><td>&#x25CF;</td><td>&#x25CB;</td><td></td><td></td><td>0,0,1</td><td>0, 0</td><td>$e(0.76431)$</td><tr>
 <tr align="center"><td><a href="/L/SymmetricPower/2/EllipticCurve/Q/389.a/">1.07683</a></td><td>$\Sym^2$ of rank 2 elliptic curve <a href="/EllipticCurve/Q/389.a1">389.a1</a></td><td>151321</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td>$0$,1</td><td>0</td><td></td><td></td><td>1</td><tr>
 <tr align="center"><td><a href="/L/ModularForm/GL3/Q/Maass/GL3Maass_4_8.95466_2.93659/">0.93372</a></td><td>$\GL(3)$ Maass form</td><td>4</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td></td><td></td><td>0,0,0</td><td>8.95466, 2.93659</td><td>$e(2/3)$</td><tr>
 </tbody></table>
 
 {% endblock %}
+

--- a/lmfdb/lfunctions/templates/Degree4.html
+++ b/lmfdb/lfunctions/templates/Degree4.html
@@ -65,7 +65,6 @@ by {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 
 
 
-
 <table border=1 cellpadding=5>
 <tbody>
 <tr align="center">
@@ -79,13 +78,14 @@ by {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 <td align="center">$\Gamma_{\C}$ parameters</td>
 <th align="center">{{ KNOWL('lfunction.sign', title='$\\varepsilon$') }}</th>
 </tr>
-<tr align="center"><td><a href="/L/SymmetricPower/3/EllipticCurve/Q/11.a.1/">2.32002</a></td><td>$\Sym^3$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11.a.1">11.a.1</a> </td><td>1331</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac32$, $\frac12$</td><td>1</td><tr>
-<tr align="center"><td><a href="/L/Genus2Curve/Q/169/a/">5.06823</a></td><td><a href="/Genus2Curve/Q/169/a/">genus 2 curve</a></td><td>169</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac12$, $\frac12$</td><td>1</td><tr>
-<tr align="center"><td><a href="/L/ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/">16.18901</a></td><td><a href="/ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/">$\SL(4,\Z)$ Maass form</a></td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td>$16.89i$, $2.272i$, $-6.035i$, $-13.13i$</td><td></td><td>1</td><tr>
-<tr align="center"><td><a href="/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/">3.67899</a></td><td><a href="/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/">Hilbert modular form over $\mathbb Q(\sqrt{5})$</a></td><td>775</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac12$, $\frac12$</td><td>1</td><tr>
-<tr align="center"><td><a href="/L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/">14.49606</a></td><td><a href="/ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/">$\Sp(4,\Z)$ Maass form</a></td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CF;</td><td>$4.720i$, $-4.720i$, $12.46i$, $-12.46i$</td><td></td><td>1</td><tr>
+<tr align="center"><td><a href="/L/SymmetricPower/3/EllipticCurve/Q/11.a/">2.32002</a></td><td>$\Sym^3$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11/a/2">11.a2</a> </td><td>1331</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac32$, $\frac12$</td><td>1</td><tr>
+<tr align="center"><td><a href="/L/Genus2Curve/Q/169/a/">5.06823</a></td><td><a href="/Genus2Curve/Q/169/a/169/1">genus 2 curve</a></td><td>169</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac12$, $\frac12$</td><td>1</td><tr>
+<tr align="center"><td><a href="/L/ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/">16.18901</a></td><td>$\SL(4,\Z)$ Maass form</td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CB;</td><td>$16.89i$, $2.272i$, $-6.035i$, $-13.13i$</td><td></td><td>1</td><tr>
+<tr align="center"><td><a href="/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/">3.67899</a></td><td><a href="/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a">Hilbert modular form over $\mathbb Q(\sqrt{5})$</a></td><td>775</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac12$, $\frac12$</td><td>1</td><tr>
+<tr align="center"><td><a href="/L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/">14.49606</a></td><td>$\Sp(4,\Z)$ Maass form</td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CF;</td><td>$4.720i$, $-4.720i$, $12.46i$, $-12.46i$</td><td></td><td>1</td><tr>
 <tr align="center"><td><a href="/L/ArtinRepresentation/4.1609.5t5.1c1">3.50464</a></td><td><a href="/ArtinRepresentation/4.1609.5t5.1c1">Artin representation</a></td><td>1609</td><td>$\left(\frac{1609}{\cdot}\right)$</td><td>&#x25CF;</td><td>&#x25CF;</td><td>0, 0, 1, 1</td><td></td><td>1</td><tr>
-<tr align="center"><td><a href="/L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/">2.48044</a></td><td><a href="/ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/">Sp(4,$\mathbb Z$) Maass</a></td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CF;</td><td>$19.81i$, $-19.81i$, $8.531i$, $-8.531i$</td><td></td><td>1</td><tr>
+<tr align="center"><td><a href="/L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/">2.48044</a></td><td>Sp(4,$\mathbb Z$) Maass form</td><td>1</td><td>triv</td><td>&#x25CB;</td><td>&#x25CF;</td><td>$19.81i$, $-19.81i$, $8.531i$, $-8.531i$</td><td></td><td>1</td><tr>
+<tr align="center"><td><a href="/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-199.1-c/0/0/">3.10180</a></td><td><a href="/EllipticCurve/2.2.5.1/199.1/c/1">Elliptic curve over $\Q(\sqrt{5})$</a></td><td>4975</td><td>triv</td><td>&#x25CF;</td><td>&#x25CF;</td><td></td><td>$\frac12$, $\frac12$</td><td>-1</td><tr>
 </tbody></table>
 
 {% endblock %}

--- a/lmfdb/lfunctions/templates/degree3browsetable.yaml
+++ b/lmfdb/lfunctions/templates/degree3browsetable.yaml
@@ -39,7 +39,7 @@ analytic_conductor: 0.010101010101
 epsilon: 1
 url: L/SymmetricPower/2/EllipticCurve/Q/11.a/
 object_url:
-object_name: $\Sym^2$ of rank 0 elliptic curve <a href="EllipticCurve/Q/11.a1">11.a1</a>
+object_name: $\Sym^2$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11/a/2">11.a2</a>
 self_dual: true
 arithmetic: true
 ---
@@ -100,19 +100,6 @@ object_name: $\Sym^2$ of rank 1 elliptic curve <a href="/EllipticCurve/Q/37.a1">
 self_dual: true
 arithmetic: true
 ---
-first_zero: 1.36848157011749
-Lfunction_texname: $L(s,\rho)$
-muRRR: [0,0]
-deltaRRR: [0,0,1]
-level: 28625
-character: $\chi_{1145}(228,\cdot)$
-analytic_conductor:
-epsilon: e(0.76431)
-url: TensorProducts/
-object_name: tensor product of an <a href="/ArtinRepresentation/3.229.4t5.1c1">Artin representation</a> and a <a href="/Character/Dirichlet/5/2">Dirichlet character</a>
-self_dual: false
-arithmetic: true
----
 first_zero: 1.07683314174049
 Lfunction_texname: $L(s,E_{389.a},\sym^2)$
 nuRC: 1
@@ -141,4 +128,20 @@ object_url:
 object_name: $\GL(3)$ Maass form
 self_dual: false
 arithmetic: false
+---
+
+XXXXXXXXXX
+
+first_zero: 1.36848157011749
+Lfunction_texname: $L(s,\rho)$
+muRRR: [0,0]
+deltaRRR: [0,0,1]
+level: 28625
+character: $\chi_{1145}(228,\cdot)$
+analytic_conductor:
+epsilon: e(0.76431)
+url: TensorProducts/
+object_name: tensor product of an <a href="/ArtinRepresentation/3.229.4t5.1c1">Artin representation</a> and a <a href="/Character/Dirichlet/5/2">Dirichlet character</a>
+self_dual: false
+arithmetic: true
 ---

--- a/lmfdb/lfunctions/templates/degree4browsetable.yaml
+++ b/lmfdb/lfunctions/templates/degree4browsetable.yaml
@@ -6,9 +6,9 @@ level: 1331
 character: 1.1
 analytic_conductor: 3.010101010101
 epsilon: 1
-url: L/SymmetricPower/3/EllipticCurve/Q/11.a.1/
+url: L/SymmetricPower/3/EllipticCurve/Q/11.a/
 object_url:
-object_name: $\Sym^3$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11.a.1">11.a.1</a> 
+object_name: $\Sym^3$ of rank 0 elliptic curve <a href="/EllipticCurve/Q/11/a/2">11.a2</a> 
 self_dual: true
 arithmetic: true
 ---
@@ -19,7 +19,7 @@ level: 169
 character: 1.1
 epsilon: 1
 url: L/Genus2Curve/Q/169/a/
-object_url: Genus2Curve/Q/169/a/
+object_url: Genus2Curve/Q/169/a/169/1
 object_name: genus 2 curve
 self_dual: true
 arithmetic: true
@@ -32,7 +32,8 @@ character: 1.1
 analytic_conductor:
 epsilon: 1
 url: L/ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/
-object_url: ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/
+comment_object_url: ModularForm/GL4/Q/Maass/GL4Maass_1_16.8997_2.27258_-6.0358/
+object_url:
 object_name: $\SL(4,\Z)$ Maass form
 self_dual: false
 arithmetic: false
@@ -45,7 +46,7 @@ character: 1.1
 analytic_conductor: 0.010101010101
 epsilon: 1
 url: L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/
-object_url: ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/
+object_url: ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a
 object_name: Hilbert modular form over $\mathbb Q(\sqrt{5})$
 self_dual: true
 arithmetic: true
@@ -57,7 +58,8 @@ level: 1
 character: 1.1
 epsilon: 1
 url: L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/
-object_url: ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/
+object_url:
+object_url_comment: ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/
 object_name: $\Sp(4,\Z)$ Maass form
 self_dual: true
 arithmetic: false
@@ -83,10 +85,24 @@ character: 1.1
 analytic_conductor:
 epsilon: 1
 url: L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/
-object_url: ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/
-object_name: Sp(4,$\mathbb Z$) Maass
+object_url:
+object_url_comment: ModularForm/GSp4/Q/Maass/GSp4Maass_1_19.8193_8.53107/
+object_name: Sp(4,$\mathbb Z$) Maass form
 self_dual: true
 arithmetic: false
+---
+first_zero: 3.10180507133562
+Lfunction_texname: $L(s,E)$
+gammaC: [$\frac12$, $\frac12$]
+level: 4975
+character: 1.1
+analytic_conductor:
+epsilon: -1
+url: L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-199.1-c/0/0/
+object_url: EllipticCurve/2.2.5.1/199.1/c/1
+object_name: Elliptic curve over $\Q(\sqrt{5})$
+self_dual: true
+arithmetic: true
 ---
 
 ********************************************

--- a/lmfdb/lfunctions/templates/yamltotable3.pl
+++ b/lmfdb/lfunctions/templates/yamltotable3.pl
@@ -91,6 +91,7 @@ $rowvals{$key}=$val;
 }
 
 print OUTFILE "</tbody></table>\n";
+print OUTFILE "\n{% endblock %}\n\n";
   
 ##############
 

--- a/lmfdb/lfunctions/templates/yamltotable4.pl
+++ b/lmfdb/lfunctions/templates/yamltotable4.pl
@@ -94,6 +94,7 @@ $rowvals{$key}=$val;
 }
 
 print OUTFILE "</tbody></table>\n";
+print OUTFILE "\n{% endblock %}\n";
 
 ##############
 


### PR DESCRIPTION
Some links did not work on the degree 3 and degree 4 L-function pages.  On degree 4, the actual Mass forms, some elliptic curve links, and on degree 3, the tensor product.  This fixes or removes links as needed.  It also adds an elliptic curve over a quadratic field to the degree 4 page.