### PR TITLE
Put Sato Tate groups on production side bar

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -237,7 +237,6 @@
       colspan: onecolumn
     - title: Sato-Tate groups
       url_for: "st.index"
-      status: beta
       colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"


### PR DESCRIPTION
I think Sato-Tate groups is now ready for the production side bar.  For Release 1.0 only weight 1 Sato-Tate groups will appear, but the code supports other weights.  There are currently a handful of weight 0 groups in the database for those who want to see how they look when reviewing this pull request.