### PR TITLE
Changed label format to conform to knowl id format

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -21,9 +21,9 @@ st0_dict = {
     'SU(2)':'\\mathrm{SU}(2)',
     'U(1)_2':'\\mathrm{U}(1)_2',
     'SU(2)_2':'\\mathrm{SU}(2)_2',
-    'U(1)xU(1)':'\\mathrm{U}(1)x\\mathrm{U}(1)',
-    'U(1)xSU(2)':'\\mathrm{U}(1)x\\mathrm{SU}(2)',
-    'SU(2)xSU(2)':'\\mathrm{SU}(2)x\\mathrm{SU}(2)',
+    'U(1)xU(1)':'\\mathrm{U}(1)\\times\\mathrm{U}(1)',
+    'U(1)xSU(2)':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)',
+    'SU(2)xSU(2)':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)',
     'USp(4)':'\\mathrm{USp}(4)'
 }
 
@@ -252,14 +252,14 @@ def render_by_label(label):
     if 'trace_histogram' in data:
         prop2 += [(None, '&nbsp;&nbsp;<img src="%s" width="200" height="114"/>' % data['trace_histogram'])]
     prop2 += [
+        ('Name', '\(%s\)'%info['pretty']),
         ('Weight', '%d'%info['weight']),
         ('Degree', '%d'%info['degree']),
-        ('Name', '\(%s\)'%info['pretty']),
         ('Subgroup of','\(%s\)'%info['ambient']),
-        ('Real dimension', '%d'%info['real_dimension']),
         ('Identity Component', '\(%s\)'%info['st0_name']),
-        ('Components', '%d'%info['components']),
+        ('Real dimension', '%d'%info['real_dimension']),
         ('Component group', '\(%s\)'%info['component_group']),
+        ('Components', '%d'%info['components']),
     ]
     bread = [
         ('Sato-Tate groups', url_for('.index')),

--- a/lmfdb/sato_tate_groups/templates/browse.html
+++ b/lmfdb/sato_tate_groups/templates/browse.html
@@ -40,7 +40,7 @@ Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') 
 <form>
 <input type='text' name='label' placeholder='USp(4)'>
 <button type='submit'>Search by label</button>
-<br><span class="formexample">e.g. 1.2.SU(2) or SU(2), or 1.4.USp(4) or USp(4)</span>
+<br><span class="formexample">e.g. 1.2.1.2.1a or N(U(1)), or 1.4.10.1.1a or USp(4)</span>
 </form>
 
 <h2> Search </h2>

--- a/lmfdb/sato_tate_groups/templates/display.html
+++ b/lmfdb/sato_tate_groups/templates/display.html
@@ -6,17 +6,19 @@
 
 <h2> {{ KNOWL('st_group.invariants', title='Invariants') }} </h2>
 <table>
-    <tr><td>{{ KNOWL('st_group.ambient', title='Subgroup of') }}:</td><td>${{info['ambient']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.name', title='Label') }}:</td><td>{{info['label']}}</td></tr>
     <tr><td>{{ KNOWL('st_group.weight', title='Weight') }}:</td><td>${{info['weight']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.degree', title='Degree') }}:</td><td>${{info['degree']}}$</td></tr>
-    <tr><td>{{ KNOWL('st_group.connected', title='Connected') }}:</td><td>${{info['connected']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.real_dimension', title='$\mathbb{R}$-dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.components', title='Components') }}:</td><td>${{info['components']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.ambient', title='Subgroup of') }}:</td><td>${{info['ambient']}}$</td></tr>
 </table>
 
 <h2> {{ KNOWL('st_group.identity_component', title='Identity Component') }} </h2>
 <table>
     <tr><td>{{ KNOWL('st_group.identity_component', title='Name') }}:</td><td>${{info['st0_name']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.index', title='Index') }}:</td><td>${{info['components']}}$</td></tr>
-    <tr><td>{{ KNOWL('st_group.real_dimension', title='Real Dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.real_dimension', title='$\\mathrm{R}$-dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
     <tr><td>Description:</td><td>${{info['st0_description']}}$</td></tr>
 </table>
 
@@ -33,10 +35,10 @@
 {% endif %}
 
 {% if info['subsups'] > 1 %}
-<h2> Subgoups and Supergroups </h2>
+<h2> {{ KNOWL('st_group.lattice_neighbors', title='Subgoups and Supergroups') }} </h2>
 <table>
-    <tr><td>{{ KNOWL('st_group.supgroups', title='Minimal Supergroups') }}:</td><td>{{info['supgroups']|safe}}</td></tr>
-    <tr><td>{{ KNOWL('st_group.subgroups', title='Maximal Subgroups') }}:</td><td>{{info['subgroups']|safe}}</td></tr>
+    <tr><td>{{ KNOWL('st_group.subgroups', title='Minimal Supergroups') }}:</td><td>{{info['supgroups']|safe}}</td></tr>
+    <tr><td>{{ KNOWL('st_group.supgroups', title='Maximal Subgroups') }}:</td><td>{{info['subgroups']|safe}}</td></tr>
 </table>
 {% endif %}
 


### PR DESCRIPTION
Changed format of Sato-Tate group labels to conform to knowl id requirements (see discussion at https://github.com/LMFDB/lmfdb/issues/1140).  The new format is:

    w.d.r.c.ns

where w=weight, d=degree, r=real dim, c=components, n are all nonnegative integers and s is a lower case letter used to break ties (n is the 2nd number in the GAP id [c,n] of the component group).

This change should be merged and pushed quickly.  Despite my best efforts I managed to slightly break the current SatoTateGroups implementation in a few places.