### PR TITLE
avoid reading code yaml files until needed (ec, ecnf)

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -362,30 +362,35 @@ class ECNF(object):
         for E0 in self.base_change:
             self.friends += [('Base-change of %s /\(\Q\)' % E0, url_for("ec.by_ec_label", label=E0))]
 
-        self.make_code_snippets()
+        self._code = None # will be set if needed by get_code()
+
+    def code(self):
+        if self._code == None:
+            self.make_code_snippets()
+        return self._code
 
     def make_code_snippets(self):
         # read in code.yaml from current directory:
 
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self.code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
+        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
 
         # Fill in placeholders for this specific curve:
 
         gen = self.field.generator_name().replace("\\","") # phi not \phi
         for lang in ['sage', 'magma', 'pari']:
-            self.code['field'][lang] = self.code['field'][lang] % self.field.poly()
+            self._code['field'][lang] = self._code['field'][lang] % self.field.poly()
             if gen != 'a':
-                self.code['field'][lang] = self.code['field'][lang].replace("<a>","<%s>" % gen)
-                self.code['field'][lang] = self.code['field'][lang].replace("a=","%s=" % gen)
+                self._code['field'][lang] = self._code['field'][lang].replace("<a>","<%s>" % gen)
+                self._code['field'][lang] = self._code['field'][lang].replace("a=","%s=" % gen)
 
         for lang in ['sage', 'magma', 'pari']:
-            self.code['curve'][lang] = self.code['curve'][lang] % self.ainvs
+            self._code['curve'][lang] = self._code['curve'][lang] % self.ainvs
 
-        for k in self.code:
+        for k in self._code:
             if k != 'prompt':
-                for lang in self.code[k]:
-                    self.code[k][lang] = self.code[k][lang].split("\n")
+                for lang in self._code[k]:
+                    self._code[k][lang] = self._code[k][lang].split("\n")
                     # remove final empty line
-                    if len(self.code[k][lang][-1])==0:
-                        self.code[k][lang] = self.code[k][lang][:-1]
+                    if len(self._code[k][lang][-1])==0:
+                        self._code[k][lang] = self._code[k][lang][:-1]

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -6,10 +6,11 @@
 </style>
 
 {% macro code(codes, item) %}
-{% for L in codes[item] %}
+{% set code = codes() %}
+{% for L in code[item] %}
 {# N.B. whitespace is preserved in the following div since the CSS has
 white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
+<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for c in code[item][L] %}{{code.prompt[L]}}&nbsp;{{c}}<br>{% endfor %}</div>
 {% endfor %}
 {% endmacro %}
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -675,13 +675,14 @@ def ec_code(**args):
     print("args has keys %s" %  to_dict(args).keys())
     label = curve_lmfdb_label(args['conductor'], args['iso'], args['number'])
     E = WebEC.by_label(label)
+    Ecode = E.code()
     lang = args['download_type']
     code = "%s %s code for working with elliptic curve %s\n\n" % (Comment[lang],Fullname[lang],label)
     if lang=='gp':
         lang = 'pari'
     for k in sorted_code_names:
-        if lang in E.code[k]:
+        if lang in Ecode[k]:
             code += "\n%s %s: \n" % (Comment[lang],code_names[k])
-            for line in E.code[k][lang]:
+            for line in Ecode[k][lang]:
                 code += line + "\n"
     return code

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -5,10 +5,11 @@
 </style>
 
 {% macro code(codes, item) %}
-{% for L in codes[item] %}
+{% set code = codes() %}
+{% for L in code[item] %}
 {# N.B. whitespace is preserved in the following div since the CSS has
 white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
+<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for c in code[item][L] %}{{code.prompt[L]}}&nbsp;{{c}}<br>{% endfor %}</div>
 {% endfor %}
 {% endmacro %}
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -332,7 +332,7 @@ class WebEC(object):
         self.newform_label = newform_label(cond,2,1,iso)
         self.newform_link = url_for("emf.render_elliptic_modular_forms", level=cond, weight=2, character=1, label=iso)
         newform_exists_in_db = is_newform_in_db(self.newform_label)
-        self.make_code_snippets()
+        self._code = None
 
         self.friends = [
             ('Isogeny class ' + self.lmfdb_iso, url_for(".by_double_iso_label", conductor=N, iso_label=iso)),
@@ -374,21 +374,26 @@ class WebEC(object):
                            ('%s' % iso, url_for(".by_double_iso_label", conductor=N, iso_label=iso)),
                            ('%s' % num,' ')]
 
+    def code(self):
+        if self._code == None:
+            self.make_code_snippets()
+        return self._code
+
     def make_code_snippets(self):
         # read in code.yaml from current directory:
 
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self.code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
+        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
 
         # Fill in placeholders for this specific curve:
 
         for lang in ['sage', 'pari', 'magma']:
-            self.code['curve'][lang] = self.code['curve'][lang] % (self.data['ainvs'],self.label)
+            self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.label)
 
-        for k in self.code:
+        for k in self._code:
             if k != 'prompt':
-                for lang in self.code[k]:
-                    self.code[k][lang] = self.code[k][lang].split("\n")
+                for lang in self._code[k]:
+                    self._code[k][lang] = self._code[k][lang].split("\n")
                     # remove final empty line
-                    if len(self.code[k][lang][-1])==0:
-                        self.code[k][lang] = self.code[k][lang][:-1]
+                    if len(self._code[k][lang][-1])==0:
+                        self._code[k][lang] = self._code[k][lang][:-1]


### PR DESCRIPTION
Similar to PR #1268 but for elliptic curves and ecnf.  Here I do not read the yaml flie and process it at all unless someone clicks on the "show code" buttons.  For elliptic_curves (over Q) it also handles the "download all code" feature which has not yet been implemented for ecnf.