### PR TITLE
Mf searching

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -135,6 +135,7 @@ app.jinja_env.trim_blocks = True
 
 # enable break and continue in jinja loops
 app.jinja_env.add_extension('jinja2.ext.loopcontrols')
+app.jinja_env.add_extension('jinja2.ext.do')
 
 # the following context processor inserts
 #  * empty info={} dict variable

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -225,6 +225,9 @@ class WebModFormSpace(WebObject, CachedRepresentation):
     def only_rational(self):
         return self._properties['hecke_orbits'].only_rational()
 
+    def data_from_dimension_db(self):
+        return self.connect_to_db()[self._dimension_table_name].find_one({'space_label':self.space_label})
+    
     def __repr__(self):
         if self.character.is_trivial():
             return "Space of (Web) Modular Forms of level {N}, weight {k}, and trivial character".format(

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -93,6 +93,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
         return info
     try:
         WMFS = WebModFormSpace_cached(level = level, weight = weight, cuspidal=True, character = character, update_from_db=True)
+        WMFS.update_from_db() ## Need to call an extra time for some reason...
         if not WMFS.has_updated():
             stop = False
             orbit = WMFS.character.character.galois_orbit()

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
@@ -147,7 +147,7 @@ The table below gives the dimensions of the space of holomorphic
 , with trivial {{KNOWL('character.dirichlet', title='character')}}.
 {% endif %}
 </div>
-
+ {% set has_na = [] %}
       <table class="ntdata">
         <thead>
           <tr class="space">
@@ -191,6 +191,7 @@ The table below gives the dimensions of the space of holomorphic
                  <a href="{{url}}">{{dim}}</a>
                  {% elif in_db == -1 %}
                      n/a
+              {% do has_na.append(1) %}
                  {% else %}
                      {{dim}}
                  {% endif %}
@@ -204,8 +205,11 @@ The table below gives the dimensions of the space of holomorphic
         </tbody>
       </table>
     </td>
-    <small>"n/a" means that there is no information about this space in our
-      database. The dimension is clickable whenever the Hecke orbits are stored for that space.
+    <small>
+    {% if has_na %}
+    "n/a" means that there is no information about this space in our database.
+    {% endif %}
+    The dimension is clickable whenever the Hecke orbits are stored for that space.
 </small>
 
 {% endif %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -24,7 +24,7 @@
 {% if not space.has_updated_from_db() %}
 {% if wmfs_rep_url is defined %}
 <p>This space is a Galois conjugate of <a href="{{ wmfs_rep_url }}"> \( S_&#123; {{space.weight}} &#125;(\chi_&#123;{{space.level}} &#125;({{ wmfs_rep_number }}, \cdot)) \)</a></p>
-{% else %}
+{% elif space.data_from_dimension_db().get('in_wdb',0) == 0  %}
 <h3>Unfortunately, we do not have this space in the database, yet.</h3>
 {% endif %}
 {% else %}


### PR DESCRIPTION
This fixes 1 and 2 in issue #648 
For 1. see 
ModularForm/GL2/Q/holomorphic/
which does not contain any n/a in the table, and 
ModularForm/GL2/Q/holomorphic/ranges/?level=1-24&weight=2-250&group=0
which does contain them.
I also needed to add a jinja2 extension 'do' to be able to test when the 'n/a' appears in the table from within the template. 

For 2. see for instance:
ModularForm/GL2/Q/holomorphic/2/122/1/?group=0  
which is truly not in the database, and 
ModularForm/GL2/Q/holomorphic/2/12/1/?group=0  
which is in the database (but where the previous test which only included  space.has_updated_from_db() 
failed for some 'mysterious' reason)

