### PR TITLE
enhanced stats and browsing for Hilbert MFs

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -445,7 +445,7 @@ def completeness_page():
     t = 'Completeness of the Hilbert Modular Forms data'
     bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
              ('Completeness', '')]
-    return render_template("single.html", kid='dq.mf.hilbert.extent',
+    return render_template("single.html", kid='dq.mf.hilbert.completeness',
                            credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @hmf_page.route("/Source")

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -69,7 +69,6 @@ def hilbert_modular_form_render_webpage():
                  ('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage"))]
         info['learnmore'] = []
         info['counts'] = get_stats().counts()
-        info['stats'] = get_stats().dstats()
         return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list())
     else:
         return hilbert_modular_form_search(**args)
@@ -469,7 +468,7 @@ def labels_page():
 def browse():
     info = {
         'counts': get_stats().counts(),
-        'dstats': get_stats().dstats(),
+        'stats': get_stats().stats(),
         'extent': dict([(d,hmf_degree_summary(d)) for d in get_stats().counts()['degrees']]),
         'full_extent': hmf_summary()
     }
@@ -493,7 +492,7 @@ def statistics_by_degree(d):
             info['error'] = "The database does not contain any Hilbert modular forms over fields of degree %s" % d
         d = 'bad'
     else:
-        info['dstats'] = stats.dstats()[d]
+        info['stats'] = stats.stats()[d]
         info['degree_stats'] = hmf_degree_summary(d)
     credit = 'John Cremona'
     if d==2:

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -9,7 +9,7 @@ from flask import Flask, session, g, render_template, url_for, request, redirect
 from sage.misc.preparser import preparse
 from lmfdb.hilbert_modular_forms import hmf_page, hmf_logger
 from lmfdb.hilbert_modular_forms.hilbert_field import findvar
-from lmfdb.hilbert_modular_forms.hmf_stats import get_stats
+from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, hmf_summary, hmf_degree_summary
 
 from lmfdb.ecnf.main import split_class_label
 from lmfdb.ecnf.WebEllipticCurve import db_ecnf
@@ -69,6 +69,7 @@ def hilbert_modular_form_render_webpage():
                  ('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage"))]
         info['learnmore'] = []
         info['counts'] = get_stats().counts()
+        info['stats'] = get_stats().dstats()
         return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list())
     else:
         return hilbert_modular_form_search(**args)
@@ -463,3 +464,57 @@ def labels_page():
              ('Labels', '')]
     return render_template("single.html", kid='mf.hilbert.label',
                            credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Labels'))
+
+@hmf_page.route("/browse/")
+def browse():
+    info = {
+        'counts': get_stats().counts(),
+        'dstats': get_stats().dstats(),
+        'extent': dict([(d,hmf_degree_summary(d)) for d in get_stats().counts()['degrees']]),
+        'full_extent': hmf_summary()
+    }
+    credit = 'John Voight'
+    t = 'Hilbert modular forms'
+    bread = [('Hilbert modular forms', url_for("hmf.hilbert_modular_form_render_webpage")),
+             ('browse', ' ')]
+    return render_template("hmf_stats.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+
+@hmf_page.route("/browse/<int:d>/")
+def statistics_by_degree(d):
+    stats = get_stats()
+    info = {
+        'counts': stats.counts(),
+        'degree': d
+    }
+    if not d in info['counts']['degrees']:
+        if d==1:
+            info['error'] = "For modular forms over $\mathbb{Q}$ go <a href=%s>here</a>" % url_for('emf.render_elliptic_modular_forms')
+        else:
+            info['error'] = "The database does not contain any Hilbert modular forms over fields of degree %s" % d
+        d = 'bad'
+    else:
+        info['dstats'] = stats.dstats()[d]
+        info['degree_stats'] = hmf_degree_summary(d)
+    credit = 'John Cremona'
+    if d==2:
+        t = 'Hilbert modular forms over real quadratic number fields'
+    elif d==3:
+        t = 'Hilbert modular forms over totally real cubic number fields'
+    elif d==4:
+        t = 'Hilbert modular forms over totally real quartic number fields'
+    elif d==5:
+        t = 'Hilbert modular forms over totally real quintic number fields'
+    elif d==6:
+        t = 'Hilbert modular forms over totally real sextic number fields'
+    else:
+        t = 'Hilbert modular forms over totally real fields of degree %s' % d
+
+    bread = [('Hilbert modular forms', url_for("hmf.hilbert_modular_form_render_webpage")),
+              ('degree %s' % d,' ')]
+
+    if d=='bad':
+        t = 'Hilbert modular forms'
+        bread = bread[:-1]
+
+    return render_template("hmf_by_degree.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -416,7 +416,7 @@ def render_hmf_webpage(**args):
                    ('Weight', '%s' % data['weight']),
                    ('Level norm', '%s' % data['level_norm']),
                    ('Level', '$' + teXify_pol(data['level_ideal']) + '$'),
-                   ('Label', '%s' % data['label_suffix']),
+                   ('Label', '%s' % data['label']),
                    ('Dimension', '%s' % data['dimension']),
                    ('CM', is_CM),
                    ('Base change', is_base_change)
@@ -445,7 +445,7 @@ def completeness_page():
     t = 'Completeness of the Hilbert Modular Forms data'
     bread = [('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
              ('Completeness', '')]
-    return render_template("single.html", kid='dq.mf.hilbert.completeness',
+    return render_template("single.html", kid='dq.mf.hilbert.extent',
                            credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @hmf_page.route("/Source")

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -136,11 +136,13 @@ class HMFstats(object):
             stats[d]['maxnorm'] = max(forms.find({'deg':d}).hint('deg_1_level_norm_1').distinct('level_norm')+[0])
             stats[d]['counts'] = {}
             for F in stats[d]['fields']:
-                ff = forms.find({'field_label':F}, ['label', 'level_norm']).hint('field_label_1')
-                fln = [f['level_norm'] for f in ff]
+                print("Field %s" % F)
+                pipeline = [{"$match": {'field_label':F}}, {"$group":{"_id":"level_norm", "nforms": {"$sum": int(1)}, "maxnorm" : {"$max": '$level_norm'}}}]
+                res = forms.aggregate(pipeline).next()
+                print("result = %s" % res)
                 stats[d]['counts'][F] = {}
-                stats[d]['counts'][F]['nforms'] = len(fln)
-                stats[d]['counts'][F]['maxnorm'] = max(fln)
+                stats[d]['counts'][F]['nforms'] = res['nforms']
+                stats[d]['counts'][F]['maxnorm'] = res['maxnorm']
                 stats[d]['counts'][F]['field_knowl'] = nf_display_knowl(F, lmfdb.base.getDBConnection(), field_pretty(F))
                 stats[d]['counts'][F]['forms'] = url_for('hmf.hilbert_modular_form_render_webpage', field_label=F)
 

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 import re
 from pymongo import ASCENDING, DESCENDING
+from flask import url_for
 import lmfdb.base
+from lmfdb.base import app
 from lmfdb.utils import comma, make_logger
+from lmfdb.ecnf.ecnf_stats import field_data, sort_field
+from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.WebNumberField import nf_display_knowl
 
 def format_percentage(num, denom):
     return "%10.2f"%((100.0*num)/denom)
@@ -17,6 +22,54 @@ def get_stats():
         the_HMFstats = HMFstats()
     return the_HMFstats
 
+def get_degree_stats(d):
+    global the_HMFstats
+    if the_HMFstats is None:
+        the_HMFstats = HMFstats()
+    return the_HMFstats.dstats()[d]
+
+def hmf_summary():
+    counts = get_stats().counts()
+    hmf_knowl = '<a knowl="mf.hilbert">Hilbert modular forms</a>'
+    nf_knowl = '<a knowl="nf.totally_real">totally real number fields</a>'
+    return ''.join([r'The database currently contains %s ' % counts['nforms_c'],
+                    hmf_knowl,
+                    r', over %s ' % counts['nfields'],
+                    nf_knowl, ' (not including $\mathbb{Q}$)',
+                    ' of degree up to %s' % counts['maxdeg']
+                ])
+
+@app.context_processor
+def ctx_hmff_summary():
+    return {'hmf_summary': hmf_summary}
+
+def hmf_degree_summary(d):
+    stats = get_degree_stats(d)
+    hmf_knowl = '<a knowl="mf.hilbert">Hilbert modular forms</a>'
+    nf_knowl = '<a knowl="nf.totally_real">totally real number fields</a>'
+    level_knowl = '<a knowl="mf.hilbert.level_norm">level norm</a>'
+    return ''.join([r'The database currently contains %s ' % stats['nforms'],
+                    hmf_knowl,
+                    r' defined over ',
+                    nf_knowl,
+                    r' of degree %s, with ' % d,
+                    level_knowl,
+                    r' up to %s.' % stats['maxnorm']])
+
+def hmf_field_summary(F):
+    stats = get_dstats()
+    hmf_knowl = '<a knowl="mf.hilbert">Hilbert modular forms</a>'
+    nf_knowl = '<a knowl="nf.totally_real">totally real number field</a>'
+    level_knowl = '<a knowl="mf.hilbert.level_norm">level norm</a>'
+    d = F.split(".")[0]
+    return ''.join([r'The database currently contains %s ' % stats[d][F]['nforms'],
+                    hmf_knowl,
+                    r' defined over the totally real ',
+                    nf_knowl,
+                    r', with ',
+                    level_knowl,
+                    r' up to %s.' % stats[d][F]['maxnorm']])
+
 class HMFstats(object):
     """
     Class for creating and displaying statistics for Hilbert modular forms
@@ -27,16 +80,15 @@ class HMFstats(object):
         self.fields = lmfdb.base.getDBConnection().hmfs.fields
         self.forms = lmfdb.base.getDBConnection().hmfs.forms
         self._counts = {}
-        self._stats = {}
+        self._dstats = {}
 
     def counts(self):
         self.init_hmf_count()
         return self._counts
 
-    def stats(self):
+    def dstats(self):
         self.init_hmf_count()
-        self.init_hmf_stats()
-        return self._stats
+        return self._dstats
 
     def init_hmf_count(self):
         if self._counts:
@@ -45,17 +97,45 @@ class HMFstats(object):
         forms = self.forms
         fields = self.fields
         counts = {}
+
         nforms = forms.count()
         counts['nforms']  = nforms
         counts['nforms_c']  = comma(nforms)
-        nfields = fields.count()
-        counts['nfields']  = nfields
+
+        ff = fields.distinct('label')
+        counts['fields'] = ff
+        counts['nfields'] = nfields = len(ff)
         counts['nfields_c']  = comma(nfields)
-        max_deg = fields.find().sort('degree', DESCENDING).limit(1)[0]['degree']
-        counts['max_deg'] = max_deg
+
+        counts['degrees'] = degrees = fields.distinct('degree')
+        counts['maxdeg'] = max_deg = max(degrees)
         counts['max_deg_c'] = comma(max_deg)
+
+        dstats = {}
+        # the hint() her tells mongo to use that index (these have
+        # been created for this)
+        for d in degrees:
+            print("Degree %s" % d)
+            dstats[d] = {}
+            dstats[d]['fields'] = [F['label'] for F in fields.find({'degree':d},['label']).hint('degree_1')]
+            print("fields done")
+            dstats[d]['nfields'] = len(dstats[d]['fields'])
+            print("nfields done")
+            dstats[d]['nforms'] = forms.find({'deg':d}).hint('deg_1').count()
+            print("nforms done")
+            dstats[d]['maxnorm'] = max(forms.find({'deg':d}).hint('deg_1_level_norm_1').distinct('level_norm')+[0])
+            dstats[d]['counts'] = {}
+            for F in dstats[d]['fields']:
+                print("Field %s" % F)
+                ff = forms.find({'field_label':F}, ['label', 'level_norm']).hint('field_label_1')
+                fln = [f['level_norm'] for f in ff]
+                dstats[d]['counts'][F] = {}
+                dstats[d]['counts'][F]['nforms'] = len(fln)
+                dstats[d]['counts'][F]['maxnorm'] = max(fln)
+                dstats[d]['counts'][F]['field_knowl'] = nf_display_knowl(F, lmfdb.base.getDBConnection(), field_pretty(F))
+                dstats[d]['counts'][F]['forms'] = url_for('hmf.hilbert_modular_form_render_webpage', field_label=F)
+
         self._counts  = counts
+        self._dstats = dstats
         logger.debug("... finished computing HMF counts.")
         #logger.debug("%s" % self._counts)
-
-

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -136,10 +136,12 @@ class HMFstats(object):
             stats[d]['maxnorm'] = max(forms.find({'deg':d}).hint('deg_1_level_norm_1').distinct('level_norm')+[0])
             stats[d]['counts'] = {}
             for F in stats[d]['fields']:
-                print("Field %s" % F)
-                pipeline = [{"$match": {'field_label':F}}, {"$group":{"_id":"level_norm", "nforms": {"$sum": int(1)}, "maxnorm" : {"$max": '$level_norm'}}}]
+                #print("Field %s" % F)
+                pipeline = [{"$match": {'field_label':F}},
+                            {"$project" : { 'level_norm' : 1 }},
+                            {"$group":{"_id":"level_norm", "nforms": {"$sum": 2}, "maxnorm" : {"$max": '$level_norm'}}}]
                 res = forms.aggregate(pipeline).next()
-                print("result = %s" % res)
+                #print("result = %s" % res)
                 stats[d]['counts'][F] = {}
                 stats[d]['counts'][F]['nforms'] = res['nforms']
                 stats[d]['counts'][F]['maxnorm'] = res['maxnorm']

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -115,18 +115,13 @@ class HMFstats(object):
         # the hint() her tells mongo to use that index (these have
         # been created for this)
         for d in degrees:
-            print("Degree %s" % d)
             dstats[d] = {}
             dstats[d]['fields'] = [F['label'] for F in fields.find({'degree':d},['label']).hint('degree_1')]
-            print("fields done")
             dstats[d]['nfields'] = len(dstats[d]['fields'])
-            print("nfields done")
             dstats[d]['nforms'] = forms.find({'deg':d}).hint('deg_1').count()
-            print("nforms done")
             dstats[d]['maxnorm'] = max(forms.find({'deg':d}).hint('deg_1_level_norm_1').distinct('level_norm')+[0])
             dstats[d]['counts'] = {}
             for F in dstats[d]['fields']:
-                print("Field %s" % F)
                 ff = forms.find({'field_label':F}, ['label', 'level_norm']).hint('field_label_1')
                 fln = [f['level_norm'] for f in ff]
                 dstats[d]['counts'][F] = {}

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -1,9 +1,8 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<div>The database contains {{info.counts.nforms_c}} Hilbert
-  newforms over {{info.counts.nfields_c}} totally real number fields
-  of degree up to {{info.counts.max_deg_c}}.
+<div>
+{{ KNOWL_INC('dq.mf.hilbert.extent') }}
 </div>
 
 <h2> Browse {{ KNOWL('mf.hilbert', title='Hilbert cusp forms') }} </h2>
@@ -13,30 +12,45 @@ By {{ KNOWL('nf', title='base field') }}:
 </p>
 <ul>
 <li>
-Real quadratic fields <a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>, 
-<a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>, 
-<a href="?field_label=2.2.12.1">\(\Q(\sqrt{3})\)</a>, ..., 
-<a href="?field_label=2.2.401.1">\(\Q(\sqrt{401})\)</a>, ...
+{{info.stats[2]['nforms']}} real quadratic fields including <a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
+<a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
+<a href="?field_label=2.2.12.1">\(\Q(\sqrt{3})\)</a>,
+<a href="?field_label=2.2.401.1">\(\Q(\sqrt{401})\)</a>
 </li>
-<li>Cubic fields <a href="?field_label=3.3.49.1">3.3.49.1</a>, ...,
-<a href="?field_label=3.3.1101.1">3.3.1101.1</a>, ...
-</li>
-<li>
-Quartic fields <a href="?field_label=4.4.725.1">4.4.725.1</a>, 
-<a href="?field_label=4.4.1125.1">4.4.1125.1</a>, ...
-<a href="?field_label=4.4.18688.1">4.4.18688.1</a>, ...
+<li>{{info.stats[3]['nforms']}} cubic fields including <a href="?field_label=3.3.49.1">3.3.49.1</a>,
+<a href="?field_label=3.3.1101.1">3.3.1101.1</a>
 </li>
 <li>
-Quintic fields <a href="?field_label=5.5.14641.1">5.5.14641.1</a>, 
-<a href="?field_label=5.5.160801.1">5.5.160801.1</a>, ...
+{{info.stats[4]['nforms']}} quartic
+fields including <a href="?field_label=4.4.725.1">4.4.725.1</a>,
+<a href="?field_label=4.4.1125.1">4.4.1125.1</a>,
+<a href="?field_label=4.4.18688.1">4.4.18688.1</a>,
 </li>
 <li>
-Sextic fields <a href="?field_label=6.6.300125.1">6.6.300125.1</a>, 
-<a href="?field_label=6.6.1397493.1">6.6.1397493.1</a>, ...
+{{info.stats[5]['nforms']}}
+quintic fields <a href="?field_label=5.5.14641.1">5.5.14641.1</a>,
+<a href="?field_label=5.5.160801.1">5.5.160801.1</a>
+</li>
+<li>
+{{info.stats[6]['nforms']}}
+sextic fields
+including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
+<a href="?field_label=6.6.1397493.1">6.6.1397493.1</a>
+</li>
+<li><a href={{url_for('hmf.browse')}}>All available fields</a>
 </li>
 </ul>
 
+<h3>Browse {{ KNOWL('mf.hilbert', title='Hilbert cusp forms') }} in
+  the database by degree of the base field:
+{% for d in info.counts.degrees-%}
+{%-if loop.index0-%}, {% endif %}
+<a href={{url_for('hmf.statistics_by_degree', d=d)}}>{{d}}</a>
+{%-endfor-%}
+</h3>
+
 <p>A <a href={{url_for('.random_hmf')}}>random Hilbert modular form</a> from the database</p>
+
 
 <h2> Find a specific form by label </h2>
 

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -12,27 +12,27 @@ By {{ KNOWL('nf', title='base field') }}:
 </p>
 <ul>
 <li>
-{{info.stats[2]['nforms']}} real quadratic fields including <a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
+{{info.counts.nfields_by_degree[2]}} real quadratic fields including <a href="?field_label=2.2.5.1">\(\Q(\sqrt{5})\)</a>,
 <a href="?field_label=2.2.8.1">\(\Q(\sqrt{2})\)</a>,
 <a href="?field_label=2.2.12.1">\(\Q(\sqrt{3})\)</a>,
 <a href="?field_label=2.2.401.1">\(\Q(\sqrt{401})\)</a>
 </li>
-<li>{{info.stats[3]['nforms']}} cubic fields including <a href="?field_label=3.3.49.1">3.3.49.1</a>,
+<li>{{info.counts.nfields_by_degree[3]}} cubic fields including <a href="?field_label=3.3.49.1">3.3.49.1</a>,
 <a href="?field_label=3.3.1101.1">3.3.1101.1</a>
 </li>
 <li>
-{{info.stats[4]['nforms']}} quartic
+{{info.counts.nfields_by_degree[4]}} quartic
 fields including <a href="?field_label=4.4.725.1">4.4.725.1</a>,
 <a href="?field_label=4.4.1125.1">4.4.1125.1</a>,
 <a href="?field_label=4.4.18688.1">4.4.18688.1</a>,
 </li>
 <li>
-{{info.stats[5]['nforms']}}
+{{info.counts.nfields_by_degree[5]}}
 quintic fields <a href="?field_label=5.5.14641.1">5.5.14641.1</a>,
 <a href="?field_label=5.5.160801.1">5.5.160801.1</a>
 </li>
 <li>
-{{info.stats[6]['nforms']}}
+{{info.counts.nfields_by_degree[6]}}
 sextic fields
 including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
 <a href="?field_label=6.6.1397493.1">6.6.1397493.1</a>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -37,10 +37,13 @@ sextic fields
 including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
 <a href="?field_label=6.6.1397493.1">6.6.1397493.1</a>
 </li>
+{# commenting out until the /browse and /browse/degree are faster
 <li><a href={{url_for('hmf.browse')}}>All available fields</a>
 </li>
+#}
 </ul>
 
+{# commenting out until the /browse and /browse/degree are faster
 <h3>Browse {{ KNOWL('mf.hilbert', title='Hilbert cusp forms') }} in
   the database by degree of the base field:
 {% for d in info.counts.degrees-%}
@@ -48,6 +51,8 @@ including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
 <a href={{url_for('hmf.statistics_by_degree', d=d)}}>{{d}}</a>
 {%-endfor-%}
 </h3>
+#}
+
 
 <p>A <a href={{url_for('.random_hmf')}}>random Hilbert modular form</a> from the database</p>
 

--- a/lmfdb/hilbert_modular_forms/templates/hmf_by_degree.html
+++ b/lmfdb/hilbert_modular_forms/templates/hmf_by_degree.html
@@ -17,7 +17,8 @@
 
 <table>
 <tr><th>Field<th>Number of newforms<th>Maximum level norm</tr>
-{% for F, dat in info.dstats.counts.iteritems() %}
+{% for F in info.stats.fields %}
+{% set dat = info.stats.counts[F] %}
 <tr>
 <td>{{dat['field_knowl'] | safe}}
 <td><a href={{dat['forms']}}>{{dat['nforms']}}</a>

--- a/lmfdb/hilbert_modular_forms/templates/hmf_by_degree.html
+++ b/lmfdb/hilbert_modular_forms/templates/hmf_by_degree.html
@@ -1,0 +1,34 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+{% if info.error %}
+
+<p>
+{{ info.error | safe }}
+</p>
+
+{% else %}
+
+<div>
+
+<p>
+{{ info.degree_stats | safe }}
+</p>
+
+<table>
+<tr><th>Field<th>Number of newforms<th>Maximum level norm</tr>
+{% for F, dat in info.dstats.counts.iteritems() %}
+<tr>
+<td>{{dat['field_knowl'] | safe}}
+<td><a href={{dat['forms']}}>{{dat['nforms']}}</a>
+<td>{{dat['maxnorm']}}
+</tr>
+{% endfor %}
+</table>
+
+</div>
+
+{% endif %}
+
+{% endblock %}
+</html>

--- a/lmfdb/hilbert_modular_forms/templates/hmf_stats.html
+++ b/lmfdb/hilbert_modular_forms/templates/hmf_stats.html
@@ -1,0 +1,19 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<div>
+{{ KNOWL_INC('dq.mf.hilbert.extent') }}
+</div>
+
+<h3>Browse by field degree:</h3>
+<ul>
+{% for d in info.counts.degrees %}
+<li>
+<a href={{url_for('hmf.statistics_by_degree', d=d)}}>Degree {{d}}</a>:
+<br> {{ info.extent[d] | safe }}
+</li>
+{% endfor %}
+</ul>
+
+{% endblock %}
+</html>

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -7,7 +7,7 @@ class HMFTest(LmfdbTest):
     def test_home(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/')
         assert 'Hilbert' in L.data
-        assert 'newforms' in L.data
+        assert 'cusp forms' in L.data
         assert 'modular' in L.data
         assert 'Browse' in L.data
         assert 'Search' in L.data
@@ -80,3 +80,12 @@ class HMFTest(LmfdbTest):
     def test_Lfun_link(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/4.4.2048.1/holomorphic/4.4.2048.1-784.2-a')
         assert 'L/ModularForm/GL2/TotallyReal/4.4.2048.1/holomorphic/4.4.2048.1-784.2-a' in L.data
+
+    def test_browse(self):
+        L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/')
+        assert 'by field degree' in L.data
+        assert 'database currently contains' in L.data
+
+    def test_browse_by_degree(self):
+        L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/2/')
+        assert 'Number of newforms' in L.data


### PR DESCRIPTION
In addition, the knowl http://www.lmfdb.org/knowledge/show/dq.mf.hilbert.extent display actual content with this code.
I modelled this in the ecnf browsing pages.  You can see differences in the top page http://localhost:37777/ModularForm/GL2/TotallyReal/
whcih shows how many fields of each degree there are, and you can browse by degree to see which fields and what level norm bound we have for eac, for example http://localhost:37777/ModularForm/GL2/TotallyReal/browse/2/
You can also get an overviewof all fields at http://localhost:37777/ModularForm/GL2/TotallyReal/browse/
I added some indexes to make the counting faster but it still takes several seconds the first time the counting is done.
