### PR TITLE
Lattice fixes after upload

### DIFF
--- a/lmfdb/import_scripts/lattices/add_q_expansion_theta.py
+++ b/lmfdb/import_scripts/lattices/add_q_expansion_theta.py
@@ -44,7 +44,7 @@ def check_add_qexp(dim, min_det=1, max_det=None, fix=False):
             if fix:
                 M=l['gram']
                 exp=[int(i) for i in gp("Vec(1+2*'x*Ser(qfrep("+str(gp(matrix(M)))+",150,0)))")]
-                lat.update({'theta_series': l['theta_series']}, {"$set": {'theta_series': exp}}, upsert=True)
+                lat.update({'label': l['label']}, {"$set": {'theta_series': exp}}, upsert=True)
                 print("Fixed lattice %s" % l['label'])
         else:
             print("q expansion stored")

--- a/lmfdb/import_scripts/lattices/lattice.py
+++ b/lmfdb/import_scripts/lattices/lattice.py
@@ -54,6 +54,8 @@ lat.create_index('label')
 lat.create_index('dim')
 lat.create_index('det')
 lat.create_index('level')
+lat.create_index('aut')
+lat.create_index('class_number')
 
 print "finished indices"
 

--- a/lmfdb/lattice/lattice_stats.py
+++ b/lmfdb/lattice/lattice_stats.py
@@ -21,7 +21,7 @@ def get_stats():
 
 def lattice_summary():
     counts = get_stats().counts()
-    return r"<p>The database currently contains %s <a title='integral lattices [lattice.definition]' knowl='lattice.definition' kwargs=''>integral lattices</a>. The largest <a title='dimension [lattice.dimension]' knowl='lattice.dimension' kwargs=''>dimension</a> is %s and the largest <a title='determinant [lattice.determinant]' knowl='lattice.determinant' kwargs=''>determinant</a> is %s. It includes data from the <a title='Catalogue of Lattices [lattice.catalogue_of_lattices]' knowl='lattice.catalogue_of_lattices' kwargs=''>Catalogue of Lattices</a>.</p><p>In the case of <a title='primitive [lattice.primitive]' knowl='lattice.primitive' kwargs=''>primitive</a> <a title='integral lattices [lattice.definition]' knowl='lattice.definition' kwargs=''>integral lattices</a> of <a title='class number[lattice.class_number]' knowl='lattice.class_number' kwargs=''>class number</a> one the database is complete.</p>" % (str(counts['nlattice_c']), str(counts['max_dim_c']), str(counts['max_det']))
+    return r"<p>The database currently contains %s <a title='integral lattices [lattice.definition]' knowl='lattice.definition' kwargs=''>integral lattices</a>. It includes data from the <a title='Catalogue of Lattices [lattice.catalogue_of_lattices]' knowl='lattice.catalogue_of_lattices' kwargs=''>Catalogue of Lattices</a>.<br>The largest  <a title='dimension [lattice.class_number]' knowl='lattice.dimension' kwargs=''>class number</a> is %s, the largest <a title='dimension [lattice.dimension]' knowl='lattice.dimension' kwargs=''>dimension</a> is %s and the largest <a title='determinant [lattice.determinant]' knowl='lattice.determinant' kwargs=''>determinant</a> is %s.</br>In the case of <a title='primitive [lattice.primitive]' knowl='lattice.primitive' kwargs=''>primitive</a> <a title='integral lattices [lattice.definition]' knowl='lattice.definition' kwargs=''>integral lattices</a> of <a title='class number[lattice.class_number]' knowl='lattice.class_number' kwargs=''>class number</a> one the database is complete.</p>" % (str(counts['nlattice_c']), str(counts['max_class_number_c']), str(counts['max_dim_c']), str(counts['max_det']))
 
 
 @app.context_processor
@@ -64,5 +64,6 @@ class Latticestats(object):
         counts['max_det'] = comma(max_det)
         max_class_number = lattice.find().sort('class_number', DESCENDING).limit(1)[0]['class_number']
         counts['max_class_number'] = max_class_number
+        counts['max_class_number_c'] = comma(max_class_number)
         self._counts  = counts
         logger.debug("... finished computing Lattice counts.")

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -76,13 +76,15 @@ def lattice_render_webpage():
     args = request.args
     if len(args) == 0:
         counts = get_stats().counts()
-        dim_list= range(2, counts['max_dim']+1, 1)
-        class_number_list=range(1, counts['max_class_number']+1, 1)
-        det_list_endpoints = [1, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000]
+        dim_list= range(1, counts['max_dim']+1, 1)
+        max_class_number=20
+        class_number_list=range(1, max_class_number+1, 1)
+        det_list_endpoints = [1, 5000, 10000, 20000, 25000, 30000]
 #        if counts['max_det']>3000:
 #            det_list_endpoints=det_list_endpoints+range(3000, max(int(round(counts['max_det']/1000)+2)*1000, 10000), 1000)
         det_list = ["%s-%s" % (start, end - 1) for start, end in zip(det_list_endpoints[:-1], det_list_endpoints[1:])]
-        info = {'dim_list': dim_list,'class_number_list': class_number_list,'det_list': det_list}
+        name_list = ["A2","Z2", "D3", "D3*", "3.1942.3884.56.1", "A5", "E8", "A14"]
+        info = {'dim_list': dim_list,'class_number_list': class_number_list,'det_list': det_list, 'name_list': name_list}
         credit = lattice_credit
         t = 'Integral Lattices'
         bread = [('Lattice', url_for(".lattice_render_webpage"))]
@@ -164,7 +166,7 @@ def lattice_search(**args):
 #        start = start_default
 
     info['query'] = dict(query)
-    res = C.Lattices.lat.find(query).sort([('dim', ASC), ('det', ASC), ('label', ASC)]).skip(start).limit(count)
+    res = C.Lattices.lat.find(query).sort([('dim', ASC), ('det', ASC), ('level', ASC), ('class_number', ASC), ('label', ASC)]).skip(start).limit(count)
     nres = res.count()
 
     # here we are checking for isometric lattices if the user enters a valid gram matrix but not one stored in the database_names, this may become slow in the future: at the moment we compare against list of stored matrices with same dimension and determinant (just compare with respect to dimension is slow)

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -259,7 +259,7 @@ def render_lattice_webpage(**args):
         if info['dim']*info['kissing']<100:
             info['shortest']=[str([tuple(v)]).strip('[').strip(']').replace('),', '), ') for v in f['shortest']]
         else:
-            max_vect_num=int(round(100/(info['dim'])));
+            max_vect_num=min(int(round(100/(info['dim']))), int(round(info['kissing']/2))-1);
             info['shortest']=[str([tuple(f['shortest'][i])]).strip('[').strip(']').replace('),', '), ') for i in range(max_vect_num+1)]
             info['all_shortest']="no"
     info['download_shortest'] = [
@@ -279,7 +279,7 @@ def render_lattice_webpage(**args):
         if info['dim']*info['class_number']<50:
             info['genus_reps']=[vect_to_matrix(n) for n in f['genus_reps']]
         else:
-            max_matrix_num=int(round(25/(info['dim'])));
+            max_matrix_num=min(int(round(25/(info['dim']))), info['class_number']);
             info['all_genus_rep']="no"
             info['genus_reps']=[vect_to_matrix(f['genus_reps'][i]) for i in range(max_matrix_num+1)]
     info['download_genus_reps'] = [

--- a/lmfdb/lattice/templates/lattice-index.html
+++ b/lmfdb/lattice/templates/lattice-index.html
@@ -43,6 +43,12 @@ By {{ KNOWL('lattice.class_number', title='Class number') }}:
 <a href="?class_number={{rnge}}">{{rnge}}</a>
 {% endfor %}
 </p>
+<p>
+Some of our favorite {{ KNOWL('lattice.definition', title='Integral Lattices') }}:
+{% for rnge in info.name_list %}
+<a href="?label={{rnge}}"> {{rnge}} </a>
+{% endfor %}
+</p>
 <p>A <a href={{url_for('.random_lattice')}}>random integral lattice</a> from the database.
 <br>
 </p>
@@ -54,7 +60,7 @@ By {{ KNOWL('lattice.class_number', title='Class number') }}:
 <form>
 <input type='text' name='label' placeholder='3.4.8.1.2'>
 <button type='submit'>Label</button>
-<br><span class="formexample">e.g. 3.4.8.1.2, $D3$, $E8$, Leech</span>
+<br><span class="formexample">e.g. 3.4.8.1.2, D3, E8, A14</span>
 </form>
 
 <h2> Search </h2>

--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -29,7 +29,10 @@
     <tr><td align=right>{{ KNOWL('lattice.normalized_minimal_vector', title='Normalized minimal vectors')}}:</td>
 <td>
 {% if info.dim == 1 %}
-    $({{info.shortest}})$</td></tr>
+    $({{info.shortest}})$</td></tr><tr><td></td><td>Download this vector for 
+        {% for e in info.download_shortest %} 
+            <a href="{{e[1]}}">{{e[0]}}</a>{% if not loop.last %},  {% endif %}
+        {% endfor %}</td></tr>
 {% else %}
     <table><tr>
     {% for n in info.shortest %}
@@ -83,7 +86,10 @@
     <tr><td>&nbsp;</td></tr>
     <tr><td align=right valign=top>{{ KNOWL('lattice.genus', title='Genus representatives') }}:</td><td>
     {% if info.dim == 1 %}
-        $({{info.genus_reps}})$
+        $({{info.genus_reps}})$</td></tr><tr><td></td><td>Download this matrix for
+            {% for e in info.download_genus_reps %} 
+            <a href="{{e[1]}}">{{e[0]}}</a>{% if not loop.last %},  {% endif %}
+            {% endfor %}</td></tr>
     {% else %}
         {% for n in info.genus_reps %}
             ${{n}}${% if not loop.last %},{% endif %}

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -20,14 +20,23 @@ class HomePageTest(LmfdbTest):
         assert 'Gram' in homepage
 
     def test_lattice_dim(self):
-        L = self.tc.get("/Lattice/10.3.3.1.1").data
-        #assert '590892' in L #coeff in theta series
-        assert '1.79191691968152438905461404915' in L #Hermite number
-        assert '8360755200' in L #group order
+        L = self.tc.get("/Lattice/9.8.16.1.1").data
+        assert '115712' in L #coeff in theta series
+        assert '1.58740105196819947475170563927' in L #Hermite number
+        assert '11612160' in L #group order
+
 
     def test_lattice_classnumber(self):
         L = self.tc.get("/Lattice/?class_number=1").data
         assert '2.13.26.1.2' in L #label (class number 1)
+
+    def test_lattice_classnumber_large(self):
+        L = self.tc.get("/Lattice/3.1942.3884.56.13").data
+        assert '648' in L #test display genus representatives
+
+    def test_lattice_classnumber_large(self):
+        L = self.tc.get("/Lattice/3.1942.3884.56.13/download/sage/genus_reps").data
+        assert 'Matrix([[2, 0, 0], [0, 14, -3], [0, -3, 70]]),' in L #test download genus representatives
 
     def test_lattice_search(self):
         L = self.tc.get("/Lattice/?dim=&det=&level=&gram=&minimum=&class_number=1&aut=&count=50").data
@@ -62,10 +71,10 @@ class HomePageTest(LmfdbTest):
         assert '0.785398163397448309615660845820' in L #Z2 lattice
 
     def test_lattice_thetadisplay(self):
-        L = self.tc.get("/Lattice/theta_display/7.576.18.1.1/0").data
-        assert '318' in L # theta display
-        assert '1908' in L # theta display
-        assert '13416' in L # theta display
+        L = self.tc.get("/Lattice/theta_display/7.576.18.1.1/40").data
+        assert '41' in L # theta display
+        assert '1848' in L # theta display
+        assert '11466' in L # theta display
 
     def test_lattice_random(self):
         L = self.tc.get("/Lattice/random").data
@@ -91,5 +100,5 @@ class HomePageTest(LmfdbTest):
  
     def test_download_genus(self):
         L = self.tc.get("/Lattice/4.5.5.1.1/download/gp/genus_reps").data
-        assert ']~),' in L
+        assert ']~)' in L 
 


### PR DESCRIPTION
Fixed lots of problems on the homepage of lattices:
http://localhost:37777/Lattice/
now the lists of determinant and class numbers is shorter, I have added a list of nice names. 
For the moment I have also removed the Leech lattice as a possibility below the label search. Once it will be in the database I will edit the change.

Add download options for A1:
http://localhost:37777/Lattice/A1

Fixed the code for displaying A5 and other lattices:
http://localhost:37777/Lattice/A5

Changed the extent of the data file, modifying the statistics to include the  biggest class number.
http://localhost:37777/Lattice/Completeness

Added more indices in the import script, as well modified the add_q_expansion function.

Changed the tests to correct errors and added more to check high class number lattices.

At the moment I am computing theta series, for the high dimensional lattices it may require time.