### PR TITLE
Change the sort of a number field search so that it can match an index.

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -485,7 +485,6 @@ def number_field_search(**args):
         return download_search(info, res)
 
     res = res.sort([('degree', ASC), ('disc_abs_key', ASC),('disc_sign', ASC)])
-    #res = res.sort([('degree', ASC), ('disc_abs_key', ASC), ('disc_sign', ASC), ('label', ASC)])
     nres = res.count()
     res = res.skip(start).limit(count)
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -484,7 +484,8 @@ def number_field_search(**args):
     if 'download' in info and info['download'] != '0':
         return download_search(info, res)
 
-    res = res.sort([('degree', ASC), ('disc_abs_key', ASC), ('disc_sign', ASC), ('label', ASC)])
+    res = res.sort([('degree', ASC), ('disc_abs_key', ASC),('disc_sign', ASC)])
+    #res = res.sort([('degree', ASC), ('disc_abs_key', ASC), ('disc_sign', ASC), ('label', ASC)])
     nres = res.count()
     res = res.skip(start).limit(count)
 


### PR DESCRIPTION
We had problems with entry lengths in the indexes, so the index wasn't made, which meant there was no index to sort on.

Test with the url in issue 1063