### PR TITLE
show narrow class no on HMF home pages

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -310,6 +310,7 @@ def render_hmf_webpage(**args):
     hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
     gen_name = findvar(hmf_field['ideals'])
     nf = WebNumberField(data['field_label'], gen_name=gen_name)
+    info['hmf_field'] = hmf_field
     info['field'] = nf
     info['base_galois_group'] = nf.galois_string()
     info['field_degree'] = nf.degree()

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -6,8 +6,8 @@
  {{ KNOWL('nf.generator', 'Generator') }} \({{
  info.field.generator_name() }}\), with {{
  KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
- \({{info.field_poly}}\); {{ KNOWL('nf.class_number', 'class number')
- }} \({{info.field.class_number()}}\).
+ \({{info.field_poly}}\); {{ KNOWL('nf.narrow_class_number', 'narrow class number')
+ }} \({{info.hmf_field.narrow_class_no}}\).
 </p>
 
 

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -7,7 +7,8 @@
  info.field.generator_name() }}\), with {{
  KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
  \({{info.field_poly}}\); {{ KNOWL('nf.narrow_class_number', 'narrow class number')
- }} \({{info.hmf_field.narrow_class_no}}\).
+ }} \({{info.hmf_field.narrow_class_no}}\) and {{ KNOWL('nf.class_number', 'class number')
+ }} \({{info.field.class_number()}}\).
 </p>
 
 


### PR DESCRIPTION
As requested by a user, see issue #1411.   This version shows the ordinary class number as well as the narrow one.  Two new knowls will be required (narrow class group and narrow class number).