### PR TITLE
general code cleanup, added statistics, fixed twists

### DIFF
--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -6,25 +6,23 @@ from pymongo import ASCENDING, DESCENDING
 from flask import url_for, make_response
 import lmfdb.base
 from lmfdb.base import getDBConnection
-from lmfdb.utils import comma, make_logger, web_latex, encode_plot
+from lmfdb.utils import comma, web_latex, encode_plot
 from lmfdb.genus2_curves.web_g2c import g2c_page, g2c_logger, list_to_min_eqn, end_alg_name, st_group_name, st0_group_name
 from lmfdb.genus2_curves.web_g2c import gl2_statement_base, factorsRR_raw_to_pretty, fod_statement, intlist_to_poly
 from sage.all import QQ, PolynomialRing, factor,ZZ, NumberField, expand, var
 from lmfdb.WebNumberField import field_pretty
 
-logger = make_logger("g2c")
-
 ###############################################################################
 # Database connection
 ###############################################################################
 
-g2cdb = None
+the_g2cdb = None
 
-def db_g2c():
-    global g2cdb
-    if g2cdb is None:
-        g2cdb = getDBConnection().genus2_curves
-    return g2cdb
+def g2cdb():
+    global the_g2cdb
+    if the_g2cdb is None:
+        the_g2cdb = lmfdb.base.getDBConnection().genus2_curves
+    return the_g2cdb
 
 ###############################################################################
 # Pretty print functions
@@ -188,7 +186,6 @@ class G2Cisog_class(object):
 
             - dbdata: the data from the database
         """
-        logger.debug("Constructing an instance of G2Cisog_class")
         self.__dict__.update(dbdata)
         self.make_class()
 
@@ -199,12 +196,12 @@ class G2Cisog_class(object):
         curves collection by its label.
         """
         try:
-            data = db_g2c().isogeny_classes.find_one({"label" : label})
+            data = g2cdb().isogeny_classes.find_one({"label" : label})
         except AttributeError:
             return "Invalid label" # caller must catch this and raise an error
         if data:
             return G2Cisog_class(data)
-        return "Class not found" # caller must catch this and raise an error
+        return "No genus 2 isogeny class data found for label" # caller must catch this and raise an error
 
     ###########################################################################
     # Main data creation for individual isogeny classes
@@ -212,7 +209,7 @@ class G2Cisog_class(object):
 
     def make_class(self):
         # Data
-        curves_data = db_g2c().curves.find({"class" :
+        curves_data = g2cdb().curves.find({"class" :
             self.label}).sort([("disc_key", pymongo.ASCENDING),
                                ("label", pymongo.ASCENDING)])
         self.curves = [ {"label" : c['label'], "equation_formatted" :
@@ -234,8 +231,8 @@ class G2Cisog_class(object):
             self.is_gl2_type_name = 'no'
 
         # Endomorphism data
-        curve = db_g2c().curves.find_one({"class" : self.label})
-        endodata = db_g2c().endomorphisms.find_one({"label" :
+        curve = g2cdb().curves.find_one({"class" : self.label})
+        endodata = g2cdb().endomorphisms.find_one({"label" :
             curve['label']})
         self.gl2_statement_base = \
             gl2_statement_base(endodata['factorsRR_base'], r'\(\Q\)')

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -2,7 +2,9 @@
 {% block content %}
 
 <p>
-The database currently contains {{info.count}} genus 2 curves over $\Q$ of absolute discriminant up to 10<sup>6</sup>.
+The database currently contains {{info["counts"]["ncurves_c"]}} <a title="Genus 2 curves [g2c.g2curve]" knowl="g2c.g2curve" kwargs="">genus 2 curves</a> over $\Q$
+of <a title="Genus 2 curves [g2c.abs_discriminant]" knowl="g2c.abs_discriminant" kwargs="">absolute discriminant</a> up to {{info["counts"]["max_D_c"]}}.
+Here are some <a href={{info["stats_url"]}}>further statistics</a>.
 </p>
 
 <h2> Browse {{ KNOWL('g2c.g2curve', title='genus 2 curves over $\Q$') }} </h2>
@@ -38,10 +40,8 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 
 
 <h2> Search </h2>
-
 <form>
 <table>
-<tr>Please enter a value or leave blank:</tr>
 <tr>
 <td>{{ KNOWL('ag.conductor', title='conductor') }}</td>
 <td><input type='text' name='cond' placeholder='169' size=10>
@@ -82,7 +82,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td><input type='text' name='torsion_order' placeholder='2' size=10>
 <td><span class="formexample"> e.g. 2 </span></td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\Q\)-automorphism group') }}</td>
-<td><select name='aut_grp' width="122" style="width: 122px">
+<td><select name='aut_grp_id' width="122" style="width: 122px">
         <option ></option>
     {% for G in info.aut_grp_list %}
         <option value='{{G}}'>{{info.aut_grp_dict[G]}}</option>
@@ -94,7 +94,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td><input type='text' name='torsion' placeholder='[2,2,2]' size=10>
 <td><span class="formexample"> e.g. [2,2,2] </span></td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\overline{\Q}\)-automorphism group') }}</td>
-<td><select name='geom_aut_grp' width="122" style="width: 122px">
+<td><select name='geom_aut_grp_id' width="122" style="width: 122px">
         <option ></option>
     {% for G in info.geom_aut_grp_list %}
         <option value='{{G}}'>{{info.geom_aut_grp_dict[G]}}</option>
@@ -127,6 +127,8 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td>Maximum number of curves to display</td>
 <td><input type='text' name='count' value=50 size=10></td>
 <td><span class="formexample"> &nbsp;</td>
+</tr>
+<tr>
 <td><button type='submit' value='Search'>Search</button></td>
 </tr>
 </table>

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -52,7 +52,7 @@ text-align: center;
 {% if info.real_geom_end_alg == 'R'%}
 \(\mathrm{ST} = {{ info.st_group_name }}\)
 {% else %}
-\(\mathrm{ST} = {{ info.st_group_name }}, \quad \mathrm{ST}_0 = {{ info.st0_group_name}}\)
+\(\mathrm{ST} = {{ info.st_group_name }}, \quad \mathrm{ST}^0 = {{ info.st0_group_name}}\)
 {% endif %}
 </p>
 

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -18,13 +18,13 @@
 </tr>
 
 <tr>
-<td><input type='text' name='cond' placeholder='169' style="width: 98px" value="{{info.cond}}"></td>
-<td><input type='text' name='abs_disc' placeholder='169' style="width: 98px" value="{{info.abs_disc}}"></td>
-<td><input type='text' name='num_rat_wpts' placeholder='1'  style="width: 98px" value="{{info.num_rat_wpts}}">
-<td><input type='text' name='torsion' placeholder='[2,2,2]'  style="width: 98px" value="{{info.torsion}}">
-<td><input type='text' name='torsion_order' placeholder='2'  style="width: 98px" value="{{info.torsion_order}}">
-<td><input type='text' name='two_selmer_rank' placeholder='1'  style="width: 98px" value="{{info.two_selmer_rank}}">
-<td><input type='text' name='analytic_rank' placeholder='1'  style="width: 98px" value="{{info.analytic_rank}}">
+<td><input type='text' name='cond' placeholder='169' style="width: 100px" value="{{info.cond}}"></td>
+<td><input type='text' name='abs_disc' placeholder='169' style="width: 100px" value="{{info.abs_disc}}"></td>
+<td><input type='text' name='num_rat_wpts' placeholder='1'  style="width: 100px" value="{{info.num_rat_wpts}}">
+<td><input type='text' name='torsion' placeholder='[2,2,2]'  style="width: 100px" value="{{info.torsion}}">
+<td><input type='text' name='torsion_order' placeholder='2'  style="width: 100px" value="{{info.torsion_order}}">
+<td><input type='text' name='two_selmer_rank' placeholder='1'  style="width: 100px" value="{{info.two_selmer_rank}}">
+<td><input type='text' name='analytic_rank' placeholder='1'  style="width: 100px" value="{{info.analytic_rank}}">
 </tr>
 
 <tr>
@@ -38,7 +38,7 @@
 </tr>
 
 <tr>
-<td><select name='is_gl2_type' style="width: 108px">
+<td><select name='is_gl2_type' style="width: 110px">
   <option ></option>
 {% if info.is_gl2_type=='True' %}
   <option value="True" selected>True</option>
@@ -52,7 +52,7 @@
 {% endif %}
 </select></td>
 
-<td><select name='st_group' style="width: 108px" >
+<td><select name='st_group' style="width: 110px" >
     <option ></option>
     {% for G in info.st_group_list %}
         {% if  G == info.st_group %}
@@ -63,7 +63,7 @@
     {% endfor %}
 </select></td>
 
-<td><select name='real_geom_end_alg' style="width: 108px">
+<td><select name='real_geom_end_alg' style="width: 110px">
     <option ></option>
     {% for G in info.real_geom_end_alg_list %}
         {% if G == info.real_geom_end_alg %}
@@ -74,10 +74,10 @@
     {% endfor %}
 </select></td>
 
-<td><select name='aut_grp' style="width: 108px">
+<td><select name='aut_grp_id' style="width: 110px">
     <option ></option>
     {% for G in info.aut_grp_list %}
-        {% if G == info.aut_grp %}
+        {% if G == info.aut_grp_id %}
             <option value='{{G}}' selected>{{info.aut_grp_dict[G]}}</option>
         {% else %}
             <option value='{{G}}'>{{info.aut_grp_dict[G]}}</option>
@@ -85,10 +85,10 @@
     {% endfor %}
 </select></td>
 
-<td><select name='geom_aut_grp' style="width: 108px">
+<td><select name='geom_aut_grp_id' style="width: 110px">
     <option ></option>
     {% for G in info.geom_aut_grp_list %}
-        {% if G == info.geom_aut_grp %}
+        {% if G == info.geom_aut_grp_id %}
             <option value='{{G}}' selected>{{info.geom_aut_grp_dict[G]}}</option>
         {% else %}
             <option value='{{G}}'>{{info.geom_aut_grp_dict[G]}}</option>
@@ -96,7 +96,7 @@
     {% endfor %}
 </select></td>
 
-<td><select name='locally_solvable' style="width: 108px">
+<td><select name='locally_solvable' style="width: 110px">
   <option ></option>
 {% if info.locally_solvable=='True' %}
   <option value="True" selected>True</option>
@@ -110,7 +110,7 @@
 {% endif %}
 </select></td>
 
-<td><select name='has_square_sha' style="width: 108px">
+<td><select name='has_square_sha' style="width: 110px">
   <option ></option>
 {% if info.has_square_sha=='True' %}
   <option value="True" selected>True</option>
@@ -128,7 +128,7 @@
 <td>&nbsp;</td>
 </tr>
 <tr>
-<td><button type='submit' value='refine'  style="width: 108px">Search again</button></td>
+<td><button type='submit' value='refine'  style="width: 110px">Search again</button></td>
 </tr>
 
 </table>
@@ -184,12 +184,5 @@ Download all search results for
 </form>
 
 {% endif %}
-
-<!--
-    <br>
-    <p class="tex2jax_ignore">
-    Results for database query {{ info.query }}
-    </p>
--->
 
 {% endblock %}

--- a/lmfdb/genus2_curves/templates/statistics_g2.html
+++ b/lmfdb/genus2_curves/templates/statistics_g2.html
@@ -1,0 +1,42 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<div>
+The database currently contains {{info.counts.ncurves_c}} genus 2 curves in {{info.counts.nclasses_c}} isogeny classes,
+with {{ KNOWL('g2c.abs_discriminant',title = "absolute discriminant")}} at most {{info.counts.max_D_c}}.
+</div>
+
+{% for d in info.stats.distributions %}
+<h2> Distribution of {{KNOWL(d.attribute['knowl'], title = d.attribute['top_title'])}} </h2>
+<div>
+<table border=1>
+{% for r in d["rows"] %}
+<tr>
+<th>{{d.attribute['row_title']}}</th>
+{% for c in r %}
+<td>\({{c.value}}\)</td>
+{% endfor %}
+</tr>
+<tr>
+<th>number of curves</th>
+{% for c in r %}
+<td><a href='{{c.query}}'>{{c.curves}}</a></td>
+{% endfor %}
+</tr>
+<tr>
+<th>proportion</th>
+{% for c in r %}
+<td>{{c.proportion}}%</td>
+{% endfor %}
+</tr>
+{%endfor %}
+
+</table>
+</div>
+{% endfor %}
+
+<p>
+</p>
+
+{% endblock %}
+</html>


### PR DESCRIPTION
Final cleanup from the Bristol LMFDB workshop of March 2016 -- cleared out some unused code and fixed some inconsistencies and duplication in the code resulting from historical cutting and pasting (so lots of changes, but very few make any functional difference).  Added statistics page, fixed a bug in searching for twists that was introduced when the new parsing validation was added in the first week of the Bristol workshop, and fixed direct searching for isogeny class labels (which was also broken when the new parsing validation was introduced).

I've done a fair amount of testing and am unable to find any obvious bugs.  Once this pull request is merged I can get others to help with further testing in preparation for LMFDB 1.0.