### PR TITLE
minor edit to test_users so pass with pymongo 3.2.2

### DIFF
--- a/lmfdb/users/test_users.py
+++ b/lmfdb/users/test_users.py
@@ -22,7 +22,7 @@ class UsersTestCase(LmfdbTest):
         # ))
 
     def tearDown(self):
-        self.users.remove("$test_user")
+        pass # self.users.remove("$test_user")
 
     ### helpers
     def get_me(self, id='$test_user'):


### PR DESCRIPTION
Just a tweak to a test file since I have pymongo 3.2.2 on my test machine.  (There seems no reason to still enforce pymongo 2.8, but there is no hurry to change that.)