### PR TITLE
uniformize "show commands using" appearance and implementation

### DIFF
--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -298,7 +298,7 @@ class WebDirichlet(WebCharObject):
         if self.modlabel:
             self.modulus = m = int(self.modlabel)
             self.H = H = DirichletGroup_conrey(m)
-        self.credit = 'Sage'
+        self.credit = 'SageMath'
         self.codelangs = ('pari', 'sage')
 
     def _char_desc(self, c, mod=None, prim=None):
@@ -454,7 +454,7 @@ class WebHecke(WebCharObject):
         #self.number = lmfdb_label2hecke(self.numlabel)
         # make this canonical
         self.modlabel = self.ideal2label(self._modulus)
-        self.credit = "Pari, Sage"
+        self.credit = "Pari, SageMath"
         self.codelangs = ('pari', 'sage')
         self.parity = None
         logger.debug('###### WebHeckeComputed')
@@ -599,7 +599,7 @@ class WebHecke(WebCharObject):
 class WebCharFamily(WebCharObject):
     """ compute first groups """
     _keys = [ 'title', 'credit', 'codelangs', 'type', 'nf', 'nflabel',
-            'nfpol', 'codeinit', 'headers', 'contents' ]   
+            'nfpol', 'code', 'headers', 'contents' ]   
     headers = [ 'modulus', 'order', 'structure', 'first characters' ]
 
     def __init__(self, **args):
@@ -886,7 +886,7 @@ class WebDirichletGroup(WebCharGroup, WebDirichlet):
     @property
     def codeinit(self):
         return {
-                'sage': 'H = DirichletGroup_conrey(%i)\n'%(self.modulus),
+                'sage': 'H = DirichletGroup_conrey(%i)'%(self.modulus),
                 'pari': 'g = idealstar(,%i,2)'%(self.modulus)
                 }
 
@@ -914,7 +914,7 @@ class WebSmallDirichletGroup(WebDirichletGroup):
         if self.modlabel:
             self.modulus = m = int(self.modlabel)
             self.H = Integers(m).unit_group()
-        self.credit = 'Sage'
+        self.credit = 'SageMath'
         self.codelangs = ('pari', 'sage')
 
     @property
@@ -1019,12 +1019,11 @@ class WebSmallDirichletCharacter(WebChar, WebDirichlet):
             return { 'sage': 'kronecker_character(%i)'%m }
         return None
 
-
     @property
     def codegaloisorbit(self):
         return { 'sage': 'chi_sage.galois_orbit()',
                  'pari': [
-                     '[mod,num,order] = [%i,%i,%i]'%(self.modulus,self.num,self.order),
+                     '[mod,num,order] = [%i,%i,%i]'%(self.modulus,self.number,self.order),
                      '[Mod(num,mod)^k | k<-[1..order-1], gcd(k,order)==1]',
                      #'order = charorder(g,chi)',
                      #'[ chi*k % order | k <-[1..order-1], gcd(k,order)==1 ]'
@@ -1196,7 +1195,7 @@ class WebHeckeExamples(WebHecke):
                      #'4.4.2403.1',
                      #'4.2.283.1',
                      ]
-        self.credit = "Pari, Sage"
+        self.credit = "Pari, SageMath"
         self.codelangs = ('pari', 'sage')
 
     @property
@@ -1226,7 +1225,7 @@ class WebHeckeFamily(WebCharFamily, WebHecke):
 
     def _compute(self):
         self.k = self.label2nf(self.nflabel)
-        self.credit = 'Pari, Sage'
+        self.credit = 'Pari, SageMath'
         self.codelangs = ('pari', 'sage')
 
     def first_moduli(self, bound=200):

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -559,16 +559,9 @@ class WebNumberField:
          # read in code.yaml from numberfields directory:
         _curdir = os.path.dirname(os.path.abspath(__file__))
         self.code = yaml.load(open(os.path.join(_curdir, "number_fields/code.yaml")))
+        self.code['show'] = {'sage':'','pari':''} # use default show names
 
         # Fill in placeholders for this specific field:
         for lang in ['sage', 'pari']:
             self.code['field'][lang] = self.code['field'][lang] % self.poly()
         self.code['field']['magma'] = self.code['field']['magma'] % self.coeffs()
-
-        for k in self.code:
-            if k != 'prompt':
-                for lang in self.code[k]:
-                    self.code[k][lang] = self.code[k][lang].split("\n")
-                    # remove final empty line
-                    if len(self.code[k][lang][-1])==0:
-                        self.code[k][lang] = self.code[k][lang][:-1]

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -5,9 +5,10 @@ import re
 from lmfdb.base import app, r
 import flask
 from flask import Flask, session, g, render_template, url_for, make_response, request, redirect
-from sage.all import gcd
+from sage.all import gcd, randint
 import tempfile
 import os
+from lmfdb.base import getDBConnection
 from lmfdb.utils import to_dict, make_logger
 from lmfdb.search_parsing import parse_range
 from lmfdb.WebCharacter import *
@@ -59,7 +60,7 @@ def render_characterNavigation():
         modulus_start = int(arg[0])
         modulus_end = int(arg[1])
         info['title'] = 'Dirichlet Characters of Moduli ' + str(modulus_start) + '-' + str(modulus_end)
-        info['credit'] = 'Sage'
+        info['credit'] = 'SageMath'
         h, c, rows, cols = ListCharacters.get_character_modulus(modulus_start, modulus_end)
         info['contents'] = c
         info['headers'] = h
@@ -76,7 +77,7 @@ def render_characterNavigation():
         info['conductor_end'] = conductor_end
         info['title'] = 'Dirichlet Characters of Conductors ' + str(conductor_start) + \
             '-' + str(conductor_end)
-        info['credit'] = "Sage"
+        info['credit'] = "SageMath"
         info['contents'] = ListCharacters.get_character_conductor(conductor_start, conductor_end + 1)
         # info['contents'] = c
         # info['header'] = h
@@ -92,7 +93,7 @@ def render_characterNavigation():
         info['order_start'] = order_start
         info['order_end'] = order_end
         info['title'] = 'Dirichlet Characters of Orders ' + str(order_start) + '-' + str(order_end)
-        info['credit'] = 'Sage'
+        info['credit'] = 'SageMath'
         info['contents'] = ListCharacters.get_character_order(order_start, order_end + 1)
         return render_template("OrderList.html", **info)
 
@@ -163,13 +164,16 @@ def render_Dirichletwebpage(modulus=None, number=None):
                              ('Dirichlet', url_for(".render_Dirichletwebpage")),
                              ('Mod %s'%m, url_for(".render_Dirichletwebpage", modulus=m))]
             info['learnmore'] = learn()
+            info['code'] = dict([(k[4:],info[k]) for k in info if k[0:4] == "code"])
+            info['code']['show'] = { lang:'' for lang in info['codelangs'] } # use default show names
             return render_template('CharGroup.html', **info)
         else:
             number = int(number)
             if gcd(modulus, number) != 1:
                 return flask.abort(404)
             if modulus < 100000:
-                info = WebDirichletCharacter(**args).to_dict()
+                webchar = WebDirichletCharacter(**args)
+                info = webchar.to_dict()
             else:
                 info = WebSmallDirichletCharacter(**args).to_dict()
             m,n = info['modlabel'], info['numlabel']
@@ -178,6 +182,8 @@ def render_Dirichletwebpage(modulus=None, number=None):
                              ('Mod %s'%m, url_for(".render_Dirichletwebpage", modulus=m)),
                              ('%s'%n, url_for(".render_Dirichletwebpage", modulus=m, number=n)) ]
             info['learnmore'] = learn()
+            info['code'] = dict([(k[4:],info[k]) for k in info if k[0:4] == "code"])
+            info['code']['show'] = { lang:'' for lang in info['codelangs'] } # use default show names
             return render_template('Character.html', **info)
 
 @characters_page.route("/calc-<calc>/Dirichlet/<int:modulus>/<int:number>")
@@ -230,6 +236,8 @@ def render_Heckewebpage(number_field=None, modulus=None, number=None):
                          ('Hecke', url_for(".render_Heckewebpage")),
                          ('Number Field %s'%number_field, url_for(".render_Heckewebpage", number_field=number_field)),
                          ('Mod %s'%m,  url_for(".render_Heckewebpage", number_field=number_field, modulus=m))]
+        info['code'] = dict([(k[4:],info[k]) for k in info if k[0:4] == "code"])
+        info['code']['show'] = { lang:'' for lang in info['codelangs'] } # use default show names
         #logger.info(info)
         return render_template('CharGroup.html', **info)
     else:
@@ -241,6 +249,8 @@ def render_Heckewebpage(number_field=None, modulus=None, number=None):
                          ('Number Field %s'%number_field,url_for(".render_Heckewebpage", number_field=number_field)),
                          ('Mod %s'%X.modulus, url_for(".render_Heckewebpage", number_field=number_field, modulus=m)),
                          ('#%s'%X.number, url_for(".render_Heckewebpage", number_field=number_field, modulus=m, number=n))]
+        info['code'] = dict([(k[4:],info[k]) for k in info if k[0:4] == "code"])
+        info['code']['show'] = { lang:'' for lang in info['codelangs'] } # use default show names
         #logger.info(info)
         return render_template('Character.html', **info)
 
@@ -282,7 +292,7 @@ def character_search(**args):
         info['bread'] = [('Characters', url_for(".render_characterNavigation")),
                          ('Dirichlet', url_for(".render_Dirichletwebpage")),
                          ('search results', ' ') ]
-        info['credit'] = 'Sage'
+        info['credit'] = 'SageMath'
         if (len(query) != 0):
             from sage.modular.dirichlet import DirichletGroup
             info['contents'] = charactertable(query)
@@ -320,10 +330,10 @@ def render_character_table(modulus=None, conductor=None, order=None):
             add &= not conductor or chi.conductor() == conductor
             add &= not order or chi.multiplicative_order() == order
             if add:
-		 if chi.multiplicative_order() == 2 and c.symbol is not None:
-                     ret.append([(j, c.symbol, chi.modulus(), chi.conductor(), chi.multiplicative_order(), chi.is_primitive(), chi.is_even())])
-                 else:
-                     ret.append([(j, chi, chi.modulus(), chi.conductor(), chi.multiplicative_order(), chi.is_primitive(), chi.is_even())])
+                if chi.multiplicative_order() == 2 and c.symbol is not None:
+                    ret.append([(j, c.symbol, chi.modulus(), chi.conductor(), chi.multiplicative_order(), chi.is_primitive(), chi.is_even())])
+                else:
+                    ret.append([(j, chi, chi.modulus(), chi.conductor(), chi.multiplicative_order(), chi.is_primitive(), chi.is_even())])
         return ret
     return [row(_) for _ in range(start, end, stepsize)]
 
@@ -339,7 +349,7 @@ def dirichlet_table():
 #    info = to_dict(args)
 #    info['modulus'] = modulus
 #    info["bread"] = [('Dirichlet Character Table', url_for("dirichlet_table")), ('result', ' ')]
-#    info['credit'] = 'Sage'
+#    info['credit'] = 'SageMath'
 #    h, c, = get_entries(modulus)
 #    info['headers'] = h
 #    info['contents'] = c
@@ -370,7 +380,7 @@ def dirichlet_group_table(**args):
     if "modulus" not in info:
         info["modulus"] = modulus
     info['bread'] = [('Characters', url_for(".render_characterNavigation")), ('Dirichlet table', ' ') ]
-    info['credit'] = 'Sage'
+    info['credit'] = 'SageMath'
     char_number_list = request.args.get("char_number_list",None)
     if char_number_list is not None:
         info['char_number_list'] = char_number_list

--- a/lmfdb/characters/templates/CharFamily.html
+++ b/lmfdb/characters/templates/CharFamily.html
@@ -2,8 +2,6 @@
 
 {% block description %}
 
-{{ addcode(codeinit,'div') }}
-
     {# First character groups #}
 
     <h2> {{type}} character groups of first conductors </h2>

--- a/lmfdb/characters/templates/CharGroup.html
+++ b/lmfdb/characters/templates/CharGroup.html
@@ -4,6 +4,8 @@
 
 
 {# Underlying group #}
+
+<p>{{ place_code('init') }}</p>
 <h2>
   Underlying
   {% if type=='Dirichlet' %}
@@ -13,8 +15,6 @@
   {% endif %}
   modulo {{modulus}}
 </h2>
-
-{{ addcode(codeinit,'div') }}
 
 {% if type=='Hecke' %}
 \( Cl_f(K) \)
@@ -26,12 +26,12 @@
 
 
 <table class="props">
-  <tr> <td colspan="3"> {{ addcode(codeorder,'div') }} </td> </tr>
+  <tr> <td colspan="3"> {{ place_code('order') }} </td> </tr>
   <tr> <td>Order</td> <td>=</td> <td>{{ order }}</td> </tr>
 
-  <tr> <td colspan="3"> {{ addcode(codestruct,'div') }} </td> </tr>
+  <tr> <td colspan="3"> {{ place_code('struct') }} </td> </tr>
   <tr> <td>Structure</td> <td>=</td> <td>{{ structure }}</td> </tr>
-  <tr> <td colspan="3"> {{ addcode(codegen,'div') }} </td> </tr>
+  <tr> <td colspan="3"> {{ place_code('gen') }} </td> </tr>
   <tr> <td> Generators </td> <td>=</td> <td>{{ generators }}</td> </tr>
 
 </table>

--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -3,7 +3,7 @@
 
 {% block description %}
  
-        {{ addcode(codeinit,'div') }}
+        {{ place_code('init') }}
 
         {# Kronecker symbol #}
         {% if symbol %}
@@ -12,7 +12,7 @@
             {{ KNOWL('character.dirichlet.kronecker_symbol', title = 'Kronecker symbol') }} representation
         </h2>
 
-        {{ addcode(codesymbol,'div') }}
+        {{ place_code('symbol') }}
         <p> {{ symbol }} </p>
         {% endif %}
         {% endif %}
@@ -22,7 +22,7 @@
             <h2>
                 Inducing {{ KNOWL('character.dirichlet.primitive', title="primitive character") }}
             </h2>
-            {{ addcode(codeinducing, 'div') }}
+            {{ place_code('inducing') }}
            <p>
             <a href="{{ url_character(
                 type = type,
@@ -39,7 +39,7 @@
             <h2>
                 {{ KNOWL('character.dirichlet.values_on_gens', title="Values on generators") }}
             </h2>
-            {{ addcode(codegenvalues, 'div') }}
+            {{ place_code('genvalues') }}
             <p>
                 {{ generators }} &rarr; {{ genvalues }}
             </p>
@@ -80,16 +80,16 @@
         <h2> {{ KNOWL('character.dirichlet.basic_properties', title="Basic properties") }} </h2>
 
         <table class="props">
-            <tr> <td colspan='3'> {{ addcode(codecond,'div') }} </td> </tr>
+            <tr> <td colspan='3'> {{ place_code('cond') }} </td> </tr>
             <tr> <td>Conductor</td> <td>=</td> <td>{{ conductor }}</td> </tr>
-            <tr> <td colspan='3'> {{ addcode(codeorder,'div') }} </td> </tr>
+            <tr> <td colspan='3'> {{ place_code('order') }} </td> </tr>
             <tr> <td> Order </td> <td>=</td> <td>{{ order }}</td> </tr>
             {% if parity %}
-            <tr> <td colspan='3'> {{ addcode(codeparity,'div') }} </td> </tr>
+            <tr> <td colspan='3'> {{ place_code('parity') }} </td> </tr>
             <tr> <td> Parity </td> <td>=</td> <td> {{ parity }}</td> </tr>
             {% endif %}
             <tr> <td> Real </td> <td>=</td> <td> {{ isreal }} </td> </tr>
-            <tr> <td colspan='3'> {{ addcode(codeisprimitive,'div') }} </td> </tr>
+            <tr> <td colspan='3'> {{ place_code('isprimitive') }} </td> </tr>
             <tr> <td> Primitive </td> <td>=</td> <td> {{ isprimitive }} </td> </tr>
         </table>
 
@@ -97,7 +97,7 @@
         <h2>
             {{ KNOWL('character.dirichlet.galois_orbit', title="Galois orbit") }}
         </h2>
-          {{ addcode(codegaloisorbit,'div') }}
+          {{ place_code('galoisorbit') }}
         <p>
         {% for mod,num,label,prim in galoisorbit %}
         {% if loop.index > limit %} ... {% break %} {% endif %}
@@ -135,7 +135,7 @@
         <h2>
             {{ KNOWL('character.dirichlet.gauss_sum', title='Gauss sum') }}
         </h2>
-        {{ addcode(codegauss,'div') }}
+        {{ place_code('gauss') }}
         {% set gauss_default = 2 %}
         <form> \( \tau_{ a }( \chi_{ {{modulus}} }({{number}},&middot;) )\;\)  at \(\;a = \)
             <input id="calc-gauss-input" size=10 placeholder={{gauss_default}}>
@@ -150,7 +150,7 @@
         <h2>
             {{ KNOWL('character.dirichlet.jacobi_sum', title='Jacobi sum') }}
         </h2>
-        {{ addcode(codejacobi,'div') }}
+        {{ place_code('jacobi') }}
         {% set jacobi_default = 1 %}
         <form> \( J(\chi_{ {{modulus}} }({{number}},&middot;),\chi_{ {{modulus}} }(n,&middot;)) \;\) for \( \; n = \)
             <input id="calc-jacobi-input" size="10" placeholder={{jacobi_default}}>
@@ -165,7 +165,7 @@
         <h2>
             {{ KNOWL('character.dirichlet.kloosterman_sum', title='Kloosterman sum') }}
         </h2>
-        {{ addcode(codekloosterman,'div') }}
+        {{ place_code('kloosterman') }}
         {% set kloosterman_default_a = 1 %}
         {% set kloosterman_default_b = 2 %} 
         <form> \(K(a,b,\chi_{ {{modulus}} }({{number}},&middot;)) \;\) at \(\; a,b = \)

--- a/lmfdb/characters/templates/Charpage.html
+++ b/lmfdb/characters/templates/Charpage.html
@@ -1,33 +1,7 @@
-{% macro addcode(entries,tag) -%}
-   {% if entries %}
-   {% for lang in codelangs %}
-     {% if lang in entries %}
-       {% set prompt = 'gp (2.8): ' if lang == 'pari' else '%s: '%lang %}
-       {% set code = entries[lang] %}
-       <{{tag}} class='{{lang}} nodisplay code codebox'>{{prompt}}{{- code if code is string else code|join('\n%s'%prompt) -}}</{{tag}}>
-     {% endif %}
-   {% endfor %}
-   {% endif %}
-{%- endmacro %}
-
 {% extends 'homepage.html' %}
 {% import 'color.css' as color %}
-{% block content %}
 
-<script>
-var cur_system = null;
-function show_code(system) {
-   {% for lang in codelangs %}
-   $('.{{lang}}').hide();
-   {% endfor %}
-    if (cur_system == system) {
-      cur_system = null;
-    } else {
-      $('.'+system).show();
-      cur_system = system;
-    }
-}
-</script>
+{% block content %}
 
 <style>
 .output {
@@ -74,15 +48,6 @@ table.values td:nth-child(even) {
 }
 </style>
 
-   {% if codelangs %}
-        <div align="center">
-            <font size="3">Show commands for:</font>
-            {% for lang in codelangs %}
-            <a onclick="show_code('{{lang}}'); return false" href='#'>{{lang}}</a>
-            {% endfor %}
-        </div>
-   {% endif %}
- 
    {% block description %}
 
    {% endblock %}

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -425,11 +425,3 @@ class ECNF(object):
 
         for lang in ['sage', 'magma', 'pari']:
             self._code['curve'][lang] = self._code['curve'][lang] % self.ainvs
-
-        for k in self._code:
-            if k != 'prompt':
-                for lang in self._code[k]:
-                    self._code[k][lang] = self._code[k][lang].split("\n")
-                    # remove final empty line
-                    if len(self._code[k][lang][-1])==0:
-                        self._code[k][lang] = self._code[k][lang][:-1]

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -1,7 +1,7 @@
 prompt:
-  sage:   'sage:'
-  pari:   'gp (2.8):'
-  magma:  'magma:'
+  sage:   'sage'
+  pari:   'gp (2.8)'
+  magma:  'magma'
 
 logo:
   sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -324,13 +324,15 @@ def show_ecnf(nf, conductor_label, class_label, number):
     bread.append((ec.conductor_label, ec.urls['conductor']))
     bread.append((ec.iso_label, ec.urls['class']))
     bread.append((ec.number, ec.urls['curve']))
+    code = ec.code()
+    code['show'] = {'magma':'','pari':'','sage':''} # use default show names
     info = {}
-
     return render_template("show-ecnf.html",
                            credit=ecnf_credit,
                            title=title,
                            bread=bread,
                            ec=ec,
+                           code = code,
                            #        properties = ec.properties,
                            properties2=ec.properties,
                            friends=ec.friends,

--- a/lmfdb/ecnf/templates/show-ecnf.html
+++ b/lmfdb/ecnf/templates/show-ecnf.html
@@ -5,31 +5,6 @@
 <div.ip>span { white-space: nowrap; font-family: serif; }
 </style>
 
-{% macro code(codes, item) %}
-{% set code = codes() %}
-{% for L in code[item] %}
-{# N.B. whitespace is preserved in the following div since the CSS has
-white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for c in code[item][L] %}{{code.prompt[L]}}&nbsp;{{c}}<br>{% endfor %}</div>
-{% endfor %}
-{% endmacro %}
-
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.pari').hide();
-    $('.magma').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-      } else {
-      $('.'+system).show();
-      cur_system = system;
-    }
-  }
-</script>
-
 {#
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script><script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script><script src="http://aleph.sagemath.org/embedded_sagecell.js">
 
@@ -56,13 +31,6 @@ function show_code(system) {
   </style>
 #}
 
-    <div align ="right">
-      Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sage</a>,
-       {# <a onclick="show_code('pari'); return false" href='#'>pari</a>, #}
-        <a onclick="show_code('pari'); return false" href='#'>gp</a>,
-        <a onclick="show_code('magma'); return false" href='#'>magma</a>
-    </div>
-
 <div>
   <h2>  Base field   {{ ec.field.knowl()|safe }} </h2>
 <p>
@@ -72,7 +40,7 @@ function show_code(system) {
  {{ec.field.latex_poly}}; {{ KNOWL('nf.class_number', 'class number')
  }} \({{ec.field.class_number()}}\).
 </p>
-    {{ code(ec.code,'field') }}
+    {{ place_code('field') }}
 </div>
 
 <style type="text/css">
@@ -87,7 +55,7 @@ cellpadding="5";
 <div style='overflow-x:auto; overflow-y:hidden'>
 {{ ec.equn }}
 </div>
-    {{ code(ec.code,'curve') }}
+    {{ place_code('curve') }}
 <p>
   {% if ec.is_minimal %}
   This is a {{ KNOWL('ec.global_minimal_model','global minimal model')}}.
@@ -101,7 +69,7 @@ cellpadding="5";
   No {{ KNOWL('ec.global_minimal_model','global minimal model')}} exists.
   {% endif %}
   {% endif %}
-    {{ code(ec.code,'is_min') }}
+    {{ place_code('is_min') }}
 </p>
 
 
@@ -117,7 +85,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_cond }}</td>
         </tr>
-        <tr><td colspan=5>    {{ code(ec.code,'cond') }}</td></tr>
+        <tr><td colspan=5>    {{ place_code('cond') }}</td></tr>
 
         <tr>
         <td>
@@ -127,7 +95,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_cond_norm }}</td>
         </tr>
-        <tr><td colspan=5>    {{ code(ec.code,'cond_norm') }}</td></tr>
+        <tr><td colspan=5>    {{ place_code('cond_norm') }}</td></tr>
 
         <tr>
         <td>
@@ -145,7 +113,7 @@ cellpadding="5";
         {% endif %}
         </tr>
 
-          <tr><td colspan=5> {{ code(ec.code,'disc') }}</td></tr>
+          <tr><td colspan=5> {{ place_code('disc') }}</td></tr>
         <tr>
         <td>
           {% if ec.is_minimal %}
@@ -159,7 +127,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
         </tr>
-        <tr><td colspan=5> {{ code(ec.code,'disc_norm') }}</td></tr>
+        <tr><td colspan=5> {{ place_code('disc_norm') }}</td></tr>
 
 {% if not ec.is_minimal %}
         <tr>
@@ -193,7 +161,7 @@ cellpadding="5";
         <td>{{ ec.fact_j }}</td>
         {% endif %}
         </tr>
-        <tr><td colspan=5>     {{ code(ec.code,'jinv') }}</td></tr>
+        <tr><td colspan=5>     {{ place_code('jinv') }}</td></tr>
 
         <tr>
         <td> \( \text{End} (E) \)</td>
@@ -205,7 +173,7 @@ cellpadding="5";
             )
         </td>
         </tr>
-        <tr><td colspan=5>     {{ code(ec.code,'cm') }}</td></tr>
+        <tr><td colspan=5>     {{ place_code('cm') }}</td></tr>
 
         <tr>
         <td> \( \text{ST} (E) \)</td>
@@ -231,7 +199,7 @@ Rank not available.
 {% else %}
 <b>Rank:</b> \( {{ ec.rank }} \)
 {% endif %}
- {{ code(ec.code,'rank') }}
+ {{ place_code('rank') }}
 
 {% if ec.rank_bounds[0] %}
 {% if ec.gens == 'not available' %}
@@ -248,12 +216,12 @@ Generators:
 
 {% endif %}
 {% endif %}
- {{ code(ec.code,'gens') }}
+ {{ place_code('gens') }}
 
 <p>
 <b>Regulator:</b>
 {{ ec.reg }}
- {{ code(ec.code,'reg') }}
+ {{ place_code('reg') }}
 </p>
 </div>
 
@@ -264,21 +232,21 @@ Generators:
 <th>Structure:</th>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
-<tr><td colspan=2> {{ code(ec.code,'tors') }}</td></tr>
-<tr><td colspan=2> {{ code(ec.code,'ntors') }}</td></tr>
+<tr><td colspan=2> {{ place_code('tors') }}</td></tr>
+<tr><td colspan=2> {{ place_code('ntors') }}</td></tr>
     {% if ec.tr %}
 <tr>
 <th>{% if ec.tr==1 %}Generator{% else %}Generators{% endif %}:</th>
 <td>{{ ec.torsion_gens }}</td>
 </tr>
-<tr><td colspan=2> {{ code(ec.code,'torgens') }}</td></tr>
+<tr><td colspan=2> {{ place_code('torgens') }}</td></tr>
     {% endif %}
 </table>
 </div>
 
 <div>
     <h2>{{KNOWL('ec.local_data', title='Local data')}} at primes of {{KNOWL('ec.bad_reduction', title='bad reduction')}} </h2>
- {{ code(ec.code,'localdata') }}
+ {{ place_code('localdata') }}
 
 {% if ec.local_data %}
 <table cellpadding="5">

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -1,7 +1,7 @@
 prompt:
-  sage:   'sage:'
-  pari:   'gp:'
-  magma:  'magma:'
+  sage:   'sage'
+  pari:   'gp'
+  magma:  'magma'
 
 logo:
   sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -378,6 +378,7 @@ def render_isogeny_class(iso_class):
     return render_template("iso_class.html",
                            properties2=class_data.properties,
                            info=class_data,
+                           code=class_data.code,
                            bread=class_data.bread,
                            credit=credit,
                            title=class_data.title,
@@ -441,10 +442,14 @@ def render_curve_webpage_by_label(label):
         credit = credit.replace(' and',',') + ' and Jeremy Rouse'
     data.modform_display = url_for(".modular_form_display", label=lmfdb_label, number="")
 
+    code = data.code()
+    code['show'] = {'magma':'','pari':'','sage':''} # use default show names
     return render_template("curve.html",
                            properties2=data.properties,
                            credit=credit,
                            data=data,
+                           # set default show names but actually code snippets are filled in only when needed
+                           code=code,
                            bread=data.bread, title=data.title,
                            friends=data.friends,
                            downloads=data.downloads,

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -175,7 +175,14 @@ class ECisog_class(object):
                       ('$\Q$', url_for(".rational_elliptic_curves")),
                       ('%s' % N, url_for(".by_conductor", conductor=N)),
                       ('%s' % iso, ' ')]
-
+        self.code = {}
+        self.code['show'] = {'sage':''} # use default show names
+        self.code['class'] = {'sage':'E = EllipticCurve("%s1")\n'%(self.lmfdb_iso) + 'E.isogeny_class()\n'}
+        self.code['curves'] = {'sage':'E.isogeny_class().curves'}
+        self.code['rank'] = {'sage':'E.rank()'}
+        self.code['q_eigenform'] = {'sage':'E.q_eigenform(10)'}
+        self.code['matrix'] = {'sage':'E.isogeny_class().matrix()'}
+        self.code['plot'] = {'sage':'E.isogeny_graph().plot(edge_labels=True)'}
 
 def make_graph(M):
     """

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -13,23 +13,6 @@ white-space: pre in order to keep line breaks! #}
 {% endfor %}
 {% endmacro %}
 
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.pari').hide();
-    $('.magma').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-      } else {
-      $('.'+system).show();
-      $('.'+system).css('display','inline-block');
-      cur_system = system;
-    }
-  }
-</script>
-
 <script type="text/javascript"
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script type="text/javascript"
@@ -69,12 +52,6 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
   </script>
 #}
 
-    <div align ="center">
-      Show commands using:  <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
-        <a onclick="show_code('pari'); return false" href='#'>pari/gp</a>,
-        <a onclick="show_code('magma'); return false" href='#'>Magma</a>
-    </div>
-
 {#
     <div align = "center">
       {{ KNOWL('sage.test', title='Start a Sage cell', kwargs='n=2')
@@ -86,7 +63,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
     <h2> {{ KNOWL('ec.q.minimal_weierstrass_equation', title='Minimal Weierstrass equation') }} </h2>
 
-    {{ code(data.code,'curve') }}
+    {{ place_code('curve') }}
 
     <p> {{ data.data.equation }} </p>
 
@@ -108,7 +85,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
     {% else %}
     <p><h3> Infinite order Mordell-Weil generators and heights</h3>
     {% endif %}
-      {{ code(data.code,'gens') }}
+      {{ place_code('gens') }}
       <div style='overflow:auto'><p>
       <table>
         <tr><td>\(P\)</td><td>&nbsp;=&nbsp;</td>
@@ -124,13 +101,13 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     {% if data.mw.tor_order!=1 %}
     <h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
-      {{ code(data.code,'tors') }}
+      {{ place_code('tors') }}
     <p> {{ data.mw.tor_gens }} </p>
     {%endif %}
 
 
     <p><h2> {{ KNOWL('ec.q.integral_points', title='Integral points') }}</h2>
-      {{ code(data.code,'intpts') }}
+      {{ place_code('intpts') }}
     {% if data.xintcoords %}
     <div class="ip">
       <p>
@@ -147,7 +124,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,'cond') }}
+          {{ place_code('cond') }}
         </td>
         </tr>
         <tr>
@@ -160,7 +137,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,'disc') }}
+          {{ place_code('disc') }}
         </td>
         </tr>
         <tr>
@@ -173,7 +150,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="6">
-          {{ code(data.code,'jinv') }}
+          {{ place_code('jinv') }}
         </td>
         </tr>
         <tr>
@@ -209,7 +186,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'rank') }}
+          {{ place_code('rank') }}
         </td>
         </tr>
         <tr>
@@ -222,7 +199,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'reg') }}
+          {{ place_code('reg') }}
         </td>
         </tr>
         <tr>
@@ -236,7 +213,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'real_period') }}
+          {{ place_code('real_period') }}
         </td>
         </tr>
         <tr>
@@ -246,7 +223,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'cp') }}
+          {{ place_code('cp') }}
         </td>
         </tr>
         <tr>
@@ -261,7 +238,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'ntors') }}
+          {{ place_code('ntors') }}
         </td>
         </tr>
         <tr>
@@ -271,7 +248,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
         <tr>
         <td colspan="4">
-          {{ code(data.code,'sha') }}
+          {{ place_code('sha') }}
         </td>
         </tr>
         <tr>
@@ -295,7 +272,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h2> {{KNOWL('ec.q.modular_parametrization', title='Modular invariants')}}</h2>
     <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}} </h3>
-          {{ code(data.code,'qexp') }}
+          {{ place_code('qexp') }}
     <p>
     <form>
         <div class="output"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
@@ -306,7 +283,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h3> {{ KNOWL('ec.q.modular_degree', title='Modular degree') }}
       and {{ KNOWL('ec.q.optimal', title='optimality') }}</h3>
-    {{ code(data.code,'moddeg') }}
+    {{ place_code('moddeg') }}
       {% if data.data.degree==0 %}
       Not available
       {% else %}
@@ -321,7 +298,7 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <p>
       <h3> {{KNOWL('ec.q.special_value', title='Special L-value', special_value = data.special_value)}} attached to the curve </h3>
-    {{ code(data.code,'L1') }}
+    {{ place_code('L1') }}
     <p>
         \( {{ data.bsd.lder_name }} \) &approx; \( {{ data.bsd.lder }} \)
     </p>
@@ -335,7 +312,7 @@ text-align: center;
 }
 </style>
 
-    {{ code(data.code,'localdata') }}
+    {{ place_code('localdata') }}
 
 <table id = "local_data">
 <tr>
@@ -393,7 +370,7 @@ data.twoadic_index }}.
 {% endif %}
 
 
-    {{ code(data.code,'galrep') }}
+    {{ place_code('galrep') }}
 
 {% if data.data.galois_data %}
 <p>
@@ -432,7 +409,7 @@ representation')}} is surjective for all primes \( p \).
 
     <h2> p-adic data </h2>
 
-    {{ code(data.code,'padicreg') }}
+    {{ place_code('padicreg') }}
 
     <p>
 {% if data.bsd.rank==0 %}

--- a/lmfdb/elliptic_curves/templates/iso_class.html
+++ b/lmfdb/elliptic_curves/templates/iso_class.html
@@ -2,30 +2,7 @@
 {% import 'color.css' as color %}
 {% block content %}
 
-<script type="text/javascript">
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.pari').hide();
-    $('.magma').hide();
-    if (cur_system == null) {
-      $('.'+system).show();
-      cur_system = system;
-    } else {
-      $('.'+system).hide();
-      cur_system = null;
-    }
-}
-</script>
-
-        <div align="right">
-          Show commands for:
-          <a onclick="show_code('sage'); return false" href='#'>sage</a>
-        </div>
-        <div class='sage nodisplay code'>
-          sage: E = EllipticCurve('{{info.lmfdb_iso}}1')<br>
-          sage: E.isogeny_class()
-        </div>
+{{ place_code('class') }}
 
 <style type="text/css">
 #isogeny_class_table th, #isogeny_class_table td {
@@ -36,7 +13,7 @@ text-align: center;
 
 
 <h2>Elliptic curves in class {{info.lmfdb_iso}}</h2>
-<div class='sage nodisplay code'>sage: E.isogeny_class().curves</div>
+{{ place_code('curves') }}
 <table id = "isogeny_class_table">
 <tr>
 <th>{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
@@ -69,7 +46,7 @@ text-align: center;
 </table>
 
 <h2>Rank</h2>
-<div class='sage nodisplay code'>sage: E.rank()</div>
+{{ place_code('rank') }}
 <p>
 {% if info.ncurves==1 %} The elliptic curve {{info.curves[0].label}} has
 {% else %} The elliptic curves in class {{info.lmfdb_iso}} have
@@ -80,7 +57,7 @@ rank \({{ info.rank}}\).
 <h2><a href="{{info.newform_link}}">
             Modular form {{ info.newform_label }}</a>
 </h2>
-<div class='sage nodisplay code'>sage: E.q_eigenform(10)</div>
+{{ place_code('q_eigenform') }}
 <div>
     <form>
         <div class="output">
@@ -97,15 +74,13 @@ rank \({{ info.rank}}\).
 
 <h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>
 
-<div class='sage nodisplay code'>sage: E.isogeny_class().matrix()</div>
+{{ place_code('matrix') }}
 <p>
   \({{info.isogeny_matrix_str}}\)
 </p>
 
 <h2> {{ KNOWL('ec.isogeny_graph', title='Isogeny graph') }} </h2>
-<div class='sage nodisplay code'>
-  sage: E.isogeny_graph().plot(edge_labels=True)
-</div>
+{{ place_code('plot') }}
 <center>
   <img src="{{info.graph_img}}" />
 </center>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -389,7 +389,7 @@ class WebEC(object):
 
         for lang in ['sage', 'pari', 'magma']:
             self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.label)
-
+        return
         for k in self._code:
             if k != 'prompt':
                 for lang in self._code[k]:

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -172,6 +172,7 @@ def render_curve_webpage_by_label(label):
                            properties2=data.properties,
                            credit=credit,
                            data=data,
+                           code=data.code,
                            bread=data.bread,
                            learnmore=learnmore_list(),
                            title=data.title,

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -9,38 +9,10 @@ table.g2 a {
 }
 
 <style>
-/* seems to be unused?
-<div.ip>span { white-space: nowrap; font-family: serif; }
-*/
 .toggle {margin-top:5px; margin-left:20px;}
 div.properties-body table tr td.label { vertical-align: top; }
 #content > h2.subhead { color:{{color.black}};}
 </style>
-
-{% macro code(codes, languages, item) %}
-{% for L in languages %}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">
-  {{codes[L]['prompt']}}&nbsp;{{codes[L][item]}}
-</div>
-{% endfor %}
-{% endmacro %}
-
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.pari').hide();
-    $('.magma').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-      } else {
-      $('.'+system).show();
-      $('.'+system).css('display','inline-block');
-      cur_system = system;
-    }
-}
-</script>
 
 <script>
 var cur_invstyle = null;
@@ -55,26 +27,17 @@ function show_invs(invstyle) {
 <script type="text/javascript"
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 <script type="text/javascript"
-        src="http://code.jquery.com/jquery-latest.min.js"></script>
+        src="http://place_code.jquery.com/jquery-latest.min.js"></script>
 {#
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 #}
-
-<div align ="center">
-    Show commands using:
-    <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
-    <!-- No pari/gp commands yet!
-    <a onclick="show_code('pari'); return false" href='#'>pari/gp</a>,
-    -->
-    <a onclick="show_code('magma'); return false" href='#'>magma</a>
-</div>
 
 {% set KNOWL_ID = "g2c.%s"|format(data['label']) %}
 <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
 
 
 <h2> {{ KNOWL('g2c.minimal_equation', title='Minimal equation') }} </h2>
-{{code(data.code,['sage','magma'],'curve')}}
+{{place_code('curve')}}
 
 <p> ${{ data.data.min_eqn_display }}$ </p>
 
@@ -83,7 +46,7 @@ function show_invs(invstyle) {
 <table>
     <tr>
         <td colspan="6">
-            {{code(data.code,['magma'],'cond')}}
+            {{place_code('cond')}}
         </td>
     </tr>
     <tr>
@@ -95,7 +58,7 @@ function show_invs(invstyle) {
     </tr>
     <tr>
         <td colspan="6">
-            {{code(data.code,['magma'],'disc')}}
+            {{place_code('disc')}}
         </td>
     </tr>
     <tr>
@@ -111,19 +74,19 @@ function show_invs(invstyle) {
     {{KNOWL("g2c.igusa_clebsch_invariants", title="Igusa-Clebsch invariants")}}
 </h3>
 <div class='igusa_clebsch'>
-    <p>{{code(data.code,['sage','magma'],'igusa_clebsch')}}</p>
+    <p>{{place_code('igusa_clebsch')}}</p>
 </div>
 <h3 class='igusa nodisplay'>
     {{KNOWL("g2c.igusa_invariants", title="Igusa invariants")}}
 </h3>
 <div class='igusa nodisplay'>
-    <p>{{code(data.code,['magma'],'igusa')}}</p>
+    <p>{{place_code('igusa')}}</p>
 </div>
 <h3 class='G2 nodisplay'>
     {{KNOWL("g2c.g2_invariants", title="G2 invariants")}}
 </h3>
 <div class='G2 nodisplay'>
-    <p>{{code(data.code,['magma'],'g2')}}</p>
+    <p>{{place_code('g2')}}</p>
 </div>
 
 <table>
@@ -218,7 +181,7 @@ function show_invs(invstyle) {
 <table>
     <tr>
         <td colspan="6">
-            {{code(data.code,['magma'],'aut')}}
+            {{place_code('aut')}}
         </td>
     </tr>
     <tr>
@@ -226,7 +189,7 @@ function show_invs(invstyle) {
     </tr>
     <tr>
         <td colspan="6">
-            {{code(data.code,['magma'],'autQbar')}}
+            {{place_code('autQbar')}}
         </td>
     </tr>
     <tr>
@@ -234,12 +197,12 @@ function show_invs(invstyle) {
     </tr>
 </table>
 
-{{code(data.code,['magma'],'num_rat_wpts')}}
+{{place_code('num_rat_wpts')}}
 <br>
 <h3 class="inline"> Number of rational {{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}: </h2>\({{data.data.num_rat_wpts}}\)
 
 <br>
-{{code(data.code,['magma'],'locally_solvable')}}
+{{place_code('locally_solvable')}}
 <br>
 <h3 class="inline"> {{ KNOWL('g2c.locally_solvable', title='Locally solvable') }}: </h3>{{data.data.locally_solvable}}
 
@@ -249,17 +212,17 @@ function show_invs(invstyle) {
 <h3 class="inline"> {{ KNOWL('g2c.analytic_rank', title='Analytic rank*') }}: </h3>\({{data.data.analytic_rank}}\)
 
 <br>
-{{code(data.code,['magma'],'two_selmer')}}
+{{place_code('two_selmer')}}
 <br>
 <h3 class="inline"> {{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank') }}: </h3>\({{data.data.two_selmer_rank}}\)
 
 <br>
-{{code(data.code,['magma'],'has_square_sha')}}
+{{place_code('has_square_sha')}}
 <br>
 <h3 class="inline"> {{ KNOWL('g2c.has_square_sha', title='Order of &#1064;*') }}: </h3>{{data.data.has_square_sha}}
 
 <br>
-{{code(data.code,['magma'],'tor_struct')}}
+{{place_code('tor_struct')}}
 <br>
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.data.tor_struct}}\)
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -736,110 +736,26 @@ class WebG2C(object):
              ]
 
         # Make code that is used on the page:
-        self.make_code_snippets()
-
-    def make_code_snippets(self):
-        sagecode = dict()
-        gpcode = dict()
-        magmacode = dict()
-
-        # Utility function to save typing!
-        def set_code(key, s, g, m):
-            sagecode[key] = s
-            gpcode[key] = g
-            magmacode[key] = m
-        sage_not_implemented = '# (not yet implemented)'
-        pari_not_implemented = '\\\\ (not yet implemented)'
-        magma_not_implemented = '// (not yet implemented)'
-
-        # Prompt
-        set_code('prompt',
-                 'sage:',
-                 'gp:',
-                 'magma:')
-
-        # Logo
-        set_code('logo',
-                 '<img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">',
-                 '<img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">',
-                 '<img src = "http://i.stack.imgur.com/0468s.png" width="50px">')
-        # Overwrite the above until we get something which looks reasonable
-        set_code('logo', '', '', '')
-
-        # Curve
-        set_code('curve',
-                 'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'
-                 % (self.data['min_eqn'][0],self.data['min_eqn'][1]),
-                 pari_not_implemented, # pari code goes here
-                 'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'
-                 % (self.data['min_eqn'][0],self.data['min_eqn'][1])
-                 )
+        self.code = {}
+        self.code['show'] = {'sage':'','magma':''} # use default show names
+        self.code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'%(self.data['min_eqn'][0],self.data['min_eqn'][1]),
+                              'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'%(self.data['min_eqn'][0],self.data['min_eqn'][1])}
         if self.data['disc'] % 4096 == 0:
             ind2 = [a[0] for a in self.data['isogeny_class']['bad_lfactors']].index(2)
             bad2 = self.data['isogeny_class']['bad_lfactors'][ind2][1]
             magma_cond_option = ': ExcFactors:=[*<2,Valuation('+str(self.data['cond'])+',2),R!'+str(bad2)+'>*]'
         else:
             magma_cond_option = ''
-        set_code('cond',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'Conductor(LSeries(C%s)); Factorization($1);'
-                 % magma_cond_option
-                 )
-        set_code('disc',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'Discriminant(C); Factorization(Integers()!$1);'
-                 )
-        set_code('igusa_clebsch',
-                 'C.igusa_clebsch_invariants(); [factor(a) for a in _]',
-                 pari_not_implemented, # pari code goes here
-                 'IgusaClebschInvariants(C); [Factorization(Integers()!a): a in $1];'
-                 )
-        set_code('igusa',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'IgusaInvariants(C); [Factorization(Integers()!a): a in $1];'
-                 )
-        set_code('g2',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'G2Invariants(C);'
-                 )
-        set_code('aut',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'AutomorphismGroup(C); IdentifyGroup($1);'
-                 )
-        set_code('autQbar',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'AutomorphismGroup(ChangeRing(C,AlgebraicClosure(Rationals()))); IdentifyGroup($1);'
-                 )
-        set_code('num_rat_wpts',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 '#Roots(HyperellipticPolynomials(SimplifiedModel(C)));'
-                 )
-        set_code('two_selmer',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'TwoSelmerGroup(Jacobian(C)); NumberOfGenerators($1);'
-                 )
-        set_code('has_square_sha',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'HasSquareSha(Jacobian(C));'
-                 )
-        set_code('locally_solvable',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'f,h:=HyperellipticPolynomials(C); g:=4*f+h^2; HasPointsLocallyEverywhere(g,2) and (#Roots(ChangeRing(g,RealField())) gt 0 or LeadingCoefficient(g) gt 0);'
-                 )
-        set_code('tor_struct',
-                 sage_not_implemented, # sage code goes here
-                 pari_not_implemented, # pari code goes here
-                 'TorsionSubgroup(Jacobian(SimplifiedModel(C))); AbelianInvariants($1);'
-                 )
-
-        self.code = {'sage': sagecode, 'pari': gpcode, 'magma': magmacode}
+        self.code['cond'] = {'magma': 'Conductor(LSeries(C%s)); Factorization($1);'% magma_cond_option}
+        self.code['disc'] = {'magma':'Discriminant(C); Factorization(Integers()!$1);'}
+        self.code['igusa_clebsch'] = {'sage':'C.igusa_clebsch_invariants(); [factor(a) for a in _]',
+                                      'magma':'IgusaClebschInvariants(C); [Factorization(Integers()!a): a in $1];'}
+        self.code['igusa'] = {'magma':'IgusaInvariants(C); [Factorization(Integers()!a): a in $1];'}
+        self.code['g2'] = {'magma':'G2Invariants(C);'}
+        self.code['aut'] = {'magma':'AutomorphismGroup(C); IdentifyGroup($1);'}
+        self.code['autQbar'] = {'magma':'AutomorphismGroup(ChangeRing(C,AlgebraicClosure(Rationals()))); IdentifyGroup($1);'}
+        self.code['num_rat_wpts'] = {'magma':'#Roots(HyperellipticPolynomials(SimplifiedModel(C)));'}
+        self.code['two_selmer'] = {'magma':'TwoSelmerGroup(Jacobian(C)); NumberOfGenerators($1);'}
+        self.code['has_square_sha'] = {'magma':'HasSquareSha(Jacobian(C));'}
+        self.code['locally_solvable'] = {'magma':'f,h:=HyperellipticPolynomials(C); g:=4*f+h^2; HasPointsLocallyEverywhere(g,2) and (#Roots(ChangeRing(g,RealField())) gt 0 or LeadingCoefficient(g) gt 0);'}
+        self.code['tor_struct'] = {'magma':'TorsionSubgroup(Jacobian(SimplifiedModel(C))); AbelianInvariants($1);'}

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -245,7 +245,7 @@ class WebModFormSpace(WebObject, CachedRepresentation):
          # read in code.yaml from numberfields directory:
         _curdir = os.path.dirname(os.path.abspath(__file__))
         self.code = yaml.load(open(os.path.join(_curdir, "../code.yaml")))
-        
+        self.code['show'] = {'sage':'','magma':''}
         # Fill in placeholders for this specific space:
         for lang in ['sage', 'magma']:
             if self.character.order == 1:
@@ -254,14 +254,6 @@ class WebModFormSpace(WebObject, CachedRepresentation):
             else:
                 self.code['newforms-nontriv-char'][lang] = self.code['newforms-nontriv-char'][lang].format(
                     N=self.level, k=self.weight, elt=list(self.character.sage_character.element()))
-
-        for k in self.code:
-            if k != 'prompt' and k != 'f':
-                for lang in self.code[k]:
-                    self.code[k][lang] = self.code[k][lang].split("\n")
-                    # remove final empty line
-                    if len(self.code[k][lang][-1])==0:
-                        self.code[k][lang] = self.code[k][lang][:-1]
 
     def __repr__(self):
         if self.character.is_trivial():

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
@@ -745,6 +745,7 @@ class WebNewForm(WebObject, CachedRepresentation):
 
     def make_code_snippets(self):
         self.code = deepcopy(self.parent.code)
+        self.code['show'] = {'sage':''}
         # Fill in placeholders for this specific newform:
         self.code['f']['sage'] = self.code['f']['sage'].format(newform_number=self.sage_newform_number())
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/code.yaml
+++ b/lmfdb/modular_forms/elliptic_modular_forms/code.yaml
@@ -1,6 +1,6 @@
 prompt:
-  sage:   'sage:'
-  magma:  'magma:'
+  sage:   'sage'
+  magma:  'magma'
 
 logo:
   sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
@@ -26,7 +26,7 @@ newforms-nontriv-char:
 newforms-triv-char:
   sage: N = Newforms({N},{k},names="a")
   magma: |
-    S:=CuspForms({N},{k});
+    S := CuspForms({N},{k});
     N := Newforms(S);
 
 f:

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -74,6 +74,7 @@ def render_web_modform_space(level=None, weight=None, character=None, label=None
         emf_logger.debug("dimension={0}".format(info['space'].dimension))
     if info.has_key('error'):
         emf_logger.debug("error={0}".format(info['error']))
+    print info['code']
     return render_template("emf_web_modform_space.html", **info)
 
     
@@ -170,6 +171,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
     friends.append(("Dirichlet character \(" + WMFS.character.latex_name + "\)", WMFS.character.url()))
     friends = uniq(friends)
     info['friends'] = friends
+    info['code'] = WMFS.code
     
     return info
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -74,7 +74,6 @@ def render_web_modform_space(level=None, weight=None, character=None, label=None
         emf_logger.debug("dimension={0}".format(info['space'].dimension))
     if info.has_key('error'):
         emf_logger.debug("error={0}".format(info['error']))
-    print info['code']
     return render_template("emf_web_modform_space.html", **info)
 
     

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -70,7 +70,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     try:
         WNF = WebNewForm_cached(level=level, weight=weight, character=character, label=label, prec=prec)
         info['character_order'] = WNF.character.order
-        info['code_snippets'] = WNF.code
+        info['code'] = WNF.code
         emf_logger.debug("defined webnewform for rendering!")
     except IndexError as e:
         WNF = None

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/display-list-newforms.html
@@ -2,39 +2,24 @@
 info in this page is set by set_info_for_web_newform in emf_render_web_newform.py
 #}
 
-{% macro code(codes, item) %}
-{% for L in codes[item] %}
-{# N.B. whitespace is preserved in the following div since the CSS has
-white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
+{# copy place_code macro from homepage.html #}
+{% macro place_code(item) %}
+{% if code and code[item] %}
+{% for L in code[item] %}
+{% if code[item][L] %}
+{% set lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]] %}
+{% set prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L %}
+{# keep the line below as is to avoid annoying line breaks #}
+<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<br>{% endfor %}</div>
+{% endif %}
 {% endfor %}
+{% endif %}
 {% endmacro %}
 
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.magma').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-    } else {
-      $('.'+system).show();
-      $('.'+system).css('display','inline-block');
-      cur_system = system;
-    }
-}
-</script>
-
-<div align ="right">
-  Show commands for:  <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
-  <a onclick="show_code('magma'); return false" href='#'>magma</a>
-</div>
-
 {% if space.character.order == 1 %}
-{{ code(space.code,'newforms-triv-char') }}
+{{ place_code('newforms-triv-char') }}
 {% else %}
-{{ code(space.code,'newforms-nontriv-char') }}
+{{ place_code('newforms-nontriv-char') }}
 {% endif %}
 
 {% if not q_expansion_prec is defined %}
@@ -71,15 +56,15 @@ function show_code(system) {
              {% if vars.update({'cyclotomicorder': f.coefficient_field.variable_name()[4:]}) %} {% endif %}
          {% endif %}
        <tr>
-	 {% if not f.has_updated_from_db() %}
-	   <td valign="top">{{ f.hecke_orbit_label }}</td>
-	   <td colspan="3"> This Hecke orbit is unfortunately not available. </td>
-	   {% else %}
+     {% if not f.has_updated_from_db() %}
+       <td valign="top">{{ f.hecke_orbit_label }}</td>
+       <td colspan="3"> This Hecke orbit is unfortunately not available. </td>
+       {% else %}
       <td valign="top"><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
       <td align="center" valign="top">
-	{{ f.dimension }}
+    {{ f.dimension }}
         </td>
-	<td align="center" valign="top">
+    <td align="center" valign="top">
         {% if f.is_rational == 1 %}
 <a title = "{{ f.coefficient_field.lmfdb_pretty }}[nf.field.data]" knowl= "nf.field.data" kwargs="label={{ f.coefficient_field.lmfdb_label }}">{{ f.coefficient_field.lmfdb_pretty }}</a></td>
         {% else %}
@@ -87,18 +72,17 @@ function show_code(system) {
               $\Q(\zeta_{ {{vars.cyclotomicorder}} })$
             {% else %}
               $\Q(\alpha_{ {{loop.index}} })$</td>
-	      {% endif %}
-	      {% set varname = '\\alpha_{%s}' % loop.index %}
-	     {%endif%}
-	      {% if f.complexity_of_first_nonvanishing_coefficients() > max_height %}
-	        {% if qexp.update({'hidden': true}) %} {% endif %}
+          {% endif %}
+          {% set varname = '\\alpha_{%s}' % loop.index %}
+         {%endif%}
+          {% if f.complexity_of_first_nonvanishing_coefficients() > max_height %}
+            {% if qexp.update({'hidden': true}) %} {% endif %}
                  <td>$q + \ldots^\ast$</td>
-		{% else %}
-		 {% if qexp.update({'visible': true}) %} {% endif %}
-	        <td>{{ f.q_expansion_latex(q_expansion_prec, varname) }}</td>
-	  {% endif %}
-		{% endif %}
-	<tr><td colspan="4">{{ code(f.code, 'f')}}{{ code(f.code, 'qexp')}}</td></tr>
+        {% else %}
+         {% if qexp.update({'visible': true}) %} {% endif %}
+            <td>{{ f.q_expansion_latex(q_expansion_prec, varname) }}</td>
+      {% endif %}
+        {% endif %}
       </tr>
     {% endfor %}
   </tbody>
@@ -153,9 +137,9 @@ Click on the label in the table above for more information about each newform.</
 </td>
         {% else %}
         <td align="left"  valign="top">$\Q(\alpha_{ {{loop.index}} })$</td>
-	<td align="left"  valign="top">
-	  {{ f.coefficient_field.relative_polynomial_latex('x') }}
-	</td>
+    <td align="left"  valign="top">
+      {{ f.coefficient_field.relative_polynomial_latex('x') }}
+    </td>
         {% endif %}
       </tr>
         {% endif %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -1,32 +1,6 @@
 {% extends 'homepage.html' %}
 
 {% block content %}
-{% macro code(codes, item) %}
-{% for L in codes[item] %}
-{# N.B. whitespace is preserved in the following div since the CSS has
-white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
-{% endfor %}
-{% endmacro %}
-
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-    } else {
-      $('.'+system).show();
-      $('.'+system).css('display','inline-block');
-      cur_system = system;
-    }
-}
-</script>
-
-<div align ="right">
-  Show commands for:  <a onclick="show_code('sage'); return false" href='#'>sagemath</a>
-</div>
 
 {% set KNOWL_ID = "mf.%s.%s.%s.%s"|format(level,weight,character,label) %}
 <h2>{{ KNOWL_INC(KNOWL_ID+'.top', title='') }}</h2>
@@ -37,42 +11,42 @@ function show_code(system) {
 {% else %}
 
 {% if character == 1 %}
-{{ code(code_snippets,'newforms-triv-char') }}
+{{ place_code('newforms-triv-char') }}
 {% else %}
-{{ code(code_snippets,'newforms-nontriv-char') }}
+{{ place_code('newforms-nontriv-char') }}
 {% endif %}
-{{ code(code_snippets, 'f')}}
+{{ place_code('f')}}
 
 <div id="qexp">
 <!-- from emf_web_newform.html -->
   <h2> {{ KNOWL('mf.elliptic.q-expansion',title='q-expansion')}}</h2>
 <div>
-  {{ code(code_snippets, 'qexp')}}
+  {{ place_code('qexp')}}
   {% if not hide_qexp %}
     <form>
         <div class="output">
           <span id="qexp_display">{{ qexp | safe }}</span>
         </div>
-	<div class="output">{{ polynomial_st | safe }}
-	</div>
-	<div class="emptyspace"><br>
+    <div class="output">{{ polynomial_st | safe }}
+    </div>
+    <div class="emptyspace"><br>
         </div>
         <button id="morebutton">Show more coefficients</button>
         <small>(To download coefficients, see below.)</small>
-	</form>
-	{% else %}
-	<p>The Fourier coefficients of this newform are large.
-	They are available for download below.<br>
-	The first non-zero Fourier coefficient $a(n)$ with $n>1$ is $a({{ index_nv }})$ and has trace ${{ trace_nv }}$ and norm ${{ norm_nv }}$.
-	</p>
-	{% endif %}
+    </form>
+    {% else %}
+    <p>The Fourier coefficients of this newform are large.
+    They are available for download below.<br>
+    The first non-zero Fourier coefficient $a(n)$ with $n>1$ is $a({{ index_nv }})$ and has trace ${{ trace_nv }}$ and norm ${{ norm_nv }}$.
+    </p>
+    {% endif %}
 </div>
 </div>
 <br>
 
 <h3>Coefficient field</h3>
 <div>
-  <div>{{ code(code_snippets, 'coefficient_field') }}</div>
+  <div>{{ place_code('coefficient_field') }}</div>
 <!-- from emf_web_newform.html -->
 The {{ KNOWL('mf.elliptic.coefficient_field',title='coefficient field')}} is 
 {% if is_rational ==1 %}
@@ -86,10 +60,10 @@ The {{ KNOWL('mf.elliptic.coefficient_field',title='coefficient field')}} is
     {% endif %}
 where $ {{ polvars['coefficient_field']}} $ has {{ KNOWL('nf.minimal_polynomial',title='minimal polynomial')}}
 <div style='overflow-x:auto; overflow-y:hidden'>{{coeff_field[0] | safe}}</div> over $\Q$.
-    {{code(code_snippets, 'absolute_polynomial')}}
+    {{place_code('absolute_polynomial')}}
     {% if coeff_field|length >2 and coeff_field[2]>2 %}
 <br/>The {{ KNOWL('nf.minimal_polynomial',title='minimal polynomial')}} of $\alpha$ over $\Q(\zeta_{ {{coeff_field[2]}} })$ is <div style='overflow-x:auto; overflow-y:hidden'>{{coeff_field[1] | safe}} </div>.
-     {{ code(code_snippets, 'relative_polynomial') }}
+     {{ place_code('relative_polynomial') }}
     {% endif %}
 {% endif %}
 </div>

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -1,7 +1,7 @@
 prompt:
-  sage:   'sage:'
-  pari:   'gp:'
-  magma:  'magma:'
+  sage:   'sage'
+  pari:   'gp'
+  magma:  'magma'
 
 logo:
   sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -383,7 +383,7 @@ def render_field_webpage(args):
     except AttributeError:
         pass
 #    del info['_id']
-    return render_template("number_field.html", properties2=properties2, credit=NF_credit, title=title, bread=bread, friends=info.pop('friends'), learnmore=info.pop('learnmore'), info=info)
+    return render_template("number_field.html", properties2=properties2, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), learnmore=info.pop('learnmore'), info=info)
 
 
 def format_coeffs2(coeffs):

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -2,41 +2,9 @@
 {% block content %}
 {# Displays individual number field homepage #}
 
-{% macro code(codes, item) %}
-{% for L in codes[item] %}
-{# N.B. whitespace is preserved in the following div since the CSS has
-white-space: pre in order to keep line breaks! #}
-<div class="{{ [L,'nodisplay', 'codebox'] | join(' ')}}">{% for code in codes[item][L] %}{{codes.prompt[L]}}&nbsp;{{code}}<br>{% endfor %}</div>
-{% endfor %}
-{% endmacro %}
-
-<script>
-var cur_system = null;
-function show_code(system) {
-    $('.sage').hide();
-    $('.pari').hide();
-    $('.magma').hide();
-    if (cur_system == system) {
-      $('.'+system).hide();
-      cur_system = null;
-    } else {
-      $('.'+system).show();
-      $('.'+system).css('display','inline-block');
-      cur_system = system;
-    }
-}
-</script>
-
-    <div align ="right">
-      Show commands for:  <a onclick="show_code('sage'); return false" href='#'>sagemath</a>,
-        <a onclick="show_code('pari'); return false" href='#'>pari/gp</a>,
-        <a onclick="show_code('magma'); return false" href='#'>magma</a>
-    </div>
-    
-
 {% set nf = info.wnf %}
 <p>
-   {{ code(nf.code,'field') }}
+   {{ place_code('field') }}
 </p>
 
         {% set KNOWL_ID = "nf.%s"|format(info['label_raw']) %}
@@ -51,18 +19,18 @@ function show_code(system) {
         {% endif %}
         <p>
             {{ info.polynomial }}
-        {{ code(nf.code,'poly') }}
+        {{ place_code('poly') }}
         </p>
 
         <p><h2> {{ KNOWL('nf.invariants', title='Invariants') }}</h2>
         <p>
           <table>
-            <tr><td>Degree:<td>&nbsp;&nbsp;<td>${{info.degree}}$<td>{{ code(nf.code,'degree') }}
-            <tr><td>Signature:<td>&nbsp;&nbsp;<td>${{info.signature}}$<td>{{ code(nf.code,'signature') }}
-             <tr><td>Discriminant:<td>&nbsp;&nbsp;<td>{{info.discriminant}}<td>{{ code(nf.code,'discriminant') }}
-            <tr><td>Ramified primes:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ code(nf.code,'ramified_primes') }}
+            <tr><td>Degree:<td>&nbsp;&nbsp;<td>${{info.degree}}$<td>{{ place_code('degree') }}
+            <tr><td>Signature:<td>&nbsp;&nbsp;<td>${{info.signature}}$<td>{{ place_code('signature') }}
+             <tr><td>Discriminant:<td>&nbsp;&nbsp;<td>{{info.discriminant}}<td>{{ place_code('discriminant') }}
+            <tr><td>Ramified primes:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
   {% if info.is_abelian %}
-			<tr><td colspan="3">&nbsp;</tr>
+            <tr><td colspan="3">&nbsp;</tr>
             <tr><td colspan="3">Extension is Galois and abelian</tr>
                 <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>
             <tr><td>{{ KNOWL('nf.dirichlet_group', title="Dirichlet group") }}:
@@ -88,40 +56,40 @@ function show_code(system) {
 {% endif %}
         <p>
             {{ info.integral_basis }}
-            {{ code(nf.code,'integral_basis') }}
+            {{ place_code('integral_basis') }}
         </p>
 
         <p><h2> {{ KNOWL('nf.ideal_class_group', title='Class group') }} and  {{ KNOWL('nf.class_number', title='class number') }}</h2>
-	<p>
+    <p>
           {{ info.class_group }}
           {{ info.grh_label|safe }}
-          {{ code(nf.code,'class_group') }}
+          {{ place_code('class_group') }}
         </p>
 
 
         <p><h2> {{ KNOWL('nf.unit_group', title='Unit group') }}</h2>
         <p>
-          {{ code(nf.code,'unit_group') }}
+          {{ place_code('unit_group') }}
 
           <table>
             <tr><td>Rank:<td>&nbsp;&nbsp;<td>${{info.unit_rank}}$
-            <td>{{ code(nf.code,'unit_rank') }}</tr>
+            <td>{{ place_code('unit_rank') }}</tr>
             <tr><td>Torsion generator:<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
-            <td>{{ code(nf.code,'unit_torsion_gen') }}</tr>
+            <td>{{ place_code('unit_torsion_gen') }}</tr>
 {% if info.unit_rank==1 %}
             <tr><td>Fundamental unit:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
                 {{ info.grh_label|safe }}
-              <td>{{ code(nf.code,'fundamental_units') }}
+              <td>{{ place_code('fundamental_units') }}
             </tr>
             {% endif %}
             {% if info.unit_rank>1 %}
             <tr><td>Fundamental units:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
                 {{ info.grh_label|safe }}
-            <td>{{ code(nf.code,'fundamental_units') }}</tr>
+            <td>{{ place_code('fundamental_units') }}</tr>
             {% endif %}
             <tr><td>Regulator:<td>&nbsp;&nbsp;<td>{{info.regulator}}
           {{ info.grh_label|safe }}
-            <td>{{ code(nf.code,'regulator') }}
+            <td>{{ place_code('regulator') }}
            </tr>
           </table>
         </p>
@@ -130,7 +98,7 @@ function show_code(system) {
         <p><h2> {{ KNOWL('nf.galois_group', title='Galois group') }}</h2>
         <p>
             {{ info.galois_group | safe }}:
-            {{ code(nf.code,'galois_group') }}
+            {{ place_code('galois_group') }}
             <table>
             <tr><td>{{ info.phrase }}</tr>
             <tr><td>
@@ -174,20 +142,20 @@ function show_code(system) {
 {% endif %}
         <p><h2> {{ KNOWL('nf.frobenius_cycle_types', title='Frobenius cycle types') }}</h2>
            <table class="ntdata" style='text-align: center'>
-	    <thead>
+        <thead>
              <tr><th>$p$</th>
             {% for p in info.frob_data %}
             <td>{{ p[0] | safe }} </td>
             {% endfor %}
              </tr>
-	    </thead>
-	    <tbody>
+        </thead>
+        <tbody>
              <tr><th>Cycle type</th>
             {% for p in info.frob_data %}
             <td>{{ p[1] | safe }} </td>
             {% endfor %}
              </tr>
-	     </tbody>
+         </tbody>
            </table>
         </p>
 
@@ -199,48 +167,48 @@ function show_code(system) {
    Cycle lengths which are repeated in a cycle type are indicated by
    exponents.
         <p>
-          {{ code(nf.code,'prime_cycle_types') }}
+          {{ place_code('prime_cycle_types') }}
         </p>
 
 {% if info.get("tim_number_field", False) %}
-	<p><h2> {{ KNOWL('artin', title='Artin representations') }}</h2>
+    <p><h2> {{ KNOWL('artin', title='Artin representations') }}</h2>
         <div>
-	<center>
-	<table>
+    <center>
+    <table>
 
-	<thead><tr>
+    <thead><tr>
     <th></th>
     <th>Label</th>
-	<th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
-	<th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
-	<th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
-	<th>{{ KNOWL('artin.gg_quotient', title='$G$') }}</th>
-	{# <th>{{ KNOWL('artin.root_number', title='Root number') }}</th> #}
-	<th>{{ KNOWL('artin.frobenius_schur_indicator', title='Ind') }}</th>
+    <th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
+    <th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
+    <th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
+    <th>{{ KNOWL('artin.gg_quotient', title='$G$') }}</th>
+    {# <th>{{ KNOWL('artin.root_number', title='Root number') }}</th> #}
+    <th>{{ KNOWL('artin.frobenius_schur_indicator', title='Ind') }}</th>
         <th>{{ KNOWL('artin.trace_of_complex_conj', title='$\chi(c)$')}}</th>
-	</tr></thead>
-	<tbody>
+    </tr></thead>
+    <tbody>
         {% for artin in info["tim_number_field"].artin_representations()%}
           <tr> <td align="left">
               {{info.mydecomp[loop.index-1]|safe}}
               <td align="left"><a href = "{{artin.url_for()}}">{{artin.label()}}</a></td><td align="center">${{artin.dimension()}}$</td>
-{#	  <td align="center">${{artin.conductor_equation()}}$</td> #}
-	  <td align="center">${{artin.factored_conductor_latex()}}$</td>
-	  {% if artin.number_field_galois_group().url_for() %}
-	     <td align="center"><a href="{{artin.number_field_galois_group().url_for()}}">${{artin.number_field_galois_group().polredabslatex()}}$</a></td>
-	  {% else %}
-	      <td align="center">${{artin.number_field_galois_group().polredabslatex()}}$</td>
-	  {% endif %}
-	  <td align="center">{{artin.number_field_galois_group().G_name()}}</td>
-	{#  <td align="center">${{artin.number_field_galois_group().size()}}$</td> #}
-	  {# <td align="center">${{artin.processed_root_number()}}$</td> #}
-	  <td align="center"> ${{artin.indicator()}}$</td>
-	  <td align="center">${{artin.trace_complex_conjugation()}}$</td>
-	  </tr>
+{#    <td align="center">${{artin.conductor_equation()}}$</td> #}
+      <td align="center">${{artin.factored_conductor_latex()}}$</td>
+      {% if artin.number_field_galois_group().url_for() %}
+         <td align="center"><a href="{{artin.number_field_galois_group().url_for()}}">${{artin.number_field_galois_group().polredabslatex()}}$</a></td>
+      {% else %}
+          <td align="center">${{artin.number_field_galois_group().polredabslatex()}}$</td>
+      {% endif %}
+      <td align="center">{{artin.number_field_galois_group().G_name()}}</td>
+    {#  <td align="center">${{artin.number_field_galois_group().size()}}$</td> #}
+      {# <td align="center">${{artin.processed_root_number()}}$</td> #}
+      <td align="center"> ${{artin.indicator()}}$</td>
+      <td align="center">${{artin.trace_complex_conjugation()}}$</td>
+      </tr>
         {% endfor %}
-	</tbody>
-	</table>
-	</center>
+    </tbody>
+    </table>
+    </center>
         </div>
         <br />
         <div>
@@ -250,8 +218,8 @@ function show_code(system) {
         permutation representation coming from this field.  Representations
         which appear with multiplicity greater than one are indicated
         by exponents on the *.
-	</div>
-	{% endif %}
+    </div>
+    {% endif %}
 
         <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>
 

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -1,7 +1,18 @@
 {% extends "base.html" %}
 {% import 'color.css' as color %}
 
-{% import 'color.css' as color %}
+{% macro place_code(item) %}
+{% if code and code[item] %}
+{% for L in code[item] %}
+{% if code[item][L] %}
+{% set lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]] %}
+{% set prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L %}
+{# keep the line below as is to avoid annoying line breaks #}
+<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<br>{% endfor %}</div>
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endmacro %}
 
 {% block body -%}
 <div id="header">
@@ -198,7 +209,32 @@
         {%- endfor %}
       </div>
     {%- endwith %}
-    
+    {% if code %}
+        <script>
+        var cur_lang = null;
+        function show_code(new_lang) {
+           {% for lang in code['show'] %}
+           $('.{{lang}}').hide();
+           {% endfor %}
+            if (cur_lang == new_lang) {
+              cur_lang = null;
+            } else {
+              $('.'+new_lang).show();
+              $('.'+new_lang).css('display','inline-block');
+              cur_lang = new_lang;
+            }
+        }
+        </script>
+        <div align="right">
+            Show commands for:
+            {% set slash = joiner("/ ") %}
+            {% for lang in code['show'] %}
+            {# override show names for standard languages to ensure consistency #}
+            {% set show = 'Pari/GP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else code['show']['lang'] %}
+            {{slash()}}<a onclick="show_code('{{lang}}'); return false" href='#'>{{show}}</a>
+            {% endfor %}
+        </div>
+    {% endif %}
     {% block content -%}
     There is nothing here. This is just a template.
     {%- endblock content %}

--- a/lmfdb/test_root.py
+++ b/lmfdb/test_root.py
@@ -43,7 +43,7 @@ class RootTest(LmfdbTest):
         assert self.C is not None
         known_dbnames = self.C.database_names()
         expected_dbnames = ['Lfunctions', 'elliptic_curves', 'numberfields', 'localfields', 'artin',
-                            'HTPicard', 'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb', 'Latices', 'MaassWaveForms',
+                            'HTPicard', 'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb', 'Lattices', 'MaassWaveForms',
                             'modularforms2', 'hgm', 'genus2_curves', 'siegel_modular_forms', 'sato_tate_groups']
         for dbn in expected_dbnames:
             assert dbn in known_dbnames, 'db "%s" missing' % dbn

--- a/lmfdb/test_root.py
+++ b/lmfdb/test_root.py
@@ -42,10 +42,9 @@ class RootTest(LmfdbTest):
     def test_db(self):
         assert self.C is not None
         known_dbnames = self.C.database_names()
-        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'numberfields', 'localfields',
-                            'MaassWaveForm', 'HTPicard', 'Lfunction',
-                            'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb',
-                            'modularforms', 'hgm', 'genus2_curves']
+        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'ecnf', 'numberfields', 'localfields', 'artin'
+                            'HTPicard', 'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb', 'Latices', 'MaassWaveForms',
+                            'modularforms2', 'hgm', 'genus2_curves', 'siegel_modular_forms', 'sato_tate_groups']
         for dbn in expected_dbnames:
             assert dbn in known_dbnames, 'db "%s" missing' % dbn
 

--- a/lmfdb/test_root.py
+++ b/lmfdb/test_root.py
@@ -42,7 +42,7 @@ class RootTest(LmfdbTest):
     def test_db(self):
         assert self.C is not None
         known_dbnames = self.C.database_names()
-        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'numberfields', 'localfields', 'artin'
+        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'numberfields', 'localfields', 'artin',
                             'HTPicard', 'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb', 'Latices', 'MaassWaveForms',
                             'modularforms2', 'hgm', 'genus2_curves', 'siegel_modular_forms', 'sato_tate_groups']
         for dbn in expected_dbnames:

--- a/lmfdb/test_root.py
+++ b/lmfdb/test_root.py
@@ -42,7 +42,7 @@ class RootTest(LmfdbTest):
     def test_db(self):
         assert self.C is not None
         known_dbnames = self.C.database_names()
-        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'ecnf', 'numberfields', 'localfields', 'artin'
+        expected_dbnames = ['Lfunctions', 'elliptic_curves', 'numberfields', 'localfields', 'artin'
                             'HTPicard', 'upload', 'knowledge', 'hmfs', 'bmfs', 'userdb', 'Latices', 'MaassWaveForms',
                             'modularforms2', 'hgm', 'genus2_curves', 'siegel_modular_forms', 'sato_tate_groups']
         for dbn in expected_dbnames:


### PR DESCRIPTION
Addresses the non-uniformity of "Show commands" code that was implemented in eight similar but all slightly different ways: see https://github.com/LMFDB/lmfdb/pull/1433#issuecomment-220806447 for a list of six example pages that you can compare side-by-side, and there are two new modular forms pages that use show commands as of PR #1433:

http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/3/6/1/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/3/6/1/a/

(note PR #1433 was never pushed to beta, I wanted to get this PR in first).

This was achieved by moving almost all the html code into homepage.html, so that it is implemented in just one place.  The macro place_code defined in homepage.html can then be used to place code snippets where ever they are needed.

I also fixed a few bugs I noticed along the way (e.g. the display code for Galois orbits of Dirichlet characters was broken), and cleaned up some inconsistent formatting in some of the code snippets.

Aside from improving the appearance (and getting rid of a few hundred lines of duplicated code), there should be no functional changes.  One thing worth noting is that the existing implementation of code snippets in the elliptic_curves and ecnf pages uses a lazy evaluation approach (it doesn't actually create code snippets until they are needed), with this PR this is no longer the case.  This has no impact on performance -- the code snippets are generally not much longer than the lazy macros that server as stand-ins (page sizes changed by less than 1 percent in the cases I measured), and in either case the time to display them is completely negligible compared to the work mathjax is doing to render the rest of the page.

I ran the full test suite on atkin and (after fixing test_root.py) everything passed except for test_acknowledgements which fails when attempting to connect to hobbes.la.asu.edu (known temporary problem).