### PR TITLE
Fix for issue #1372

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -73,6 +73,9 @@ def render_elliptic_modular_form_navigation_wp(**args):
         limits_weight = (weight, weight)
     elif limits_weight is None:
         limits_weight = (2, 12) # default values
+    # we don't have weight 1 in database, reset range here to exclude it
+    if limits_weight[0]==1:
+        limits_weight=(2,limits_weight[1])
     if is_set['level']:
         limits_level = (level, level) 
     elif limits_level is None:
@@ -105,13 +108,10 @@ def render_elliptic_modular_form_navigation_wp(**args):
         s['cchi']=int(1)
     else:
         s['gamma1_label']={"$exists":True}
-    g = db_dim.find(s).sort([('level',int(1)),('weight',int(1))])
+    # g = db_dim.find(s).sort([('level',int(1)),('weight',int(1))]) never used
     table = {}
     info['table'] = {}
     level_range = range(limits_level[0],limits_level[1]+1)
-    # we don't have weight 1 in database
-    if limits_weight[0]==1:
-        limits_weight=(2,limits_weight[1])
     weight_range = range(limits_weight[0],limits_weight[1]+1)
     if group == 0:
         weight_range = filter(is_even,weight_range)


### PR DESCRIPTION
Weight 1 modular forms are not currently in the database and the code has a specific branch to handle this, but it was in the wrong place, causing a crash.

Moved the check up so that it now simply says no data is available in the requested range (as it should).