### PR TITLE
Optimize random_object_from_collection

### DIFF
--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -1,6 +1,5 @@
-from pymongo import WriteConcern
-from time import time
-#
+import time
+
 # rewrite_collection(db,incoll,outcoll,func)
 #
 # function to pipe an existing collection to a new collection through a user specified function
@@ -18,32 +17,33 @@ from time import time
 #
 # For collections with large records, you will want to specify a batchsize smaller than 1000
 #
-def rewrite_collection(db,incoll,outcoll,func, batchsize=1000, reindex=True):
+def rewrite_collection(db,incoll,outcoll,func, batchsize=1000, reindex=True, filter=None, projection=None):
     if outcoll in db.collection_names():
-        print "Collection %s already exists, unable to write"%(outcoll)
+        print "Collection %s already exists in database %s, please drop it first" % (outcoll, db.name)
         return
-    start = time()
-    inrecs = db[incoll].find()
-    # increase wtimeout to avoid BulkWriteErrors caused by timeouts
-    db.create_collection(outcoll,write_concern=WriteConcern(wtimeout=int(60000)))
+    if not incoll in db.collection_names():
+        print "Collection %s not found in database %s" % (coll, db.name)
+        return
+    start = time.time()
+    inrecs = db[incoll].find(filter, projection)
+    db.create_collection(outcoll)
     outrecs = []
     cnt = 0
     tot = inrecs.count()
     for r in inrecs:
-        r.pop('_id') # remove mongo db id attribute
         outrecs.append(func(r))
         cnt += 1
         if len(outrecs) >= batchsize:
             db[outcoll].insert_many(outrecs)
-            print "%d of %d records (%.1f percent) inserted in %.3f secs"%(cnt,tot,100.0*cnt/tot,time()-start)
+            print "%d of %d records (%.1f percent) inserted in %.3f secs"%(cnt,tot,100.0*cnt/tot,time.time()-start)
             outrecs=[]
     if outrecs:
         db[outcoll].insert_many(outrecs)
     assert db[outcoll].count() == tot
-    print "inserted %d records in %.3f secs"%(cnt, time()-start)
+    print "inserted %d records in %.3f secs"%(cnt, time.time()-start)
     if reindex:
         reindex_collection(db,incoll,outcoll)
-    print "Rewrote %s to %s, total time %.3f secs"%(incoll, outcoll, time()-start)
+    print "Rewrote %s to %s, total time %.3f secs"%(incoll, outcoll, time.time()-start)
 
 # reindex_collection(db,incoll,outcoll)
 #
@@ -54,9 +54,32 @@ def reindex_collection(db,incoll,outcoll):
     keys = [(k,indexes[k]['key']) for k in indexes if k != '_id_']
     keys.sort() # sort indexes by keyname so (attr1) < (attr1,attr2) < (attr1,attr2,attr3) < ...
     for i in range(len(keys)):
-        now = time()
+        now = time.time()
         key = [(a[0],int(1) if a[1] > 0 else int(-1)) for a in keys[i][1]] # deal with legacy floats (1.0 vs 1)
         db[outcoll].create_index(key)
-        print "created index %s in %.3f secs"%(keys[i][0],time()-now)
+        print "created index %s in %.3f secs"%(keys[i][0],time.time()-now)
 
+def add_counter(rec=None):
+    if not rec:
+        old_num = add_counter.num
+        add_counter.num = 0
+        return old_num
+    add_counter.num += 1
+    rec['num'] = add_counter.num
+    return rec
+add_counter.num = 0
 
+# create_random_object_index(db,coll)
+#
+# Creates (or recreates) a collection named coll.rand used to support fast random object access
+# The new collection consists of records with "_id" taken from coll and a sequentially assigned "num" (starting at 1)
+# An index is created on num which can be used to efficiently generate random object ids in coll
+#
+def create_random_object_index(db,incoll):
+    outcoll = incoll+".rand"
+    if outcoll in db.collection_names():
+        print "Dropping existing collection %s in db %s" % (outcoll,db.name)
+        db[outcoll].drop()
+    add_counter() # reset counter
+    rewrite_collection (db, incoll, outcoll, add_counter, reindex=False, projection={'_id':True})
+    db[outcoll].create_index('num')

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -31,12 +31,12 @@ def random_value_from_collection(collection,attribute):
     import pymongo
     n = collection.rand.count()
     if n:
-        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True})[attribute]
+        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True}).get(attribute)
     if pymongo.version_tuple[0] < 3:
-        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()[attribute] # don't both optimizing this
+        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next().get(attribute) # don't both optimizing this
     else:
         # Changed in version 3.0: The aggregate() method always returns a CommandCursor. The pipeline argument must be a list.
-        return collection.aggregate([{ '$sample': { 'size': int(1) } }, { '$project' : {'_id':False,attribute:True}} ]).next()[attribute]
+        return collection.aggregate([{ '$sample': { 'size': int(1) } }, { '$project' : {'_id':False,attribute:True}} ]).next().get(attribute)
 
 cache = SimpleCache()
 

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -17,12 +17,25 @@ from flask import url_for
 
 def random_object_from_collection(collection):
     import pymongo
+    n = collection.rand.count()
+    if n:
+        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
     if pymongo.version_tuple[0] < 3:
-        return collection.aggregate({ '$sample': { 'size': 1 } }, cursor = {} ).next()
+        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()
     else:
         # Changed in version 3.0: The aggregate() method always returns a CommandCursor. The pipeline argument must be a list.
-        return collection.aggregate([{ '$sample': { 'size': 1 } } ]).next()
+        return collection.aggregate([{ '$sample': { 'size': int(1) } } ]).next()
 
+def random_value_from_collection(collection,attribute):
+    import pymongo
+    n = collection.rand.count()
+    if n:
+        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True})[attribute]
+    if pymongo.version_tuple[0] < 3:
+        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()[attribute] # don't both optimizing this
+    else:
+        # Changed in version 3.0: The aggregate() method always returns a CommandCursor. The pipeline argument must be a list.
+        return collection.aggregate([{ '$sample': { 'size': int(1) } }, { '$project' : {'_id':False,attribute:True}} ]).next()[attribute]
 
 cache = SimpleCache()
 

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -7,6 +7,7 @@ import logging
 
 import re
 
+from random import randint
 from flask import request, make_response
 from functools import wraps
 from werkzeug.contrib.cache import SimpleCache

--- a/perfmon/random_timings.sh
+++ b/perfmon/random_timings.sh
@@ -2,13 +2,13 @@
 # curl script to measure load times for top level LMFDB pages
 while true
 do
-for object in "/ArtinRepresentation/random" "/GaloisGroup/random" "/LocalField/random" "/ModularForm/GL2/TotallyReal/random" "/EllipticCurve/Q/random" "/EllipticCurve/random" "Genus2Curve/random" "/NumberField/random" "SatoTateGroup/random" "Lattice/random"
+for object in "ArtinRepresentation/random" "GaloisGroup/random" "LocalField/random" "ModularForm/GL2/TotallyReal/random" "EllipticCurve/Q/random" "EllipticCurve/random" "Genus2Curve/random" "NumberField/random" "SatoTateGroup/random" "Lattice/random"
 do 
-url=http://www.lmfdb.org/${object};
-for i in `seq 1 $1`;
+url=http://${1}/${object};
+for i in `seq 1 $2`;
 do
 echo -e $url : $(curl -silent -o /dev/null -w "Connect: %{time_connect} TTFB: %{time_starttransfer} Total time: %{time_total} \n" ${url});
 done;
-sleep 30
+sleep 5
 done;
 done;


### PR DESCRIPTION
This pull request implements a faster way to obtain random objects from a collection.

The file rewrite.py contains a new utility function create_random_object_index, which, given a database to which the caller has write access and a collection name "coll" creates a new collection "coll.rand" with the same object ids as coll and a single indexed attribute "num" that runs from 1 to coll.count()

The function random_object_from_collection has been modified to look for the colleciton coll.rand, and if it exists use an indexed lookup on num to more efficiently retrieve random objects.  From measurements taken directly on the mongo db and in sage/python, it is 20-30 times faster for large collections than using the .aggregate method.

Random object indexes have been added to the larger collections (e.g. curves2, nfcurves, fields, etc.. on both lmfdb.warwick.ac.uk and in the cloud).  They will not be used until this PR is merged and pushed (and if they are not present, there is no harm, the random object index will be used if it is there and otherwise random_object_from_collection falls back to using .aggregate).

There is also a new function random_value_from_collection in utils.py that takes a collection name and an attribute and returns the value of that attribute in a randomly chosen object (it will return None if the value is not present in the chosen object).  This is slightly more efficient and useful, for example, when one just wants the label of a random object.  Currently the function random_value_from_collection is not used anywhere, but most of the places where random_object_from_collection is currently used could use this function instead.

