### PR TITLE
Only show L-function friend if conductor & dimension make it reasonable.

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -206,7 +206,8 @@ def render_artin_representation_webpage(label):
                 friends.append(("Determinant character", url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
 
     # once the L-functions are in the database, the link can always be shown
-    if the_rep.dimension() <= 6:
+    #if the_rep.dimension() <= 6:
+    if int(the_rep.conductor())**the_rep.dimension() <= 50000000:
         friends.append(("L-function", url_for("l_functions.l_function_artin_page",
                                           label=the_rep.label())))
     info={}


### PR DESCRIPTION
The cutoff is the analogous to the one used for Dedekind zeta-functions.

In dimension 3, this allows the link for the first few Artin reps, but not ones near the bottom of the first page of search results.