### PR TITLE
changed HMF L-function test to one which is now listed (most are hidden)

### DIFF
--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -78,8 +78,8 @@ class HMFTest(LmfdbTest):
         assert 'heckeEigenvaluesArray := [4, -4,' in L.data
 
     def test_Lfun_link(self):
-        L = self.tc.get('/ModularForm/GL2/TotallyReal/4.4.2048.1/holomorphic/4.4.2048.1-784.2-a')
-        assert 'L/ModularForm/GL2/TotallyReal/4.4.2048.1/holomorphic/4.4.2048.1-784.2-a' in L.data
+        L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a')
+        assert         'L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a' in L.data
 
     def test_browse(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/')


### PR DESCRIPTION
After PR #1135 many HMF L-functions are hidden, wit hno link from the associated HMF web page.  That broke a test (base degree 4, large level) to I replaced it with a smaller one which is still there.
