### PR TITLE
Error message positive integers

### DIFF
--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -199,7 +199,7 @@ def parse_ints(inp, query, qfield, parse_singleton=int):
     if LIST_RE.match(inp):
         collapse_ors(parse_range2(inp, qfield, parse_singleton), query)
     else:
-        raise ValueError("It needs to be an integer (such as 25), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
+        raise ValueError("It needs to be a positive integer (such as 25), a range of positive integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
 
 @search_parser(clean_info=True, prep_ranges=True) # see SearchParser.__call__ for actual arguments when calling
 def parse_signed_ints(inp, query, qfield, parse_one=None):


### PR DESCRIPTION
fixed error message: now it says positive integer instead of integer (for integers there is a parsing function parse_signed_ints)

now:
http://beta.lmfdb.org/EllipticCurve/Q/?start=&conductor=-2&jinv=&rank=&torsion=&torsion_structure=[2%2C3%2C5]&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100

with this pull:
http://localhost:37777/EllipticCurve/Q/?start=&conductor=-2&jinv=&rank=&torsion=&torsion_structure=[2%2C3%2C5]&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100