### PR TITLE
Mongo client configfile

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -20,7 +20,6 @@ from werkzeug.contrib.cache import SimpleCache
 # logfocus
 logfocus = None
 
-
 def set_logfocus(lf):
     global logfocus
     logfocus = lf
@@ -34,26 +33,28 @@ def get_logfocus():
 # getDBConnection() and should always be obtained from that)
 _C = None
 
+DEFAULT_DB_PORT = 37010
+#FIXME perhaps the global dbport removed
+dbport = DEFAULT_DB_PORT
+
+
 def getDBConnection():
     return _C
 
-def makeDBConnection(dbport):
+def makeDBConnection(port, **kwargs):
     global _C
     if not _C:
-        logging.info("establishing db connection at port %s ..." % dbport)
+        logging.info("establishing db connection at port %s ..." % port)
         import pymongo
         logging.info("using pymongo version %s" % pymongo.version)
         from pymongo.mongo_client import MongoClient
-        _C = MongoClient(port=dbport)
+        _C = MongoClient(port = port,  **kwargs)
         mongo_info = _C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
 
-AUTO_RECONNECT_MAX = 10
-AUTO_RECONNECT_DELAY = 1
-AUTO_RECONNECT_ATTEMPTS = 0
-DEFAULT_DB_PORT = 37010
-dbport = DEFAULT_DB_PORT
 
+# Global to track of many auto reconnect attempts for _db_reconnect
+AUTO_RECONNECT_ATTEMPTS = 0
 
 def _db_reconnect(func):
     """
@@ -64,6 +65,11 @@ def _db_reconnect(func):
       * http://paste.pocoo.org/show/224441/
     and similar workarounds
     """
+    # maximal number of auto reconnect attempts
+    AUTO_RECONNECT_MAX = 10
+    # delay between attempts
+    AUTO_RECONNECT_DELAY = 1
+
     def retry(*args, **kwargs):
         global AUTO_RECONNECT_ATTEMPTS
         while True:
@@ -88,9 +94,9 @@ def _db_reconnect(func):
 # _db_reconnect(Connection._send_message_with_response)
 
 
-def _init(dbport):
+def _init(port, **kwargs):
     import pymongo
-    makeDBConnection(dbport)
+    makeDBConnection(port = port, **kwargs)
     C = getDBConnection()
 
     from os.path import dirname, join

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -224,6 +224,12 @@ def get_configuration():
     #FIXME logfile isn't used
     logfile = "flasklog"
 
+    # default options to pass to the MongoClient
+    from pymongo import ReadPreference
+    mongo_client_options = {"port": 37010, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
+    read_preference_classes = {"PRIMARY": ReadPreference.PRIMARY, "PRIMARY_PREFERRED": ReadPreference.PRIMARY_PREFERRED , "SECONDARY": ReadPreference.SECONDARY, "SECONDARY_PREFERRED": ReadPreference.SECONDARY_PREFERRED, "NEAREST": ReadPreference.NEAREST };
+
+
         
     # deals with argv's
     if not sys.argv[0].endswith('nosetests'):
@@ -279,9 +285,6 @@ def get_configuration():
     import os
     #perhaps the filename could be an argv
     mongo_client_config_filename = "mongoclient.config"
-    from pymongo import ReadPreference
-    mongo_client_options = {"port": 37010, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
-    read_preference_classes = {"PRIMARY": ReadPreference.PRIMARY, "PRIMARY_PREFERRED": ReadPreference.PRIMARY_PREFERRED , "SECONDARY": ReadPreference.SECONDARY, "SECONDARY_PREFERRED": ReadPreference.SECONDARY_PREFERRED, "NEAREST": ReadPreference.NEAREST };
     """
     Example mongoclient.config equivalent to default
     [db]

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -226,7 +226,7 @@ def get_configuration():
 
     # default options to pass to the MongoClient
     from pymongo import ReadPreference
-    mongo_client_options = {"port": 37010, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
+    mongo_client_options = {"port": DEFAULT_DB_PORT, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
     read_preference_classes = {"PRIMARY": ReadPreference.PRIMARY, "PRIMARY_PREFERRED": ReadPreference.PRIMARY_PREFERRED , "SECONDARY": ReadPreference.SECONDARY, "SECONDARY_PREFERRED": ReadPreference.SECONDARY_PREFERRED, "NEAREST": ReadPreference.NEAREST };
 
 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -48,7 +48,7 @@ import raw
 from modular_forms.maass_forms.picard import mwfp
 
 import sys
-import base
+#import base
 from base import app, render_template, request, DEFAULT_DB_PORT, set_logfocus, _init
 
 @app.errorhandler(404)
@@ -215,14 +215,17 @@ def get_configuration():
         # but let's keep track of it anyway.
 
     # default options to pass to the app.run()
-    options = {"port": 37777, "host": "127.0.0.1", "debug": False}
+    flask_options = {"port": 37777, "host": "127.0.0.1", "debug": False}
     # Default option to pass to _init
     threading_opt = False 
     # the logfocus can be set to the string-name of a logger you want
     # follow on the debug level and all others will be set to warning
     logfocus = None
+    #FIXME logfile isn't used
     logfile = "flasklog"
-    dbport = DEFAULT_DB_PORT
+
+        
+    # deals with argv's
     if not sys.argv[0].endswith('nosetests'):
       try:
         import getopt
@@ -244,15 +247,16 @@ def get_configuration():
                 usage()
                 sys.exit()
             elif opt in ("-p", "--port"):
-                options["port"] = int(arg)
+                flask_options["port"] = int(arg)
             elif opt in ("-h", "--host"):
-                options["host"] = arg
+                flask_options["host"] = arg
+            #FIXME logfile isn't used
             elif opt in ("-l", "--log"):
                 logfile = arg
             elif opt in ("--dbport"):
-                dbport = int(arg)
+                mongo_client_options["port"] = int(arg)
             elif opt == "--debug":
-                options["debug"] = True
+                flask_options["debug"] = True
             elif opt == "--logfocus":
                 logfocus = arg
                 logging.getLogger(arg).setLevel(logging.DEBUG)
@@ -261,16 +265,55 @@ def get_configuration():
             # --debug is set, in which case they default to True but can
             # be turned off)
             elif opt == "--enable-reloader":
-                options["use_reloader"] = True
+                flask_options["use_reloader"] = True
             elif opt == "--disable-reloader":
-                options["use_reloader"] = False
+                flask_options["use_reloader"] = False
             elif opt == "--enable-debugger":
-                options["use_debugger"] = True
+                flask_options["use_debugger"] = True
             elif opt == "--disable-debugger":
-                options["use_debugger"] = False
+                flask_options["use_debugger"] = False
       except:
           pass # something happens on the server -> TODO: FIXME
-    return { 'flask_options' : options, 'dbport' : dbport}
+    
+    #deals with kwargs for mongoclient 
+    import os
+    #perhaps the filename could be an argv
+    mongo_client_config_filename = "mongoclient.config"
+    from pymongo import ReadPreference
+    mongo_client_options = {"port": 37010, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
+    read_preference_classes = {"PRIMARY": ReadPreference.PRIMARY, "PRIMARY_PREFERRED": ReadPreference.PRIMARY_PREFERRED , "SECONDARY": ReadPreference.SECONDARY, "SECONDARY_PREFERRED": ReadPreference.SECONDARY_PREFERRED, "NEAREST": ReadPreference.NEAREST };
+    """
+    Example mongoclient.config equivalent to default
+    [db]
+    port = 37010
+    host = localhost
+    replicaset =
+    read_preference = NEAREST
+    """
+    if os.path.exists(mongo_client_config_filename):
+        from ConfigParser import ConfigParser;
+        parser = ConfigParser()
+        parser.read(mongo_client_config_filename);
+        for key, value in parser.items("db"):
+            if key in mongo_client_options.keys():
+                if key == "port":
+                    mongo_client_options["port"] = int(value);
+                elif key == "read_preference":
+                    if value in read_preference_classes:
+                        mongo_client_options["read_preference"] = read_preference_classes[value];
+                    else:
+                        try:
+                            mongo_client_options["read_preference"] = int(value);
+                        except ValueError:
+                            #it wasn't a number...
+                            pass;
+                else:
+                    mongo_client_options[key] = value        
+
+
+
+
+    return { 'flask_options' : flask_options, 'mongo_client_options' : mongo_client_options}
 
 configuration = None
 
@@ -308,7 +351,7 @@ if True:
     if not configuration:
         configuration = get_configuration()
     logging.info("configuration: %s" % configuration)
-    _init(configuration['dbport'])
+    _init(**configuration['mongo_client_options'])
     app.logger.addHandler(file_handler)
 
 def getDownloadsFor(path):


### PR DESCRIPTION
Hello,

Now you can read, from `mongoclient.config`, how do you want the LMFDB to connect to the MongoDB.
Explicitly, you can pass: `port`, `host`, `replicaSet` and `read_preference` to `pymongo.MongoClient`.
The config file is `mongoclient.config`, and here is an example of one equivalent to the default settings:
```
[db]
port = 37010
host = localhost
replicaset =
read_preference = NEAREST
```


We need something like this to have the client to connect to something else than localhost:37010, and we will also need the other arguments in the future.

All this could have been done with command line arguments, however, those are hard to pass through gunicorn, and the solution becomes quite ugly.

Regular users, and Warwick won't notice a difference until they create `mongoclient.config` and write something nontrivial on it.

Also, at the moment the config file overruns the command line arguments, the only one is affected is --dbport.
If you want it the other way around, we can simply swap the order that they are processed.


I have also tweaked the position of some global variables in `lmfb/base.py`








