### PR TITLE
call p2sage on root number, fix p2sage.

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -121,7 +121,7 @@ def makeLfromdata(L, fromdb=False):
 
     if 'coeff_info' in data:   # hack, works only for Dirichlet L-functions
         base_power_int = int(data['coeff_info'][0][2:-3])
-        print 'base_power_int',base_power_int
+        #print 'base_power_int',base_power_int
         L.dirichlet_coefficients_analytic = L.dirichlet_coefficients_arithmetic[:]
         for n in range(0, len(L.dirichlet_coefficients_arithmetic)):
             an = L.dirichlet_coefficients_arithmetic[n]
@@ -150,7 +150,7 @@ def makeLfromdata(L, fromdb=False):
                 else:
                     L.dirichlet_coefficients_arithmetic[n] = " $e\\left(\\frac{" + str(an_power_int) + "}{" + str(this_base_power_int)  + "}\\right)$"
                     L.dirichlet_coefficients_analytic[n] = exp(2*pi*I*float(an_power_int)/float(this_base_power_int)).n()
-        print "rename L.dirichlet_coefficients_analytic"
+        #print "rename L.dirichlet_coefficients_analytic"
         L.dirichlet_coefficients = L.dirichlet_coefficients_analytic[:]
     # Note: a better name would be L.dirichlet_coefficients_analytic, but that
     # would require more global changes.

--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -7,6 +7,7 @@ from lmfdb.lfunctions import logger
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db \
      import MaassDB
 
+from Lfunctionutilities import p2sage
 
 def getLmaassByDatabaseId(dbid):
     collList = [('Lfunction','LemurellMaassHighDegree'),
@@ -78,7 +79,8 @@ def getGenus2Ldata(label,label_type="url"):
 
         if Ldata['self_dual']:
             neg_zeros = ["-" + str(pos_zero) for pos_zero in Ldata['positive_zeros']]
-            neg_plot = [ [-1*pt[0], Ldata['root_number'] * pt[1]] for pt in pos_plot ][1:]
+            root_number = p2sage(Ldata['root_number'])
+            neg_plot = [ [-1*pt[0], root_number * pt[1]] for pt in pos_plot ][1:]
 
         else:   # can't happen for genus 2 curves
             dual_L_label = Ldata['conjugate']
@@ -108,7 +110,7 @@ def getGenus2Ldata(label,label_type="url"):
 
         neg_plot.reverse()
         Ldata['plot'] = neg_plot[:] + pos_plot[:]
-        print "Ldata['plot']",Ldata['plot']
+        #print "Ldata['plot']",Ldata['plot']
 
     except ValueError:
         Ldata = None

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -12,9 +12,19 @@ from lmfdb.base import getDBConnection
 ###############################################################
 
 def p2sage(s):
-    # convert python type to sage
-    # this interprets strings, so e.g. '1/2' gets converted to Rational
-    return sage_eval(str(s))
+    # convert numbers which have be stored as strings into a sage type
+
+    # I really don't like the use of sage_eval here. It may be ok as long
+    # as we are only calling this function on trusted input from the database,
+    # but someone is going to forget that someday... --JWB
+
+    x = PolynomialRing(RationalField(),"x").gen()
+    a = PolynomialRing(RationalField(),"a").gen()
+    z = sage_eval(str(s), locals={'x' : x, 'a' : a})
+    if type(z) in [list, tuple]:
+        return [p2sage(x) for x in z]
+    else:
+        return z
 
 def pair2complex(pair):
     ''' Turns the pair into a complex number.

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -591,7 +591,7 @@ def initLfunction(L, args, request):
                  url_for('.l_function_dirichlet_page',
                          modulus=nmod,number=nnum))
         info['navi'] = (Lprev,Lnext)
-        print info['navi']
+        #print info['navi']
         snum = str(L.characternumber)
         smod = str(L.charactermodulus)
         charname = WebDirichlet.char2tex(smod, snum)


### PR DESCRIPTION
The plotting code was trying to multiply the values of the plot by the
root number, which was a string in some cases. Meanwhile, p2sage didn't
really do the right thing, because it was returning a list of strings
sometimes when the input was a list of strings. Additionally, it didn't
take into account that the input might expect some variables to be
defined.