### PR TITLE
Commas

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -553,11 +553,13 @@ def frobs(K):
             old = 2
             for j in dec:
                 if old == 1:
-                    s += '\: '
+                    s += '{,}'
+                    #s += '\: '
                 s += str(j[0])
                 if j[1] > 1:
                     s += '^{' + str(j[1]) + '}'
-                old = j[1]
+                #old = j[1]
+                old = 1
             s += '$'
             ans.append([p, s])
         else:

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -550,16 +550,14 @@ def frobs(K):
             dec = [[x, dec.count(x)] for x in vals]
             dec2 = ["$" + str(x[0]) + ('^{' + str(x[1]) + '}$' if x[1] > 1 else '$') for x in dec]
             s = '$'
-            old = 2
+            firstone = 1
             for j in dec:
-                if old == 1:
-                    s += '{,}'
-                    #s += '\: '
+                if firstone == 0:
+                    s += '{,}\,'
                 s += str(j[0])
                 if j[1] > 1:
                     s += '^{' + str(j[1]) + '}'
-                #old = j[1]
-                old = 1
+                firstone = 0
             s += '$'
             ans.append([p, s])
         else:


### PR DESCRIPTION
In the cycle types on a number field page, reformat them to use commas to separate parts of the cycles.  See, e.g.,  http://127.0.0.1:37777/NumberField/11.1.5781612911.1
