### PR TITLE
Add news link to sidebar

### DIFF
--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -149,6 +149,12 @@ def roadmap():
     b = [(t, url_for('roadmap'))]
     return render_template('roadmap.html', title=t, body_class=_bc, bread=b)
 
+@app.route("/news")
+def news():
+    t = "News"
+    b = [(t, url_for('news'))]
+    return render_template(_single_knowl, title="LMFDB in the news", kid='doc.news.in_the_news', body_class=_bc, bread=b)
+
 ## INTRO PAGES END
 
 @app.route('/Variety')

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -13,6 +13,8 @@
       url_for: "universe"
     - title: Future Plans
       url_for: "roadmap"
+    - title: News
+      url_for: "news"
 
 2L-functions:
    type: L


### PR DESCRIPTION
Added a "News" item in the "Introduction and More" section of the sidebar that links to the knowl doc.news.in_the_news that lists recent news articles that reference the LMFDB  (in the future it could link to an intermediate page that might also contain announcements, information about workshops, etc...).

This addresses a suggestion of Terry Tao.