### PR TITLE
hide some zeros and plots

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -526,11 +526,11 @@ def initLfunction(L, args, request):
                         replace('/Lfunction/', '/L/Plot/').
                         replace('/L-function/', '/L/Plot/'))  # info['plotlink'] = url_for('plotLfunction',  **args)
 #    # an inelegant way to remove the plot in certain cases
-#    try: 
-#        if not L.fromDB and not L.plot:
-#            info['plotlink'] = ""
-#    except:
-#        pass
+    if L.Ltype() == 'ellipticmodularform':
+        if  ( (L.number == 1 and (1 + L.level) * L.weight > 100) or 
+               L.level * L.weight > 50):
+            info['zeroeslink'] = ""
+            info['plotlink'] = ""
 
 
     info['bread'] = []


### PR DESCRIPTION
Don't show the zeros or plots for L-functions of holomorphic cusp forms, when the
weight or level are not small.

Fixes issue #1232