### PR TITLE
remove beta status for Lattices!

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -240,7 +240,6 @@
       colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"
-      status: beta
     - title: Subgroups of
       part2:
          - title: $\SL(2)$


### PR DESCRIPTION
***1 Upvote*** This is a trivial change -- deletes one lnes from sidebar.yaml -- which works as one would hope, i.e. when the website start up with --debug or with environment variable BETA set, there is no change, but if neither of those (as on www.lmfdb.org) then Lattices appear in the sidebar.

There has been a lot of work on the Lattice pages, including very recently, and also a lot of data uploaded.  There are now 39293 lattices (see the detailed Extent knowl) and we want these to be in before the release.