### PR TITLE
Make class group factors be increasing

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -452,7 +452,7 @@ def number_field_search(**args):
         parse_bracketed_posints(info,query,'signature',split=False,exactlength=2)
         parse_signed_ints(info,query,'discriminant',qfield=('disc_sign','disc_abs_key'),parse_one=make_disc_key)
         parse_ints(info,query,'class_number')
-        parse_bracketed_posints(info,query,'class_group',split=False,check_divisibility='decreasing')
+        parse_bracketed_posints(info,query,'class_group',split=False,check_divisibility='increasing')
         parse_primes(info,query,'ur_primes',name='Unramified primes',qfield='ramps',mode='complement',to_string=True)
         if 'ram_quantifier' in info and str(info['ram_quantifier']) == 'some':
             mode = 'append'

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -101,8 +101,8 @@ Enter values into one or more boxes to restrict the search.
 <span class="formexample"> e.g. 5</span></td>
 <td>
 <td align=left>{{KNOWL('nf.ideal_class_group', title = 'class group')}} structure
-  <td><input type='text' name='class_group' size=10 example='[2,2]'>
-<span class="formexample"> e.g. [ ], [3], or [2,2]</span></td>
+  <td><input type='text' name='class_group' size=10 example='[2,4]'>
+<span class="formexample"> e.g. [ ], [3], or [2,4]</span></td>
 </tr>
 <tr>
 <td align="left" colspan="4">Maximum number of fields to display <input type='text' name='count' value="{{info.count}}" size="6" />


### PR DESCRIPTION
It was observed that class groups of number fields, and torsion subgroups of elliptic curves are described in different ways, even though they are both finite abelian groups.  One had the sizes of the cyclic factors weakly increasing, and the other was weakly decreasing.  This changes number fields so that their class groups follow the convention of elliptic curves.

To test, search for global number fields with class group [2,4] (now works), but [4,2] will now give an error.