### PR TITLE
Hidden Sato-Tate group implementation, not reachable from anywhere

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -17,7 +17,7 @@ from lmfdb.search_parsing import parse_bool, parse_ints, parse_signed_ints, pars
 from lmfdb.number_fields.number_field import make_disc_key
 from lmfdb.genus2_curves import g2c_page, g2c_logger
 from lmfdb.genus2_curves.isog_class import G2Cisog_class, url_for_label, isog_url_for_label
-from lmfdb.genus2_curves.web_g2c import WebG2C, list_to_min_eqn, isog_label, st_group_name, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
+from lmfdb.genus2_curves.web_g2c import WebG2C, g2cdb, list_to_min_eqn, isog_label, st_group_name, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
 
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
@@ -27,13 +27,6 @@ credit_string = "Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight,
 # global database connection and stats objects
 ###############################################################################
 
-the_g2cdb = None
-def g2cdb():
-    global the_g2cdb
-    if the_g2cdb is None:
-        the_g2cdb = lmfdb.base.getDBConnection().genus2_curves
-    return the_g2cdb
-    
 the_g2cstats = None
 def g2cstats():
     global the_g2cstats
@@ -88,10 +81,6 @@ geom_aut_grp_dict = {
 ###############################################################################
 # Routing for top level, random_curve, by_conductor, and stats
 ###############################################################################
-
-@app.route("/G2C")
-def G2C_redirect():
-    return redirect(url_for(".index", **request.args))
 
 def learnmore_list():
     return [('Completeness of the data', url_for(".completeness_page")),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -541,9 +541,7 @@ class WebG2C(object):
     @staticmethod
     def by_label(label):
         """
-        Searches for a specific elliptic curve in the curves
-        collection by its label
-        label is string separated by "."
+        Searches for a specific genus 2 curve in the curves collection by its label
         """
         try:
             data = g2cdb().curves.find_one({"label" : label})

--- a/lmfdb/sato_tate_groups/__init__.py
+++ b/lmfdb/sato_tate_groups/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from lmfdb.base import app
+from flask import Blueprint
+
+st_page = Blueprint("st", __name__, template_folder='templates', static_folder="static")
+
+@st_page.context_processor
+def body_class():
+    return {'body_class': 'st'}
+
+import main
+
+app.register_blueprint(st_page, url_prefix="/SatoTateGroup")

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -88,7 +88,7 @@ def render_stgroup_by_label(label):
     st0 = stdb().st0_groups.find_one({'label':data['identity_component']})
     if not st0:
         title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', url_for(".index"))]
+        bread = [('Sato-Tate groups', ' ')]
         flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate identity component currently in the database." % (data['identity_component'])),"error")
         return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
     info['st0_name']=st0['pretty']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -75,11 +75,10 @@ def by_label(label):
 def render_stgroup_by_label(label):
     credit = credit_string
     data = stdb().st_groups.find_one({'label': label})
-    print data
     info = {}
     if data is None:
         title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', url_for(".index"))]
+        bread = [('Sato-Tate groups', ' ')]
         flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate group currently in the database." % (label)),"error")
         return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
     for attr in ['label','weight','degree','pretty','real_dimension','components']:

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -96,7 +96,7 @@ def render_stgroup_by_label(label):
     G = stdb().small_groups.find_one({'label':data['component_group']})
     if not G:
         title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', url_for(".index"))]
+        bread = [('Sato-Tate groups', ' ')]
         flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate component group currently in the database." % (data['component_group'])),"error")
         return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
     info['component_group']=G['pretty']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+from flask import flash, render_template, url_for, redirect
+from markupsafe import Markup
+from lmfdb.sato_tate_groups import st_page
+from lmfdb.utils import web_latex, random_object_from_collection
+from lmfdb.base import getDBConnection
+
+from sage.all import ZZ, QQ, latex, matrix
+credit_string = "Andrew Sutherland"
+
+###############################################################################
+# Database connection
+###############################################################################
+
+the_stdb = None
+
+def stdb():
+    global the_stdb
+    if the_stdb is None:
+        the_stdb = getDBConnection().sato_tate_groups
+    return the_stdb
+
+###############################################################################
+# Utility functions
+###############################################################################
+
+def boolean_name(value):
+    return '\\mathrm{True}' if value else '\\mathrm{False}'
+    
+def comma_separated_list(list):
+    return ', '.join(list)
+
+def string_matrix(m):
+    if len(m) == 0:
+        return ''
+    return '\\begin{bmatrix}' + '\\\\'.join(['&'.join(m[i]) for i in range(len(m))]) + '\\end{bmatrix}'
+
+def stgroup_link(weight, degree, name):
+    label = "%d.%d.%s"%(weight,degree,name)
+    data = stdb().st_groups.find_one({'label':label})
+    if not data:
+        return name
+    return """<a href=%s>\(%s\)</a>"""% (url_for(".by_label", label=label), data['pretty'])
+
+###############################################################################
+# Learnmore display functions
+###############################################################################
+
+def learnmore_list():
+    return [('Completeness of the data', url_for(".completeness_page")),
+            ('Source of the data', url_for(".how_computed_page")),
+            ('Sato-Tate group labels', url_for(".labels_page"))]
+
+# Return the learnmore list with the matchstring entry removed
+def learnmore_list_remove(matchstring):
+    return filter(lambda t:t[0].find(matchstring) <0, learnmore_list())
+
+###############################################################################
+# Pages
+###############################################################################
+
+@st_page.route("/random")
+def random():
+    data = random_object_from_collection(stdb().st_groups)
+    return redirect(url_for(".by_label", label=data['label']))
+
+@st_page.route("/<label>")
+def by_label(label):
+    return render_stgroup_by_label(label)
+
+###############################################################################
+# Rendering
+###############################################################################
+
+def render_stgroup_by_label(label):
+    credit = credit_string
+    data = stdb().st_groups.find_one({'label': label})
+    print data
+    info = {}
+    if data is None:
+        title = "Sato-Tate group lookup error"
+        bread = [('Sato-Tate groups', url_for(".index"))]
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate group currently in the database." % (label)),"error")
+        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+    for attr in ['label','weight','degree','pretty','real_dimension','components']:
+        info[attr] = data[attr]
+    info['ambient'] = '\\mathrm{USp}(%d)'%info['degree'] if info['weight']%2 == 1 else '\\mathrm{O}(%d)'%info['degree']
+    info['connected']=boolean_name(info['components'] == 1)
+    st0 = stdb().st0_groups.find_one({'label':data['identity_component']})
+    if not st0:
+        title = "Sato-Tate group lookup error"
+        bread = [('Sato-Tate groups', url_for(".index"))]
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate identity component currently in the database." % (data['identity_component'])),"error")
+        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+    info['st0_name']=st0['pretty']
+    info['st0_description']=st0['description']
+    G = stdb().small_groups.find_one({'label':data['component_group']})
+    if not G:
+        title = "Sato-Tate group lookup error"
+        bread = [('Sato-Tate groups', url_for(".index"))]
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate component group currently in the database." % (data['component_group'])),"error")
+        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+    info['component_group']=G['pretty']
+    info['abelian']=boolean_name(G['abelian'])
+    info['cyclic']=boolean_name(G['cyclic'])
+    info['gens']=comma_separated_list([string_matrix(m) for m in data['gens']])
+    info['numgens']=len(info['gens'])
+    info['subgroups'] = comma_separated_list([stgroup_link(data['weight'],data['degree'],name) for name in data['subgroups']])
+    info['supgroups'] = comma_separated_list([stgroup_link(data['weight'],data['degree'],name) for name in data['supgroups']])
+    info['subsups'] = len(info['subgroups'])+len(info['supgroups'])
+    if data['moments']:
+        info['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%n for n in range(len(data["moments"][0])-1)]]
+        info['moments'] += data['moments']
+    else:
+        info['moments'] = []
+    if data['counts']:
+        c=data['counts']
+        print c
+        info['probabilities'] = [['\\mathrm{P}[%s=%d]=\\frac{%d}{%d}'%(c[i][0],c[i][1][j][0],c[i][1][j][1],data['components']) for j in range(len(c[i][1]))] for i in range(len(c))]
+    else:
+        info['probabilities'] = []
+    prop2 = [
+        ('Label', '%s'%info['label']),
+        ('Subgroup of','\(%s\)'%info['ambient']),
+        ('Name', '\(%s\)'%info['pretty']),
+        ('Weight', '%d'%info['weight']),
+        ('Degree', '%d'%info['degree']),
+        ('Identity Component', '\(%s\)'%info['st0_name']),
+        ('Real dimension', '%d'%info['real_dimension']),
+        ('Components', '%d'%info['components']),
+        ('Component group', '\(%s\)'%info['component_group']),
+    ]
+    bread = [('Sato-Tate groups', ' '), ('Weight %d'% info['weight'], ' '), ('Degree %d'% info['degree'], ' '), (data['name'], '')]
+    title = 'Sato-Tate group \(' + info['pretty'] + '\) of weight %d'% info['weight'] + ' and degree %d'% info['degree']
+    return render_template("display.html",
+                           properties2=prop2,
+                           credit=credit_string,
+                           info=info,
+                           bread=bread,
+                           learnmore=learnmore_list(),
+                           title=title)
+                           #friends=data.friends)
+                           #downloads=data.downloads)
+
+@st_page.route("/Completeness")
+def completeness_page():
+    t = 'Completeness of Sato-Tate group data'
+    bread = [('Sato-Tate groups', ' '), ('Completeness','')]
+    return render_template("single.html", kid='dq.st.extent',
+                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+
+@st_page.route("/Source")
+def how_computed_page():
+    t = 'Source of Sato-Tate group data'
+    bread = [('Sato-Tate groups', ' '), ('Source','')]
+    return render_template("single.html", kid='dq.st.source',
+                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
+@st_page.route("/Labels")
+def labels_page():
+    t = 'Labels for Sato-Tate groups'
+    bread = [('Sato-Tate groups', ' '), ('Labels','')]
+    return render_template("single.html", kid='st.label',
+                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/sato_tate_groups/templates/display.html
+++ b/lmfdb/sato_tate_groups/templates/display.html
@@ -1,0 +1,74 @@
+{% extends "homepage.html" %}
+{% block content %}
+
+{% set KNOWL_ID = "st_group.%s"|format(info['label']) %}
+<h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
+
+<h2> {{ KNOWL('st_group.invariants', title='Invariants') }} </h2>
+<table>
+    <tr><td>{{ KNOWL('st_group.ambient', title='Subgroup of') }}:</td><td>${{info['ambient']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.weight', title='Weight') }}:</td><td>${{info['weight']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.degree', title='Degree') }}:</td><td>${{info['degree']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.connected', title='Connected') }}:</td><td>${{info['connected']}}$</td></tr>
+</table>
+
+<h2> {{ KNOWL('st_group.identity_component', title='Identity Component') }} </h2>
+<table>
+    <tr><td>{{ KNOWL('st_group.st0_name', title='Name') }}:</td><td>${{info['st0_name']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.index', title='Index') }}:</td><td>${{info['components']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.real_dimension', title='Real Dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.st0_description', title='Description') }}:</td><td>${{info['st0_description']}}$</td></tr>
+</table>
+
+{% if info['components'] > 1 %}
+<h2> {{ KNOWL('st_group.component_group', title='Component Group') }} </h2>
+<table>
+    <tr><td>{{ KNOWL('st_group.component_group', title='Name') }}:</td><td>${{info['component_group']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.order', title='Order') }}:</td><td>${{info['components']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.abelian', title='Abelian') }}:</td><td>${{info['abelian']}}$</td></tr>
+    {% if info['numgens'] > 0 %}
+        <tr><td>{{ KNOWL('st_group.generators', title='Generators') }}:</td><td>${{info['gens']}}$</td></tr>
+    {% endif %}
+</table>
+{% endif %}
+
+{% if info['subsups'] > 1 %}
+<h2> {{ KNOWL('st_group.lattice_neighbors', title='Subgoups and Supergroups') }} </h2>
+<table>
+    <tr><td>{{ KNOWL('st_group.subgroups', title='Minimal Supergroups') }}:</td><td>{{info['supgroups']|safe}}</td></tr>
+    <tr><td>{{ KNOWL('st_group.supgroups', title='Maximal Subgroups') }}:</td><td>{{info['subgroups']|safe}}</td></tr>
+</table>
+{% endif %}
+
+{% if info['moments'] != [] %}
+<h2> {{ KNOWL('st_group.moments', title='Moment Statistics') }} </h2>
+<table border=1>
+    {% for m in info['moments'] %}
+        <tr>
+        {% for a in m %}
+            {% if m[0] == 'x' %}
+                <th align="right">${{a}}$</th>
+            {% else %}
+                <td align="right">${{a}}$</td>
+            {% endif %}
+        {% endfor %}
+        </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+{% if info['probabilities'] != [] %}
+<h2> {{ KNOWL('st_group.probabilities', title='Event Probabilities') }} </h2>
+<table border=1>
+    {% for m in info['probabilities'] %}
+        <tr>
+        {% for a in m %}
+            <td align="right">${{a}}$</td>
+        {% endfor %}
+        </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+
+{% endblock %}

--- a/lmfdb/sato_tate_groups/templates/error.html
+++ b/lmfdb/sato_tate_groups/templates/error.html
@@ -1,0 +1,7 @@
+{% extends "homepage.html" %}
+
+{% block content %}
+<div>
+<input type=button value="Back" onClick="history.go(-1)">
+</div>
+{% endblock %}

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -25,6 +25,7 @@ import lfunctions
 # import maass_form_picard
 # import maass_waveforms
 import genus2_curves
+import sato_tate_groups
 import users
 import knowledge
 import upload


### PR DESCRIPTION
Initial implementation of Sato-Tate groups.  There is still some work to do on the data and there are knowls that need to be written, but the display code should be stable.  Currently these pages cannot be reached from anywhere, so there is no danger in merging.   I would like to get this pull request merged and pushed to beta so that people can look at them (by typing in urls directly) and we can then decide whether to link them to the genus 2 pages (which will be a very small change).

There are also a few tiny changes to some of the genus2 files that are just clean up, they are not related to the Sato-Tate group changes (I meant to push these separately but I didn't).