### PR TITLE
fixed ecnf browse templates to sort by discriminant, Issue 1484

### DIFF
--- a/lmfdb/ecnf/templates/by_degree.html
+++ b/lmfdb/ecnf/templates/by_degree.html
@@ -26,8 +26,10 @@
  </h3>
 <table>
 <tr><th> Field <th> Number of curves <th> Number of isogeny classes <th> Maximum conductor norm </tr>
-{% for F, Fdat in sdat.iteritems() %}
-<tr><td> <a href="{{url_for('ecnf.show_ecnf1',nf=F)}}">{{F}}</a> <td> {{Fdat.ncurves}} <td> {{Fdat.nclasses}} <td> {{Fdat.maxnorm}} </tr>
+{% for F in info.counts.fields_by_degree[info.degree] %}
+{% if F in sdat %}
+<tr><td> <a href="{{url_for('ecnf.show_ecnf1',nf=F)}}">{{F}}</a> <td> {{sdat[F].ncurves}} <td> {{sdat[F].nclasses}} <td> {{sdat[F].maxnorm}} </tr>
+{% endif %}
 {% endfor %}
 </table>
 

--- a/lmfdb/ecnf/templates/by_signature.html
+++ b/lmfdb/ecnf/templates/by_signature.html
@@ -21,8 +21,10 @@
   signature {{info.sig}}</h2>
 <table>
 <tr><th> Field <th> Number of curves <th> Number of isogeny classes <th> Maximum conductor norm </tr>
-{% for F, Fdat in sdat.iteritems() %}
-<tr><td> <a href="{{url_for('ecnf.show_ecnf1',nf=F)}}">{{F}}</a> <td> {{Fdat.ncurves}} <td> {{Fdat.nclasses}} <td> {{Fdat.maxnorm}} </tr>
+{% for F in info.counts.fields_by_degree[info.degree] %}
+{% if F in sdat %}
+<tr><td> <a href="{{url_for('ecnf.show_ecnf1',nf=F)}}">{{F}}</a> <td> {{sdat[F].ncurves}} <td> {{sdat[F].nclasses}} <td> {{sdat[F].maxnorm}} </tr>
+{% endif %}
 {% endfor %}
 </table>
 


### PR DESCRIPTION
This fixed #1484 .  I tturned out to be very simple since I already had a correctly orderd list of field labels, so just ad to edit two templates to use it instead of the random order of a dictionary's keys.

To test this click on both a degree and a signature from the page EllipticCurve/browse/ since these use different templates and both have been changed.  A good example is signature (0,1).