### PR TITLE
Clean up top

### DIFF
--- a/lmfdb/templates/contact.html
+++ b/lmfdb/templates/contact.html
@@ -5,8 +5,16 @@
 
 <div>
 <p>
-For questions, inquiries, feedback or any other issues, including bug
-reports, please <b>either</b>
+If you are interested in becoming involved with the LMFDB,
+please 
+<a href="mailto:lmfdb-support@googlegroups.com"
+target="_blank">email</a>
+the <a href="http://groups.google.co.uk/d/forum/lmfdb-support"
+target="_blank">LMFDB mailing list</a>.
+</p>
+
+<p>
+To report an error or ask a question about the website content, please <b>either</b>
 <a href="mailto:lmfdb-support@googlegroups.com"
 target="_blank">email</a>
 the <a href="http://groups.google.co.uk/d/forum/lmfdb-support"
@@ -14,6 +22,7 @@ target="_blank">LMFDB support mailing list</a>, <b>or</b> use the
 <a href="{{feedbackpage}}" target=_blank>Feedback Form</a>, or both.
 </p>
 
+<!--
 <p>
 If you see a problem with the
 website <a href="http://www.lmfdb.org">www.lmfdb.org</a>, before making a
@@ -21,9 +30,10 @@ report, please check to see if the issue has already been fixed on the
 beta testing site <a href="http://beta.lmfdb.org">beta.lmfdb.org</a>: just
 replace 'www' replaced by 'beta' in the URL.
 </p>
+-->
 
 <p>
-To be most helpful, bug reports should include
+To be most helpful, error reports should include
 <ul>
 <li>a one line description of the problem,
 <li>the exact URL which shows the issue (copied and pasted from the

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -29,6 +29,7 @@
             <input type="text" placeholder="search ..." name="q" size="13" />
           </form>
             &middot;
+<!--
           <a href="{{ feedbackpage }}" target=_blank">
              Feedback</a>
             &middot;
@@ -38,8 +39,9 @@
              <a href="{{ url_for("menutoggle", show=True)}}">Show Menu</a>
           {% endif %}
             &middot;
+-->
           {% if user_is_admin -%}
-            <a href="{{ url_for('users.register') }}">Registertokens</a>
+            <a href="{{ url_for('users.register') }}">RT</a>
             &middot;
           {% endif %}
           {% if user_is_authenticated -%}
@@ -52,10 +54,21 @@
             <a href="{{ url_for('users.info') }}">Login</a>
           {%- endif %}
           <br/>
+<!--
           <span id="communication-wrapper">
             <img id="communication-img" src="{{ url_for('static', filename='images/progress-green.gif') }}" />
             <span id="communication"></span>
           </span>
+-->
+      </div>
+      <div class="undertopright">
+          <a href="{{ feedbackpage }}" target=_blank">Feedback</a>
+            &middot;
+          {% if g.show_menu %}
+             <a href="{{ url_for("menutoggle", show=False)}}">Hide Menu</a>
+          {% else %}
+             <a href="{{ url_for("menutoggle", show=True)}}">Show Menu</a>
+          {% endif %}
       </div>
 {# deleting the confusing prev/next character links, 
    but leaving the code in case it is useful later

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -28,30 +28,22 @@
           <form method="GET" action="{{ url_for('search') }}" id="search-topright">
             <input type="text" placeholder="search ..." name="q" size="13" />
           </form>
-            &middot;
-<!--
-          <a href="{{ feedbackpage }}" target=_blank">
-             Feedback</a>
-            &middot;
-          {% if g.show_menu %}
-             <a href="{{ url_for("menutoggle", show=False)}}">Hide Menu</a>
-          {% else %}
-             <a href="{{ url_for("menutoggle", show=True)}}">Show Menu</a>
-          {% endif %}
-            &middot;
--->
           {% if user_is_admin -%}
-            <a href="{{ url_for('users.register') }}">RT</a>
             &middot;
+            <a href="{{ url_for('users.register') }}">RT</a>
           {% endif %}
           {% if user_is_authenticated -%}
+            &middot;
             <a href="{{ url_for('users.info') }}">{{ username }}</a> 
             &middot;
             <a href="{{ url_for('users.logout') }}">Logout</a>
           {%- else -%}
             {# <a href="{{ url_for('users.register_new') }}">Register</a>
             &middot; #}
+            {% if BETA %}
+            &middot;
             <a href="{{ url_for('users.info') }}">Login</a>
+            {% endif %}
           {%- endif %}
           <br/>
 <!--
@@ -62,7 +54,7 @@
 -->
       </div>
       <div class="undertopright">
-          <a href="{{ feedbackpage }}" target=_blank">Feedback</a>
+          <a href="{{ url_for('contact') }}" target=_blank">Feedback</a>
             &middot;
           {% if g.show_menu %}
              <a href="{{ url_for("menutoggle", show=False)}}">Hide Menu</a>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -204,7 +204,7 @@ body.knowl #header {
     font-size: 180%;
     font-weight: bold;
     font-family: sans-serif;
-    min-height: 100px;
+    min-height: 82px;
     position: relative;
     color: {{color.header_text_title}};
 }
@@ -231,7 +231,8 @@ body.knowl #header {
   font-family: sans-serif;
   min-height: 18px;
   font-size: 90%;
-  padding: 2px 5px;
+  padding-top: 2px;
+  padding-right: 5px;
   position: absolute;
   top: 0px;
   right: 0px;
@@ -243,6 +244,19 @@ body.knowl #header {
   display: none;
   padding: 4px;
 }
+#header .undertopright {
+  text-align: right;
+  white-space:nowrap;
+  color: {{color.header_text_topright}};
+  font-family: sans-serif;
+  min-height: 18px;
+  font-size: 90%;
+  padding-right: 5px;
+}
+#header .undertopright a {
+    color: {{color.header_text_topright}};
+}
+
 #header #navi {
   white-space: nowrap;
   text-align: right;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -231,7 +231,7 @@ body.knowl #header {
   font-family: sans-serif;
   min-height: 18px;
   font-size: 90%;
-  padding-top: 2px;
+  padding-top: 5px;
   padding-right: 5px;
   position: absolute;
   top: 0px;


### PR DESCRIPTION
Rearrange the top right of every page so that it does not overlap long breadcrumbs.
Have the Feedback link go to the contact page.
Reorganize the contact page so that a welcoming message is first, and email is before
Feedback of error reporting.

The only tricky thing was to hide the login on the production version.  (We decided to do this
because you can't edit knowls on the production version, and a random user should not
even see the option to log in.)

I commented out the suggestion to see if bugs have been fixed on beta, because we should
draw less attention to beta, and bug fixes are supposed to be pushed to production.  But I
only commented it out because it was not discusses as a group.