### PR TITLE
Fixed wrong title in learn more box

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -57,7 +57,7 @@ def index():
     if len(args) == 0:
         learnmore = [#('Completeness of the data', url_for(".completeness_page")),
                 ('Source of the data', url_for(".how_computed_page")),
-                ('Galois group labels', url_for(".labels_page"))]
+                ('Artin representations labels', url_for(".labels_page"))]
         return render_template("artin-representation-index.html", title="Artin Representations", bread=bread, learnmore=learnmore)
     else:
         return artin_representation_search(**args)


### PR DESCRIPTION
In the learn more box it say "Galois groups labels" but it links to Artin representations labels".