### PR TITLE
limit symmetrix square/cube ec L-functions to N<=300/50

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -147,8 +147,10 @@ class ECisog_class(object):
 
         self.friends =  [('L-function', self.lfunction_link)]
         if not self.CM:
-            self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso)),
-                             ('Symmetric 4th power L-function', url_for("l_functions.l_function_ec_sym_page", power='4', label=self.lmfdb_iso))]
+            if int(N)<=300:
+                self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso))]
+            if int(N)<=50:
+                self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', label=self.lmfdb_iso))]
         if newform_exists_in_db:
             self.friends +=  [('Modular form ' + self.newform_label, self.newform_link)]
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -340,8 +340,10 @@ class WebEC(object):
             ('All twists ', url_for(".rational_elliptic_curves", jinv=self.jinv)),
             ('L-function', url_for("l_functions.l_function_ec_page", label=self.lmfdb_label))]
         if not self.cm:
-            self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso)),
-            ('Symmetric 4th power L-function', url_for("l_functions.l_function_ec_sym_page", power='4', label=self.lmfdb_iso))]
+            if N<=300:
+                self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso))]
+            if N<=50:
+                self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', label=self.lmfdb_iso))]
         if newform_exists_in_db:
             self.friends += [('Modular form ' + self.newform_label, self.newform_link)]
 


### PR DESCRIPTION
For elliptic curves over Q (and their isogeny classes) only offer Sym^2 L-functions for n<=300 and Sym^3 for N<=50; never Sym^4.  This is to avoid anything which takes over 20s.
The SYm-power L-functions own page wtill offers too many higher powers.  Somewhere around lfunctions/main.py:713  could deal with that (later?).

See discussion at #1160 