### PR TITLE
remove one test after #1167

### DIFF
--- a/lmfdb/test_homepage.py
+++ b/lmfdb/test_homepage.py
@@ -69,7 +69,8 @@ class HomePageTest(LmfdbTest):
         """
         homepage = self.tc.get("/").data
         self.check(homepage, "/bigpicture", 'some varieties are modular')
-        self.check(homepage, "/knowledge/", 'Recently modified Knowls')
+        # removed in PR #1167
+        #self.check(homepage, "/knowledge/", 'Recently modified Knowls')
 
     # Box 6
     def test_box6(self):


### PR DESCRIPTION
Trivial -- after #1167  we don't test for "knowledge" in the top home page.