### PR TITLE
use jinv to speedup minimal twist lookup

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -216,7 +216,7 @@ class WebEC(object):
             data['minq_info'] = '(itself)'
         else:
             minq_ainvs = [str(c) for c in minq.ainvs()]
-            data['minq_label'] = db_ec().find_one({'ainvs': minq_ainvs})['lmfdb_label']
+            data['minq_label'] = db_ec().find_one({'jinv':str(self.E.j_invariant()),'ainvs': minq_ainvs})['lmfdb_label']
             data['minq_info'] = '(by %s)' % minqD
 
         minq_N, minq_iso, minq_number = split_lmfdb_label(data['minq_label'])


### PR DESCRIPTION
Currently elliptic curve lookups spend 2-3 seconds finding the minimal twist using a query on the unindexed field 'ainvs'.  This pull request adds 'jinv' to the query, which makes it essentially instantaneous (this is also faster than putting an index on ainvs).

This pull should be merged to master, prod, and beta asap, as it will substantially speed up all elliptic curve pages.