### PR TITLE
don't factor j-invariants over number fields

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -202,13 +202,14 @@ class ECNF(object):
         self.fact_j = None
         # See issue 1258: some j factorizations work bu take too long (e.g. EllipticCurve/6.6.371293.1/1.1/a/1)
         # If these are really wanted, they could be precomputed and stored in the db
-        # if j.is_zero():
-        #     self.fact_j = web_latex(j)
-        # else:
-        #     try:
-        #         self.fact_j = web_latex(j.factor())
-        #     except (ArithmeticError, ValueError):  # if not all prime ideal factors principal
-        #         pass
+        if j.is_zero():
+            self.fact_j = web_latex(j)
+        else:
+            if self.field.K().degree() < 3: #j.numerator_ideal().norm()<1000000000000:
+                try:
+                    self.fact_j = web_latex(j.factor())
+                except (ArithmeticError, ValueError):  # if not all prime ideal factors principal
+                    pass
 
         # CM and End(E)
         self.cm_bool = "no"

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -200,13 +200,15 @@ class ECNF(object):
         self.j = web_latex(j)
 
         self.fact_j = None
-        if j.is_zero():
-            self.fact_j = web_latex(j)
-        else:
-            try:
-                self.fact_j = web_latex(j.factor())
-            except (ArithmeticError, ValueError):  # if not all prime ideal factors principal
-                pass
+        # See issue 1258: some j factorizations work bu take too long (e.g. EllipticCurve/6.6.371293.1/1.1/a/1)
+        # If these are really wanted, they could be precomputed and stored in the db
+        # if j.is_zero():
+        #     self.fact_j = web_latex(j)
+        # else:
+        #     try:
+        #         self.fact_j = web_latex(j.factor())
+        #     except (ArithmeticError, ValueError):  # if not all prime ideal factors principal
+        #         pass
 
         # CM and End(E)
         self.cm_bool = "no"


### PR DESCRIPTION
See issue #1258  -- no factorization of j-invariants for elliptic curves over number fields is done.

There should not be a similar problems for discriminants since these have very limited support, while the numerator of j is much more random.

I hoped for some discussion of this over at #1258  but soemone can vote this up my merging :)