### PR TITLE
trivial test fix

### DIFF
--- a/lmfdb/test_homepage.py
+++ b/lmfdb/test_homepage.py
@@ -40,7 +40,7 @@ class HomePageTest(LmfdbTest):
         self.check(homepage,"/ModularForm/GL2/Q/holomorphic/1/12/1/a/", '0.2993668')
         self.check(homepage,"/L/ModularForm/GL2/Q/holomorphic/1/12/1/a/0/", 'approx 0.839345512')
         self.check(homepage,"/EllipticCurve/Q/5077/a/1", r'y^2 + y = x^{3} - 7 x + 6')
-        self.check(homepage,"/L/EllipticCurve/Q/5077.a/", 'is an elliptic curve of conductor 5077')
+        self.check(homepage,"/L/EllipticCurve/Q/5077.a/", 'is an elliptic curve in isogeny class 5077.a')
 
     # Box 3
     def test_box3(self):


### PR DESCRIPTION
PR #1112 broke a test trivially as the title of an elliptic curve L-function changed.  This just corrects the test.