### PR TITLE
made number field search result download more efficient

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -598,10 +598,17 @@ def download_search(info, res):
     else:
         s += 'data = ['
     s += '\\\n'
+    Qx = PolynomialRing(QQ,'x')
+    str2pol = lambda s: Qx([QQ(str(c)) for c in s.split(',')])
     for f in res:
-        wnf = WebNumberField.from_data(f)
-        entry = ', '.join(
-            [str(wnf.poly()), str(wnf.disc()), str(wnf.galois_t()), str(wnf.class_group_invariants_raw())])
+#        wnf = WebNumberField.from_data(f)
+#        entry = ', '.join(
+#            [str(wnf.poly()), str(wnf.disc()), str(wnf.galois_t()), str(wnf.class_group_invariants_raw())])
+        pol = str2pol(f['coeffs'])
+        D = decodedisc(f['disc_abs_key'], f['disc_sign'])
+        gal_t = f['galois']['t']
+        cl = string2list(f['class_group'])
+        entry = ', '.join([str(pol), str(D), str(gal_t), str(cl)])
         s += '[' + entry + ']' + ',\\\n'
     s = s[:-3]
     if dltype == 'gp':

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -125,7 +125,7 @@
 <br>
 <br>
 <form>
-Download all search results for 
+Download all {{info.number}} search results for
 <input type="submit" name="Submit" value="gp">
 <input type="submit" name="Submit" value="sage">
 <input type="submit" name="Submit" value="magma">


### PR DESCRIPTION
See Issue #1079.   It is now possible to download 1.36 million number fields in a little over 2 minutes, no timeout.  The key is to avoid constructing the WebNumberField object for each.