### PR TITLE
Precomputing extra data for elliptic curves/Q, and using it

### DIFF
--- a/lmfdb/ecnf/hmf_check_find.py
+++ b/lmfdb/ecnf/hmf_check_find.py
@@ -16,9 +16,9 @@ from lmfdb.base import getDBConnection
 from sage.rings.all import ZZ, QQ
 from sage.databases.cremona import cremona_to_lmfdb
 
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=dbport)
+from lmfdb.base import getDBConnection
+print "getting connection"
+C= getDBConnection()
 C['admin'].authenticate('lmfdb', 'lmfdb')
 
 print "authenticating on the elliptic_curves database"

--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -72,9 +72,9 @@ from sage.rings.all import ZZ, QQ
 from sage.databases.cremona import cremona_to_lmfdb
 from lmfdb.ecnf.ecnf_stats import field_data
 
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=dbport)
+from lmfdb.base import getDBConnection
+print "getting connection"
+C= getDBConnection()
 
 print "authenticating on the elliptic_curves database"
 import yaml

--- a/lmfdb/ecnf/import_ecnf_data.py
+++ b/lmfdb/ecnf/import_ecnf_data.py
@@ -88,24 +88,6 @@ qcurves = C.elliptic_curves.curves
 C['admin'].authenticate('lmfdb', 'lmfdb') # read-only
 
 
-# The following ensure_index command checks if there is an index on
-# label, conductor, rank and torsion. If there is no index it creates
-# one.  Need: once torsion structure is computed, we should have an
-# index on that too.
-
-# The following have not yet been thoroughly thought about!
-nfcurves.ensure_index('label')
-nfcurves.ensure_index('short_label')
-nfcurves.ensure_index('conductor_norm')
-nfcurves.ensure_index('rank')
-nfcurves.ensure_index('torsion')
-nfcurves.ensure_index('jinv')
-nfcurves.ensure_index('number')
-nfcurves.ensure_index('degree')
-nfcurves.ensure_index('field_label')
-
-print "finished indices"
-
 # We have to look up number fields in the database from their labels,
 # but only want to do this once for each label, so we will maintain a
 # dict of label:field pairs:

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -84,7 +84,7 @@ sha:
   magma: MordellWeilShaInformation(E);
 
 qexp:
-  sage:  E.q_eigenform(10)
+  sage:  E.q_eigenform(20)
   pari:  |
     xy = elltaniyama(E);
     deriv(xy[1])/(2*xy[2]+E.a1*xy[1]+E.a3)

--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -4,6 +4,7 @@ from pymongo import ASCENDING, DESCENDING
 import lmfdb.base
 from lmfdb.base import app
 from lmfdb.utils import comma, make_logger
+from lmfdb.elliptic_curves.web_ec import db_ec
 from flask import url_for
 
 def format_percentage(num, denom):
@@ -36,7 +37,7 @@ class ECstats(object):
 
     def __init__(self):
         logger.debug("Constructing an instance of ECstats")
-        self.ecdb = lmfdb.base.getDBConnection().elliptic_curves.curves
+        self.ecdb = db_ec()
         self._counts = {}
         self._stats = {}
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -15,24 +15,12 @@ from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, web_latex_spli
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.ec_stats import get_stats
 from lmfdb.elliptic_curves.isog_class import ECisog_class
-from lmfdb.elliptic_curves.web_ec import WebEC, parse_points, match_lmfdb_label, match_lmfdb_iso_label, match_cremona_label, split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, class_cremona_label, curve_lmfdb_label, curve_cremona_label
+from lmfdb.elliptic_curves.web_ec import WebEC, parse_points, match_lmfdb_label, match_lmfdb_iso_label, match_cremona_label, split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, class_cremona_label, curve_lmfdb_label, curve_cremona_label, ecdb, db_ec
 from lmfdb.search_parsing import split_list, parse_rational, parse_ints, parse_bracketed_posints, parse_primes, parse_count, parse_start
 
 import sage.all
 from sage.all import ZZ, QQ, EllipticCurve, latex, matrix, srange
 q = ZZ['x'].gen()
-
-#########################
-#   Database connection
-#########################
-ecdb = None
-
-def db_ec():
-    global ecdb
-    if ecdb is None:
-        ecdb = lmfdb.base.getDBConnection().elliptic_curves.curves
-    return ecdb
-
 
 #########################
 #   Utility functions
@@ -206,10 +194,13 @@ def elliptic_curve_search(**args):
                 # Now we do have a valid curve over Q, but it might
                 # not be in the database.
                 ainvs = [str(c) for c in E.minimal_model().ainvs()]
-                data = db_ec().find_one({'ainvs': ainvs})
+                xainvs = ''.join(['[',','.join(ainvs),']'])
+                data = db_ec().find_one({'xainvs': xainvs})
                 if data is None:
-                    info['conductor'] = E.conductor()
-                    return elliptic_curve_jump_error(label, info, missing_curve=True)
+                    data = db_ec().find_one({'ainvs': ainvs})
+                    if data is None:
+                        info['conductor'] = E.conductor()
+                        return elliptic_curve_jump_error(label, info, missing_curve=True)
                 return by_ec_label(data['lmfdb_label'])
             except (TypeError, ValueError, ArithmeticError):
                 return elliptic_curve_jump_error(label, info)
@@ -361,9 +352,12 @@ def by_weierstrass(eqn):
     E = EllipticCurve(ainvs).global_minimal_model()
     N = E.conductor()
     ainvs = [str(ai) for ai in E.ainvs()]
-    data = db_ec().find_one({'ainvs': ainvs})
+    xainvs = ''.join(['[',','.join(ainvs),']'])
+    data = db_ec().find_one({'xainvs': xainvs})
     if data is None:
-        return elliptic_curve_jump_error(eqn, {'conductor':N}, missing_curve=True)
+        data = db_ec().find_one({'ainvs': ainvs})
+        if data is None:
+            return elliptic_curve_jump_error(eqn, {'conductor':N}, missing_curve=True)
     return redirect(url_for(".by_ec_label", label=data['lmfdb_label']), 301)
 
 def render_isogeny_class(iso_class):

--- a/lmfdb/elliptic_curves/import_ec_data.py
+++ b/lmfdb/elliptic_curves/import_ec_data.py
@@ -80,10 +80,9 @@ import pymongo
 from lmfdb import base
 from sage.rings.all import ZZ
 from lmfdb.utils import web_latex
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
+from lmfdb.base import getDBConnection
 print "getting connection"
-C= MongoClient(port=dbport)
+C= getDBConnection()
 print "authenticating on the elliptic_curves database"
 import yaml
 pw_dict = yaml.load(open(os.path.join(os.getcwd(), os.extsep, os.extsep, os.extsep, "passwords.yaml")))
@@ -638,9 +637,27 @@ def add_extra_data(N1,N2,store=False):
         if store:
             newcurves.append(C)
         else:
-            print("Not writing updated %s to database.\n" % C['label'])
+            pass
+            #print("Not writing updated %s to database.\n" % C['label'])
     # insert the final left-overs since the last full batch
     if store and len(newcurves):
         curves2.insert_many(newcurves)
 
     print("\nfinished updating conductors from %s to %s" % (N1,N2))
+
+def add_extra_data1(C):
+    """Add these fields to a single curve record in the db (for use with
+    the rewrite script in data_mgt/utilities/rewrite.py):
+
+   - 'xainvs': (string) '[a1,a2,a3,a4,a6]' (will replace 'ainvs' in due course)
+   - 'equation': (string)
+   - 'local_data': (list of dicts, one per prime)
+   - 'signD': (sign of discriminant) int (+1 or -1)
+   - 'min_quad_twist': (dict) {label:string, disc: int} #NB Cremona label
+   - 'heights': (list of floats) heights of generators
+   - 'aplist': (list of ints) a_p for p<100
+   - 'anlist': (list of ints) a_p for p<20
+
+    """
+    C.update(make_extra_data(C['label'],C['number'],C['ainvs'],C['gens']))
+    return C

--- a/lmfdb/elliptic_curves/import_ec_lfunction_data.py
+++ b/lmfdb/elliptic_curves/import_ec_lfunction_data.py
@@ -68,10 +68,9 @@ import pymongo
 from lmfdb import base
 from sage.rings.all import ZZ
 
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
+from lmfdb.base import getDBConnection
 print "getting connection"
-C= MongoClient(port=dbport)
+C= getDBConnection()
 print "authenticating on the elliptic_curves database"
 import yaml
 pw_dict = yaml.load(open(os.path.join(os.getcwd(), os.extsep, os.extsep, os.extsep, "passwords.yaml")))

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -163,7 +163,7 @@ class ECisog_class(object):
                            ]
 
 
-        self.downloads = [('Download coefficients of newform', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=100)),
+        self.downloads = [('Download coefficients of newform', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=1000)),
                          ('Download stored data for all curves', url_for(".download_EC_all", label=self.lmfdb_iso))]
 
         if self.lmfdb_iso == self.iso:

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -294,14 +294,20 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 {# %%%%%%%%%%%%%%%% END OF TABLE %%%%%%%%%%%%%%%%%%% #}
 
     <h2> {{KNOWL('ec.q.modular_parametrization', title='Modular invariants')}}</h2>
-    <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}} </h3>
+    <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}}
+          {{data.newform_label}} </h3>
           {{ code(data.code,'qexp') }}
     <p>
+{#
     <form>
+#}
         <div class="output"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
         <div class="emptyspace"><br></div>
+{#
         <button id="morebutton">More coefficients</button>
     </form>
+#}
+      For more coefficients, see the Downloads section to the right.
     </p>
 
     <h3> {{ KNOWL('ec.q.modular_degree', title='Modular degree') }}
@@ -350,14 +356,14 @@ text-align: center;
 {% for pr in data.local_data %}
 <tr>
 <td> \({{pr.p}}\)</td>
-<td>\({{pr.tamagawa_number}}\)</td>
-<td>{{pr.kodaira_symbol}}</td>
+<td>\({{pr.cp}}\)</td>
+<td>{{pr.kod}}</td>
 <td>
-{% if pr.reduction_type==0 %}
+{% if pr.red==0 %}
  Additive
- {% elif pr.reduction_type==1 %}
+ {% elif pr.red==1 %}
   Split multiplicative
-  {% elif pr.reduction_type==-1 %}
+  {% elif pr.red==-1 %}
    Non-split multiplicative
 {% endif %}
 </td>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -60,7 +60,7 @@ padicdb = None
 def db_ec():
     global ecdb
     if ecdb is None:
-        ecdb = lmfdb.base.getDBConnection().elliptic_curves.curves
+        ecdb = lmfdb.base.getDBConnection().elliptic_curves.curves2
     return ecdb
 
 def padic_db():

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -11,7 +11,7 @@ from lmfdb.search_parsing import split_list
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label, is_newform_in_db
 import sage.all
-from sage.all import EllipticCurve, latex, matrix, ZZ, QQ
+from sage.all import EllipticCurve, latex, matrix, ZZ, QQ, prod, Factorization, PowerSeriesRing
 
 ROUSE_URL_PREFIX = "http://users.wfu.edu/rouseja/2adic/" # Needs to be changed whenever J. Rouse and D. Zureick-Brown move their data
 
@@ -143,38 +143,141 @@ class WebEC(object):
 
     def make_curve(self):
         # To start with the data fields of self are just those from
-        # the database.  We need to reformat these, construct the
-        # actual elliptic curve E, and compute some further (easy)
-        # data about it.
-        #
+        # the database.  We need to reformat these.
 
-        # Weierstrass equation
+        # Old version: required constructing the actual elliptic curve
+        # E, and computing some further data about it.
+
+        # New version (May 2016): extra data fields now in the
+        # database so we do not have to construct the curve or do any
+        # computation with it on the fly.  As a failsafe the old way
+        # is still included.
 
         data = self.data = {}
-        data['ainvs'] = [int(ai) for ai in self.ainvs]
-        self.E = EllipticCurve(data['ainvs'])
-        data['equation'] = web_latex(self.E)
-
-        # conductor, j-invariant and discriminant
-
-        data['conductor'] = N = ZZ(self.conductor)
-        bad_primes = N.prime_factors()
         try:
-            data['j_invariant'] = QQ(str(self.jinv))
-        except KeyError:
-            data['j_invariant'] = self.E.j_invariant()
+            data['ainvs'] = [int(c) for c in self.xainvs[1:-1].split(',')]
+        except AttributeError:
+            data['ainvs'] = [int(ai) for ai in self.ainvs]
+        data['conductor'] = N = ZZ(self.conductor)
+        data['j_invariant'] = QQ(str(self.jinv))
         data['j_inv_factor'] = latex(0)
-        if data['j_invariant']:
+        if data['j_invariant']: # don't factor 0
             data['j_inv_factor'] = latex(data['j_invariant'].factor())
         data['j_inv_str'] = unicode(str(data['j_invariant']))
         data['j_inv_latex'] = web_latex(data['j_invariant'])
-        data['disc'] = D = self.E.discriminant()
-        data['disc_latex'] = web_latex(data['disc'])
-        data['disc_factor'] = latex(data['disc'].factor())
-        data['cond_factor'] =latex(N.factor())
-        data['cond_latex'] = web_latex(N)
+        mw = self.mw = {}
+        mw['rank'] = self.rank
+        mw['int_points'] = ''
+        if self.xintcoords:
+            a1, a2, a3, a4, a6 = [ZZ(a) for a in data['ainvs']]
+            def lift_x(x):
+                f = ((x + a2) * x + a4) * x + a6
+                b = (a1*x + a3)
+                d = (b*b + 4*f).sqrt()
+                return (x, (-b+d)/2)
+            mw['int_points'] = ', '.join(web_latex(lift_x(x)) for x in self.xintcoords)
 
-        # CM and endomorphism ring
+        mw['generators'] = ''
+        mw['heights'] = []
+        if self.gens:
+            mw['generators'] = [web_latex(tuple(P)) for P in parse_points(self.gens)]
+
+        mw['tor_order'] = self.torsion
+        tor_struct = [int(c) for c in self.torsion_structure]
+        if mw['tor_order'] == 1:
+            mw['tor_struct'] = '\mathrm{Trivial}'
+            mw['tor_gens'] = ''
+        else:
+            mw['tor_struct'] = ' \\times '.join(['\Z/{%s}\Z' % n for n in tor_struct])
+            mw['tor_gens'] = ', '.join(web_latex(tuple(P)) for P in parse_points(self.torsion_generators))
+
+        # try to get all the data we need from the database entry (now in self)
+        try:
+            data['equation'] = self.equation
+            local_data = self.local_data
+            badprimes = [ZZ(ld['p']) for ld in local_data]
+            D = self.signD * prod([ld['p']**ld['ord_disc'] for ld in local_data])
+            data['disc'] = D
+            Nfac = Factorization([(ZZ(ld['p']),ld['ord_cond']) for ld in local_data])
+            Dfac = Factorization([(ZZ(ld['p']),ld['ord_disc']) for ld in local_data])
+
+            data['minq_D'] = minqD = self.min_quad_twist['disc']
+            minq_label = self.min_quad_twist['label']
+            data['minq_label'] = db_ec().find_one({'label':minq_label}, ['lmfdb_label'])['lmfdb_label']
+            data['minq_info'] = '(itself)' if minqD==1 else '(by %s)' % minqD
+            try:
+                data['degree'] = self.degree
+            except AttributeError:
+                data['degree']  =0 # invalid, but will be displayed nicely
+            mw['heights'] = self.heights
+            if self.number == 1:
+                data['an'] = self.anlist
+                data['ap'] = self.aplist
+            else:
+                r = db_ec.find_one({'lmfdb_label':self.lmfdb_label, 'number':1}, ['anlist','aplist'])
+                data['an'] = r['anlist']
+                data['ap'] = r['aplist']
+
+        # otherwise fall back to computing it from the curve
+        except AttributeError:
+            print("Falling back to constructing E")
+            self.E = EllipticCurve(data['ainvs'])
+            data['equation'] = web_latex(self.E)
+            data['disc'] = D = self.E.discriminant()
+            Nfac = N.factor()
+            Dfac = D.factor()
+            bad_primes = [p for p,e in Nfac]
+            try:
+                data['degree'] = self.degree
+            except AttributeError:
+                try:
+                    data['degree'] = self.E.modular_degree()
+                except RuntimeError:
+                    data['degree'] = 0  # invalid, but will be displayed nicely
+            minq, minqD = self.E.minimal_quadratic_twist()
+            data['minq_D'] = minqD
+            if minqD == 1:
+                data['minq_label'] = self.lmfdb_label
+                data['minq_info'] = '(itself)'
+            else:
+                # This relies on the minimal twist being in the
+                # database, which is true when the database only
+                # contains the Cremona database.  It would be a good
+                # idea if, when the database is extended, we ensured
+                # that for any curve included, all twists of smaller
+                # conductor are also included.
+                minq_ainvs = [str(c) for c in minq.ainvs()]
+                data['minq_label'] = db_ec().find_one({'jinv':str(self.E.j_invariant()),
+                                                       'ainvs': minq_ainvs},['lmfdb_label'])['lmfdb_label']
+                data['minq_info'] = '(by %s)' % minqD
+
+            if self.gens:
+                self.generators = [self.E(g) for g in parse_points(self.gens)]
+                mw['heights'] = [P.height() for P in self.generators]
+
+            data['an'] = self.E.anlist(20,python_ints=True)
+            data['ap'] = self.E.aplist(100,python_ints=True)
+            self.local_data = local_data = []
+            for p in bad_primes:
+                ld = self.E.local_data(p, algorithm="generic")
+                local_data_p = {}
+                local_data_p['p'] = p
+                local_data_p['cp'] = ld.tamagawa_number()
+                local_data_p['kod'] = web_latex(ld.kodaira_symbol()).replace('$', '')
+                local_data_p['red'] = ld.bad_reduction_type()
+                local_data_p['ord_cond'] = ld.conductor_valuation()
+                local_data_p['ord_disc'] = ld.discriminant_valuation()
+                local_data_p['ord_den_j'] = max(0,-self.E.j_invariant().valuation(p))
+                local_data.append(local_data_p)
+
+        jfac = Factorization([(ZZ(ld['p']),ld['ord_den_j']) for ld in local_data])
+
+        minq_N, minq_iso, minq_number = split_lmfdb_label(data['minq_label'])
+
+        data['disc_factor'] = latex(Dfac)
+        data['cond_factor'] =latex(Nfac)
+        data['disc_latex'] = web_latex(D)
+        data['cond_latex'] = web_latex(N)
 
         data['CMD'] = self.cm
         data['CM'] = "no"
@@ -190,69 +293,8 @@ class WebEC(object):
         else:
             data['ST'] = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.SU(2)'),'\\mathrm{SU}(2)')
 
-        # modular degree
-
-        try:
-            data['degree'] = self.degree
-        except AttributeError:
-            try:
-                data['degree'] = self.E.modular_degree()
-            except RuntimeError:
-                data['degree']  # invalid, but will be displayed nicely
-
-        # Minimal quadratic twist
-
-        E_pari = self.E.pari_curve()
-        from sage.libs.pari.all import PariError
-        try:
-            minq, minqD = self.E.minimal_quadratic_twist()
-        except PariError:  # this does occur with 164411a1
-            ec.debug("PariError computing minimal quadratic twist of elliptic curve %s" % lmfdb_label)
-            minq = self.E
-            minqD = 1
-        data['minq_D'] = minqD
-        if self.E == minq:
-            data['minq_label'] = self.lmfdb_label
-            data['minq_info'] = '(itself)'
-        else:
-            minq_ainvs = [str(c) for c in minq.ainvs()]
-            data['minq_label'] = db_ec().find_one({'jinv':str(self.E.j_invariant()),'ainvs': minq_ainvs})['lmfdb_label']
-            data['minq_info'] = '(by %s)' % minqD
-
-        minq_N, minq_iso, minq_number = split_lmfdb_label(data['minq_label'])
-
-        # rational and integral points
-
-        mw = self.mw = {}
-
-        xintpoints_projective = [self.E.lift_x(x) for x in self.xintcoords]
-        xintpoints = [P.xy() for P in xintpoints_projective]
-        mw['int_points'] = ', '.join(web_latex(P) for P in xintpoints)
-
-        # Generators of infinite order
-
-        mw['rank'] = self.rank
-        try:
-            self.generators = [self.E(g) for g in parse_points(self.gens)]
-            mw['generators'] = [web_latex(P.xy()) for P in self.generators]
-            mw['heights'] = [P.height() for P in self.generators]
-        except AttributeError:
-            mw['generators'] = ''
-            mw['heights'] = []
-
-        # Torsion subgroup: order, structure, generators
-
-        mw['tor_order'] = self.torsion
-        tor_struct = [int(c) for c in self.torsion_structure]
-        if mw['tor_order'] == 1:
-            mw['tor_struct'] = '\mathrm{Trivial}'
-            mw['tor_gens'] = ''
-        else:
-            mw['tor_struct'] = ' \\times '.join(['\Z/{%s}\Z' % n
-                                                 for n in tor_struct])
-            mw['tor_gens'] = ', '.join(web_latex(self.E(g).xy()) for g in parse_points(self.torsion_generators))
-
-        # Images of Galois representations
+        data['p_adic_primes'] = [p for i,p in enumerate(sage.all.prime_range(5, 100))
+                                 if (N*data['ap'][i]) %p !=0]
 
         try:
             data['galois_images'] = [trim_galois_image_code(s) for s in self.galois_images]
@@ -270,10 +312,9 @@ class WebEC(object):
             from sage.matrix.all import Matrix
             data['twoadic_gen_matrices'] = ','.join([latex(Matrix(2,2,M)) for M in self.twoadic_gens])
             data['twoadic_rouse_url'] = ROUSE_URL_PREFIX + self.twoadic_label + ".html"
+
         # Leading term of L-function & BSD data
-
         bsd = self.bsd = {}
-
         r = self.rank
         if r >= 2:
             bsd['lder_name'] = "L^{(%s)}(E,1)/%s!" % (r,r)
@@ -300,36 +341,16 @@ class WebEC(object):
         data['p_adic_data_exists'] = False
         if data['Gamma0optimal']:
             data['p_adic_data_exists'] = (padic_db().find({'lmfdb_iso': self.lmfdb_iso}).count()) > 0
-        data['p_adic_primes'] = [p for p in sage.all.prime_range(5, 100)
-                                 if self.E.is_ordinary(p) and not p.divides(N)]
 
-        # Local data
-
-        local_data = self.local_data = []
-        # if we use E.tamagawa_numbers() it calls E.local_data(p) which
-        # used to crash on some curves e.g. 164411a1
-        tamagawa_numbers = []
-        for p in bad_primes:
-            local_info = self.E.local_data(p, algorithm="generic")
-            local_data_p = {}
-            local_data_p['p'] = p
-            local_data_p['tamagawa_number'] = local_info.tamagawa_number()
-            tamagawa_numbers.append(ZZ(local_info.tamagawa_number()))
-            local_data_p['kodaira_symbol'] = web_latex(local_info.kodaira_symbol()).replace('$', '')
-            local_data_p['reduction_type'] = local_info.bad_reduction_type()
-            local_data_p['ord_cond'] = local_info.conductor_valuation()
-            local_data_p['ord_disc'] = local_info.discriminant_valuation()
-            local_data_p['ord_den_j'] = max(0,-self.E.j_invariant().valuation(p))
-            local_data.append(local_data_p)
-
+        tamagawa_numbers = [ZZ(ld['cp']) for ld in local_data]
         cp_fac = [cp.factor() for cp in tamagawa_numbers]
         cp_fac = [latex(cp) if len(cp)<2 else '('+latex(cp)+')' for cp in cp_fac]
         bsd['tamagawa_factors'] = r'\cdot'.join(cp_fac)
         bsd['tamagawa_product'] = sage.misc.all.prod(tamagawa_numbers)
 
         cond, iso, num = split_lmfdb_label(self.lmfdb_label)
-        data['newform'] =  web_latex(self.E.q_eigenform(10))
-        self.newform_label = newform_label(cond,2,1,iso)
+        data['newform'] =  web_latex(PowerSeriesRing(QQ, 'q')(data['an'], 20, check=True))
+        data['newform_label'] = self.newform_label = newform_label(cond,2,1,iso)
         self.newform_link = url_for("emf.render_elliptic_modular_forms", level=cond, weight=2, character=1, label=iso)
         newform_exists_in_db = is_newform_in_db(self.newform_label)
         self._code = None
@@ -347,14 +368,18 @@ class WebEC(object):
         if newform_exists_in_db:
             self.friends += [('Modular form ' + self.newform_label, self.newform_link)]
 
-        self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=100)),
+        self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=1000)),
                           ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label)),
                           ('Download Magma code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
                           ('Download Sage code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
                           ('Download GP code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp'))
         ]
 
-        self.plot = encode_plot(self.E.plot())
+        try:
+            self.plot = encode_plot(self.E.plot())
+        except AttributeError:
+            self.plot = encode_plot(EllipticCurve(data['ainvs']).plot())
+
         self.plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
         self.properties = [('Label', self.lmfdb_label),
                            (None, self.plot_link),

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -60,7 +60,13 @@ padicdb = None
 def db_ec():
     global ecdb
     if ecdb is None:
-        ecdb = lmfdb.base.getDBConnection().elliptic_curves.curves2
+        ec = lmfdb.base.getDBConnection().elliptic_curves
+        if 'curves2' in ec.collection_names():
+            #print("Using new collection curves2")
+            ecdb = ec.curves2
+        else:
+            #print("Using old collection curves")
+            ecbd = ec.curves
     return ecdb
 
 def padic_db():

--- a/lmfdb/hilbert_modular_forms/check_conjugates.py
+++ b/lmfdb/hilbert_modular_forms/check_conjugates.py
@@ -19,10 +19,10 @@ from lmfdb.website import DEFAULT_DB_PORT as dbport
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.hilbert_modular_forms.hilbert_field import (findvar, niceideals,
  conjideals, str2ideal, HilbertNumberField)
-from pymongo import MongoClient
 
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=dbport)
+from lmfdb.base import getDBConnection
+print "getting connection"
+C= getDBConnection()
 C['admin'].authenticate('lmfdb', 'lmfdb') ## read-only on all databases by default
 
 print "authenticating on the hmfs database"

--- a/lmfdb/hilbert_modular_forms/import_hmf_data.py
+++ b/lmfdb/hilbert_modular_forms/import_hmf_data.py
@@ -7,9 +7,9 @@ import sage.misc.preparser
 import subprocess
 from sage.interfaces.magma import magma
 
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=dbport)
+from lmfdb.base import getDBConnection
+print "getting connection"
+C= getDBConnection()
 C['admin'].authenticate('lmfdb', 'lmfdb') # read-only
 
 import yaml

--- a/lmfdb/hilbert_modular_forms/import_hmf_data_new_Galois_squarefull_forms.py
+++ b/lmfdb/hilbert_modular_forms/import_hmf_data_new_Galois_squarefull_forms.py
@@ -10,9 +10,9 @@ from sage.interfaces.magma import magma
 
 from sage.all import ZZ, Integer
 
-from lmfdb.website import DEFAULT_DB_PORT as dbport
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=dbport)
+from lmfdb.base import getDBConnection
+print "getting connection"
+C= getDBConnection()
 C['admin'].authenticate('lmfdb', 'lmfdb') # read-only
 
 import yaml


### PR DESCRIPTION
I think this is ready for review now.  Some of the code here in the revised import script is for the one-off creation of a new collections called curves2 with the same data as in curves but with additional fields for each curve to avoid computation on the fly.  This has been run so at Warwick both collections exist.

The live code gets its data from curves 2 if it exists otherwise from curves.  This is a temporary measure and once the new collection is in the cloud too that test can be removed (we will eventually rename curves to something else and rename curves2 to curves).

Independently of that, if the extra data cannot be read from the database (whatever the collection was called) it is still recomputed on the fly.  I put that in for testing and while I had not yet converted all the data.  It is harmless, but also could be removed later.

The new collection is fully indexed.  I have a list of the indices created which I will put in the correct place in the inventory, as well as updating the inventory, when this is finished.  Anyone is welcome to see it.

Finally: even with the new data we still create the Sage elliptic curve just to create the plot.  I see no way round this and do not think it costs a lot.  One plan was to make each curve's home page load before the plot was ready, as we do for L-function plots, but that would take me some time to work out how to do and I don't want to delay the rest of this any more (I did most of it a week ago).  We could also adapt the plot function to simply take the 5-tuple of coefficients as input.  I have not seriously considered precomputing and storing all the plots, but that is certainly an option.