### PR TITLE
Add top/bottom knowls to Galois groups.

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -199,6 +199,7 @@ def render_group_webpage(args):
             info['err'] = "Group " + label + " was not found in the database."
             info['label'] = label
             return search_input_error(info, bread)
+        data['label_raw'] = label.lower()
         title = 'Galois Group: ' + label
         wgg = WebGaloisGroup.from_data(data)
         n = data['n']

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -10,6 +10,8 @@ table.reptable td, table.reptable th {
 }
 </style>
 
+{% set KNOWL_ID = "gg.%s"|format(info['label_raw']) %}
+<h2>{{ KNOWL_INC(KNOWL_ID+'.top', title='') }}</h2>
 
   <p><h2>{{ KNOWL('gg.group_action_invariants', title='Group action invariants') }}</h2>
     <table>
@@ -121,5 +123,7 @@ list of indecomposable integral representations:
     </table>
   {% endif %}
 {% endif %}
+
+<h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>
 
 {% endblock %}


### PR DESCRIPTION
Does what the title says.  The only such knowl currently is a bottom knowl for 4T3.

Note, you can use label 4t3 or 4T3 in the url, and this uses the lower case version for making top/bottom knowls.  It is intended as a proof of concept that it is easy to have top/bottom knowls for objects where the preferred labels have uppercase characters.