### PR TITLE
add Sato-Tate groups to beta sidebar

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -236,7 +236,8 @@
       url_for: "galois_groups.index"
       colspan: onecolumn
     - title: Sato-Tate groups
-      status: future
+      url_for: "st.index"
+      status: beta
       colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"


### PR DESCRIPTION
Does what it says.  No change to sidebar in non-beta mode.