### PR TITLE
No meaningless toggle

### DIFF
--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -44,20 +44,6 @@ table.ntdata tr.more:nth-child(2n) { background: {{color.table_ntdata_background
  <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: &nbsp;  <button class='arithmetic active' onclick="show_normalization('arithmetic'); return false">arithmetic</button>
 <button class='analytic inactive' onclick="show_normalization('analytic'); return false">analytic</button></div>
 
-{% elif BETA %}
-<div align='center'><div style="display: inline-block; vertical-align:top;">{{ KNOWL('lfunction.normalization', title='Normalization') }}:  &nbsp; 
-</div>
-<div style="display: inline-block; vertical-align:top;">
-<button class='active'>analytic</button>
-</div>
-<div style="display: inline-block; align:left;">
-<button class='inactive'>arithmetic</button>
-<br>
-<span style="font-size: 80%;">
-(not yet available)
-</span>
-</div>
-</div>
 {% endif %}
 
 {% if knowltype and label %}

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -44,6 +44,22 @@ table.ntdata tr.more:nth-child(2n) { background: {{color.table_ntdata_background
  <div align='center'>{{ KNOWL('lfunction.normalization', title='Normalization') }}: &nbsp;  <button class='arithmetic active' onclick="show_normalization('arithmetic'); return false">arithmetic</button>
 <button class='analytic inactive' onclick="show_normalization('analytic'); return false">analytic</button></div>
 
+{% elif Ltype=="riemann" %}
+
+{% elif algebraic %}
+<div align='center'><div style="display: inline-block; vertical-align:top;">{{ KNOWL('lfunction.normalization', title='Normalization') }}:  &nbsp; 
+</div>
+<div style="display: inline-block; vertical-align:top;">
+<button class='active'>analytic</button>
+</div>
+<div style="display: inline-block; align:left;">
+<button class='inactive'>arithmetic</button>
+<br>
+<span style="font-size: 80%;">
+(not yet available)
+</span>
+</div>
+</div>
 {% endif %}
 
 {% if knowltype and label %}


### PR DESCRIPTION
Don't show the arithmetic/analytic option for nonarithmetic L-functions.
Examples:
/L/ModularForm/GL4/Q/Maass/1/1/24.10897_2.342098_-9.91705/0.29748570/
/L/Riemann/
/L/Genus2Curve/Q/78533/a/
/L/ModularForm/GL2/Q/holomorphic/11/2/1/a/0/
/L/NumberField/3.1.59.1/
