### PR TITLE
Fix display of intransitive inertia groups

### DIFF
--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -403,7 +403,8 @@ def group_display_inertia(code, C):
     if str(code[1]) == "t":
         return group_display_knowl(code[2][0], code[2][1], C)
     ans = "Intransitive group isomorphic to "
-    if len(code[2]) > 1:
+    if code[2] and len(code[2]) > 1:
+    #if len(code[2]) > 1:
         ans += group_display_short(code[2][0], code[2][1], C)
         return ans
     ans += code[3]


### PR DESCRIPTION
Fix issue #1493: there was a mismatch in the code between how we store information about inertia subgroups which are intransitive subgroups of S_n and the code.

To test, go to any local field pointed to in the issue.