### PR TITLE
Fix for the Leech lattice

### DIFF
--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -448,7 +448,7 @@ def download_lattice_full_lists_v(**args):
     outstr = c + ' Full list of normalized minimal vectors downloaded from the LMFDB on %s. \n\n'%(mydate)
     outstr += download_assignment_start[lang] + '\\\n'
     if res['name']==['Leech']:
-        outstr += str(res['shortest']).strip('u').replace("'", "")
+        outstr += str(res['shortest']).replace("'", "").replace("u", "")
     else:
         outstr += str(res['shortest'])
     outstr += download_assignment_end[lang]

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -260,6 +260,9 @@ def render_lattice_webpage(**args):
     else:
         if f['dim']==1:
             info['shortest']=str(f['shortest']).strip('[').strip(']')
+        elif f['name']=="Leech"
+            info['shortest']=[str([[1,-2,-2,-2,2,-1,-1,3,3,0,0,2,2,-1,-1,-2,2,-2,-1,-1,0,0,-1,2], [1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3], [1,-2,-2,-1,1,-1,-1,2,2,0,0,2,2,0,0,-2,2,-1,-1,-1,0,-1,-1,2]])]
+            info['all_shortest']="no"
         else:
             if info['dim']*info['kissing']<100:
                 info['shortest']=[str([tuple(v)]).strip('[').strip(']').replace('),', '), ') for v in f['shortest']]

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -260,9 +260,6 @@ def render_lattice_webpage(**args):
     else:
         if f['dim']==1:
             info['shortest']=str(f['shortest']).strip('[').strip(']')
-        elif f['name']=="Leech"
-            info['shortest']=[str([[1,-2,-2,-2,2,-1,-1,3,3,0,0,2,2,-1,-1,-2,2,-2,-1,-1,0,0,-1,2], [1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3], [1,-2,-2,-1,1,-1,-1,2,2,0,0,2,2,0,0,-2,2,-1,-1,-1,0,-1,-1,2]])]
-            info['all_shortest']="no"
         else:
             if info['dim']*info['kissing']<100:
                 info['shortest']=[str([tuple(v)]).strip('[').strip(']').replace('),', '), ') for v in f['shortest']]
@@ -270,6 +267,13 @@ def render_lattice_webpage(**args):
                 max_vect_num=min(int(round(100/(info['dim']))), int(round(info['kissing']/2))-1);
                 info['shortest']=[str([tuple(f['shortest'][i])]).strip('[').strip(']').replace('),', '), ') for i in range(max_vect_num+1)]
                 info['all_shortest']="no"
+        info['download_shortest'] = [
+            (i, url_for(".render_lattice_webpage_download", label=info['label'], lang=i, obj='shortest_vectors')) for i in ['gp', 'magma','sage']]
+
+    if f['name']==['Leech']:
+        info['shortest']=[str([1,-2,-2,-2,2,-1,-1,3,3,0,0,2,2,-1,-1,-2,2,-2,-1,-1,0,0,-1,2]), 
+str([1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3]), str([1,-2,-2,-1,1,-1,-1,2,2,0,0,2,2,0,0,-2,2,-1,-1,-1,0,-1,-1,2])]
+        info['all_shortest']="no"
         info['download_shortest'] = [
             (i, url_for(".render_lattice_webpage_download", label=info['label'], lang=i, obj='shortest_vectors')) for i in ['gp', 'magma','sage']]
 

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -447,7 +447,10 @@ def download_lattice_full_lists_v(**args):
     c = download_comment_prefix[lang]
     outstr = c + ' Full list of normalized minimal vectors downloaded from the LMFDB on %s. \n\n'%(mydate)
     outstr += download_assignment_start[lang] + '\\\n'
-    outstr += str(res['shortest'])
+    if res['name']==['Leech']:
+        outstr += str(res['shortest']).strip('u').replace("'", "")
+    else:
+        outstr += str(res['shortest'])
     outstr += download_assignment_end[lang]
     outstr += '\n'
     return outstr

--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -126,7 +126,6 @@
 {% endif %}
 {% endif %}
 
-<p>{{info}}</p>
 
 {% set KNOWL_ID = "lattice.%s"|format(info['label']) %}
 <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>

--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -121,7 +121,7 @@
 <p>This {{ KNOWL('lattice.definition', title='integral lattice') }} {{KNOWL('lattice.name', title='is')}} the {{ info.name }} lattice.</p>
 {% endif %}
 
-{% if info.comments != " " %}
+{% if info.comments != "" %}
 <p>{{info.comments}}.</p>
 {% endif %}
 {% endif %}

--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -126,6 +126,7 @@
 {% endif %}
 {% endif %}
 
+<p>{{info}}</p>
 
 {% set KNOWL_ID = "lattice.%s"|format(info['label']) %}
 <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>


### PR DESCRIPTION
this fixes Issue #1092 
for the Leech lattice shortest vectors and theta series are stored as list of strings
the download function has been modified for this lattice
all test pass

PS For all except 3 lattices A12, A13, A14, the first 150 coefficients of the associated theta series have been computed and stores (just finished)