### PR TITLE
Search by label HMF

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -104,7 +104,7 @@ def hilbert_modular_form_by_label(lab):
         flash(Markup("No Hilbert modular form in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
         return redirect(url_for(".hilbert_modular_form_render_webpage"))
     else:
-        return redirect(url_for(".render_hmf_webpage", field_label=split_full_label(lab)[0], label=lab, data=res))
+        return redirect(url_for(".render_hmf_webpage", field_label=split_full_label(lab)[0], label=lab))
 
 
 def hilbert_modular_form_search(**args):


### PR DESCRIPTION
On beta if you search by label "2.2.5.1-76.1-a", it returns a messy URL and says Bad Request Request Line is too large (7817 > 4094) (noticed by John Voight).

This pull request goes back to the inefficient way and solve the issue.

