### PR TITLE
Fixes issue #1173

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -341,6 +341,9 @@ def elliptic_curve_search(**args):
     
     if 'download' in info and info['download'] != 0:
         return download_search(info)
+
+    if not 'query' in info:
+        info['query'] = {}
     
     bread = [('Elliptic Curves', url_for(".index")),
              ('Search Results', '.')]
@@ -351,8 +354,6 @@ def elliptic_curve_search(**args):
         try:
             nf, cond_label, iso_label, number = split_full_label(label.strip())
         except ValueError:
-            if not 'query' in info:
-                info['query'] = {}
             info['err'] = ''
             return search_input_error(info, bread)
 


### PR DESCRIPTION
Previously info['query'] was not set when displaying an error due to bad input.  This is now fixed.

In current version: type "abc" into the number field box and press search.  You will then see the error message "Error: abc is not a valid input for base number field. It must be of the form ..., such as 2.2.5.1." followed by a server error.

With fix: do the same thing and you will see the error message and be taken to the search results page (no server error).