### PR TITLE
In showing roots of an Artin representation, modify output depending on

### DIFF
--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -24,12 +24,16 @@
     <h2> Galois action </h2>
      
     <h3>Roots of defining polynomial</h3>
+    {% if object.number_field_galois_group().computation_minimal_polynomial()|length > 2 %}
     <div>
     The roots of $f$ are computed in an extension of $\Q_{ {{object.number_field_galois_group().residue_characteristic()}} }$ to precision {{object.number_field_galois_group().computation_precision()}}.
     </div>
     <div>
     Minimal polynomial of a generator $a$ of $K$ over $\mathbb{Q}_{ {{object.number_field_galois_group().residue_characteristic()}} }$: ${{object.number_field_galois_group().computation_minimal_polynomial().latex()}}$
     </div>
+    {% else %}
+    The roots of $f$ are computed in $\Q_{ {{object.number_field_galois_group().residue_characteristic()}} }$ to precision {{object.number_field_galois_group().computation_precision()}}.
+    {% endif %}
    <div>
     Roots:
     {#


### PR DESCRIPTION
whether roots are in Q_p or an extension.

This implements a change suggested by @JohnCremona in a different pull request

Example with roots in Q_p: ArtinRepresentation/3.2e2_523e2.6t8.1c1

Example with roots in an extension of Q_p:  ArtinRepresentation/5.2e4_12119e3.6t14.1c1