### PR TITLE
changed permutation and transitive group notation in HigherGenus/C/aut/

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -35,13 +35,13 @@ By genus:
 	    <td>
 	  Search by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}
           <input type="text" name="jump_to" value=""
-        placeholder="2.6T3.0.2-2-2-3">
+        placeholder="2.12-4.0.2-2-2-3">
 	    </td>
 	    <td>
           <button type="submit" value="Find">Find</button>
 	      </td>
 	      <td>
-		<span class="formexample">family with automorphisms label, e.g. 2.6T3.0.2-2-2-3 </span>
+		<span class="formexample">family with automorphisms label, e.g. 2.12-4.0.2-2-2-3 </span>
 	      </td>
 	    </tr>
 	  </table>
@@ -65,9 +65,9 @@ By genus:
           <tr>
             <td align=right>
 	      Group:
-            </td><td><input type="text" name="trangplabel" value="" placeholder="6T1"></td>
+            </td><td><input type="text" name="group" value="" placeholder="[4,2]"></td>
       <td>
-	<span class="formexample">e.g. 2T1</span>
+	<span class="formexample">e.g. [4,2]</span>
       </td>
           </tr>
 	  <tr>
@@ -79,7 +79,7 @@ By genus:
       </td> </tr>
           <tr>
           <td align=right>
-              Maximum number of fields to display:
+              Maximum number of families to display:
             </td><td><input type="text" name="count" value="20" size="10"></td>
           </tr>
   </table>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -9,14 +9,14 @@
 
 <tr>
 <td align=left> 
-Genus:</td><td align=left> <input type='text' name='genus' size=3 value="">
+Genus:</td><td align=left> <input type='text' name='genus' size=3 value="{{info.genus}}">
 </td>
 <td align=left> 
-Group: <td align=left> <input type="text" name="trangplabel" size="8" value="" > 
+Group: <td align=left> <input type="text" name="group" size="8" value="{{info.group}}" > 
 
 <td align=left> 
 {{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
-<td align=left> <input type="text" name="signature" size="15" value="" >
+<td align=left> <input type="text" name="signature" size="15" value="{{info.signature}}" >
 
 
 </tr>
@@ -44,7 +44,7 @@ Group: <td align=left> <input type="text" name="trangplabel" size="8" value="" >
 <td><button type='submit' value='Find'>Find</button></td>
 </tr>
 <tr>
-<td colspan="3" rowspan="2"><span class="formexample"> a higher genus curve with automorphisms label, e.g. 4.g4_1.0.4.4-4-4-4</span></td>
+<td colspan="3" rowspan="2"><span class="formexample"> a higher genus curve with automorphisms label, e.g. 3.4-2.0.2-2-2-2-2-2</span></td>
 </tr>
 </table>
 </form>
@@ -70,8 +70,7 @@ Group: <td align=left> <input type="text" name="trangplabel" size="8" value="" >
 
   <th>Label</th>
   <th>Genus</th>
-  <th>Dimension</th>
-  <th>Group</th>
+  <th>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension')}}</th>
   <th>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma group')}}</th>
   <th>Signature</th>
 <!--<th>{{KNOWL('lf.slope_content',title='label')}}</th>-->
@@ -84,10 +83,9 @@ Group: <td align=left> <input type="text" name="trangplabel" size="8" value="" >
 
   <td align='left'><a href="/HigherGenus/C/aut/{{field.label}}">{{field.label}}</a></td>
     <td>{{field.genus}}</td>
-  <td>{{field.r}}</td>
-  <td>{{info.group_display(field.trangplabel)}}</td>
+  <td>{{field.dim}}</td>
   <td>{{field.group}}</td>
-    <td>${{info.sign_display(field.signature)}}$</td>
+   <td>${{info.sign_display(field.signature)}}$</td>
 
 
 </tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-curve.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-curve.html
@@ -17,7 +17,7 @@ table,td {
 
   <table>
       <tr><td> Genus:  </td><td> {{ info.genus }} </td></tr>
-      <tr><td> Dimension of the family: </td><td> {{info.dim}} </td></tr>
+      <tr><td>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family:')}}</td><td> {{info.dim}} </td></tr>
 
        {% if info.eqn  %}
           <tr><td>Model of curve(s) in the family:</td><td>${{info.eqn}}$</td></tr>
@@ -29,8 +29,10 @@ table,td {
 
 <p> <h2>Group </h2>
   <table>
-       <tr><td>Permutation group:</td> <td>{{info.trgroup}}</td></tr>
- <!--<tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr> -->
+   {% if info.specialname %}
+   <tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr>
+   {% endif %}
+     <tr><td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td><td>SmallGroup{{info.gpid}}</td></tr>
     </table>
 </p>
 
@@ -39,36 +41,36 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     {% endif %}
 
 
-  <h2>Cover</h2> <table>
+<h2>Cover</h2><table>
       <tr><td> Quotient genus: </td> <td>{{info.g0}}</td></tr>
       <tr><td> Number of {{ KNOWL('curve.highergenus.aut.branchpoints', title='branch points') }}: </td> <td>{{info.r}}</td></tr>
-      	<tr><td> {{ KNOWL('curve.highergenus.aut.degree',title='Degree of the covering')}}: </td> <td>{{info.deg}}</td></tr>
       <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
       <tr> &nbsp;</tr> </table> 
 
-      <table><tr><td> {{ KNOWL('curve.highergenus.aut.generating_vectors', title='Generating vector')}} in {{info.trgroup}}:</td> <td>      
+      <table><tr><td> {{ KNOWL('curve.highergenus.aut.generating_vectors', title='Generating vector')}} in ${{info.group}}$:</td> <td>      
         <tbody>
         {% for gen in info.genvecs%}
-        <tr> <td> </td> <td><center>{{gen}}</center></td></tr>
+        <tr> <td> </td> <td>{{gen}}</td></tr>
         {% endfor %}
  </td></tr>
           </table>
 
 
+ {% if info.ishyp %}     
 
   <p><h2>Other Data</h2>
     <table>
      
-      <tr><td>Hyperelliptic curves:</td><td>{{info.ishyp}}</td></tr>
+      <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
    {% if info.hypinv  %}
-       <tr><td>Hyperelliptic Involution:</td> <td>{{info.hypinv}}</td></tr>
+       <tr><td>Hyperelliptic involution:</td> <td>{{info.hypinv}}</td></tr>
    {% endif %}
   
     </table>
   </p>
   
 
- 
+ {% endif %}
 
 
 

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -9,16 +9,16 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
     # All tests should pass
     #
     def test_url_label(self):
-		L = self.tc.get('/HigherGenus/C/aut/2.12T13.0.2-4-6')
-		assert '[ 0; 2, 4, 6 ]' in L.data
+	L = self.tc.get('/HigherGenus/C/aut/2.24-8.0.2-4-6')
+	assert '[ 0; 2, 4, 6 ]' in L.data
 
 
     def test_url_naturallabel(self):
-		L = self.tc.get('/HigherGenus/C/aut/junk')
-		assert 'was not found in the database' in L.data # error mesage
+	L = self.tc.get('/HigherGenus/C/aut/junk')
+	assert 'was not found in the database' in L.data # error mesage
 
 
 
     def test_search_genus_group(self):
-               	L = self.tc.get('/HigherGenus/C/aut/?genus=2&trangplabel=6T1&signature=&count=20&Submit=Search')
-                assert '2 matches' in L.data
+        L = self.tc.get('/HigherGenus/C/aut/?genus=2&group=%5B6%2C2%5D&signature=&count=20&Submit=Search')
+        assert '2 matches' in L.data


### PR DESCRIPTION
When I extended the group action data to higher genus, I ran into an issue with the transitive group labeling.  Many entries were of transitive groups of degree greater than 32, hence I could not write them in the “dTn” notation.  

I’ve reverted to using the GAP or Magma SmallGroup(s,n) notation, where s is the order of the group, and n is which entry of that order in the database the group is.  I have changed the generating vector from permutations to “words” on the generators of the group also.

This forced a small change in the labeling. Instead of, say  2.6T2.0… I now put 2.6-1.0… (since the transitive group 6T2 corresponds in the data to the group (6,1) in GAP/Magma.) 

Here are corrections I needed to make to the pages (for example: HigherGenus/C/aut/3.48-48.0.2-4-6)
- Change “Permutation Group” to “GAP/Magma notation”, along with a common name of the group listed as “Isomorphism Class” if this particular group is listed in the group dictionary given in “genus2_curves/data.py”
- Removed “Degree of the covering”
- Removed “Automorphism Group” friend (Related Object).
- “Generating Vector” and “Hyperelliptic Involution” not listed as permutations 
- Change “Properties” to reflect group notation

I also needed to modify the search (HigherGenus/C/aut/)
- Search the group in new notation (as a list of 2 integers).
- Updated the order which the search functionality displays entries (first by genus, second by dimension of the family)

A few other odds and ends
- Updated test_hgcwa.py to account for new labeling
- Removed a few “import” commands in main.py that are no longer being used
- Fixed /template/hgcwa-search.py so that the “Next” button properly works.
- Changed the word “fields” to “families” in HigherGenus/C/aut/ as commented on in  #1043
- Added a couple of knowl links to signature and dimension of the family.  Still need to write all of these, especially to explain notation.
- All equations should no longer have unnecessarily parentheses as commented on in #1043
