### PR TITLE
removed redundant import preparse from hilbert_modular_forms.py

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -6,7 +6,6 @@ import pymongo
 import lmfdb.base
 from lmfdb.base import app, getDBConnection
 from flask import Flask, session, g, render_template, url_for, request, redirect, make_response
-from sage.misc.preparser import preparse
 from lmfdb.hilbert_modular_forms import hmf_page, hmf_logger
 from lmfdb.hilbert_modular_forms.hilbert_field import findvar
 from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, get_counts, hmf_summary, hmf_degree_summary


### PR DESCRIPTION
See #1332.   Without this (which was redundant anyway) Sage 7.2 cannot run the code.  Now it can.  To test just check that the server starts up with 7.2.  I tested on both 7.1 and 7.2 so you don't have to and I will merge this myself.