### PR TITLE
Minimal change, trying to speed up /EllipticCurve/Q

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -89,18 +89,19 @@ def rational_elliptic_curves(err_args=None):
             for field in ['conductor', 'jinv', 'torsion', 'rank', 'sha', 'optimal', 'torsion_structure', 'msg']:
                 err_args[field] = ''
             err_args['count'] = '100'
-    counts = get_stats().counts()
+    # counts = get_stats().counts()
 
-    conductor_list_endpoints = [1, 100, 1000, 10000, 100000, counts['max_N'] + 1]
+    conductor_list_endpoints = [1, 100, 1000, 10000, 100000]
     conductor_list = ["%s-%s" % (start, end - 1) for start, end in zip(conductor_list_endpoints[:-1],
                                                                        conductor_list_endpoints[1:])]
-    rank_list = range(counts['max_rank'] + 1)
+    # rank_list = range(counts['max_rank'] + 1)
+    rank_list = range(5)
     torsion_list = range(1,11) + [12, 16]
     info = {
         'rank_list': rank_list,
         'torsion_list': torsion_list,
         'conductor_list': conductor_list,
-        'counts': counts,
+        # 'counts': counts,
         'stats_url': url_for(".statistics")
     }
     credit = 'John Cremona and Andrew Sutherland'

--- a/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
@@ -40,7 +40,7 @@
   can only occur at primes 277, 349, 353, 389, 461, 523, 587.
   The nonlift weight 2 eigenform at $p=277$ is proven;
   the others are conjectured.
-<!--
+
   The Fourier coefficients and some eigenvalues of the nonlift weight 2 eigenform 
   in $S_2(K(277))$
   and of the conjectured nonlift weight 2 eigenforms in
@@ -49,5 +49,5 @@
   are given in the
 <a href="{{ url_for( 'ModularForm_GSp4_Q_top_level', group='Kp', page = 'forms') }}">
 main page</a>
- for this group.-->
+ for this group.
 </p>

--- a/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
@@ -40,7 +40,7 @@
   can only occur at primes 277, 349, 353, 389, 461, 523, 587.
   The nonlift weight 2 eigenform at $p=277$ is proven;
   the others are conjectured.
-
+  
   The Fourier coefficients and some eigenvalues of the nonlift weight 2 eigenform 
   in $S_2(K(277))$
   and of the conjectured nonlift weight 2 eigenforms in

--- a/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
@@ -40,7 +40,6 @@
   can only occur at primes 277, 349, 353, 389, 461, 523, 587.
   The nonlift weight 2 eigenform at $p=277$ is proven;
   the others are conjectured.
-  
   The Fourier coefficients and some eigenvalues of the nonlift weight 2 eigenform 
   in $S_2(K(277))$
   and of the conjectured nonlift weight 2 eigenforms in

--- a/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Kp_basic.html
@@ -40,6 +40,7 @@
   can only occur at primes 277, 349, 353, 389, 461, 523, 587.
   The nonlift weight 2 eigenform at $p=277$ is proven;
   the others are conjectured.
+<!--
   The Fourier coefficients and some eigenvalues of the nonlift weight 2 eigenform 
   in $S_2(K(277))$
   and of the conjectured nonlift weight 2 eigenforms in
@@ -48,5 +49,5 @@
   are given in the
 <a href="{{ url_for( 'ModularForm_GSp4_Q_top_level', group='Kp', page = 'forms') }}">
 main page</a>
- for this group.
+ for this group.-->
 </p>


### PR DESCRIPTION
Currently /EllipticCurve/Q is slow to load.  Right now, it calls "counts" in order to get ranges for browse.  I hard coded these.  I have slightly improved performance on my local copy, but it's hard to tell if this will make a difference when it goes to the cloud/Warwick.  I'd like to try, and I'm doing this in stages with the minimal change here.  

If this doesn't work, we could then try replacing this code which computes something with instead hard coded lines in the template.  (For example, what is happening in the function zip?)  Since this page is going to be loaded a zillion times, we really shouldn't be doing anything nontrivial. 