### PR TITLE
Hmf sage

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -266,7 +266,7 @@ def download_hmf_sage(**args):
     outstr += 'primes = [ZF.ideal(I) for I in primes_array]\n\n'
 
     if f["hecke_polynomial"] != 'x':
-        outstr += 'hecke_pol = ' + f["hecke_polynomial"] + '\n'
+        outstr += 'heckePol = ' + f["hecke_polynomial"] + '\n'
         outstr += 'K.<e> = NumberField(heckePol)\n'
     else:
         outstr += 'heckePol = x\nK = QQ\ne = 1\n'

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -277,7 +277,7 @@ def download_hmf_sage(**args):
 
     outstr += 'AL_eigenvalues = {}\n'
     for s in f["AL_eigenvalues"]:
-        outstr += 'ALEigenvalues[ZF.ideal(s[0])] = s[1]\n'
+        outstr += 'AL_eigenvalues[ZF.ideal(%s)] = %s\n' % (s[0],s[1])
 
     outstr += '\n# EXAMPLE:\n# pp = ZF.ideal(2).factor()[0][0]\n# hecke_eigenvalues[pp]\n'
 


### PR DESCRIPTION
Fixes for #1412 -- after fixing the first one, others were revealed.  To test this you need an example where the Hecke field is not Q and where there are Atkin-Lehner eigenvalues, such as ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-121.3-a

I did run the Sage code and it looks fine (clearly no-one else ever had for dimension>1).  The Magma code also looks good (no changes there).