### PR TITLE
Added links to Sato-Tate groups to ec and ecnf pages

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -215,6 +215,12 @@ class ECNF(object):
                 self.End = "\(\Z[\sqrt{%s}]\)" % (d4)
             else:
                 self.End = "\(\Z[(1+\sqrt{%s})/2]\)" % self.cm
+            if self.signature == [0,1] and self.abs_disc == -self.cm:
+                self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.U(1)'),'\\mathrm{U}(1)')
+            else:
+                self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.N(U(1))'),'N(\\mathrm{U}(1))')
+        else:
+            self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.SU(2)'),'\\mathrm{SU}(2)')
 
         # Q-curve / Base change
         self.qc = "no"

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -206,6 +206,13 @@ cellpadding="5";
         </tr>
         <tr><td colspan=5>     {{ code(ec.code,'cm') }}</td></tr>
 
+        <tr>
+        <td> \( \text{ST} (E) \)</td>
+        <td>=</td>
+        <td>{{ ec.ST|safe }}</td>
+        </td>
+        </tr>
+
 </table>
 </div>
 

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -193,6 +193,12 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
         </td>
         </tr>
 
+        <tr>
+        <td> \( \text{ST} (E) \)</td>
+        <td>&nbsp;=&nbsp;</td>
+        <td>{{ data.data.ST|safe }}</td>
+        </tr>
+
        </table>
 
     <h2> {{ KNOWL('ec.q.bsd_invariants', title='BSD invariants') }} </h2>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -186,6 +186,9 @@ class WebEC(object):
                 data['EndE'] = "\(\Z[\sqrt{%s}]\)" % d4
             else:
                 data['EndE'] = "\(\Z[(1+\sqrt{%s})/2]\)" % data['CMD']
+            data['ST'] = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.N(U(1))'),'N(\\mathrm{U}(1))')
+        else:
+            data['ST'] = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.SU(2)'),'\\mathrm{SU}(2)')
 
         # modular degree
 


### PR DESCRIPTION
Small change to add the Sato-Tate group of an elliptic curve over Q or other number field as an invariant listed on the curves home page immediately below the endomorphism ring.

Over Q the Sato-Tate group is either N(U(1)) (CM case) or SU(2) (no CM).
Examples of both can be found at:

http://localhost:37777/EllipticCurve/Q/27/a/1
http://localhost:37777/EllipticCurve/Q/11/a/1

Over a number field K the Sato-Tate there are 3 possibilities: U(1), N(U(1)), or SU(2) depending on whether we have CM with CM field contained in K, CM field not in K, or no CM.

Examples of all three cases can be found at:

http://localhost:37777/EllipticCurve/2.0.11.1/%5B9%2C2%2C1%5D/CMa/1
http://localhost:37777/EllipticCurve/2.0.11.1/%5B1024%2C0%2C32%5D/c/1
http://localhost:37777/EllipticCurve/4.4.3600.1/100.1/f/1

Note that the branch is named ecstlink, not master.