### PR TITLE
added the missing import os

### DIFF
--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -85,6 +85,7 @@ map(root_static_file, ['favicon.ico'])
 @app.route("/robots.txt")
 def robots_txt():
     if "www.lmfdb.org".lower() in request.url_root.lower():
+        import os
         fn = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "robots.txt")
         if os.path.exists(fn):
             return open(fn).read()


### PR DESCRIPTION
I can't test this. But it was an easy fix

```
Exception on /robots.txt [GET]
Traceback (most recent call last):
  File "/home/lmfdb/sage3/local/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/lmfdb/sage3/local/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/lmfdb/sage3/local/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/lmfdb/sage3/local/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/lmfdb/sage3/local/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/lmfdb/lmfdb-git-prod/lmfdb/website.py", line 88, in robots_txt
    fn = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "robots.txt")
NameError: global name 'os' is not defined
```