### PR TITLE
Issue1081

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -379,6 +379,18 @@ def elliptic_curve_search(**args):
     else:
         info['include_base_change'] = "on"
 
+    if 'include_Q_curves' in info:
+        if info['include_Q_curves'] == 'exclude':
+            query['q_curve'] = False
+        elif info['include_Q_curves'] == 'only':
+            query['q_curve'] = True
+
+    if 'include_cm' in info:
+        if info['include_cm'] == 'exclude':
+            query['cm'] = 0
+        elif info['include_cm'] == 'only':
+            query['cm'] = {'$ne' : 0}
+
     info['query'] = query
     count = parse_count(info, 50)
     start = parse_start(info)

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -75,6 +75,14 @@ Please enter a value or leave blank:
            <option value="on" selected="yes">include</option>
          </select>
   </td>
+  <td align=right>{{ KNOWL('ec.q_curve',title="Q_curves") }} </td>
+  <td>
+         <select name='include_Q_curves'>
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+         </select>
+  </td>
     </tr>
 
    <tr>
@@ -92,13 +100,22 @@ Please enter a value or leave blank:
            <option value="on" selected="yes">include</option>
          </select>
   </td>
+     <td align=right>{{ KNOWL('ec.complex_multiplication',title =
+     "CM") }}  curves </td>
+     <td>
+         <select name='include_cm'>
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+         </select>
+     </td>
  </tr>
 
     <tr>
           <td align=right>
           {{ KNOWL('ec.j_invariant', title="j-invariant") }}
           </td>
-          <td>
+          <td colspan=2>
           <input type='text' name='jinv' example=" (818172355/1024)*a-(2133314821/512)" size=20 value="{{jinv}}" />
           </td>
           <td colspan=2>

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -21,6 +21,8 @@
 <td align=left>{{ KNOWL('ec.conductor',title = "conductor") }} norm</td>
 <td align=left>{{ KNOWL('ec.isogeny',title="isogenous") }} curves</td>
 <td align=left>{{ KNOWL('ec.base_change',title="base change") }} curves</td>
+<td align=left>{{ KNOWL('ec.q_curve',title="Q-curves") }}</td>
+<td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} curves</td>
 <td align=left>{{ KNOWL('ec.torsion_order',title="torsion order") }}</td>
 <td align=left>{{ KNOWL('ec.torsion_subgroup', title="torsion structure") }}</td>
 <td align=left>{{ KNOWL('ec.j_invariant', title="j-invariant") }}</td>
@@ -50,11 +52,47 @@
 {% endif %}
          </select>
 </td>
+<td>         <select name='include_Q_curves'>
+{% if info.include_Q_curves == "include" %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% else %}
+{% if info.include_Q_curves == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% endif %}
+{% endif %}
+         </select>
+</td>
+<td>         <select name='include_cm'>
+{% if info.include_cm == "include" %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% else %}
+{% if info.include_cm == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% endif %}
+{% endif %}
+         </select>
+</td>
           <td>
-          <input type='text' name='torsion' size=10 value="{{info.torsion}}" />
+          <input type='text' name='torsion' size=6 value="{{info.torsion}}" />
           </td>
           <td>
-          <input type='text' name='torsion_structure' size=10 value="{{info.torsion_structure}}" />
+          <input type='text' name='torsion_structure' size=8 value="{{info.torsion_structure}}" />
           </td>
           <td>
           <input type='text' name='jinv' size=20 value="{{info.jinv}}" />

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -222,6 +222,12 @@ def elliptic_curve_search(**args):
         parse_ints(info,query,'rank')
         parse_ints(info,query,'sha','analytic order of &#1064;')
         parse_bracketed_posints(info,query,'torsion_structure',maxlength=2,process=str,check_divisibility='increasing')
+        if 'include_cm' in info:
+            if info['include_cm'] == 'exclude':
+                query['cm'] = 0
+            elif info['include_cm'] == 'only':
+                query['cm'] = {'$ne' : 0}
+
         parse_primes(info, query, 'surj_primes', name='surjective primes',
                      qfield='non-surjective_primes', mode='complement')
         if info.get('surj_quantifier') == 'exactly':

--- a/lmfdb/elliptic_curves/templates/browse_search.html
+++ b/lmfdb/elliptic_curves/templates/browse_search.html
@@ -103,6 +103,16 @@ Please enter a value or leave blank:
            </td>
            <td><span class="formexample"> e.g. 0 </span>
            </td>
+   <td>
+    {{ KNOWL('ec.complex_multiplication',title="CM") }}
+    </td>
+     <td>
+         <select name='include_cm'>
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+         </select>
+     </td>
     </tr>
 
     <tr>

--- a/lmfdb/elliptic_curves/templates/search_results.html
+++ b/lmfdb/elliptic_curves/templates/search_results.html
@@ -14,31 +14,38 @@
 <tr>
 <td align=left>{{ KNOWL('ec.q.conductor', title='Conductor') }}</td>
 <td align=left>{{ KNOWL('ec.q.j_invariant', title='j-invariant') }}</td>
+<td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} </td>
 <td align=left>{{ KNOWL('ec.q.rank', title='Rank') }}</td>
 <td align=left>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</td>
 <td align=left>{{ KNOWL('ec.q.torsion_subgroup', title='Torsion structure') }}</td>
 <td align=left>{{ KNOWL('ec.q.analytic_sha_order', title='Analytic order of &#1064;') }}</td>
-<td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
 </tr>
 
 <tr>
 <td align=left><input type='text' name='conductor' size=10 value={{info.conductor}}></td>
 <td align=left><input type='text' name='jinv'size=5 value={{info.jinv}}></td>
-<td align=left><input type='text' name='rank'size=2 value={{info.rank}}></td>
-<td align=left><input type='text' name='torsion' size=5 value={{info.torsion}}> </td>
-<td align=left><input type='text' name='torsion_structure' size=5 value={{info.torsion_structure}}> </td>
-<td align=left><input type='text' name='sha' size=5 value={{info.sha}}> </td>
-<td align=left>
-<select name='optimal'>
-{% if info.optimal=='on' %}
-  <option value="">No</option>
-  <option selected="yes" value="on">Yes</option>
+<td>         <select name='include_cm'>
+{% if info.include_cm == "include" %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
 {% else %}
-  <option value="">No</option>
-  <option value="on">Yes</option>
+{% if info.include_cm == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
 {% endif %}
-</select>
+{% endif %}
+         </select>
 </td>
+<td align=left><input type='text' name='rank'size=2 value={{info.rank}}></td>
+<td align=left><input type='text' name='torsion' size=6 value={{info.torsion}}> </td>
+<td align=left><input type='text' name='torsion_structure' size=7 value={{info.torsion_structure}}> </td>
+<td align=left><input type='text' name='sha' size=5 value={{info.sha}}> </td>
 </tr>
 
 <tr>
@@ -46,8 +53,7 @@
 </td>
 <td align=left colspan=2>{{KNOWL('ec.q.non-surjective_prime', title='non-surjective primes')}} 
 </td>
-<td align=left colspan=3>Maximum number of curves to display
-</td>
+<td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
 </tr>
 <tr>
 <td align=left>
@@ -65,11 +71,25 @@
   </select>
 <input type='text' name='nonsurj_primes' size=10  value={{info.nonsurj_primes}}>
 </td>
-<td align=left colspan=3><input type='text' name='count' value={{info.count}} size=10>
+<td align=left>
+<select name='optimal'>
+{% if info.optimal=='on' %}
+  <option value="">No</option>
+  <option selected="yes" value="on">Yes</option>
+{% else %}
+  <option value="">No</option>
+  <option value="on">Yes</option>
+{% endif %}
+</select>
 </td>
 </tr>
 
-<tr> <td>
+<tr>
+<td align=left colspan=2>Maximum number of curves to display
+</td>
+<td align=left><input type='text' name='count' value={{info.count}} size=10>
+</td>
+<td colspan=3>
 <button type='submit' value='refine'>Refine or change search</button>
 </td> </tr>
 </table>


### PR DESCRIPTION
Issue #1081 asked for the ability to search for Q-curves.  The first commit here adds both that and also searching for CM curves.  In both cases the default "include" has no effect, while "exclude" and "only" do what that suggests.  Bothe the main browse-search page http://localhost:37777/EllipticCurve/ and the search results page (e.g. http://localhost:37777/EllipticCurve/?field=2.2.5.1&include_base_change=on&include_Q_curves=only&conductor_norm=&include_isogenous=on&include_cm=include&jinv=&torsion=&torsion_structure=&count= for the search originally wanted) are affected.

The second commit adds a similar CM option for elliptic curves over Q which was often requested.  If a reviewer wants I can split these into two requests.
