### PR TITLE
fix for issue 1105

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -226,8 +226,12 @@ class WebModFormSpace(WebObject, CachedRepresentation):
         return self._properties['hecke_orbits'].only_rational()
 
     def data_from_dimension_db(self):
-        return self.connect_to_db()[self._dimension_table_name].find_one({'space_label':self.space_label})
-    
+        res = self.connect_to_db()[self._dimension_table_name].find_one({'space_label':self.space_label})
+        # make sure that the return value is always a dict.
+        if res == None:
+            return {}
+        return res
+
     def __repr__(self):
         if self.character.is_trivial():
             return "Space of (Web) Modular Forms of level {N}, weight {k}, and trivial character".format(


### PR DESCRIPTION
The function data_from_dimension_db() now returns an empty dict instead of None when the space is missing from the db, which means that a URL such as 
http://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/12000/12/1/
shows a polite message "Unfortunately, we do not have this space in the database, yet." instead of throwing an error.
