### PR TITLE
Mongo replica set client

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -47,7 +47,7 @@ def makeDBConnection(port, **kwargs):
         logging.info("establishing db connection at port %s ..." % port)
         import pymongo
         logging.info("using pymongo version %s" % pymongo.version)
-        if pymongo.version_tuple[0] >= 3 or kwargs.get("replicaset") == '':
+        if pymongo.version_tuple[0] >= 3 or kwargs.get("replicaset",None) is None:
             from pymongo import MongoClient
             _C = MongoClient(port = port,  **kwargs)
         else:

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -55,16 +55,16 @@ def makeDBConnection(port, **kwargs):
             _C = MongoReplicaSetClient(port = port,  **kwargs)
         mongo_info = _C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
-        logging.info("_C = %s", _C)
+        logging.info("_C = %s", (_C,) )
         #the reads are not necessarily from host/address
         #those depend on the cursor, and can be checked with cursor.conn_id or cursor.address 
         if pymongo.version_tuple[0] >= 3:
-            logging.info("_C.address = %s" % _C.address)
+            logging.info("_C.address = %s" % (_C.address,) )
         else:
-            logging.info("_C.host = %s" % _C.host)
+            logging.info("_C.host = %s" % (_C.host,) )
 
-        logging.info("_C.nodes = %s" %  _C.nodes)
-        logging.info("_C.read_preference = %s" %  _C.read_preference)
+        logging.info("_C.nodes = %s" %  (_C.nodes,) )
+        logging.info("_C.read_preference = %s" %  (_C.read_preference,) )
 
 
 

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -55,6 +55,17 @@ def makeDBConnection(port, **kwargs):
             _C = MongoReplicaSetClient(port = port,  **kwargs)
         mongo_info = _C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
+        logging.info("_C = %s", _C)
+        #the reads are not necessarily from host/address
+        #those depend on the cursor, and can be checked with cursor.conn_id or cursor.address 
+        if pymongo.version_tuple[0] >= 3:
+            logging.info("_C.address = %s" % _C.address)
+        else:
+            logging.info("_C.host = %s" % _C.host)
+
+        logging.info("_C.nodes = %s" %  _C.nodes)
+        logging.info("_C.read_preference = %s" %  _C.read_preference)
+
 
 
 # Global to track of many auto reconnect attempts for _db_reconnect

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -47,8 +47,12 @@ def makeDBConnection(port, **kwargs):
         logging.info("establishing db connection at port %s ..." % port)
         import pymongo
         logging.info("using pymongo version %s" % pymongo.version)
-        from pymongo.mongo_client import MongoClient
-        _C = MongoClient(port = port,  **kwargs)
+        if pymongo.version_tuple[0] >= 3:
+            from pymongo import MongoClient
+            _C = MongoClient(port = port,  **kwargs)
+        else:
+            from pymongo import MongoReplicaSetClient
+            _C = MongoReplicaSetClient(port = port,  **kwargs)
         mongo_info = _C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
 

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -47,7 +47,7 @@ def makeDBConnection(port, **kwargs):
         logging.info("establishing db connection at port %s ..." % port)
         import pymongo
         logging.info("using pymongo version %s" % pymongo.version)
-        if pymongo.version_tuple[0] >= 3:
+        if pymongo.version_tuple[0] >= 3 or kwargs.get("replicaset") == '':
             from pymongo import MongoClient
             _C = MongoClient(port = port,  **kwargs)
         else:

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -315,6 +315,13 @@ def get_configuration():
                         except ValueError:
                             #it wasn't a number...
                             pass;
+                elif key == "replicaset":
+                    #if the string is empty
+                    if not value:
+                        #enforcing None to be the default if
+                        mongo_client_options["replicaset"] = None
+                    else: 
+                        mongo_client_options["replicaset"] = value
                 else:
                     mongo_client_options[key] = value        
 


### PR DESCRIPTION
For pymongo 2.x it is highly advisable to use MongoReplicaSetClient instead of just MongoClient.

I tested it with pymongo 2.8 and 3.2.2

For more details see:
https://api.mongodb.org/python/2.8/api/pymongo/mongo_replica_set_client.html
https://jira.mongodb.org/browse/PYTHON-1091?focusedCommentId=1254814&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1254814
