### PR TITLE
Added search by dim and browse/search by hyperelliptic label

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -102,7 +102,11 @@ def higher_genus_w_automorphisms_search(**args):
         parse_ints(info,query,'genus',name='Genus')
         parse_list(info,query,'signature',name='Signature')
         parse_ints(info,query,'dim',name='Dimension of the family')
-        parse_bool(info,query,'hyperelliptic', minus_one_to_zero=False)
+        if 'inc_hyper' in info:
+            if info['inc_hyper'] == 'exclude':
+                query['hyperelliptic'] = False
+            elif info['inc_hyper'] == 'only':
+                query['hyperelliptic'] = True
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -10,7 +10,7 @@ from lmfdb import base
 from lmfdb.base import app, getDBConnection
 from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
 from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, make_logger
-from lmfdb.search_parsing import parse_ints, parse_count, parse_start, parse_list, clean_input
+from lmfdb.search_parsing import parse_ints, parse_count, parse_bool, parse_start, parse_list, clean_input
 
 from sage.all import Permutation
 
@@ -101,6 +101,8 @@ def higher_genus_w_automorphisms_search(**args):
         parse_list(info,query,'group', name='Group')
         parse_ints(info,query,'genus',name='Genus')
         parse_list(info,query,'signature',name='Signature')
+        parse_ints(info,query,'dim',name='Dimension of the family')
+        parse_bool(info,query,'hyperelliptic', minus_one_to_zero=False)
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -91,9 +91,10 @@ By genus:
               <tr>  <td align=right>
 	       Hyperelliptic Curve(s):
             </td>  <td> <select name='hyperelliptic'>
-                   <option value='0'> </option>
-                   <option value='True'>Yes</option>
-                   <option value='False'>No</option>
+                    <option value='0'>include </option>
+		    <option value='False'>exclude</option>
+                    <option value='True'>only</option>
+                 
                   </select>
                 </td>  <td>
 	<span class="formexample">Leave blank for both.</span>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -18,11 +18,16 @@ text-align:right;
 
       <h2>Browse {{KNOWL('g2c.aut_grp', title="automorphisms")}} of higher genus curves</h2>
 
-       <p>
+<p>
 By genus:
 {% for gen in info.genus_list %}
 <a href="?genus={{gen}}">{{gen}}</a>
-{% endfor %}
+{% endfor %}</p>
+
+<p>Hyperelliptic curves by genus:
+{% for gen in info.genus_list %}
+<a href="?genus={{gen}}&hyperelliptic=True">{{gen}}</a>
+{% endfor %} 
 </p>
 
 
@@ -76,7 +81,24 @@ By genus:
             </td><td><input type="list" name="signature" value="" placeholder="[0,2,3,3,6]"></td>
       <td>
 	<span class="formexample">e.g. [0,2,3,3,6].</span>
-      </td> </tr>
+	  </td> </tr>
+	 <tr><td align=right>
+              {{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
+            </td><td><input type="integer" name="dim" value="" placeholder="1"></td>
+      <td>
+	<span class="formexample">e.g. 1, or a range like 0..2</span>
+	 </td> </tr>
+              <tr>  <td align=right>
+	       Hyperelliptic Curve(s):
+            </td>  <td> <select name='hyperelliptic'>
+                   <option value='0'> </option>
+                   <option value='True'>Yes</option>
+                   <option value='False'>No</option>
+                  </select>
+                </td>  <td>
+	<span class="formexample">Leave blank for both.</span>
+	 </td></tr>
+	 
           <tr>
           <td align=right>
               Maximum number of families to display:

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -97,7 +97,7 @@ By genus:
                  
                   </select>
                 </td>  <td>
-	<span class="formexample">Leave blank for both.</span>
+	<span class="formexample"></span>
 	 </td></tr>
 	 
           <tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -91,9 +91,9 @@ By genus:
               <tr>  <td align=right>
 	       Hyperelliptic Curve(s):
             </td>  <td> <select name='hyperelliptic'>
-                    <option value='0'>include </option>
-		    <option value='False'>exclude</option>
-                    <option value='True'>only</option>
+                    <option value='include'>include </option>
+		    <option value='exclude'>exclude</option>
+                    <option value='only'>only</option>
                  
                   </select>
                 </td>  <td>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -9,7 +9,7 @@
 
 <tr>
 <td align=left> 
-Genus:</td><td align=left> <input type='text' name='genus' size=3 value="{{info.genus}}">
+Genus:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
 </td>
 <td align=left> 
 Group: <td align=left> <input type="text" name="group" size="8" value="{{info.group}}" > 
@@ -18,6 +18,23 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 {{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
 <td align=left> <input type="text" name="signature" size="15" value="{{info.signature}}" >
 
+</tr>
+
+<tr>
+  
+  <td align=left> 
+{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
+<td align=left> <input type="text" name="dim" size="5" value="{{info.dim}}" > 
+
+
+<td align=right>
+	       Hyperelliptic Curve(s):
+            </td>  <td> <select name='hyperelliptic'>
+                   <option value='0'></option>
+                   <option value='True'>Yes</option>
+                   <option value='False'>No</option>
+                  </select>
+                </td> 
 
 </tr>
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -29,13 +29,26 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 
 <td align=right>
 	       Hyperelliptic Curve(s):
-            </td>  <td> <select name='hyperelliptic'>
-                     <option value='0'>include</option>
-                     <option value='False'>exclude</option>
-                   <option value='True'>only</option>
-    
-                  </select>
-                </td> 
+</td>
+
+  <td> <select name='inc_hyper'>
+{% if info.inc_hyper == "only" %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% else %}
+{% if info.inc_hyper == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% endif %}
+{% endif %}
+</td> 
+
 
 </tr>
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -30,9 +30,10 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 <td align=right>
 	       Hyperelliptic Curve(s):
             </td>  <td> <select name='hyperelliptic'>
-                   <option value='0'></option>
-                   <option value='True'>Yes</option>
-                   <option value='False'>No</option>
+                     <option value='0'>include</option>
+                     <option value='False'>exclude</option>
+                   <option value='True'>only</option>
+    
                   </select>
                 </td> 
 


### PR DESCRIPTION
On the main page for Higher Genus w/Automorphisms:
/HigherGenus/C/aut/

Added browse of hyperelliptic curves only by genus.

Added option to search by dimension of the family of curves.
Added option to specify whether results in search should be hyperelliptic curves or not.

(Also impacted search result pages.)