### PR TITLE
Improve number field download

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -483,12 +483,12 @@ def number_field_search(**args):
 
     fields = C.numberfields.fields
 
-    res = fields.find(
-        query).sort([('degree', ASC), ('disc_abs_key', ASC), ('disc_sign', ASC), ('label', ASC)])
+    res = fields.find(query)
 
     if 'download' in info and info['download'] != '0':
         return download_search(info, res)
 
+    res = res.sort([('degree', ASC), ('disc_abs_key', ASC), ('disc_sign', ASC), ('label', ASC)])
     nres = res.count()
     res = res.skip(start).limit(count)
 
@@ -602,9 +602,9 @@ def download_search(info, res):
     else:
         s += 'data = ['
     s += '\\\n'
+    cntr = 0
     for f in res:
         wnf = WebNumberField.from_data(f)
-        cgi = wnf.class_group_invariants()
         entry = ', '.join(
             [str(wnf.poly()), str(wnf.disc()), str(wnf.galois_t()), str(wnf.class_group_invariants_raw())])
         s += '[' + entry + ']' + ',\\\n'

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -602,7 +602,6 @@ def download_search(info, res):
     else:
         s += 'data = ['
     s += '\\\n'
-    cntr = 0
     for f in res:
         wnf = WebNumberField.from_data(f)
         entry = ', '.join(


### PR DESCRIPTION
Before, a giant number field download would crash lmfdb.  Now, it takes a long time (if you ask for 10000 or more fields), but that part is unavoidable, and at least it doesn't crash.