### PR TITLE
Fix critical issue #1207 in classical modular forms

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
@@ -96,7 +96,7 @@ info in this page is set by set_info_for_web_newform in emf_render_web_newform.p
         <td align="left">{{ f.coefficient_field.relative_polynomial_latex('x') }}</td>
         {% elif not f.coefficient_field.lmfdb_label and f.coefficient_field.lmfdb_label != '1.1.1.1'%}
         <td align="left">$\Q(\alpha_{ {{loop.index}} })$</td>
-        <td align="left">{{ f.coefficient_field.relative_polynomial_latex('x') }}</td>
+        <td align="left">{{ f.coefficient_field.relative_polynomial_latex('x') if f.coefficient_field.degree() > 1 else '\(x\)'}}</td>
         {% endif %}
     </tr>
     {% endfor %}

--- a/lmfdb/templates/universe.html
+++ b/lmfdb/templates/universe.html
@@ -101,7 +101,7 @@ div#svg_examples{
 
 
 svg{
-	width:72%;
+	width:88%;
         margin-left:5%;
 }
 svg *{


### PR DESCRIPTION
This is a simple one line fix, the code was failing because the rational coefficient field has no method .relative_polynomial_latex. 

Note: test_non_triv_character fails, but it failed before this change as well, I will raise a separate (non-criticla) issue for this.