### PR TITLE
Add label to properties box of artin rep, galois groups, local fields

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -184,7 +184,8 @@ def render_artin_representation_webpage(label):
         processed_root_number = "not computed"
     else:
         processed_root_number = str(the_rep.sign())
-    properties = [("Dimension", str(the_rep.dimension())),
+    properties = [("Label", label),
+                  ("Dimension", str(the_rep.dimension())),
                   ("Group", the_rep.group()),
                   #("Conductor", str(the_rep.conductor())),
                   ("Conductor", "$" + the_rep.factored_conductor_latex() + "$"),
@@ -231,8 +232,9 @@ def render_artin_representation_webpage(label):
     #info['pol5']=str(the_rep.central_char(5))
     #info['pol7']=str(the_rep.central_char(7))
     #info['pol11']=str(the_rep.central_char(11))
+    learnmore=[('Artin representations labels', url_for(".labels_page"))]
 
-    return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, properties2=properties, extra_data=extra_data, info=info)
+    return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, properties2=properties, extra_data=extra_data, info=info, learnmore=learnmore)
 
 @artin_representations_page.route("/random")
 def random_representation():

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -258,14 +258,14 @@ def render_group_webpage(args):
         one = C.numberfields.fields.find_one(query)
         if one:
             friends.append(('Number fields with this Galois group', url_for('number_fields.number_field_render_webpage')+"?galois_group=%dT%d" % (n, t) )) 
-        prop2 = [
-            ('Order:', '\(%s\)' % order),
-            ('n:', '\(%s\)' % data['n']),
-            ('Cyclic:', yesno(data['cyc'])),
-            ('Abelian:', yesno(data['ab'])),
-            ('Solvable:', yesno(data['solv'])),
-            ('Primitive:', yesno(data['prim'])),
-            ('$p$-group:', yesno(pgroup)),
+        prop2 = [('Label', label),
+            ('Order', '\(%s\)' % order),
+            ('n', '\(%s\)' % data['n']),
+            ('Cyclic', yesno(data['cyc'])),
+            ('Abelian', yesno(data['ab'])),
+            ('Solvable', yesno(data['solv'])),
+            ('Primitive', yesno(data['prim'])),
+            ('$p$-group', yesno(pgroup)),
         ]
         pretty = group_display_pretty(n,t,C)
         if len(pretty)>0:

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -166,6 +166,7 @@ def render_field_webpage(args):
         gn = GG[0]
         gt = GG[1]
         prop2 = [
+            ('Label', label),
             ('Base', '\(\Q_{%s}\)' % p),
             ('Degree', '\(%s\)' % data['n']),
             ('e', '\(%s\)' % e),


### PR DESCRIPTION
Can check on the home pages of each type of object.  Also added learnmore for artin rep labels, and removed colons from Galois groups properties boxes.