### PR TITLE
Mongo client

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -52,6 +52,10 @@ name: Brian Conrey
 affil: University of Bristol and AIM
 url: http://www.aimath.org/conrey/
 ---
+name: Edgar Costa
+url: http://www.math.dartmouth.edu/~edgarcosta/
+affil: Dartmouth College
+---
 name: John Cremona
 affil: University of Warwick
 url: http://www2.warwick.ac.uk/fac/sci/maths/people/staff/john_cremona/
@@ -145,6 +149,9 @@ name: Sally Koutsoliotas
 url: http://www.bucknell.edu/x18772.xml
 affil: Bucknell University
 ---
+name: Patrick Kühn
+affil: Universität Zürich
+---
 name: Watson Ladd
 affil: University of California
 ---
@@ -204,15 +211,15 @@ name: Nathan Ryan
 url: http://www.eg.bucknell.edu/~ncr006/
 affil: Bucknell University
 ---
-name: Ralf Schmidt
-url: http://www2.math.ou.edu/~rschmidt/
-affil: University of Oklahoma
----
-name:  Harald Schilly
-url:   http://harald.schil.ly
+name: Harald Schilly
+url: http://harald.schil.ly
 email: harald@schil.ly
 affil: University of Vienna
 location: Vienna, Austria
+---
+name: Ralf Schmidt
+url: http://www2.math.ou.edu/~rschmidt/
+affil: University of Oklahoma
 ---
 name: Gagan Sekhon
 ---
@@ -245,14 +252,14 @@ affil: University of Washington
 notes:
   - Creator of <a href="http://www.sagemath.org">SageMath</a>
 ---
+name: Fredrik Str&ouml;mberg
+affil: University of Nottingham
+url: https://sites.google.com/site/fredrikstroemberg/
+---
 name: Andrew Sutherland
 url: http://math.mit.edu/~drew
 email: drew@math.mit.edu
 affil: MIT
----
-name: Fredrik Str&ouml;mberg
-affil: University of Nottingham
-url: https://sites.google.com/site/fredrikstroemberg/
 ---
 name: Holly Swisher
 url: http://people.oregonstate.edu/~swisherh/home/
@@ -306,7 +313,5 @@ affil: The University of North Carolina Greensboro
 name: David Yuen
 affil: Lake Forest College
 url: http://www.lakeforest.edu/academics/faculty/yuen/
----
-name: Patrick Kühn
-affil: Universität Zürich
+
 

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -43,12 +43,8 @@ def makeDBConnection(dbport):
         logging.info("establishing db connection at port %s ..." % dbport)
         import pymongo
         logging.info("using pymongo version %s" % pymongo.version)
-        if pymongo.version_tuple[0] < 3:
-            from pymongo import Connection
-            _C = Connection(port=dbport)
-        else:
-            from pymongo.mongo_client import MongoClient
-            _C = MongoClient(port=dbport)
+        from pymongo.mongo_client import MongoClient
+        _C = MongoClient(port=dbport)
         mongo_info = _C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
 


### PR DESCRIPTION
In short, I got rid of the usage of Connection in base.py, and forced the usage of MongoClient instead.
MongoClient is available since PyMongo 2.4, when Connection became deprecated.

ps: we are using PyMongo 2.8 at the moment.


