### PR TITLE
Add random items to index pages for artin rep, galois groups, local fields

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -6,16 +6,16 @@ import pymongo
 ASC = pymongo.ASCENDING
 import flask
 from lmfdb.base import app, getDBConnection
-from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response, flash
+from flask import render_template, render_template_string, request, abort, Blueprint, url_for, flash, redirect
 from markupsafe import Markup
 
 from lmfdb.artin_representations import artin_representations_page, artin_logger
-from lmfdb.utils import to_dict
+from lmfdb.utils import to_dict, random_object_from_collection
 from lmfdb.search_parsing import parse_primes, parse_restricted, parse_galgrp, parse_ints, parse_paired_fields, parse_count, parse_start, clean_input
 
 from lmfdb.transitive_group import *
 from lmfdb.WebCharacter import WebDirichletCharacter
-import re
+import re, random
 
 
 from lmfdb.math_classes import *
@@ -233,6 +233,14 @@ def render_artin_representation_webpage(label):
     #info['pol11']=str(the_rep.central_char(11))
 
     return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, properties2=properties, extra_data=extra_data, info=info)
+
+@artin_representations_page.route("/random")
+def random_representation():
+    rep = random_object_from_collection(ArtinRepresentation.collection())
+    num = random.randrange(0, len(rep['GaloisConjugates']))
+    label = rep['Baselabel']+"c"+str(num+1)
+    return redirect(url_for(".render_artin_representation_webpage", label=label), 301)
+
 
 @artin_representations_page.route("/Completeness")
 def completeness_page():

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -39,6 +39,10 @@ By {{ KNOWL('artin.gg_quotient',title="group") }}:
 <a href="?group=A7">$A_7$</a>,
 <a href="?group=S7">$S_7$</a>
 
+<p>
+A <a href={{url_for('.random_representation')}}>random Artin representation</a> from the database.
+</p>
+
 <h2>Go to a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
 
 <div><form>

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -7,8 +7,8 @@ ASC = pymongo.ASCENDING
 import flask
 from lmfdb import base
 from lmfdb.base import app, getDBConnection
-from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, make_logger, list_to_latex_matrix
+from flask import render_template, render_template_string, request, abort, Blueprint, url_for, redirect
+from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, make_logger, list_to_latex_matrix, random_object_from_collection
 from lmfdb.search_parsing import LIST_RE, clean_input, prep_ranges, parse_bool, parse_ints, parse_count, parse_start
 import os
 import re
@@ -282,6 +282,10 @@ def render_group_webpage(args):
 def search_input_error(info, bread):
     return render_template("gg-search.html", info=info, title='Galois Group Search Input Error', bread=bread)
 
+@galois_groups_page.route("/random")
+def random_group():
+    label = random_object_from_collection(base.getDBConnection().transitivegroups.groups)['label']
+    return redirect(url_for(".by_label", label=label), 301)
 
 @galois_groups_page.route("/Completeness")
 def completeness_page():

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -28,6 +28,9 @@ Browse by type:
 <a href="?prim=-1">Imprimitive</a>
 <p>
 
+<p>
+A <a href={{url_for('.random_group')}}>random Galois group</a> from the database.
+</p>
 
 <h2>Find a specific Galois group</h2>
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -8,8 +8,8 @@ ASC = pymongo.ASCENDING
 import flask
 from lmfdb import base
 from lmfdb.base import app, getDBConnection
-from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, make_logger
+from flask import render_template, render_template_string, request, abort, Blueprint, url_for, redirect
+from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, make_logger, random_object_from_collection
 from lmfdb.search_parsing import parse_galgrp, parse_ints, parse_count, parse_start, clean_input
 from sage.all import ZZ, var, PolynomialRing, QQ
 from lmfdb.local_fields import local_fields_page, logger
@@ -255,6 +255,11 @@ def printquad(code, p):
 def search_input_error(info, bread):
     return render_template("lf-search.html", info=info, title='Local Field Search Input Error', bread=bread)
 
+@local_fields_page.route("/random")
+def random_field():
+    label = random_object_from_collection(base.getDBConnection().localfields.fields)['label']
+    return redirect(url_for(".by_label", label=label), 301)
+
 @local_fields_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of the local field data'
@@ -283,3 +288,4 @@ def how_computed_page():
     return render_template("single.html", kid='dq.lf.source',
                            credit=LF_credit, title=t, bread=bread, 
                            learnmore=learnmore)
+

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -68,7 +68,9 @@ of $\Q_p$ up to isomorphism.
 </table>
 <p>
 
-
+<p>
+A <a href={{url_for('.random_field')}}>random local number field</a> from the database.
+</p>
 
 
     <h2>Find a specific local number field</h2>


### PR DESCRIPTION
To test, for j in {artin rep, Galois group, local fields},
  go to index page for $j
  click on new link for random item

In case you are curious, code for Artin representations is slightly different for 2 reasons: (1) it still uses the original code for accessing the database (not written by me), but works fine, and (2) database records are for Galois orbits which then hold information about each individual rep'n, and we have pages for the individual rep'ns.  So, we randomly pick an orbit, and then randomly pick a rep'n from it. 