### PR TITLE
Fix to issue #1250 plus optimization

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -255,8 +255,9 @@ def show_ecnf1(nf):
     info['more'] = int(start + count < nres)
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs
-    if nf_label:
-        info['stats'] = ecnf_field_summary(nf_label)
+    #don't risk recomputing all the ecnf stats just to show curves for a single number field
+    #if nf_label:
+        #info['stats'] = ecnf_field_summary(nf_label)
     if nres == 1:
         info['report'] = 'unique match'
     else:

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -53,37 +53,37 @@
          </select>
 </td>
 <td>         <select name='include_Q_curves'>
-{% if info.include_Q_curves == "include" %}
-           <option value="include" selected="yes">include</option>
+{% if info.include_Q_curves == "only" %}
+           <option value="include">include</option>
            <option value="exclude">exclude</option>
-           <option value="only">only</option>
+           <option value="only" selected="yes">only</option>
 {% else %}
 {% if info.include_Q_curves == "exclude" %}
            <option value="include">include</option>
            <option value="exclude" selected="yes">exclude</option>
            <option value="only">only</option>
 {% else %}
-           <option value="include">include</option>
+           <option value="include" selected="yes">include</option>
            <option value="exclude">exclude</option>
-           <option value="only" selected="yes">only</option>
+           <option value="only">only</option>
 {% endif %}
 {% endif %}
          </select>
 </td>
 <td>         <select name='include_cm'>
-{% if info.include_cm == "include" %}
-           <option value="include" selected="yes">include</option>
+{% if info.include_cm == "only" %}
+           <option value="include">include</option>
            <option value="exclude">exclude</option>
-           <option value="only">only</option>
+           <option value="only" selected="yes">only</option>
 {% else %}
 {% if info.include_cm == "exclude" %}
            <option value="include">include</option>
            <option value="exclude" selected="yes">exclude</option>
            <option value="only">only</option>
 {% else %}
-           <option value="include">include</option>
+           <option value="include" selected="yes">include</option>
            <option value="exclude">exclude</option>
-           <option value="only" selected="yes">only</option>
+           <option value="only">only</option>
 {% endif %}
 {% endif %}
          </select>


### PR DESCRIPTION
This addresses issue #1250 and improves performance of field links on EllipticCurves/

To test the fix to #1250, go to www.lmfdb.org and click on one of the fields listed at the top of the page to go to http://www.lmfdb.org/EllipticCurve/3.3.1957.1/, for example.  You will see that both Q-curves and CM curves are set to only.

But with the pull request applied, e.g. go to http://127.0.0.1:37777/EllipticCurve/3.3.1957.1/, you should see that both Q-curves and CM curves are set to include.

Additionally, in order to improve the performance of these pages, the currently displayed statistics about the number of curves, isogeny classes, and conductors that occur over the number field are suppressed.  This reduce the page load time from >5s to under 0.5s.  We can put the statistics back in once they are stored in the database as discussed in https://github.com/LMFDB/lmfdb/issues/1247