### PR TITLE
fixed ec data download Issue #1492

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -491,7 +491,7 @@ def download_EC_qexp(label, limit):
 
 @ec_page.route("/download_all/<label>")
 def download_EC_all(label):
-    CDB = lmfdb.base.getDBConnection().elliptic_curves.curves
+    CDB = db_ec()
     N, iso, number = split_lmfdb_label(label)
     if number:
         data = CDB.find_one({'lmfdb_label': label})
@@ -503,30 +503,13 @@ def download_EC_all(label):
         if len(data_list) == 0:
             return elliptic_curve_jump_error(label, {})
 
-    # titles of all entries of curves
-    dump_data = []
-    titles = [str(c) for c in data_list[0]]
-    titles = [t for t in titles if t[0] != '_']
-    titles.sort()
-    dump_data.append(titles)
+    # For each curve we will output all data fields except the '_id':
+    # (This should also be possible by adding projection={'_id':False}
+    # to the find() call but on testing that timed out.)
     for data in data_list:
-        data1 = []
-        for t in titles:
-            d = data[t]
-            if t == 'ainvs':
-                data1.append(format_ainvs(d))
-            elif t in ['torsion_generators', 'torsion_structure']:
-                data1.append([eval(g) for g in d])
-            elif t == 'x-coordinates_of_integral_points':
-                data1.append(split_list(d))
-            elif t == 'gens':
-                data1.append(parse_points(d))
-            elif t in ['iso', 'label', 'lmfdb_iso', 'lmfdb_label']:
-                data1.append(str(d))
-            else:
-                data1.append(d)
-        dump_data.append(data1)
-    response = make_response('\n'.join(str(an) for an in dump_data))
+        data.pop('_id')
+
+    response = make_response('\n\n'.join(str(d) for d in data_list))
     response.headers['Content-type'] = 'text/plain'
     return response
 


### PR DESCRIPTION
This is a fix for #1492.  It simplifies the code and is not sensitive to exactly which data fields each curve has, by simply outputing each as a string representation of the dictionary (without the '_id' field).  This makes the output much simpler to parse by eye, and trivial to read into python.  Before, there was first a sorted list of strings ('titles') for the keys, and then for each curve a list of the  values.

If there was any chance of anyone actually using the old format as an api to the data then this change would break that but I find that most unlikely.

Even better would be to output the whole lot as a yaml file, but I do not know how to do that using flask.make_response().