### PR TITLE
optimize torsion_structure query + bug fix to parse_bracketed_posints

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -3,6 +3,7 @@ import re
 import time
 import ast
 from pymongo import ASCENDING, DESCENDING
+from operator import mul
 import lmfdb.base
 from lmfdb.base import app
 from flask import Flask, session, g, render_template, url_for, request, redirect, make_response, send_file
@@ -222,6 +223,9 @@ def elliptic_curve_search(**args):
         parse_ints(info,query,'rank')
         parse_ints(info,query,'sha','analytic order of &#1064;')
         parse_bracketed_posints(info,query,'torsion_structure',maxlength=2,process=str,check_divisibility='increasing')
+        # speed up slow torsion_structure searches by also setting torsion
+        if 'torsion_structure' in query and not 'torsion' in query:
+            query['torsion'] = reduce(mul,[int(n) for n in query['torsion_structure']],1)
         if 'include_cm' in info:
             if info['include_cm'] == 'exclude':
                 query['cm'] = 0

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -290,6 +290,9 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
             example = "[1,2,3] or [5,6]"
         raise ValueError("It needs to be a %s in square brackets, such as %s." % (lstr, example))
     else:
+        if inp == '[]': # fixes bug in the code below (split never returns an empty list)
+            query[qfield] = []
+            return
         if check_divisibility == 'decreasing':
             # Check that each entry divides the previous
             L = [int(a) for a in inp[1:-1].split(',')]

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -272,7 +272,8 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
     if process is None: process = lambda x: x
     if (not BRACKETED_POSINT_RE.match(inp) or
         (maxlength is not None and inp.count(',') > maxlength - 1) or
-        (exactlength is not None and inp.count(',') != exactlength - 1)):
+        (exactlength is not None and inp.count(',') != exactlength - 1) or
+        (exactlength is not None and inp == '[]' and exactlength > 0)):
         if exactlength == 2:
             lstr = "pair of integers"
             example = "[2,3] or [3,3]"


### PR DESCRIPTION
Currently searching for torsion structure is slow because mongo db indexes on arrayed fields do not work well, for example searching for torsion_structure=[2,8] is much (5x) slower than searching for torsion=16&torsion_structure=[2,8].  Changed the code to always set torsion appropriately if torsion_structure is set and torsion is not.

This pull request also fixes a bug in parse_bracketed_posints which always raised an error for empty lists (because ''.split(',') does not return an empty list, it returns ['']).

The speedup is hard to test locally, but once pushed to beta it should speed up queries like

http://beta.lmfdb.org/EllipticCurve/Q/?torsion_structure=[2,8]

substantially.

The fix to parse_bracketed_posints can be tested by comparing:

http://beta.lmfdb.org/EllipticCurve/Q/?torsion_structure=[]
http://127.0.0.1:37777/EllipticCurve/Q/?torsion_structure=[]
