### PR TITLE
When calling polredabs on a polynomial provided by a user, call polredbest first

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -178,7 +178,7 @@ class WebNumberField:
         pol = PolynomialRing(QQ, 'x')(str(pol))
         pol *= pol.denominator()
         R = pol.parent()
-        pol = R(pari(pol).polredabs())
+        pol = R(pari(pol).polredbest().polredabs())
         return cls.from_coeffs([int(c) for c in pol.coefficients(sparse=False)])
 
     # If we already have the database entry


### PR DESCRIPTION
This speeds up the computation of polredabs when the coeffiicents of the given polynomial are large.  When coefficients are small, this is slower, but things are already fast in that case.  So this makes fast cases slightly slower, and slow cases.

For example, in gp,

x^5 - 331137220*x^4 + 37922047405356360*x^3 - 1127174691845938128093840*x^2 + 52208293424667465123438066822480*x - 16507431553557006099641796204889368224

takes 1/50 the time with this change.