### PR TITLE
fixed Issue 1505

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -132,7 +132,7 @@ class ECisog_class(object):
         self.newform = web_latex(self.E.q_eigenform(10))
         self.newform_label = newform_label(N,2,1,iso)
         self.newform_link = url_for("emf.render_elliptic_modular_forms", level=N, weight=2, character=1, label=iso)
-        newform_exists_in_db = is_newform_in_db(self.newform_label)
+        self.newform_exists_in_db = is_newform_in_db(self.newform_label)
 
         self.lfunction_link = url_for("l_functions.l_function_ec_page", label=self.lmfdb_iso)
 
@@ -151,7 +151,7 @@ class ECisog_class(object):
                 self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso))]
             if int(N)<=50:
                 self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', label=self.lmfdb_iso))]
-        if newform_exists_in_db:
+        if self.newform_exists_in_db:
             self.friends +=  [('Modular form ' + self.newform_label, self.newform_link)]
 
         self.properties = [('Label', self.lmfdb_iso),

--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -272,8 +272,13 @@ src="http://code.jquery.com/jquery-latest.min.js"></script>
 
     <h2> {{KNOWL('ec.q.modular_parametrization', title='Modular invariants')}}</h2>
     <h3> {{KNOWL('ec.q.modular_form', title='Modular form')}}
-          {{data.newform_label}} </h3>
-          {{ place_code('qexp') }}
+{% if data.newform_exists_in_db %}
+<a href="{{data.newform_link}}">{{ data.newform_label }}</a>
+{% else %}
+{{ data.newform_label }}
+{% endif %}
+</h3>
+    {{ place_code('qexp') }}
     <p>
 {#
     <form>

--- a/lmfdb/elliptic_curves/templates/iso_class.html
+++ b/lmfdb/elliptic_curves/templates/iso_class.html
@@ -54,8 +54,13 @@ text-align: center;
 rank \({{ info.rank}}\).
 </p>
 
-<h2><a href="{{info.newform_link}}">
-            Modular form {{ info.newform_label }}</a>
+<h2>
+{{KNOWL('ec.q.modular_form', title='Modular form')}}
+{% if info.newform_exists_in_db %}
+<a href="{{info.newform_link}}">{{ info.newform_label }}</a>
+{% else %}
+{{ info.newform_label }}
+{% endif %}
 </h2>
 {{ place_code('q_eigenform') }}
 <div>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -358,7 +358,7 @@ class WebEC(object):
         data['newform'] =  web_latex(PowerSeriesRing(QQ, 'q')(data['an'], 20, check=True))
         data['newform_label'] = self.newform_label = newform_label(cond,2,1,iso)
         self.newform_link = url_for("emf.render_elliptic_modular_forms", level=cond, weight=2, character=1, label=iso)
-        newform_exists_in_db = is_newform_in_db(self.newform_label)
+        self.newform_exists_in_db = is_newform_in_db(self.newform_label)
         self._code = None
 
         self.friends = [
@@ -371,7 +371,7 @@ class WebEC(object):
                 self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', label=self.lmfdb_iso))]
             if N<=50:
                 self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', label=self.lmfdb_iso))]
-        if newform_exists_in_db:
+        if self.newform_exists_in_db:
             self.friends += [('Modular form ' + self.newform_label, self.newform_link)]
 
         self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=1000)),


### PR DESCRIPTION
This fixed Issue #1505 and also makes the Moular Form section of the pages for elliptic curves and isogeny classes more consistent: in ecah case the words "Modular Form" in the section title are a knowl, and the modular form is a link if anf only if the form exists in the database.

Question for the reviewer: it is a fairly recent addition to have the modular form label in the title at all, and I am not sure whether it should be, and/or whether it should link to the modular form itself -- which is already listed in the Related Objects box.

To test this look at both a curve and a clas page for cases which do/do not have the modular form in the database.  For example:
http://localhost:37777/EllipticCurve/Q/37/a/1
http://localhost:37777/EllipticCurve/Q/37/a
http://localhost:37777/EllipticCurve/Q/234446/a/1
http://localhost:37777/EllipticCurve/Q/234446/a