### PR TITLE
Factor reindexing out of rewrite_collection.

### DIFF
--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -51,7 +51,7 @@ def rewrite_collection(db,incoll,outcoll,func, batchsize=1000, reindex=True):
 #
 def reindex_collection(db,incoll,outcoll):
     indexes = db[incoll].index_information()
-    keys = [(k,indexes[k]['key']) for k in indexes]
+    keys = [(k,indexes[k]['key']) for k in indexes if k != '_id_']
     keys.sort() # sort indexes by keyname so (attr1) < (attr1,attr2) < (attr1,attr2,attr3) < ...
     for i in range(len(keys)):
         now = time()

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -4,7 +4,8 @@ from time import time
 # rewrite_collection(db,incoll,outcoll,func)
 #
 # function to pipe an existing collection to a new collection through a user specified function
-# that may update records as the pass through.  All indexes will be recreated (in lex order)
+# that may update records as the pass through.  All indexes will be recreated (in lex order),
+# unless reindex is set to false.
 #
 # Arguments:
 #
@@ -17,7 +18,7 @@ from time import time
 #
 # For collections with large records, you will want to specify a batchsize smaller than 1000
 #
-def rewrite_collection(db,incoll,outcoll,func, batchsize=1000):
+def rewrite_collection(db,incoll,outcoll,func, batchsize=1000, reindex=True):
     if outcoll in db.collection_names():
         print "Collection %s already exists, unable to write"%(outcoll)
         return
@@ -40,12 +41,22 @@ def rewrite_collection(db,incoll,outcoll,func, batchsize=1000):
         db[outcoll].insert_many(outrecs)
     assert db[outcoll].count() == tot
     print "inserted %d records in %.3f secs"%(cnt, time()-start)
+    if reindex:
+        reindex_collection(db,incoll,outcoll)
+    print "Rewrote %s to %s, total time %.3f secs"%(incoll, outcoll, time()-start)
+
+# reindex_collection(db,incoll,outcoll)
+#
+# Take indexes from incoll and create them in outcoll (in lex order).
+#
+def reindex_collection(db,incoll,outcoll):
     indexes = db[incoll].index_information()
-    keys = [(k,indexes[k]['key']) for k in indexes if k != '_id_']
+    keys = [(k,indexes[k]['key']) for k in indexes]
     keys.sort() # sort indexes by keyname so (attr1) < (attr1,attr2) < (attr1,attr2,attr3) < ...
     for i in range(len(keys)):
         now = time()
-        key = [(a[0],int(1) if a[1] > 0 else int(-1)) for a in keys[i][1]] # deal with legacy floats (1.0 vs 1)
+        key = [(a[0],1 if a[1] > 0 else -1) for a in keys[i][1]] # deal with legacy floats (1.0 vs 1)
         db[outcoll].create_index(key)
         print "created index %s in %.3f secs"%(keys[i][0],time()-now)
-    print "Rewrote %s to %s, total time %.3f secs"%(incoll, outcoll, time()-start)
+
+

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -55,7 +55,7 @@ def reindex_collection(db,incoll,outcoll):
     keys.sort() # sort indexes by keyname so (attr1) < (attr1,attr2) < (attr1,attr2,attr3) < ...
     for i in range(len(keys)):
         now = time()
-        key = [(a[0],1 if a[1] > 0 else -1) for a in keys[i][1]] # deal with legacy floats (1.0 vs 1)
+        key = [(a[0],int(1) if a[1] > 0 else int(-1)) for a in keys[i][1]] # deal with legacy floats (1.0 vs 1)
         db[outcoll].create_index(key)
         print "created index %s in %.3f secs"%(keys[i][0],time()-now)
 


### PR DESCRIPTION
Default behavior is the same, but now you can separate copying and reindexing.  Why?

Suppose you want to add many new records to an existing database.  You can make a copy using rewrite_collection and not build new indexes, add the entries, then create the indexes in the new database.
