### PR TITLE
Changes to allow us to use an index on ramified primes

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -455,9 +455,10 @@ def number_field_search(**args):
         parse_primes(info,query,'ur_primes',name='Unramified primes',qfield='ramps',mode='complement',to_string=True)
         if 'ram_quantifier' in info and str(info['ram_quantifier']) == 'some':
             mode = 'append'
+            parse_primes(info,query,'ram_primes','ramified primes','ramps',mode,to_string=True)
         else:
-            mode = 'exact'
-        parse_primes(info,query,'ram_primes','ramified primes','ramps',mode,to_string=True)
+            mode = 'liststring'
+            parse_primes(info,query,'ram_primes','ramified primes','ramps_all',mode,to_string=True)
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -458,7 +458,7 @@ def number_field_search(**args):
             parse_primes(info,query,'ram_primes','ramified primes','ramps',mode,to_string=True)
         else:
             mode = 'liststring'
-            parse_primes(info,query,'ram_primes','ramified primes','ramps_all',mode,to_string=True)
+            parse_primes(info,query,'ram_primes','ramified primes','ramps_all',mode)
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -253,6 +253,9 @@ def parse_primes(inp, query, qfield, mode=None, to_string=False):
             primes = [str(p) for p in primes]
         if mode == 'complement':
             query[qfield] = {"$nin": primes}
+        elif mode == 'liststring':
+            sprimes = sorted(primes)
+            query[qfield] = ",".join(sprimes)
         elif mode == 'exact':
             query[qfield] = sorted(primes)
         elif mode == "append":

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -250,12 +250,13 @@ def parse_primes(inp, query, qfield, mode=None, to_string=False):
         format_ok = all([ZZ(p).is_prime(proof=False) for p in primes])
     if format_ok:
         if to_string:
+            primes = sorted(primes)
             primes = [str(p) for p in primes]
         if mode == 'complement':
             query[qfield] = {"$nin": primes}
         elif mode == 'liststring':
-            sprimes = sorted(primes)
-            query[qfield] = ",".join(sprimes)
+            primes = [str(p) for p in primes]
+            query[qfield] = ",".join(primes)
         elif mode == 'exact':
             query[qfield] = sorted(primes)
         elif mode == "append":


### PR DESCRIPTION
Set the "all" toggle for ramiified primes when searching for number fields, and search.

This should work with the warwick database -- you need to move the numberfield database to the cloud before moving to prod because it involves a new "field", ramps_all, in the database, and two new indexes (ramps_all, and (degree, ramps_all)).

As a side note, the data has a few more number fields.  A bigger upload I mentioned elsewhere is on whole while I revise the preparation/upload process to make use of insert_many.