### PR TITLE
rename BZGZ curve the Gauss elliptic curve on homepage Hall of Fame

### DIFF
--- a/lmfdb/index_boxes.yaml
+++ b/lmfdb/index_boxes.yaml
@@ -10,7 +10,7 @@ title: Hall of Fame
 content: <p><ul class="list"><li><a href="/L/Riemann/">Riemann zeta function</a></li>
     <li><a href="/ModularForm/GL2/Q/holomorphic/1/12/1/a/">Ramanujan \(\Delta\) function</a> and <a href="/L/ModularForm/GL2/Q/holomorphic/1/12/1/a/0/">its L-function </a></li>
     <li><a href="/Genus2Curve/Q/277/a/277/1">C277</a> and <a href="/L/Genus2Curve/Q/277/a/">its L-function</a></li>
-    <li><a href="/EllipticCurve/Q/5077/a/1">BGZG curve</a> and <a href="/L/EllipticCurve/Q/5077.a/">its L-function </a></li>
+    <li><a href="/EllipticCurve/Q/5077/a/1">Gauss elliptic curve</a> and <a href="/L/EllipticCurve/Q/5077.a/">its L-function </a></li>
     <li><a href="/L/ModularForm/GSp4/Q/Maass/GSp4Maass_1_12.4687_4.72095/#footer">Grand Canyon L-function</a></li>
     </ul></p>
 image: plot


### PR DESCRIPTION
Change "BZGZ curve" to "Gauss elliptic curve" on home page (Hall of Fame section).  The relevant hisotirical knowl has already been edited to mention the Gauss connection.