### PR TITLE
fixed one HMF test for missing elliptic curve

### DIFF
--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -19,7 +19,7 @@ class HMFTest(LmfdbTest):
         assert 'edirect' in L.data
 
     def test_EC(self): #778
-        L = self.tc.get('/ModularForm/GL2/TotallyReal/3.3.733.1/holomorphic/3.3.733.1-146.1-a')
+        L = self.tc.get('ModularForm/GL2/TotallyReal/6.6.300125.1/holomorphic/6.6.300125.1-631.2-d')
         assert 'Elliptic curve not available' in L.data     #TODO remove or change url when
                                                             #the elliptic curve is in the database
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.89.1/holomorphic/2.2.89.1-2.1-a')


### PR DESCRIPTION
There is a test for when we don't have an elliptic curve (yet) for a HMF of dimension 1.  This has had to be changed since I found that one.  I changed it to one I will not be looking for very soon..