### PR TITLE
Mf searching

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -325,8 +325,12 @@ def render_elliptic_modular_form_navigation_wp(**args):
         weight_range = filter(is_even,weight_range)
     if len(weight_range)>1:
         info['weight_range']="{0}-{1}".format(limits_weight[0],limits_weight[1])
+    elif len(weight_range)==1:
+        info['weight_range']="{0}".format(limits_weight[0])
     if len(level_range)>1:
         info['level_range']="{0}-{1}".format(limits_level[0],limits_level[1])
+    if len(level_range)==1:
+        info['level_range']="{0}".format(limits_level[0])        
     for n in level_range:
         info['table'][n]={}
         for k in weight_range:


### PR DESCRIPTION
This fixes problem nr. 3 in issue #1094 
i.e: If you search levels 1-12 and weight 2 the table you get is fine but in the boxes underneath you see 2-36 in the weight box, where it should be what you entered earlier.
and the same problem for the level aspect. See e.g.

ModularForm/GL2/Q/holomorphic/ranges/?level=3&weight=2-12&group=0
and
ModularForm/GL2/Q/holomorphic/ranges/?level=3-20&weight=2&group=0

For lmfdb version 2.0 (or anything > 1.0) I think we should use wtforms (or flask-wtforms) instead since this will deal with all things related to populating and displaying forms consistently. 