### PR TITLE
fix ec sign(disc)

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -205,7 +205,7 @@ class WebEC(object):
             D = self.signD * prod([ld['p']**ld['ord_disc'] for ld in local_data])
             data['disc'] = D
             Nfac = Factorization([(ZZ(ld['p']),ld['ord_cond']) for ld in local_data])
-            Dfac = Factorization([(ZZ(ld['p']),ld['ord_disc']) for ld in local_data])
+            Dfac = Factorization([(ZZ(ld['p']),ld['ord_disc']) for ld in local_data], unit=ZZ(self.signD))
 
             data['minq_D'] = minqD = self.min_quad_twist['disc']
             minq_label = self.min_quad_twist['label']
@@ -220,7 +220,7 @@ class WebEC(object):
                 data['an'] = self.anlist
                 data['ap'] = self.aplist
             else:
-                r = db_ec.find_one({'lmfdb_label':self.lmfdb_label, 'number':1}, ['anlist','aplist'])
+                r = db_ec().find_one({'lmfdb_iso':self.lmfdb_iso, 'number':1}, ['anlist','aplist'])
                 data['an'] = r['anlist']
                 data['ap'] = r['aplist']
 


### PR DESCRIPTION
A bug in PR #1439 meant that even when we have extra ec data as in the curves2 collection we were in effect ignoring it.  (Cautionary tale: I had a block of a dozen or more lines all within a single try/except block and something triggered the exception which was not one of the things I was planning for).  Then when I fixed that *and ran the tests* another small bug was discovered (curves with negative discriminant omiited the minus sign in the disc's factorization).
