### PR TITLE
Modified display of elliptic curve factors

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -252,7 +252,7 @@ affil: Reed College
 url: http://people.reed.edu/~jerry/
 ---
 name: Jeroen Sijsling
-affil: Dartmouth College
+affil: Universität Ulm
 url: https://sites.google.com/site/sijsling/
 ---
 name: Samir Siksek

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -515,7 +515,7 @@ def spl_statement(coeffss, lmfdb_labels, condnorms):
                 % (url_for_ec(lmfdb_label), lmfdb_label)
         # Otherwise give defining equation:
         else:
-            statement += """<br>\(4 y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with<br>\
+            statement += """<br>\(y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with<br>\
             \(g_4 = %s\)<br>\
             \(g_6 = %s\)<br>\
             Conductor norm: %s"""\


### PR DESCRIPTION
A very trivial fix. Consider the page

http://www.lmfdb.org/Genus2Curve/Q/169/a/169/1

Here the elliptic curve factors are displayed with a left hand side 4 y^2. This is silly and should just be y^2.

(The reason is that this evolved from a correct version y^2 = 4 x^3 - g_4 / 12 - g_6 / 216 via a typo. And those denominator factors 12 and 216 which become 48 and 864 in the current easier-to-copy version are also not there for a particular reason; I just noticed that in practice they perform well.)

Also changed my affiliation.