### PR TITLE
added download of Sage/Magma/GP code for elliptic curves/Q

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -121,5 +121,5 @@ galrep:
 
 padicreg:
   sage: |
-    [E.padic_regulator(p) for p in primes(3,20)]
+    [E.padic_regulator(p) for p in primes(3,20) if E.conductor().valuation(p)<2]
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -631,3 +631,47 @@ def labels_page():
     return render_template("single.html", kid='ec.q.lmfdb_label',
                            credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
 
+@ec_page.route('/<conductor>/<iso>/<number>/download/<download_type>')
+def ec_code_download(**args):
+    response = make_response(ec_code(**args))
+    response.headers['Content-type'] = 'text/plain'
+    return response
+
+sorted_code_names = ['curve', 'tors', 'intpts', 'cond', 'disc', 'jinv', 'rank', 'reg', 'real_period', 'cp', 'ntors', 'sha', 'qexp', 'moddeg', 'L1', 'localdata', 'galrep', 'padicreg']
+
+code_names = {'curve': 'Define the curve',
+                 'tors': 'Torsion subgroup',
+                 'intpts': 'Integral points',
+                 'cond': 'Conductor',
+                 'disc': 'Discriminant',
+                 'jinv': 'j-invariant',
+                 'rank': 'Rank',
+                 'reg': 'Regulator',
+                 'real_period': 'Real Period',
+                 'cp': 'Tamagawa numbers',
+                 'ntors': 'Torsion order',
+                 'sha': 'Order of Sha',
+                 'qexp': 'q-expansion of modular form',
+                 'moddeg': 'Modular degree',
+                 'L1': 'Special L-value',
+                 'localdata': 'Local data',
+                 'galrep': 'mod p Galois image',
+                 'padicreg': 'p-adic regulator'}
+
+Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP'}
+Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\'}
+
+def ec_code(**args):
+    print("args has keys %s" %  to_dict(args).keys())
+    label = curve_lmfdb_label(args['conductor'], args['iso'], args['number'])
+    E = WebEC.by_label(label)
+    lang = args['download_type']
+    code = "%s %s code for working with elliptic curve %s\n\n" % (Comment[lang],Fullname[lang],label)
+    if lang=='gp':
+        lang = 'pari'
+    for k in sorted_code_names:
+        if lang in E.code[k]:
+            code += "\n%s %s: \n" % (Comment[lang],code_names[k])
+            for line in E.code[k][lang]:
+                code += line + "\n"
+    return code

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -340,7 +340,11 @@ class WebEC(object):
             ('Modular form ' + newform_label(cond,2,1,iso), url_for("emf.render_elliptic_modular_forms", level=int(N), weight=2, character=1, label=iso))]
 
         self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=100)),
-                          ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label))]
+                          ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label)),
+                          ('Download Magma code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
+                          ('Download Sage code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
+                          ('Download GP code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp'))
+        ]
 
         self.plot = encode_plot(self.E.plot())
         self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot


### PR DESCRIPTION
Any elliptic curve (over Q) page, e.g. EllipticCurve/Q/12349/a/1 now has 3 lines added on the right side under Downloads, for downloading all the relevant code snippets (the same ones you see when clicking on "Show commands for...") in a single file with comments.  The file is displayed in the browser  for ease of cut-and-paste or saving the file.