### PR TITLE
General code cleanup + performance improvements

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -1,24 +1,21 @@
 # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 import StringIO
-import ast
+from ast import literal_eval
 import re
 import time
-import pymongo
 from pymongo import ASCENDING, DESCENDING
 from operator import mul
-import lmfdb.base
 from lmfdb.base import app
-from flask import Flask, flash, session, g, render_template, url_for, request, redirect, make_response, send_file
+from flask import flash, render_template, url_for, request, redirect, make_response, send_file
 from markupsafe import Markup
-import tempfile
-import os
 
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, comma, random_object_from_collection
+from lmfdb.utils import to_dict, comma, random_object_from_collection
 from lmfdb.search_parsing import parse_bool, parse_ints, parse_signed_ints, parse_bracketed_posints, parse_count, parse_start
 from lmfdb.number_fields.number_field import make_disc_key
 from lmfdb.genus2_curves import g2c_page, g2c_logger
-from lmfdb.genus2_curves.isog_class import G2Cisog_class, url_for_label, isog_url_for_label, st_group_name, st_group_href
-from lmfdb.genus2_curves.web_g2c import WebG2C, g2cdb, list_to_min_eqn, isog_label, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
+from lmfdb.genus2_curves.isogeny_class import G2Cisogeny_class, st_group_name, st_group_href
+from lmfdb.genus2_curves.web_g2c import WebG2C, g2cdb, list_to_min_eqn, isogeny_class_label, st0_group_name, aut_group_name, boolean_name, globally_solvable_name
 
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
@@ -80,7 +77,7 @@ geom_aut_grp_dict = {
         '[48,29]':'tilde{S}_4'}
 
 ###############################################################################
-# Routing for top level, random_curve, by_conductor, and stats
+# Routing for top level, random_curve,  and stats
 ###############################################################################
 
 def learnmore_list():
@@ -98,20 +95,15 @@ def index():
 
 @g2c_page.route("/Q/")
 def index_Q():
-    if len(request.args) != 0:
-        return genus2_curve_search(**request.args)
+    if len(request.args) > 0:
+        return genus2_curve_search(data=request.args)
     info = {'counts' : g2cstats().counts()}
     info["stats_url"] = url_for(".statistics")
-    info["curve_url"] =  lambda dbc: url_for_label(dbc['label'])
-    info["browse_curves"] = [
-        g2cdb().curves.find_one({"label":"169.a.169.1"}),
-        g2cdb().curves.find_one({"label":"1116.a.214272.1"}),
-        g2cdb().curves.find_one({"label":"1152.a.147456.1"}),
-        g2cdb().curves.find_one({"label":"1369.a.50653.1"}),
-        g2cdb().curves.find_one({"label":"12500.a.12500.1"}),
-    ]
-    info["conductor_list"] = ['1-499', '500-999', '1000-99999','100000-1000000'   ]
-    info["discriminant_list"] = ['1-499', '500-999', '1000-99999','100000-1000000'   ]
+    info["curve_url"] =  lambda label: url_for_curve_label(label)
+    curve_labels = ('169.a.169.1', '1116.a.214272.1', '1152.a.147456.1', '1369.a.50653.1', '15360.f.983040.2')
+    info["curve_list"] = [ {'label':label,'url':url_for_curve_label(label)} for label in curve_labels ]
+    info["conductor_list"] = ('1-499', '500-999', '1000-99999','100000-1000000')
+    info["discriminant_list"] = ('1-499', '500-999', '1000-99999','100000-1000000')
     info["st_group_list"] = st_group_list
     info["st_group_dict"] = st_group_dict
     info["real_geom_end_alg_list"] = real_geom_end_alg_list
@@ -121,51 +113,78 @@ def index_Q():
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
     title = 'Genus 2 curves over $\Q$'
-    bread = [('Genus 2 Curves', url_for(".index")), ('$\Q$', ' ')]
+    bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '))
     return render_template("browse_search_g2.html", info=info, credit=credit_string, title=title, learnmore=learnmore_list(), bread=bread)
-
-@g2c_page.route("/Q/<int:conductor>/")
-def by_conductor(conductor):
-    return genus2_curve_search(cond=conductor, **request.args)
 
 @g2c_page.route("/Q/random")
 def random_curve():
     label = random_object_from_collection(g2cdb().curves)['label']
-    # This version leaves the word 'random' in the URL:
-    #return render_curve_webpage_by_label(label)
-    # This version uses the curve's own URL:
-    return redirect(url_for(".by_g2c_label", label=label), 301)
+    return redirect(url_for_curve_label(label), 301)
 
 @g2c_page.route("/Q/stats")
 def statistics():
-    info = {
-        'counts': g2cstats().counts(),
-        'stats': g2cstats().stats(),
-    }
+    info = { 'counts': g2cstats().counts(), 'stats': g2cstats().stats() }
     title = 'Genus 2 curves over $\Q$: statistics'
-    bread = [('Genus 2 Curves', url_for(".index")),
-        ('$\Q$', url_for(".index_Q")),
-        ('statistics', ' ')]
+    bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('statistics', ' '))
     return render_template("statistics_g2.html", info=info, credit=credit_string, title=title, bread=bread, learnmore=learnmore_list())
 
 ###############################################################################
-# Curve pages
+# Curve and isogeny class pages
 ###############################################################################
 
-@g2c_page.route("/Q/<int:conductor>/<iso_label>/<int:disc>/<int:number>")
-def by_full_label(conductor,iso_label, disc,number):
-    full_label = str(conductor)+"."+iso_label+"."+str(disc)+"."+str(number)
-    g2c_logger.debug(full_label)
-    return render_curve_webpage_by_label(full_label)
+@g2c_page.route("/Q/<int:cond>/<alpha>/<int:disc>/<int:num>")
+def by_url_curve_label(cond, alpha, disc, num):
+    label = str(cond)+"."+alpha+"."+str(disc)+"."+str(num)
+    return render_curve_webpage(label)
+
+@g2c_page.route("/Q/<int:cond>/<alpha>/<int:disc>/")
+def by_url_isogeny_class_discriminant(cond, alpha, disc):
+    data = {}
+    if len(request.args) > 0:
+        # if changed conductor or discriminat, fall back to a general search
+        if ('cond' in request.args and request.args['cond'] != str(cond)) or \
+           ('abs_disc' in request.args and request.args['abs_disc'] != str(disc)):
+            return redirect (url_for(".index", **request.args), 301)
+        data = to_dict(request.args)
+    class_label = str(cond)+"."+alpha
+    data['cond'] = cond
+    data['class'] = class_label
+    data['abs_disc'] = disc
+    data['bread'] = (('Genus 2 Curves', url_for(".index")),
+        ('$\Q$', url_for(".index_Q")),
+        ('%s' % cond, url_for(".by_conductor", cond=cond)),
+        ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
+        ('%s' % disc, '.'))
+    data['title'] = 'Genus 2 Curve search results for isogeny class %s and discriminant %s' % (class_label,disc)
+    return genus2_curve_search(data=data, **request.args)
+
+@g2c_page.route("/Q/<int:cond>/<alpha>/")
+def by_url_isogeny_class_label(cond, alpha):
+    label = str(cond)+"."+alpha
+    return render_isogeny_class_webpage(label)
+
+@g2c_page.route("/Q/<int:cond>/")
+def by_conductor(cond):
+    data = {}
+    if len(request.args) > 0:
+        # if changed conductor or discriminat, fall back to a general search
+        if 'cond' in request.args and request.args['cond'] != str(cond):
+            return redirect (url_for(".index", **request.args), 301)
+        data = to_dict(request.args)
+    data['cond'] = cond
+    data['bread'] = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('%s' % cond, '.'))
+    data['title'] = 'Genus 2 Curve search results for conductor %s' % cond
+    return genus2_curve_search(data=data, **request.args)
 
 @g2c_page.route("/Q/<label>")
-def by_g2c_label(label):
-    g2c_logger.debug(label)
-    return render_curve_webpage_by_label(label)
+def by_label(label):
+    # handles curve, isogeny class, and Lhash labels
+    return genus2_curve_search(data={'jump':label}, **request.args)
 
-def render_curve_webpage_by_label(label):
+def render_curve_webpage(label):
     credit = credit_string
     data = WebG2C.by_label(label)
+    # check for error message string
     if isinstance(data,str):
         return data
     return render_template("curve_g2.html",
@@ -179,18 +198,10 @@ def render_curve_webpage_by_label(label):
                            friends=data.friends)
                            #downloads=data.downloads)
 
-###############################################################################
-# Isogeny class pages
-###############################################################################
-
-@g2c_page.route("/Q/<int:conductor>/<iso_label>/")
-def by_double_iso_label(conductor, iso_label):
-    full_iso_label = str(conductor)+"."+iso_label
-    return render_isogeny_class(full_iso_label)
-
-def render_isogeny_class(iso_class):
+def render_isogeny_class_webpage(label):
     credit = credit_string
-    class_data = G2Cisog_class.by_label(iso_class)
+    class_data = G2Cisogeny_class.by_label(label)
+    # check for error message string
     if isinstance(class_data,str):
         return class_data
     return render_template("isogeny_class_g2.html",
@@ -202,14 +213,48 @@ def render_isogeny_class(iso_class):
                            title=class_data.title,
                            friends=class_data.friends)
                            #downloads=class_data.downloads)
+                           
+
+def url_for_curve_label(label):
+    L = label.split(".")
+    return url_for(".by_url_curve_label", cond=L[0], alpha=L[1], disc=L[2], num=L[3])
+
+def url_for_isogeny_class_label(label):
+    L = label.split(".")
+    return url_for(".by_url_isogeny_class_label", cond=L[0], alpha=L[1])
+
+def class_from_curve_label(label):
+    return '.'.join(label.split(".")[:2])
 
 ################################################################################
 # Searching
 ################################################################################
 
 def genus2_curve_search(**args):
-    info = to_dict(args)
-    
+    info = to_dict(args['data'])
+    if 'jump' in info:
+        jump = info["jump"].strip()
+        curve_label_regex = re.compile(r'\d+\.[a-z]+.\d+.\d+$')
+        if curve_label_regex.match(jump):
+            return redirect(url_for_curve_label(jump), 301)
+        else:
+            class_label_regex = re.compile(r'\d+\.[a-z]+$')
+            if class_label_regex.match(jump):
+                return redirect(url_for_isogeny_class_label(jump), 301)
+            else:
+                # Handle direct Lhash input
+                class_label_regex = re.compile(r'#\d+$')
+                if class_label_regex.match(jump) and ZZ(jump[1:]) < 2**61:
+                    c = g2cdb().isogeny_classes.find_one({'hash':int(jump[1:])})
+                    if c:
+                        return redirect(url_for_isogeny_class_label(c["label"]), 301)
+                    else:
+                        errmsg = "Hash not found"
+                else:
+                    errmsg = "Invalid label"
+        flash(Markup(errmsg + " <span style='color:black'>%s</span>"%(jump)),"error")
+        return redirect(url_for(".index"))
+
     if 'download' in info and info['download'] == '1':
         return download_search(info)
     
@@ -221,42 +266,14 @@ def genus2_curve_search(**args):
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
-    query = {}  # database callable
-    bread = [('Genus 2 Curves', url_for(".index")),
-             ('$\Q$', url_for(".index_Q")),
-             ('Search Results', '.')]
-    #if 'SearchAgain' in args:
-    #    return rational_genus2_curves()
-
-    if 'jump' in args:
-        curve_label_regex = re.compile(r'\d+\.[a-z]+.\d+.\d+$')
-        if curve_label_regex.match(info["jump"].strip()):
-            data = render_curve_webpage_by_label(info["jump"].strip())
-        else:
-            class_label_regex = re.compile(r'\d+\.[a-z]+$')
-            if class_label_regex.match(info["jump"].strip()):
-                data = render_isogeny_class(info["jump"].strip())
-            else:
-                class_label_regex = re.compile(r'#\d+$')
-                if class_label_regex.match(info["jump"].strip()) and ZZ(info["jump"][1:]) < 2**61:
-                    c = g2cdb().isogeny_classes.find_one({'hash':int(info["jump"][1:])})
-                    if c:
-                        data = render_isogeny_class(c["label"])
-                    else:
-                        data = "Hash not found"
-                else:
-                    data = "Invalid label"
-        if isinstance(data,str):
-            flash(Markup(data + " <span style='color:black'>%s</span>"%(info["jump"])),"error")
-            return redirect(url_for(".index"))
-        return data
+    query = {}
     try:
         parse_ints(info,query,'abs_disc','absolute discriminant')
         parse_bool(info,query,'is_gl2_type')
         parse_bool(info,query,'has_square_sha')
         parse_bool(info,query,'locally_solvable')
         parse_bracketed_posints(info, query, 'torsion', 'torsion structure', maxlength=4,check_divisibility="increasing")
-        parse_ints(info,query,'cond','conductor')
+        parse_ints(info,query,'cond')
         parse_ints(info,query,'num_rat_wpts','Weierstrass points')
         parse_ints(info,query,'torsion_order')
         if 'torsion' in query and not 'torsion_order' in query:
@@ -264,24 +281,29 @@ def genus2_curve_search(**args):
         parse_ints(info,query,'two_selmer_rank','2-Selmer rank')
         parse_ints(info,query,'analytic_rank','analytic rank')
         # G2 invariants and drop-list items don't require parsing -- they are all strings (supplied by us, not the user)
-        if info.get('g20') and info.get('g21') and info.get('g22'):
+        if 'g20' in info and 'g21' in info and 'g22' in info:
             query['g2inv'] = [ info['g20'], info['g21'], info['g22'] ]
+        if 'class' in info:
+            query['class'] = info['class']
         for fld in ('st_group', 'real_geom_end_alg', 'aut_grp_id', 'geom_aut_grp_id'):
             if info.get(fld): query[fld] = info[fld]
     except ValueError as err:
         info['err'] = str(err)
         return render_template("search_results_g2.html", info=info, title='Genus 2 Curves Search Input Error', bread=bread, credit=credit_string)
     info["query"] = dict(query)
+    
+    # Database query happens here
+    cursor = g2cdb().curves.find(query,{'_id':int(0),'label':int(1),'min_eqn':int(1),'st_group':int(1),'is_gl2_type':int(1),'analytic_rank':int(1)})
+
     count = parse_count(info, 50)
     start = parse_start(info)
-    cursor = g2cdb().curves.find(query)
     nres = cursor.count()
     if(start >= nres):
         start -= (1 + (start - nres) / count) * count
     if(start < 0):
         start = 0
 
-    res = cursor.sort([("cond", pymongo.ASCENDING), ("class", pymongo.ASCENDING),  ("disc_key", pymongo.ASCENDING),  ("label", pymongo.ASCENDING)]).skip(start).limit(count)
+    res = cursor.sort([("cond", ASCENDING), ("class", ASCENDING),  ("disc_key", ASCENDING),  ("label", ASCENDING)]).skip(start).limit(count)
     nres = res.count()
 
     if nres == 1:
@@ -296,29 +318,26 @@ def genus2_curve_search(**args):
     for v in res:
         v_clean = {}
         v_clean["label"] = v["label"]
-        v_clean["isog_label"] = v["class"]
-        isogeny_class = g2cdb().isogeny_classes.find_one({'label' :
-            isog_label(v["label"])})
-        v_clean["is_gl2_type"] = isogeny_class["is_gl2_type"]
-        if isogeny_class["is_gl2_type"] == True:
-            v_clean["is_gl2_type_display"] = '&#10004;' #checkmark
-        else:
-            v_clean["is_gl2_type_display"] = ''
+        v_clean["class"] = class_from_curve_label(v["label"])
+        v_clean["is_gl2_type"] = v["is_gl2_type"] 
+        v_clean["is_gl2_type_display"] = '&#10004;' if v["is_gl2_type"] else '' # display checkmark if true, blank otherwise
         v_clean["equation_formatted"] = list_to_min_eqn(v["min_eqn"])
-        v_clean["st_group_name"] = st_group_name(isogeny_class['st_group'])
-        v_clean["st_group_href"] = st_group_href(isogeny_class['st_group'])
+        v_clean["st_group_name"] = st_group_name(v['st_group'])
+        v_clean["st_group_href"] = st_group_href(v['st_group'])
         v_clean["analytic_rank"] = v["analytic_rank"]
         res_clean.append(v_clean)
 
     info["curves"] = res_clean
-    info["curve_url"] = lambda dbc: url_for_label(dbc['label'])
-    info["isog_url"] = lambda dbc: isog_url_for_label(dbc['label'])
+    info["curve_url"] = lambda label: url_for_curve_label(label)
+    info["class_url"] = lambda label: url_for_isogeny_class_label(label)
     info["start"] = start
     info["count"] = count
     info["more"] = int(start+count<nres)
     
+    bread = info.get('bread',(('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('Search Results', '.')))
+    title = info.get('title','Genus 2 Curve search results')
     credit = credit_string
-    title = 'Genus 2 Curves search results'
+    
     return render_template("search_results_g2.html", info=info, credit=credit,learnmore=learnmore_list(), bread=bread, title=title)
 
 ################################################################################
@@ -425,7 +444,7 @@ def download_search(info):
     filename = 'genus2_curves' + download_file_suffix[lang]
     mydate = time.strftime("%d %B %Y")
     # reissue saved query here
-    res = g2cdb().curves.find(ast.literal_eval(info["query"]))
+    res = g2cdb().curves.find(literal_eval(info["query"]),{'_id':int(0),'min_eqn':int(1)})
     c = download_comment_prefix[lang]
     s =  '\n'
     s += c + ' Genus 2 curves downloaded from the LMFDB downloaded on %s. Found %s curves.\n'%(mydate, res.count())
@@ -455,20 +474,20 @@ def download_search(info):
 @g2c_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of genus 2 curve data over $\Q$'
-    bread = [('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Completeness','')]
+    bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Completeness',''))
     return render_template("single.html", kid='dq.g2c.extent',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @g2c_page.route("/Source")
 def how_computed_page():
     t = 'Source of genus 2 curve data over $\Q$'
-    bread = [('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Source','')]
+    bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Source',''))
     return render_template("single.html", kid='dq.g2c.source',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @g2c_page.route("/Labels")
 def labels_page():
     t = 'Labels for genus 2 curves over $\Q$'
-    bread = [('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Labels','')]
+    bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '),('Labels',''))
     return render_template("single.html", kid='g2c.label',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -266,6 +266,8 @@ def genus2_curve_search(**args):
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
+    bread = info.get('bread',(('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('Search Results', '.')))
+
     query = {}
     try:
         parse_ints(info,query,'abs_disc','absolute discriminant')
@@ -334,7 +336,6 @@ def genus2_curve_search(**args):
     info["count"] = count
     info["more"] = int(start+count<nres)
     
-    bread = info.get('bread',(('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('Search Results', '.')))
     title = info.get('title','Genus 2 Curve search results')
     credit = credit_string
     

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -11,20 +11,20 @@ Here are some <a href={{info["stats_url"]}}>further statistics</a>.
 <p>
 By {{ KNOWL('ag.conductor', title='conductor')}}:
 {% for rnge in info.conductor_list %}
-<a href="?cond={{rnge}}">{{rnge}}</a>
+<a href="?cond={{rnge}}">{{rnge}}</a>&nbsp;
 {% endfor %}
 </p>
 
 <p>
 By {{ KNOWL('g2c.abs_discriminant', title='absolute discriminant')}}:
 {% for rnge in info.discriminant_list %}
-<a href="?abs_disc={{rnge}}">{{rnge}}</a>
+<a href="?abs_disc={{rnge}}">{{rnge}}</a>&nbsp;
 {% endfor %}
 </p>
 <p>
 Some of our favorite curves:
-{% for curve in info.browse_curves: %}
- <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a>
+{% for curve in info.curve_list: %}
+<a href = "{{curve.url}}"> {{curve.label}} </a>&nbsp;
 {% endfor %}
 </p>
 <p>

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -240,7 +240,7 @@ function show_invs(invstyle) {
 
 <br>
 
-<h3 style="display: inline"> Decomposition </h3>
+<h3 style="display: inline"> {{ KNOWL('g2c.decomposition', title='Decomposition') }} </h3>
 
 <!-- Description of a splitting field of minimal degree: -->
 <p>{{data.endodata.spl_fod_statement|safe}}</p>

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -128,7 +128,7 @@
 <td>&nbsp;</td>
 </tr>
 <tr>
-<td><button type='submit' value='refine'  style="width: 110px">Search again</button></td>
+<td><button type='submit' value='refine' style="width: 110px">Search again</button></td>
 </tr>
 
 </table>
@@ -156,8 +156,8 @@
 </tr>
 {% for curve in info.curves: %}
 <tr>
-    <td> <a href = "{{info.curve_url(curve)}}"> {{curve.label}} </a> </td>
-    <td> <a href = "{{info.isog_url(curve)}}"> {{curve.isog_label}} </a> </td>
+    <td> <a href = "{{info.curve_url(curve.label)}}"> {{curve.label}} </a> </td>
+    <td> <a href = "{{info.class_url(curve.class)}}"> {{curve.class}} </a> </td>
     <td> \({{curve.equation_formatted}}\) </td>
     <td align=center> {{curve.st_group_href|safe}} </td>
     <td align=center> {{curve.is_gl2_type_display | safe}} </td>

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -1,58 +1,137 @@
 # -*- coding: utf8 -*-
 from lmfdb.base import LmfdbTest
-import math
-import unittest2
 
 class Genus2Test(LmfdbTest):
 
     # All tests should pass
+    def test_stats(self):
+        L = self.tc.get('/Genus2Curve/Q/stats')
+        assert 'Sato-Tate groups' in L.data and 'proportion' in L.data
+        
+    def test_cond_range(self):
+        L = self.tc.get('/Genus2Curve/Q/?cond=100000-1000000')
+        assert '100000.a.200000.1' in L.data
 
-    def test_Cond_search(self):
-        L = self.tc.get('/Genus2Curve/Q/?cond=100-200&count=100')
-        assert '196.a.21952.1' in L.data
+    def test_disc_range(self):
+        L = self.tc.get('/Genus2Curve/Q/?abs_disc=100000-1000000')
+        assert '336.a.172032.1' in L.data
+
+    def test_by_curve_label(self):
+        L = self.tc.get('/Genus2Curve/Q/169.a.169.1',follow_redirects=True)
+        assert 'square of an elliptic curve' in L.data and 'E_6' in L.data
+        L = self.tc.get('/Genus2Curve/Q/1152.a.147456.1',follow_redirects=True)
+        assert 'two non-isogenous elliptic curves' in L.data and '24.a5' in L.data and '48.a5' in L.data
+        L = self.tc.get('/Genus2Curve/Q/15360.f.983040.2',follow_redirects=True)
+        assert 'N(G_{1,3})' in L.data and '480.b3' in L.data and '32.a3' in L.data
+
+    def test_isogeny_class_label(self):
+        L = self.tc.get('/Genus2Curve/Q/1369/a/')
+        assert '1369.1' in L.data and '50653.1' in L.data and 'G_{3,3}' in L.data
+        
+    def test_Lfunction_link(self):
+        L = self.tc.get('/L/Genus2Curve/Q/1369/a',follow_redirects=True)
+        assert 'G_{3,3}' in L.data and 'Motivic weight' in L.data
+        
+    def test_twist_link(self):
+        L = self.tc.get('/Genus2Curve/Q/?g22=1016576&g20=5071050752/9&g21=195344320/9')
+        for label in ['576.b.147456.1', '1152.a.147456.1', '2304.b.147456.1', '4608.a.4608.1','4608.b.4608.1']:
+            assert label in L.data
+            
+    def test_by_conductor(self):
+        L = self.tc.get('/Genus2Curve/Q/15360/')
+        for x in "abcdefghij":
+            assert "15360."+x in L.data
+        L = self.tc.get('/Genus2Curve/Q/15360/?abs_disc=169')
+        assert '0 matches' in L.data
+            
+    def test_by_url_isogeny_class_label(self):
+        L = self.tc.get('/Genus2Curve/Q/336/a/')
+        assert '336.a.172032.1' in L.data
+
+    def test_by_url_curve_label(self):
+        # Two elliptic curve factors and decomposing endomorphism algebra:
+        L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
+        assert '32.a1' in L.data and '34.a3' in L.data
+        # RM curve:
+        L = self.tc.get('/Genus2Curve/Q/17689/e/866761/1')
+        assert 'simple over' in L.data and 'G_{3,3}' in L.data
+        # QM curve:
+        L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
+        assert 'quaternion algebra' in L.data and 'J(E_2)' in L.data
+        L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
+        # Square over a quadratic extension that is CM over one extension and
+        # multiplication by a quaternion algebra ramifying at infinity over another
+        assert 'square of an elliptic curve' in L.data and '2.2.8.1-64.1-a3'\
+            in L.data and r'\mathbf{H}' in L.data and '(CM)' in L.data
+
+    def test_by_url_isogeny_class_discriminant(self):
+        L = self.tc.get('/Genus2Curve/Q/15360/f/983040/')
+        assert '15360.f.983040.1' in L.data and '15360.f.983040.2' in L.data and not '15360.d.983040.1' in L.data
+
+    def test_random(self):
+        L = self.tc.get('/Genus2Curve/Q/random',follow_redirects=True)
+        assert 'geometric invariants' in L.data
+
+    def test_conductor_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?cond=1225')
+        assert '1225.a.6125.1' in L.data
 
     def test_disc_search(self):
-        L = self.tc.get('/Genus2Curve/Q/?start=0&count=50&cond=1988&abs_disc=&num_rat_wpts=&torsion=&torsion_order=&two_selmer_rank=&analytic_rank=&is_gl2_type=&st_group=&real_geom_end_alg=&aut_grp=&geom_aut_grp=&locally_solvable=&has_square_sha=')
+        L = self.tc.get('/Genus2Curve/Q/?abs_disc=3976')
         assert '1988.a.3976.1' in L.data
+
+    def test_rational_weierstrass_points_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?num_rat_wpts=4')
+        assert '360.a.6480.1' in L.data
+
+    def test_torsion_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?torsion=[2,2,2]')
+        assert '1584.a.684288.1' in L.data
+
+    def test_torsion_order_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?torsion_order=39')
+        assert '1116.a.214272.1' in L.data
+
+    def test_two_selmer_rank_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?two_selmer_rank=6')
+        assert '65520.b.131040.1' in L.data
+
+    def test_analytic_rank_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?analytic_rank=4')
+        assert '440509.a.440509.1' in L.data
+
+    def test_gl2_type_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?gl2_type=True')
+        assert '169.a.169.1' in L.data
+
+    def test_st_group_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?st_group=J(E_6)')
+        assert '6075.a.18225.1' in L.data
+
+    def test_st0_group_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?real_geom_end_alg=C x R')
+        assert '448.a.448.1' in L.data
+
+    def test_automorphism_group_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?aut_grp_id=[12,4]')
+        assert '196.a.21952.1' in L.data
+
+    def test_geometric_automorphism_group_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?geom_aut_grp_id=[48,29]')
+        assert '4096.b.65536.1' in L.data
+
+    def test_locally_solvable_serach(self):
+        L = self.tc.get('/Genus2Curve/Q/?locally_solvable=False')
+        assert '336.a.172032.1' in L.data
+        
+    def test_sha_search(self):
+        L = self.tc.get('/Genus2Curve/Q/?has_square_sha=False')
+        assert  '336.a.172032.1' in L.data and not '169.a.169.1' in L.data
+        L = self.tc.get('/Genus2Curve/Q/?locally_solvable=True&has_square_sha=False')
+        assert 'displaying all 0 matches' in L.data
 
     def test_torsion(self):
         L = self.tc.get('/Genus2Curve/Q/976/a/999424/1')
         assert '\Z/{29}\Z' in L.data
-        L = self.tc.get('/Genus2Curve/Q/118606.a.118606.1')
+        L = self.tc.get('/Genus2Curve/Q/118606/a/118606/1')
         assert 'trivial' in L.data
-
-    def test_sha_loc_solv(self):
-        L = self.tc.get('/Genus2Curve/Q/?start=0&count=50&has_square_sha=True')
-        assert '169.a.169.1' in L.data
-        L = self.tc.get('/Genus2Curve/Q/?start=0&count=50&cond=&abs_disc=&num_rat_wpts=&torsion=&torsion_order=&two_selmer_rank=&analytic_rank=&is_gl2_type=&st_group=&real_geom_end_alg=&aut_grp=&geom_aut_grp=&locally_solvable=True&has_square_sha=False')
-        assert 'displaying all 0 matches' in L.data
-        L = self.tc.get('/Genus2Curve/Q/?start=0&count=50&cond=&abs_disc=&num_rat_wpts=&torsion=&torsion_order=&two_selmer_rank=&analytic_rank=&is_gl2_type=&st_group=&real_geom_end_alg=&aut_grp=&geom_aut_grp=&locally_solvable=False')
-        assert '336.a.172032.1' in L.data
-
-    def test_by_double_iso_label(self):
-        L = self.tc.get('/Genus2Curve/Q/336/a/')
-        assert '336.a.172032.1' in L.data
-
-    def test_by_full_label(self):
-        # Two elliptic curve factors and decomposing endomorphism algebra:
-        L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
-        assert '32.a1' in L.data and '34.a3' in L.data
-        # RM case, should we ever want this:
-        #L = self.tc.get('/Genus2Curve/Q/17689/e/866761/1')
-        #assert '17689' in L.data
-        # QM curve:
-        L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
-        assert 'quaternion algebra' in L.data
-        L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
-        # Square over a quadratic extension that is CM over one extension and
-        # multiplication by a quaternion algebra ramifying at infinity over
-        # another:
-        assert 'square of an elliptic curve' in L.data and '2.2.8.1-64.1-a3'\
-            in L.data and r'\mathbf{H}' in L.data and '(CM)' in L.data
-
-    def test_by_g2c_label(self):
-        # This curve also decomposes as a square, this time of a curve without
-        # a label:
-        L = self.tc.get('/Genus2Curve/Q/169.a.169.1')
-        assert 'square of an elliptic curve' in L.data and '\Z/{19}\Z'\
-            in L.data

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -3,7 +3,7 @@
 import re
 from lmfdb.lfunctions import logger
 from sage.all import *
-from lmfdb.genus2_curves.isog_class import list_to_factored_poly_otherorder
+from lmfdb.genus2_curves.isogeny_class import list_to_factored_poly_otherorder
 from lmfdb.number_fields import group_display_knowl
 from lmfdb.base import getDBConnection
 


### PR DESCRIPTION
I went through the code cleaning up a number of legacy issues and left over detritus from the original "clone=and-conquer" implementation that simply adapted the elliptic curves python code and html templates.  I also made a number of performance improvements and added many new tests.  There are a lot of code changes, but most do not impact the functionality in any way (or do so invisibly).  Here are a few functional changes that are visible:

- If you go to http://www.lmfdb.org/Genus2Curve/Q/169/ and click "search again" you will get a server error.  This is fixed in http://127.0.0.1:37777/Genus2Curve/Q/169/.
- If you go to http://www.lmfdb.org/Genus2Curve/Q/random you will be redirected to a random curve page with a "dotted" curve label in the URL, but if you go to http://127.0.0.1:37777/Genus2Curve/Q/random you will see a "slashed" curve label in the URL (as desired).
- The bread crumbs on curve pages have been made more uniform and now reflect all four components of the label.  Clicking on any intermediate bread crumb takes you to an appropriate page (see http://127.0.0.1:37777/Genus2Curve/Q/15360/f/983040/, for example), and when that page is a search page (as opposed to an isogeny class home page), refining the search works as it should.  If you change the search parameters in a way that contradicts the bread crumbs it will take you to a general search page.

The main performance improvements involve avoiding some unnecessary redirects, avoiding querying the isogeny_classes collection for data that is now stored in the curves collection (and has been for a while), and using the projection parameter in queries (the second optional parameter to .find(), see https://docs.mongodb.com/manual/reference/method/db.collection.find/) to restrict the amount of data that needs to transferred from the mongo db to the web server.  This significantly speeds up operations that involve large amounts of data, such as the download button.
If you go to http://www.lmfdb.org/Genus2Curve/Q/?cond=, for example and click the "sage" button to download all 66158 curves, it will take 5-10 seconds, but if you go to http://127.0.0.1:37777/Genus2Curve/Q/?cond= and do the same thing it will take only a few seconds (depending on your internet connection) even though the later may need to transfer data much further than the cloud server.

Analogous versions of two of the bugs fixed in this PR exist in the elliptic curves code, I am about to open an issue for this.

The performance improvements gained by using the projection parameter in large .find() calls would also help in many other places (even more than it does in genus2_curves).  Notable examples include the search and download functions in elliptic_curves and ecnf (see lines 243 and 563 of LMFDB/lmfdb/elliptic_curves/elliptic_curve.py, and lines 407 and 588 of lmfdb/ecnf/main.py,  @JohnCremona), and the search function in numberfields (see line 477 of LMFDB/lmfdb/number_fields/number_field.py, @jwj61 ).  There is no need to force mongo db to send the full contents of every record that matches a query to the LMFDB application when only a few attributes are needed (those displayed in the columns of the search results, of the data included in the download file).  In fact, for queries whose purpose is just to retrieve a list of labels, if the projection parameter is set to {'_id':int(0),'label':int(1)} and there is an index on 'label', mongo db can process the query using only the index, it doesn't need to look at the collection at all.

