### PR TITLE
add approx= to ec heights table

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -111,10 +111,10 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
       {{ code(data.code,'gens') }}
       <div style='overflow:auto'><p>
       <table>
-        <tr><td>\(P\)</td>
+        <tr><td>\(P\)</td><td>&nbsp;=&nbsp;</td>
           {% for pt in data.mw.generators %}<td>{{pt}}</td>{% endfor %}
           </tr>
-        <tr><td>\(\hat{h}(P)\)</td>
+        <tr><td>\(\hat{h}(P)\)</td><td>&nbsp;&approx;&nbsp;</td>
           {% for ht in data.mw.heights %}<td>{{ht}}</td>{% endfor %}
           </tr>
         </table>


### PR DESCRIPTION
Decorate table of heights of generators of an elliptic curve to show that they are only approximate.