### PR TITLE
fixing ec modular form display error

### DIFF
--- a/lmfdb/ecnf/templates/show-ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/show-ecnf-isoclass.html
@@ -76,22 +76,6 @@ Rank not yet determined.
 <p>Not available.</p>
 {% endif %}
 
-<script type="text/javascript">
-var number_of_coefficients = 10;
-function more_handler(evt) {
-    number_of_coefficients += number_of_coefficients;
-    evt.preventDefault();
-    $("#modform_output").load("/EllipticCurve/Q/modular_form_display/{{info.lmfdb_label}}/"+number_of_coefficients,
-        function() {
-            {# tell mathjx to render the output #}
-            MathJax.Hub.Queue(['Typeset', MathJax.Hub, "modform_output"]);
-        });
-}
-$(function() {
-    $("#morebutton").click(function(e) {more_handler(e)});
-});
-</script>
-
 {% if DEBUG %}
 <hr>
 <div>

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -369,7 +369,7 @@ def render_isogeny_class(iso_class):
         return elliptic_curve_jump_error(iso_class, {}, wellformed_label=False)
     if class_data == "Class not found":
         return elliptic_curve_jump_error(iso_class, {}, wellformed_label=True)
-    class_data.modform_display = url_for(".modular_form_display", label=class_data.lmfdb_iso+"1", number="")
+    class_data.modform_display = url_for(".modular_form_display", label=class_data.lmfdb_iso+"1", number=10)
 
     return render_template("iso_class.html",
                            properties2=class_data.properties,
@@ -381,11 +381,12 @@ def render_isogeny_class(iso_class):
                            downloads=class_data.downloads,
                            learnmore=learnmore_list())
 
+@ec_page.route("/modular_form_display/<label>")
 @ec_page.route("/modular_form_display/<label>/<number>")
-def modular_form_display(label, number):
+def modular_form_display(label, number=10):
     try:
         number = int(number)
-    except:
+    except ValueError:
         number = 10
     if number < 10:
         number = 10
@@ -448,7 +449,7 @@ def render_curve_webpage_by_label(label):
 
     if data.twoadic_label:
         credit = credit.replace(' and',',') + ' and Jeremy Rouse'
-    data.modform_display = url_for(".modular_form_display", label=lmfdb_label, number="")
+    data.modform_display = url_for(".modular_form_display", label=lmfdb_label, number=10)
 
     return render_template("curve.html",
                            properties2=data.properties,


### PR DESCRIPTION
Fix for #1230 
After this I don't see how the problematical URL EllipticCurve/Q/modular_form_display/90.b  could ever be created (it works infe if you add /10 to that URL, this 10 denoting the number of coefficients, which is the default anyway.)

I also removed a redundant javascript function in show-ecnf-isoclass.html since it has no function and is left over from the elliptic curves (/Q) equivalent template.