### PR TITLE
adapted imports in 4 places for compatibility with Sage-7.2

### DIFF
--- a/lmfdb/HeckeCharacters.py
+++ b/lmfdb/HeckeCharacters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # HeckeCharacters.py
 
-from sage.all import gp, xmrange, Integer, pari, gcd
+from sage.all import gp, xmrange, Integer, pari, gcd, LCM
 from sage.misc.cachefunc import cached_method
 from sage.groups.abelian_gps.abelian_group import AbelianGroup_class
 from sage.groups.abelian_gps.abelian_group_element import AbelianGroupElement
@@ -90,9 +90,6 @@ class HeckeCharGroup(DualAbelianGroup_class):
         names = tuple([ "chi%i"%i for i in range(ray_class_group.ngens()) ])
         if base_ring is None:
             from sage.rings.number_field.number_field import CyclotomicField
-            # FIXME: following is deprecated starting from sage 7.1
-            # replace by from sage.arith.all import LCM
-            from sage.rings.arith import LCM
             base_ring = CyclotomicField(LCM(ray_class_group.gens_orders()))
         DualAbelianGroup_class.__init__(self, ray_class_group, names, base_ring)
         """ ray_class_group accessible as self.group() """

--- a/lmfdb/hypergm/plot.py
+++ b/lmfdb/hypergm/plot.py
@@ -1,6 +1,6 @@
 import sage
 
-from sage.rings.arith import lcm, gcd
+from sage.all import lcm, gcd
 from sage.plot.graphics import Graphics
 from sage.plot.line import line
 from sage.plot.circle import circle

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -14,8 +14,7 @@ from lmfdb.WebNumberField import *
 import re
 
 import sage.all
-from sage.all import ZZ, QQ, PolynomialRing, NumberField, CyclotomicField, latex, AbelianGroup, euler_phi, pari, prod
-from sage.rings.arith import primes
+from sage.all import ZZ, QQ, PolynomialRing, NumberField, CyclotomicField, latex, AbelianGroup, euler_phi, pari, prod, primes
 
 from lmfdb.transitive_group import *
 

--- a/lmfdb/symL/symL.py
+++ b/lmfdb/symL/symL.py
@@ -23,7 +23,7 @@ import sage.rings.all
 
 from sage.schemes.elliptic_curves.constructor import EllipticCurve
 
-from sage.rings.arith import binomial
+from sage.all import binomial
 from sympowlmfdb import sympowlmfdb
 
 


### PR DESCRIPTION
All I did was import from sage.all instead of lower down the tree so that it waas not necessary to use try/except for the new/old places where a few functions were imported (LCM, binomial, lcm, gcd, primes) in 4 files.
I tested this on both Sage 7.1 and 7.2 and so should you ;) 
