### PR TITLE
Add the option to search for number fields unramified outside a set

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -453,9 +453,13 @@ def number_field_search(**args):
         parse_ints(info,query,'class_number')
         parse_bracketed_posints(info,query,'class_group',split=False,check_divisibility='increasing')
         parse_primes(info,query,'ur_primes',name='Unramified primes',qfield='ramps',mode='complement',to_string=True)
-        if 'ram_quantifier' in info and str(info['ram_quantifier']) == 'some':
+        # modes are now contained (in), exactly, include
+        if 'ram_quantifier' in info and str(info['ram_quantifier']) == 'include':
             mode = 'append'
             parse_primes(info,query,'ram_primes','ramified primes','ramps',mode,to_string=True)
+        elif 'ram_quantifier' in info and str(info['ram_quantifier']) == 'contained':
+            parse_primes(info,query,'ram_primes','ramified primes','ramps_all','subsets',to_string=False)
+            pass # build list
         else:
             mode = 'liststring'
             parse_primes(info,query,'ram_primes','ramified primes','ramps_all',mode)

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -86,11 +86,13 @@ Enter values into one or more boxes to restrict the search.
    <td><input type='text' name='ur_primes' size=10 example='2,3'>
 <span class="formexample"> e.g. 2,3</span></td>
 <td>
-<td align=left><select name='ram_quantifier'>
-  <option value='some'>some</option>
-  <option value='all'>all</option>
-  </select>
+<td>
 {{KNOWL('nf.ramified_prime', title='ramified primes')}} 
+<select name='ram_quantifier'>
+  <option value='contained'>contained in</option>
+  <option value='exactly'>exactly</option>
+  <option value='include'>include</option>
+  </select>
   <td><input type='text' name='ram_primes' size=10 example='2,3'>
 <span class="formexample"> e.g. 2,3</span></td>
 </tr>

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -87,11 +87,11 @@ Enter values into one or more boxes to restrict the search.
 <span class="formexample"> e.g. 2,3</span></td>
 <td>
 <td>
-{{KNOWL('nf.ramified_prime', title='ramified primes')}} 
+set of {{KNOWL('nf.ramified_prime', title='ramified primes')}} 
 <select name='ram_quantifier'>
-  <option value='contained'>contained in</option>
-  <option value='exactly'>exactly</option>
-  <option value='include'>include</option>
+  <option value='contained'>subset of</option>
+  <option value='exactly' selected='yes'>equal to</option>
+  <option value='include'>superset of</option>
   </select>
   <td><input type='text' name='ram_primes' size=10 example='2,3'>
 <span class="formexample"> e.g. 2,3</span></td>

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -23,20 +23,29 @@
 </tr>
 <tr>
 <td align='left'> {{KNOWL('nf.discriminant', title='discriminant')}} range <td align='left' colspan='2'> <input type='text' name='discriminant' size='20' value="{{info.discriminant}}"></td>
-<td align=right>
-{% if info.ram_quantifier == 'some' %}
+<td align=right colspan="2">
+ {{KNOWL('nf.ramified_prime', title='ramified primes')}}
+{% if info.ram_quantifier == 'contained' %}
 <select name = "ram_quantifier">
-  <option selected='yes' value='some'>some</option>
-  <option value='all'>all</option>
+  <option value='contained' selected='yes'>contained in</option>
+  <option value='exactly'>exactly</option>
+  <option value='include'>include</option>
+</select>
+{% elif info.ram_quantifier == 'exactly' %}
+<select name = "ram_quantifier">
+  <option value='contained'>contained in</option>
+  <option value='exactly' selected='yes'>exactly</option>
+  <option value='include'>include</option>
 </select>
 {% else %}
 <select name = "ram_quantifier">
-  <option value='some'>some</option>
-  <option selected='yes' value='all'>all</option>
+  <option value='contained'>contained in</option>
+  <option value='exactly' >exactly</option>
+  <option value='include' selected='yes'>include</option>
 </select>
 {% endif %}
-<td align=left>
- {{KNOWL('nf.ramified_prime', title='ramified primes')}}<td align=left> <input type='text' name='ram_primes' size=5 value="{{info.ram_primes}}"></td>
+ <td align=left> <input type='text' name='ram_primes' size=5 value="{{info.ram_primes}}"></td>
+
 </tr>
 
 <tr>

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -24,24 +24,24 @@
 <tr>
 <td align='left'> {{KNOWL('nf.discriminant', title='discriminant')}} range <td align='left' colspan='2'> <input type='text' name='discriminant' size='20' value="{{info.discriminant}}"></td>
 <td align=right colspan="2">
- {{KNOWL('nf.ramified_prime', title='ramified primes')}}
+set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
 {% if info.ram_quantifier == 'contained' %}
 <select name = "ram_quantifier">
-  <option value='contained' selected='yes'>contained in</option>
-  <option value='exactly'>exactly</option>
-  <option value='include'>include</option>
+  <option value='contained' selected='yes'>subset of</option>
+  <option value='exactly'>equal to</option>
+  <option value='include'>superset of</option>
 </select>
 {% elif info.ram_quantifier == 'exactly' %}
 <select name = "ram_quantifier">
-  <option value='contained'>contained in</option>
-  <option value='exactly' selected='yes'>exactly</option>
-  <option value='include'>include</option>
+  <option value='contained'>subset of</option>
+  <option value='exactly' selected='yes'>equal to</option>
+  <option value='include'>superset of</option>
 </select>
 {% else %}
 <select name = "ram_quantifier">
-  <option value='contained'>contained in</option>
-  <option value='exactly' >exactly</option>
-  <option value='include' selected='yes'>include</option>
+  <option value='contained'>subset of</option>
+  <option value='exactly' >equal to</option>
+  <option value='include' selected='yes'>superset of</option>
 </select>
 {% endif %}
  <td align=left> <input type='text' name='ram_primes' size=5 value="{{info.ram_primes}}"></td>

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -247,16 +247,25 @@ def parse_primes(inp, query, qfield, mode=None, to_string=False):
     format_ok = LIST_POSINT_RE.match(inp)
     if format_ok:
         primes = [int(p) for p in inp.split(',')]
+        primes = sorted(primes)
         format_ok = all([ZZ(p).is_prime(proof=False) for p in primes])
     if format_ok:
         if to_string:
-            primes = sorted(primes)
             primes = [str(p) for p in primes]
         if mode == 'complement':
             query[qfield] = {"$nin": primes}
         elif mode == 'liststring':
             primes = [str(p) for p in primes]
             query[qfield] = ",".join(primes)
+        elif mode == 'subsets':
+            # need all subsets of the list of primes 
+            powerset = [[]]
+            for p in primes:
+                powerset.extend([a+[p] for a in powerset])
+            # now set up a big $or clause
+            powerset = [','.join([str(p) for p in a]) for a in powerset]
+            powerset = [{qfield: a} for a in powerset]
+            collapse_ors(['$or', powerset], query)
         elif mode == 'exact':
             query[qfield] = sorted(primes)
         elif mode == "append":


### PR DESCRIPTION
This is a feature requested in the discussion of another pull request, and is (to me) the most natural way to specify ramification.

Comments, particularly on wording and placement of the ramified primes entry area are welcome.  They are on the main number field search/browse page and the search results page.