### PR TITLE
hide Knowledge when not logged in

### DIFF
--- a/lmfdb/index_boxes.yaml
+++ b/lmfdb/index_boxes.yaml
@@ -37,7 +37,9 @@ links:
 title: Explore and Learn
 image: map
 content: <p>The LMFDB makes visible the connections predicted by the Langlands program.
-    Knowls offer background information when you need it.</p><p><a href="/bigpicture">LMFDB map</a>&nbsp;&nbsp;&nbsp;&nbsp;<a class="knowl" href="/knowledge/">Knowledge</a></p>
+    Knowls offer background information when you need it.</p><p><a href="/bigpicture">LMFDB map</a></p>
+# content: <p>The LMFDB makes visible the connections predicted by the Langlands program.
+#     Knowls offer background information when you need it.</p><p><a href="/bigpicture">LMFDB map</a>&nbsp;&nbsp;&nbsp;&nbsp;<a class="knowl" href="/knowledge/">Knowledge</a></p>
 control: 0
 links:
   - [ 0,0 ]

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -2,6 +2,7 @@
 {%- for key, heading, value in sidebar.data -%}
 {%- if BETA or not value.status -%}{# an entire section may be omitted e.g. Motives #}
 
+{% if user_is_authenticated or key != '9Know' %}
 {{heading | safe}}
 
 {% if value.type == 'L' %}
@@ -211,6 +212,7 @@
 {# nothing needs doing as only the header appears, e.g. Knowledge #}
 
 {% endif %} {# if value.type == ... #}
+{%- endif -%} {# user_is_authenticated or not Knowledge #}
 {%- endif -%} {# if BETA or not value.status #}
 {%- endfor -%} {# for key, heading, value in sidebar.data #}
 


### PR DESCRIPTION
This does two thongs (see discussion at #1166):
1. The sidebar does not include Knowledge at the bottom when not logged in (similar to the Data section)
2. The lower left browse box in the top home page, titled Explore and Learn, does not have the Knowledge link at all.  (It still mention knowls and the word Knowl could be a knowl pointing to http://beta.lmfdb.org/knowledge/show/doc.knowl).