### PR TITLE
created browse and search functionality on index page for Higher Genus curves

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/__init__.py
+++ b/lmfdb/higher_genus_w_automorphisms/__init__.py
@@ -3,7 +3,9 @@ from lmfdb.base import app
 from lmfdb.utils import make_logger
 from flask import Blueprint
 
-higher_genus_w_automorphisms_page = Blueprint("higher_genus_w_automorphisms", __name__, template_folder='templates', static_folder="static")
+higher_genus_w_automorphisms_page = Blueprint("higher_genus_w_automorphisms",
+                                       __name__, template_folder='templates',
+                                       static_folder="static")
 logger = make_logger(higher_genus_w_automorphisms_page)
 
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -18,16 +18,22 @@ text-align:right;
 
       <h2>Browse {{KNOWL('g2c.aut_grp', title="automorphisms")}} of higher genus curves</h2>
 
-        TO DO List by genus
+       <p>
+By genus:
+{% for gen in info.genus_list %}
+<a href="?genus={{gen}}">{{gen}}</a>
+{% endfor %}
+</p>
 
 
-    <h2>Find specific automorphisms of  higher genus curve</h2>
+
+    <h2>Find specific automorphisms of higher genus curve</h2>
 
     <form name="search" method = "get" action="{{search}}">
         <table class="">
 	  <tr>
 	    <td>
-	  Search by {{KNOWL('lf.field.label',title="label")}}
+	  Search by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}
           <input type="text" name="jump_to" value=""
         placeholder="2.6T3.0.2-2-2-3">
 	    </td>
@@ -48,40 +54,37 @@ text-align:right;
         <table class="">
           <tr align=left>
             <td align=right>
-            genus:
-            </td><td><input type="integer" name="g" value=""
+            Genus:
+            </td><td><input type="integer" name="genus" value=""
       placeholder="3"></td>
       <td>
 	<span class="formexample">e.g. 4, or a range like 3..5</span>
       </td>
           </tr>
+
           <tr>
             <td align=right>
-              {{KNOWL('curve.highergenus.aut.signature',title='signature')}}:
-            </td><td><input type="list" name="sign" value="" placeholder="[0,2,3,3,6]"></td>
+	      Group:
+            </td><td><input type="text" name="trangplabel" value="" placeholder="6T1"></td>
+      <td>
+	<span class="formexample">e.g. 2T1</span>
+      </td>
+          </tr>
+	  <tr>
+            <td align=right>
+              {{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
+            </td><td><input type="list" name="signature" value="" placeholder="[0,2,3,3,6]"></td>
       <td>
 	<span class="formexample">e.g. [0,2,3,3,6].</span>
-      </td>
-          </tr>
-          <tr>
-            <td align=right>
-              <!-- {{KNOWL('lf.ramification_index',title='Group')}} :-->
-	      Group:
-            </td><td><input type="list" name="group" value="" placeholder="[6,2]"></td>
-      <td>
-	<span class="formexample">e.g. [2,1], or [4,2]</span>
-      </td>
-          </tr>
+      </td> </tr>
           <tr>
           <td align=right>
               Maximum number of fields to display:
-            </td><td><input type="text" name="count" value="{{info.count}}" size="10"></td>
+            </td><td><input type="text" name="count" value="20" size="10"></td>
           </tr>
   </table>
         <button type="submit" name="Submit" value="Search">Search</button>
       </form>
-
-
-
+   
 
 {% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -9,15 +9,15 @@
 
 <tr>
 <td align=left> 
-{{KNOWL('lf.degree',title='genus')}}:</td><td align=left> <input type='text' name='n' size=3 value="{{info.g}}">
+Genus:</td><td align=left> <input type='text' name='genus' size=3 value="">
 </td>
 <td align=left> 
-{{KNOWL('lf.discriminant_exponent',title='signature')}}:
-<td align=left> <input type="text" name="c" size="3" value="{{info.sign}}" >
+Group: <td align=left> <input type="text" name="trangplabel" size="8" value="" > 
 
 <td align=left> 
-{{KNOWL('nf.galois_group',title='group')}}:
-<td align=left> <input type="text" name="gal" size="8" value="{{info.group}}" > 
+{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
+<td align=left> <input type="text" name="signature" size="15" value="" >
+
 
 </tr>
 
@@ -68,11 +68,12 @@
 <thead>
 <tr>
 
-  <th>label</th>
-  <th>genus</th>
-  <th>dimension</th>
-  <th>{{KNOWL('curve.highergenus.aut.groupnotation',title='group')}}</th>
-  <th>signature</th>
+  <th>Label</th>
+  <th>Genus</th>
+  <th>Dimension</th>
+  <th>Group</th>
+  <th>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma group')}}</th>
+  <th>Signature</th>
 <!--<th>{{KNOWL('lf.slope_content',title='label')}}</th>-->
 </tr>
 </thead>
@@ -84,8 +85,9 @@
   <td align='left'><a href="/HigherGenus/C/aut/{{field.label}}">{{field.label}}</a></td>
     <td>{{field.genus}}</td>
   <td>{{field.r}}</td>
+  <td>{{info.group_display(field.trangplabel)}}</td>
   <td>{{field.group}}</td>
-    <td>{{field.signature}}</td>
+    <td>${{info.sign_display(field.signature)}}$</td>
 
 
 </tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-curve.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-curve.html
@@ -35,7 +35,7 @@ table,td {
 </p>
 
 {% if info.fullauto  %}
-The full automorphism group for this family is ${{info.fullauto}}$ with signature {{info.signH}}.
+The full automorphism group for this family is ${{info.fullauto}}$ with signature ${{info.signH}}$.
     {% endif %}
 
 

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -10,7 +10,7 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
     #
     def test_url_label(self):
 		L = self.tc.get('/HigherGenus/C/aut/2.12T13.0.2-4-6')
-		assert '[ 0; 2, 4, 6 ]' in L.data
+		assert '[0;2,4,6]' in L.data
 
 
     def test_url_naturallabel(self):
@@ -19,3 +19,6 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
 
 
 
+    def test_search_genus_group(self):
+               	L = self.tc.get('/HigherGenus/C/aut/?genus=2&trangplabel=6T1&signature=&count=20&Submit=Search')
+                assert '2 matches' in L.data

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -10,7 +10,7 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
     #
     def test_url_label(self):
 		L = self.tc.get('/HigherGenus/C/aut/2.12T13.0.2-4-6')
-		assert '[0;2,4,6]' in L.data
+		assert '[ 0; 2, 4, 6 ]' in L.data
 
 
     def test_url_naturallabel(self):


### PR DESCRIPTION
1. Made a series of small changes in files /lmfdb/higher_genus_w_automorphisms/_init_.py
 and /lmfdb/higher_genus_w_automorphisms/main.py to better conform to Python style guides
(see notes from pull request #922).

2. On page:  /HigherGenus/C/aut/   the "Browse" now allows browsing by genus (although there is only currently genus 2 data in the database), and the "Search" works now. There is now a test for the search functionality in the test_hgcwa.py file.

3. Uniformized names in "Learn More About" box across files, also made several other small word choice changes to clarify meaning on the pages or make consistent my capitalization usage. See for example:
/lmfdb/HigherGenus/C/aut/Completeness
/lmfdb/HigherGenus/C/aut/
/lmfdb/HigherGenus/C/aut/?genus=2

The next two comments are for any of the individual pages. Here is one example for both:
/lmfdb/HigherGenus/C/aut/2.12T13.0.2-4-6
4. The "Automorphism Group" link now actually connects to the corresponding transitive group and not just the index page for /GaloisGroups.
5. The signature data is now always in LaTeX mode, so I changed the test which was changed for pull request #922 back to "[0;2,4,6]". (This involved creating a function called sign_display to turn a list of integers into the signature notation--that ";" between the first and second number.)