### PR TITLE
fixed random element function for pymongo>=3

### DIFF
--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -21,7 +21,7 @@ def random_object_from_collection(collection):
         return collection.aggregate({ '$sample': { 'size': 1 } }, cursor = {} ).next()
     else:
         # Changed in version 3.0: The aggregate() method always returns a CommandCursor. The pipeline argument must be a list.
-        return collection.aggregate({ '$sample': { 'size': 1 } } ).next()
+        return collection.aggregate([{ '$sample': { 'size': 1 } } ]).next()
 
 
 cache = SimpleCache()


### PR DESCRIPTION
#1073 worked fine with pymongo 2.8 but not for version 3 and above.  After this fix it works on both (I tested).
I could not remember why we forced pymongo 2.8 in requirements.txt, but git blame says that it was Harald on 1 Nov 2015 and the reason was that the then current version was 3.0.3 which was broken.  Well, the current version now is 3.2.2 and it works fine, so I'll also make that change.