### PR TITLE
Added absolute path to mongoclient configuration path

### DIFF
--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -298,7 +298,7 @@ def get_configuration():
     replicaset =
     read_preference = NEAREST
     """
-    config_dir = '/'.join( os.path.dirname(__file__).split('/')[0:-1])
+    config_dir = '/'.join( os.path.dirname(os.path.abspath(__file__)).split('/')[0:-1])
     mongo_client_config_filename = '{0}/{1}'.format(config_dir,mongo_client_config_filename)
     if os.path.exists(mongo_client_config_filename):
         from ConfigParser import ConfigParser;

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -298,6 +298,8 @@ def get_configuration():
     replicaset =
     read_preference = NEAREST
     """
+    config_dir = '/'.join( os.path.dirname(__file__).split('/')[0:-1])
+    mongo_client_config_filename = '{0}/{1}'.format(config_dir,mongo_client_config_filename)
     if os.path.exists(mongo_client_config_filename):
         from ConfigParser import ConfigParser;
         parser = ConfigParser()


### PR DESCRIPTION
The current configuration only reads the configuration from mongoclient.config if the script is started from the same directory as the config file. 
To be able to change the mongoclient configuration when either the startup script is run from another directory or lmfdb is imported as a module (something I often do on the sage command line) I added an absolute path to mongo_client_config_filename in website.py 

I know that there are a multitude of ways to obtain path names in python, if my way is in anyway "bad" feel free to replace it with another method.
For reference see also pull requests #1078  #1074 