### PR TITLE
Add sato-tate group browsing and linked in genus2

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -16,8 +16,8 @@ from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, comma, random_
 from lmfdb.search_parsing import parse_bool, parse_ints, parse_signed_ints, parse_bracketed_posints, parse_count, parse_start
 from lmfdb.number_fields.number_field import make_disc_key
 from lmfdb.genus2_curves import g2c_page, g2c_logger
-from lmfdb.genus2_curves.isog_class import G2Cisog_class, url_for_label, isog_url_for_label
-from lmfdb.genus2_curves.web_g2c import WebG2C, g2cdb, list_to_min_eqn, isog_label, st_group_name, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
+from lmfdb.genus2_curves.isog_class import G2Cisog_class, url_for_label, isog_url_for_label, st_group_name, st_group_href
+from lmfdb.genus2_curves.web_g2c import WebG2C, g2cdb, list_to_min_eqn, isog_label, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
 
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
@@ -302,6 +302,7 @@ def genus2_curve_search(**args):
             v_clean["is_gl2_type_display"] = ''
         v_clean["equation_formatted"] = list_to_min_eqn(v["min_eqn"])
         v_clean["st_group_name"] = st_group_name(isogeny_class['st_group'])
+        v_clean["st_group_href"] = st_group_href(isogeny_class['st_group'])
         v_clean["analytic_rank"] = v["analytic_rank"]
         res_clean.append(v_clean)
 

--- a/lmfdb/genus2_curves/isog_class.py
+++ b/lmfdb/genus2_curves/isog_class.py
@@ -7,7 +7,7 @@ from flask import url_for, make_response
 import lmfdb.base
 from lmfdb.base import getDBConnection
 from lmfdb.utils import comma, web_latex, encode_plot
-from lmfdb.genus2_curves.web_g2c import g2c_page, g2c_logger, list_to_min_eqn, end_alg_name, st_group_name, st0_group_name
+from lmfdb.genus2_curves.web_g2c import g2c_page, g2c_logger, list_to_min_eqn, end_alg_name, st0_group_name, st_group_name, st_group_href
 from lmfdb.genus2_curves.web_g2c import gl2_statement_base, factorsRR_raw_to_pretty, fod_statement, intlist_to_poly
 from sage.all import QQ, PolynomialRing, factor,ZZ, NumberField, expand, var
 from lmfdb.WebNumberField import field_pretty
@@ -221,6 +221,7 @@ class G2Cisog_class(object):
 
         # Data derived from Sato-Tate group
         self.st_group_name = st_group_name(self.st_group)
+        self.st_group_href = st_group_href(self.st_group)
         self.st0_group_name = st0_group_name(self.real_geom_end_alg)
         # Later used in Lady Gaga box:
         self.real_geom_end_alg_disp = [r'\End(J_{\overline{\Q}}) \otimes \R',
@@ -259,7 +260,7 @@ class G2Cisog_class(object):
                 ('Label', self.label),
                 ('Number of curves', str(self.ncurves)),
                 ('Conductor','%s' % self.cond),
-                ('Sato-Tate group', '\(%s\)' % self.st_group_name),
+                ('Sato-Tate group', self.st_group_href),
                 ('\(%s\)' % self.real_geom_end_alg_disp[0],
                  '\(%s\)' % self.real_geom_end_alg_disp[1]),
                 ('\(\mathrm{GL}_2\)-type','%s' % self.is_gl2_type_name)

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -266,18 +266,14 @@ function show_invs(invstyle) {
 <br>
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 
-{% if data.data.real_geom_end_alg == 'R'%}
-    \(\mathrm{ST} \simeq {{ data.data.st_group_name }}\)
-{% else %}
 <table>
     <tr>
-        <td>\(\mathrm{ST}\)</td><td>\(\simeq\)</td> <td>\({{ data.data.st_group_name}}\)</td>
+        <td>\(\mathrm{ST}\)</td><td>\(\simeq\)</td> <td>{{ data.data.st_group_href|safe}}</td>
     </tr>
     <tr>
         <td>\(\mathrm{ST}^0\)</td><td>\(\simeq\)</td> <td>\({{ data.data.st0_group_name}}\) </td>
     </tr>
 </table>
-{% endif %}
 
 <br>
 

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -52,10 +52,10 @@ text-align: center;
 
 <h2>{{ KNOWL('g2c.st_group', title='Sato-Tate group')}}</h2>
 <p>
-{% if info.real_geom_end_alg == 'R'%}
-\(\mathrm{ST} = {{ info.st_group_name }}\)
+{% if info.st_group == 'USp(4)'%}
+\(\mathrm{ST} =\) {{ info.st_group_href|safe }}
 {% else %}
-\(\mathrm{ST} = {{ info.st_group_name }}, \quad \mathrm{ST}^0 = {{ info.st0_group_name}}\)
+\(\mathrm{ST} =\) {{ info.st_group_href|safe }}, \(\quad \mathrm{ST}^0 = {{ info.st0_group_name}}\)
 {% endif %}
 </p>
 

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -159,7 +159,7 @@
     <td> <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a> </td>
     <td> <a href = "{{info.isog_url(curve)}}"> {{curve.isog_label}} </a> </td>
     <td> \({{curve.equation_formatted}}\) </td>
-    <td align=center> \({{curve.st_group_name}}\) </td>
+    <td align=center> {{curve.st_group_href|safe}} </td>
     <td align=center> {{curve.is_gl2_type_display | safe}} </td>
     <td align=center> {{curve.analytic_rank}} </td>
 </tr>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -107,6 +107,15 @@ def ring_pretty(L, f):
         return r'\Z [' + str(f//2) + r'\sqrt{' + str(D) + r'}]'
     return r'\Z [\frac{1 +' + str(f) + r'\sqrt{' + str(D) + r'}}{2}]'
 
+def st_group_name(st_group):
+    return '\\mathrm{USp}(4)' if st_group == 'USp(4)' else st_group
+
+def url_for_st_group(st_group):
+    return url_for('st.by_label', label='1.4.'+st_group)
+    
+def st_group_href(st_group):
+    return '<a href="%s">$%s$</a>' % (url_for_st_group(st_group),st_group_name(st_group))
+
 ###############################################################################
 # Plot functions
 ###############################################################################
@@ -266,12 +275,6 @@ def st0_group_name(name):
     else:
         return name
 
-def st_group_name(name):
-    if name == 'USp(4)':
-        return '\\mathrm{USp}(4)'
-    else:
-        return name
-        
 def aut_group_name(name):
     return group_dict[name]
 
@@ -291,6 +294,7 @@ def get_st_data(isogeny_class):
     data = {}
     data['isogeny_class'] = isogeny_class
     data['st_group_name'] = st_group_name(isogeny_class['st_group'])
+    data['st_group_href'] = st_group_href(isogeny_class['st_group'])
     data['st0_group_name'] = st0_group_name(isogeny_class['real_geom_end_alg'])
     # Later used in Lady Gaga box:
     data['real_geom_end_alg_disp'] = [ r'\End(J_{\overline{\Q}}) \otimes \R',
@@ -693,7 +697,7 @@ class WebG2C(object):
                ('Conductor','%s' % self.cond),
                ('Discriminant', '%s' % data['disc']),
                ('Invariants', '%s </br> %s </br> %s </br> %s' % tuple(data['ic_norm'])),
-               ('Sato-Tate group', '\(%s\)' % data['st_group_name']),
+               ('Sato-Tate group', data['st_group_href']),
                ('\(%s\)' % data['real_geom_end_alg_disp'][0],
                 '\(%s\)' % data['real_geom_end_alg_disp'][1]),
                ('\(\mathrm{GL}_2\)-type','%s' % data['is_gl2_type_name'])]

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
-from flask import flash, render_template, url_for, redirect
+import re
+from pymongo import ASCENDING, DESCENDING
+from flask import flash, render_template, url_for, redirect, request
 from markupsafe import Markup
 from lmfdb.sato_tate_groups import st_page
-from lmfdb.utils import web_latex, random_object_from_collection
+from lmfdb.utils import to_dict, random_object_from_collection
 from lmfdb.base import getDBConnection
+from lmfdb.search_parsing import parse_bool, parse_ints, parse_rational, parse_count, parse_start
 
-from sage.all import ZZ, QQ, latex, matrix
-credit_string = "Andrew Sutherland"
+###############################################################################
+# Globals
+###############################################################################
+
+credit_string = 'Andrew Sutherland'
+
+# use a list and a dictionary (for pretty printing) so that we can control the display order (switch to ordered dictionary once everyone is on python 3.1)
+st0_list = ( 'U(1)', 'SU(2)', 'U(1)_2', 'SU(2)_2','U(1)xU(1)', 'U(1)xSU(2)','SU(2)xSU(2)','USp(4)' )
+st0_dict = {} # populated below
 
 ###############################################################################
 # Database connection
@@ -18,6 +28,8 @@ def stdb():
     global the_stdb
     if the_stdb is None:
         the_stdb = getDBConnection().sato_tate_groups
+        for r in the_stdb.st0_groups.find():
+            st0_dict[r['label']] = r['pretty']
     return the_stdb
 
 ###############################################################################
@@ -36,20 +48,29 @@ def string_matrix(m):
     return '\\begin{bmatrix}' + '\\\\'.join(['&'.join(m[i]) for i in range(len(m))]) + '\\end{bmatrix}'
 
 def stgroup_link(weight, degree, name):
-    label = "%d.%d.%s"%(weight,degree,name)
+    label = '%d.%d.%s'%(weight,degree,name)
     data = stdb().st_groups.find_one({'label':label})
     if not data:
         return name
-    return """<a href=%s>\(%s\)</a>"""% (url_for(".by_label", label=label), data['pretty'])
-
+    return '''<a href=%s>\(%s\)</a>'''% (url_for('.by_label', label=label), data['pretty'])
+    
+def stgroup_ambient(weight, degree):
+    return '\\mathrm{USp}(%d)'%degree if weight%2 == 1 else '\\mathrm{O}(%d)'%degree
+    
+def trace_moments(moments):
+    for m in moments:
+        if m[0] == 'a_1'or m[0] == 's_1':
+            return m[1:10]
+    return ''
+    
 ###############################################################################
 # Learnmore display functions
 ###############################################################################
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
-            ('Sato-Tate group labels', url_for(".labels_page"))]
+    return [('Completeness of the data', url_for('.completeness_page')),
+            ('Source of the data', url_for('.how_computed_page')),
+            ('Sato-Tate group labels', url_for('.labels_page'))]
 
 # Return the learnmore list with the matchstring entry removed
 def learnmore_list_remove(matchstring):
@@ -59,46 +80,134 @@ def learnmore_list_remove(matchstring):
 # Pages
 ###############################################################################
 
-@st_page.route("/random")
+@st_page.route('/')
+def index():
+    if len(request.args) != 0:
+        return search(**request.args)
+    weight_list= [0,1]
+    degree_list=range(1, 5, 1)
+    group_list = [ '1.2.N(U(1))', '1.2.SU(2)', '1.4.G_{3,3}', '1.4.USp(4)' ]
+    group_dict = { '1.2.N(U(1))':'N(\\mathrm{U}(1))', '1.2.SU(2)':'\\mathrm{SU}(2)', '1.4.G_{3,3}':'G_{3,3}', '1.4.USp(4)':'\\mathrm{USp}(4)' }
+    stdb()  # make sure st0_dict has been loaded
+    info = {'weight_list' : weight_list, 'degree_list' : degree_list, 'st0_list' : st0_list, 'st0_dict' : st0_dict, 'group_list': group_list, 'group_dict' : group_dict}
+    title = 'Sato-Tate groups'
+    bread = [('Sato-Tate groups', '.')]
+    return render_template('browse.html', info=info, credit=credit_string, title=title, learnmore=learnmore_list_remove('Completeness'), bread=bread)
+
+@st_page.route('/random')
 def random():
     data = random_object_from_collection(stdb().st_groups)
-    return redirect(url_for(".by_label", label=data['label']))
+    return redirect(url_for('.by_label', label=data['label']))
 
-@st_page.route("/<label>")
+@st_page.route('/<label>')
 def by_label(label):
-    return render_stgroup_by_label(label)
+    return render_by_label(label)
+    
+###############################################################################
+# Searching
+###############################################################################
+
+def search(**args):
+    info = to_dict(args)
+    query = {}
+    if 'label' in info:
+        label_regex = re.compile(r'\d+.\d+.\S+')
+        if label_regex.match(info['label'].strip()):
+            return render_by_label(info['label'].strip())
+        else:
+            query = { 'name':info['label'] }
+            cursor = stdb().st_groups.find(query)
+            print cursor.count()
+            if cursor.count() == 0:
+                flash(Markup("Error: <span style='color:black'>%s</span> is not the name of a Sato-Tate group currently in the database"%(info["label"])),"error")
+                return redirect(url_for(".index"))
+            if cursor.count() == 1:
+                return render_by_label(cursor.next()['label'])
+    info['st0_list'] = st0_list
+    info['st0_dict'] = st0_dict
+    bread = [('Sato-Tate groups', url_for('.index')),('Search Results', '.')]
+    if not query:
+        try:
+            parse_ints(info,query,'weight')
+            parse_ints(info,query,'degree')
+            if info.get('identity_component'):
+                query['identity_component'] = info['identity_component']
+            parse_ints(info,query,'components')
+            parse_rational(info,query,'trace_zero_density')
+        except ValueError as err:
+            info['err'] = str(err)
+            return render_template('results.html', info=info, title='Sato-Tate groups search input rror', bread=bread, credit=credit_string)
+        cursor = stdb().st_groups.find(query)
+    info['query'] = dict(query)
+    count = parse_count(info, 50)
+    start = parse_start(info)
+    nres = cursor.count()
+    if (start >= nres):
+        start -= (1 + (start - nres) / count) * count
+    if (start < 0):
+        start = 0
+    res = cursor.sort([('weight', ASCENDING), ('degree', ASCENDING),  ('identity_component', ASCENDING),  ('name', ASCENDING)]).skip(start).limit(count)
+    nres = res.count()
+
+    if nres == 1:
+        info['report'] = 'unique match'
+    else:
+        if nres > count or start != 0:
+            info['report'] = 'displaying matches %s-%s of %s' % (start + 1, min(nres, start + count), nres)
+        else:
+            info['report'] = 'displaying all %s matches' % nres
+    res_clean = []
+
+    for v in res:
+        v_clean = {}
+        v_clean['label'] = v['label']
+        v_clean['weight'] = v['weight']
+        v_clean['degree'] = v['degree']
+        v_clean['name'] = v['name']
+        v_clean['pretty'] = v['pretty']
+        v_clean['ambient'] = stgroup_ambient(v['weight'],v['degree'])
+        v_clean['real_dimension'] = v['real_dimension']
+        v_clean['identity_component'] = st0_dict[v['identity_component']]
+        v_clean['components'] = v['components']
+        v_clean['trace_zero_density'] = v['trace_zero_density']
+        v_clean['trace_moments'] = trace_moments(v['moments'])
+        res_clean.append(v_clean)
+
+    info['stgroups'] = res_clean
+    info['stgroup_url'] = lambda dbc: url_for('.by_label', label=dbc['label'])
+    info['start'] = start
+    info['count'] = count
+    info['more'] = int(start+count<nres)
+    
+    credit = credit_string
+    title = 'Sato-Tate group search results'
+    return render_template('results.html', info=info, credit=credit,learnmore=learnmore_list(), bread=bread, title=title)
 
 ###############################################################################
 # Rendering
 ###############################################################################
 
-def render_stgroup_by_label(label):
+def render_by_label(label):
     credit = credit_string
     data = stdb().st_groups.find_one({'label': label})
     info = {}
     if data is None:
-        title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', ' ')]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate group currently in the database." % (label)),"error")
-        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate group currently in the database." % (label)),'error')
+        return redirect(url_for(".index"))
     for attr in ['label','weight','degree','pretty','real_dimension','components']:
         info[attr] = data[attr]
-    info['ambient'] = '\\mathrm{USp}(%d)'%info['degree'] if info['weight']%2 == 1 else '\\mathrm{O}(%d)'%info['degree']
+    info['ambient'] = stgroup_ambient(info['weight'],info['degree'])
     info['connected']=boolean_name(info['components'] == 1)
     st0 = stdb().st0_groups.find_one({'label':data['identity_component']})
     if not st0:
-        title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', ' ')]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate identity component currently in the database." % (data['identity_component'])),"error")
-        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate identity component currently in the database." % (data['identity_component'])),'error')
+        return redirect(url_for(".index"))
     info['st0_name']=st0['pretty']
     info['st0_description']=st0['description']
     G = stdb().small_groups.find_one({'label':data['component_group']})
     if not G:
-        title = "Sato-Tate group lookup error"
-        bread = [('Sato-Tate groups', ' ')]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate component group currently in the database." % (data['component_group'])),"error")
-        return render_template("error.html", title=title, properties=[], bread=bread, learnmore=learnmore_list())
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label of a Sato-Tate component group currently in the database." % (data['component_group'])),'error')
+        return redirect(url_for(".index"))
     info['component_group']=G['pretty']
     info['abelian']=boolean_name(G['abelian'])
     info['cyclic']=boolean_name(G['cyclic'])
@@ -108,56 +217,60 @@ def render_stgroup_by_label(label):
     info['supgroups'] = comma_separated_list([stgroup_link(data['weight'],data['degree'],name) for name in data['supgroups']])
     info['subsups'] = len(info['subgroups'])+len(info['supgroups'])
     if data['moments']:
-        info['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%n for n in range(len(data["moments"][0])-1)]]
+        info['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%n for n in range(len(data['moments'][0])-1)]]
         info['moments'] += data['moments']
     else:
         info['moments'] = []
     if data['counts']:
         c=data['counts']
-        print c
         info['probabilities'] = [['\\mathrm{P}[%s=%d]=\\frac{%d}{%d}'%(c[i][0],c[i][1][j][0],c[i][1][j][1],data['components']) for j in range(len(c[i][1]))] for i in range(len(c))]
     else:
         info['probabilities'] = []
-    prop2 = [
-        ('Label', '%s'%info['label']),
-        ('Subgroup of','\(%s\)'%info['ambient']),
-        ('Name', '\(%s\)'%info['pretty']),
+    prop2 = [('Label', '%s'%info['label'])]
+    if 'trace_histogram' in data:
+        prop2 += [(None, '&nbsp;&nbsp;<img src="%s" width="200" height="114"/>' % data['trace_histogram'])]
+    prop2 += [
         ('Weight', '%d'%info['weight']),
         ('Degree', '%d'%info['degree']),
-        ('Identity Component', '\(%s\)'%info['st0_name']),
+        ('Name', '\(%s\)'%info['pretty']),
+        ('Subgroup of','\(%s\)'%info['ambient']),
         ('Real dimension', '%d'%info['real_dimension']),
+        ('Identity Component', '\(%s\)'%info['st0_name']),
         ('Components', '%d'%info['components']),
         ('Component group', '\(%s\)'%info['component_group']),
     ]
-    bread = [('Sato-Tate groups', ' '), ('Weight %d'% info['weight'], ' '), ('Degree %d'% info['degree'], ' '), (data['name'], '')]
+    bread = [
+        ('Sato-Tate groups', url_for('.index')),
+        ('Weight %d'% info['weight'], url_for('.index')+'?weight='+str(info['weight'])),
+        ('Degree %d'% info['degree'], url_for('.index')+'?weight='+str(info['weight'])+'&degree='+str(info['degree'])),
+        (data['name'], '')
+    ]
     title = 'Sato-Tate group \(' + info['pretty'] + '\) of weight %d'% info['weight'] + ' and degree %d'% info['degree']
-    return render_template("display.html",
+    return render_template('display.html',
                            properties2=prop2,
                            credit=credit_string,
                            info=info,
                            bread=bread,
                            learnmore=learnmore_list(),
                            title=title)
-                           #friends=data.friends)
-                           #downloads=data.downloads)
 
-@st_page.route("/Completeness")
+@st_page.route('/Completeness')
 def completeness_page():
     t = 'Completeness of Sato-Tate group data'
-    bread = [('Sato-Tate groups', ' '), ('Completeness','')]
-    return render_template("single.html", kid='dq.st.extent',
+    bread = [('Sato-Tate groups', url_for('.index')), ('Completeness','')]
+    return render_template('single.html', kid='dq.st.extent',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
-@st_page.route("/Source")
+@st_page.route('/Source')
 def how_computed_page():
     t = 'Source of Sato-Tate group data'
-    bread = [('Sato-Tate groups', ' '), ('Source','')]
-    return render_template("single.html", kid='dq.st.source',
+    bread = [('Sato-Tate groups', url_for('.index')), ('Source','')]
+    return render_template('single.html', kid='dq.st.source',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
-@st_page.route("/Labels")
+@st_page.route('/Labels')
 def labels_page():
     t = 'Labels for Sato-Tate groups'
-    bread = [('Sato-Tate groups', ' '), ('Labels','')]
-    return render_template("single.html", kid='st.label',
+    bread = [('Sato-Tate groups', url_for('.index')), ('Labels','')]
+    return render_template('single.html', kid='st.label',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/sato_tate_groups/templates/browse.html
+++ b/lmfdb/sato_tate_groups/templates/browse.html
@@ -1,0 +1,94 @@
+{% extends "homepage.html" %}
+{% import 'color.css' as color %}
+{% block content %}
+<div>
+{{ KNOWL_INC('dq.st.extent') }}
+</div>
+
+<h2> Browse {{ KNOWL('st_group.definition', title='Sato-Tate groups') }}</h2>
+
+<p>
+By {{ KNOWL('st_group.weight', title='Weight') }}: 
+{% for r in info.weight_list %}
+    <a href="?weight={{r}}">{{r}}</a>
+{% endfor %}
+</p>
+<p>
+By {{ KNOWL('st_group.degree', title='Degree') }}:
+{% for r in info.degree_list %}
+    <a href="?degree={{r}}">{{r}}</a>
+{% endfor %}
+</p>
+<p>
+By {{ KNOWL('st_group.identity_component', title='Identity component') }}: 
+{% for r in info.st0_list %}
+    &nbsp;<a href="?identity_component={{r}}">${{info.st0_dict[r]}}$</a>
+{% endfor %}
+</p>
+<p>
+Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') }}:
+{% for r in info.group_list %}
+    &nbsp;<a href="?label={{r}}"> ${{info.group_dict[r]}}$ </a>
+{% endfor %}
+</p>
+<p>A <a href={{url_for('.random')}}>random Sato-Tate group</a> from the database.
+<br>
+</p>
+
+<h2> Find a specific {{ KNOWL('st_group.definition', title='Sato-Tate group') }} by {{KNOWL('st_group.label', title='label')}} or by {{KNOWL('st_group.name', title='name')}}</h2>
+
+<form>
+<input type='text' name='label' placeholder='USp(4)'>
+<button type='submit'>Search by label</button>
+<br><span class="formexample">e.g. 1.2.SU(2) or SU(2), or 1.4.USp(4) or USp(4)</span>
+</form>
+
+<h2> Search </h2>
+
+<p>Please enter a value or leave blank:</p>
+<form>
+<table>
+<tr>
+<td>{{ KNOWL('st_group.weight', title='Weight') }}:</td>
+<td><input type='text' name='weight' placeholder='1' size=10>
+<td><span class="formexample"> e.g. 1 or 0-3</td>
+</tr>
+<tr>
+<td>{{ KNOWL('st_group.degree', title='Degree') }}:</td>
+<td><input type='text' name='degree' placeholder='4' size=10>
+<td><span class="formexample"> e.g. 4 or 1-6</td>
+</tr>
+<tr>
+<td>{{KNOWL('st_group.identity_component',title='Sato-Tate identity component')}}</td>
+<td><select name='identity_component' width="122" style="width: 122px">
+        <option ></option>
+    {% for r in info.st0_list %}
+        <option value='{{r}}'>{{r}}</option>
+    {% endfor %}
+<td><span class="formexample"> e.g. U(1) or USp(4)</td>
+</select></td>
+
+</tr>
+<tr>
+<td>{{ KNOWL('st_group.components', title='Components') }}:</td>
+<td><input type='text' name='components' placeholder='1' size=10>
+<td><span class="formexample"> e.g. 1 (connected) or 4-12</td>
+</tr>
+<tr>
+<td>{{ KNOWL('st_group.trace_zero_density', title='Trace zero density')}}:</td>
+<td><input type='text' name='trace_zero_density' placeholder='1/2' size=10>
+<td><span class="formexample"> e.g. 0, 1/2, or 3/8</td>
+</tr>
+
+<tr><td colspan='3'>Maximum number of results to display &nbsp; <input type='text' name='count' value=50 size='5' />
+</td>
+</tr>
+
+<tr>
+<td colspan=3><button type='submit' value='Search'>Search</button>
+</td>
+</tr>
+</table>
+</form>
+
+{% endblock %}

--- a/lmfdb/sato_tate_groups/templates/display.html
+++ b/lmfdb/sato_tate_groups/templates/display.html
@@ -14,10 +14,10 @@
 
 <h2> {{ KNOWL('st_group.identity_component', title='Identity Component') }} </h2>
 <table>
-    <tr><td>{{ KNOWL('st_group.st0_name', title='Name') }}:</td><td>${{info['st0_name']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.identity_component', title='Name') }}:</td><td>${{info['st0_name']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.index', title='Index') }}:</td><td>${{info['components']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.real_dimension', title='Real Dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
-    <tr><td>{{ KNOWL('st_group.st0_description', title='Description') }}:</td><td>${{info['st0_description']}}$</td></tr>
+    <tr><td>Description:</td><td>${{info['st0_description']}}$</td></tr>
 </table>
 
 {% if info['components'] > 1 %}

--- a/lmfdb/sato_tate_groups/templates/error.html
+++ b/lmfdb/sato_tate_groups/templates/error.html
@@ -1,7 +1,0 @@
-{% extends "homepage.html" %}
-
-{% block content %}
-<div>
-<input type=button value="Back" onClick="history.go(-1)">
-</div>
-{% endblock %}

--- a/lmfdb/sato_tate_groups/templates/results.html
+++ b/lmfdb/sato_tate_groups/templates/results.html
@@ -1,0 +1,96 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<h2>Refine search </h2>
+
+<form id='re-search'>
+<input type="hidden" name="start" value="{{info.start}}"/>
+<input type="hidden" name="count" value="{{info.count}}"/>
+
+<table>
+<td>{{ KNOWL('st_group.weight', title='weight') }}</td>
+<td>{{ KNOWL('st_group.degree', title='degree')}}</td>
+<td>{{ KNOWL('st_group.identity_component', title='\(\mathrm{ST}^0\)') }}</td>
+<td>{{ KNOWL('st_group.components', title='components')}}</td>
+<td>{{ KNOWL('st_group.trace_zero_density', title='\(\mathrm{P}[a_1=0]\)')}}</td>
+</tr>
+
+<tr>
+<td><input type='text' name='weight' placeholder='1' style="width: 100px" value="{{info.weight}}"></td>
+<td><input type='text' name='degree' placeholder='4' style="width: 100px" value="{{info.degree}}"></td>
+<td><select name='identity_component' style="width: 110px" >
+    <option ></option>
+    {% for G in info.st0_list %}
+        {% if  G == info.identity_component %}
+            <option value='{{G}}' selected>{{G}}</option>
+        {% else %}
+            <option value='{{G}}'>{{G}}</option>
+        {% endif %}
+    {% endfor %}
+</select></td>
+<td><input type='text' name='components' placeholder='1' style="width: 100px" value="{{info.components}}"></td>
+<td><input type='text' name='trace_zero_density' placeholder='1/2' style="width: 100px" value="{{info.trace_zero_density}}"></td>
+</tr>
+<tr>
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td><button type='submit' value='refine'  style="width: 110px">Search again</button></td>
+</tr>
+
+</table>
+</form>
+
+{% if info.err is not defined %}
+
+<h2> Results ({{info.report}})
+{% if info.start > 0 %}
+<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
+{% endif %}
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
+{% endif %}
+</h2>
+
+<table class="ntdata">
+<tr>
+    <th>{{ KNOWL('st_group.label', title='label') }}</th>
+    <th>{{ KNOWL('st_group.weight', title='wt') }}</th>
+    <th>{{ KNOWL('st_group.degree', title='deg') }}</th>
+    <th>{{ KNOWL('st_group.name', title='name') }}</th>
+    <th>{{ KNOWL('st_group.ambient', title='in') }}</th>
+    <th>{{ KNOWL('st_group.real_dimension', title='\(\mathrm{dim}_{\mathbb{R}}\)') }}</th>
+    <th>{{ KNOWL('st_group.identity_component', title='\(\mathrm{ST}^0\)') }}</th>
+    <th>{{ KNOWL('st_group.components', title='&nbsp;&nbsp;c') }}</th>
+    <th>{{ KNOWL('st_group.trace_zero_density', title='\(\mathrm{P}[t=0]\)') }}</th>
+    <th colspan="11">{{ KNOWL('st_group.trace_moments', title='trace moments') }} \(M_0\ \ldots\ M_8\)</th>
+</tr>
+{% for group in info.stgroups: %}
+<tr>
+    <td> <a href = "{{info.stgroup_url(group)}}"> {{group.label}} </a> </td>
+    <td align=right> {{group.weight}} </td>
+    <td align=right> {{group.degree}} </td>
+    <td> ${{group.pretty}}$ </td>
+    <td> ${{group.ambient}}$ </td>
+    <td align=right> {{group.real_dimension}} </td>
+    <td> ${{group.identity_component}}$ </td>
+    <td align=right> {{group.components}} </td>
+    <td align=center> {{group.trace_zero_density}} </td>
+    {% for m in group.trace_moments %}
+        <td align=right>{{m}}</td>
+    {% endfor %}
+</tr>
+{% endfor %}
+</table>
+
+<hr>
+{% if info.start > 0 %}
+<a href="#" class="navlink" onclick="decrease_start_by_count_and_submit_form('re-search');return false">Previous</A>
+{% endif %}
+{% if info.more > 0 %}
+<a href="#" class="navlink" onclick="increase_start_by_count_and_submit_form('re-search');return false">Next</A>
+{% endif %}
+
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Added searching/browsing for Sato-Tate groups, and support for a (static) histogram thumbnail in the properties box.  Currently only USp(4) has a histogram, but I will add them for others tomorrow (this will not require any code it just means putting them in the database).

The Sato-Tate pages are now linked to from the genus 2 curve and isogeny class pages (but this is easy to undo if need be).

This should make Sato-Tate groups a candidate for inclusion in the sidebar -- once this is pushed people can play with it and see what they think.  I still need to add some data and write knowls, but there should be no further code changes (other than bug fixes).