### PR TITLE
Fixes #1530 and #1532

### DIFF
--- a/lmfdb/lfunctions/LfunctionComp.py
+++ b/lmfdb/lfunctions/LfunctionComp.py
@@ -1,15 +1,14 @@
 # Functions for getting info about elliptic curves and related modular forms
-# TODO: These should be (is already) part of the elliptic curve code?
 
 import re
 from lmfdb import base
 from pymongo import ASCENDING
 import lmfdb.utils
 from lmfdb.lfunctions import logger
-from lmfdb.elliptic_curves.web_ec import lmfdb_label_regex
+from lmfdb.elliptic_curves.web_ec import lmfdb_label_regex, db_ec
 
 
-def isogenyclasstable(Nmin, Nmax):
+def isogeny_class_table(Nmin, Nmax):
     ''' Returns a table of all isogeny classes of elliptic curves with
      conductor in the ranges NMin, NMax.
     '''
@@ -18,25 +17,22 @@ def isogenyclasstable(Nmin, Nmax):
     query = {'number': 1, 'conductor': {'$lte': Nmax, '$gte': Nmin}}
 
     # Get all the curves and sort them according to conductor
-    cursor = base.getDBConnection().elliptic_curves.curves.find(query)
+    cursor = db_ec().find(query,{'_id':False,'conductor':True,'lfmdb_label':True,'lmfdb_iso':True})
     res = cursor.sort([('conductor', ASCENDING), ('lmfdb_label', ASCENDING)])
 
     iso_list = [E['lmfdb_iso'] for E in res]
 
     return iso_list
+    
+def isogeny_class_cm(label):
+    return db_ec().find_one({'lmfdb_iso':label},{'_id':False,'cm':True})['cm']
 
 
 def nr_of_EC_in_isogeny_class(label):
     ''' Returns the number of elliptic curves in the isogeny class
      with given label.
     '''
-    i = 1
-    connection = base.getDBConnection()
-    data = connection.elliptic_curves.curves.find_one({'lmfdb_label': label + str(i)})
-    while not data is None:
-        i += 1
-        data = connection.elliptic_curves.curves.find_one({'lmfdb_label': label + str(i)})
-    return i - 1
+    return db_ec().find({'lmfdb_iso':label}).count()
 
 
 def modform_from_EC(label):

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -19,7 +19,7 @@ from Lfunctionutilities import (p2sage, lfuncDShtml, lfuncEPtex, lfuncFEtex,
 from lmfdb.WebCharacter import WebDirichlet
 from lmfdb.lfunctions import l_function_page, logger
 from lmfdb.elliptic_curves.web_ec import cremona_label_regex, lmfdb_label_regex
-from LfunctionComp import isogenyclasstable
+from LfunctionComp import isogeny_class_table, isogeny_class_cm
 import LfunctionDatabase
 from lmfdb import base
 from pymongo import ASCENDING
@@ -624,7 +624,7 @@ def initLfunction(L, args, request):
             # info['friends'].append(('L-function ' + label.replace('.', '.2'),
             #                         url_for('.l_function_emf_page', level=L.modform['level'],
             #                             weight=2, character=1, label=L.modform['iso'], number=0)))
-        if not L.E.has_cm: # only show symmetric powers for non-CM curves
+        if not isogeny_class_cm(label): # only show symmetric powers for non-CM curves
             info['friends'].append(
                 ('Symmetric square L-function', url_for(".l_function_ec_sym_page",
                                                         power='2', label=label)))
@@ -655,14 +655,15 @@ def initLfunction(L, args, request):
             for i in range(1, L.nr_of_curves_in_class + 1):
                 info['friends'].append(('Elliptic curve ' + L.ellipticcurve + str(i),
                                         url_for("ec.by_ec_label", label=L.ellipticcurve + str(i))))
-            info['friends'].append(
-                ('Symmetric square L-function',
-                 url_for(".l_function_ec_sym_page", power='2',
-                         label=L.ellipticcurve)))
-            info['friends'].append(
-                ('Symmetric cube L-function',
-                 url_for(".l_function_ec_sym_page", power='3',
-                         label=L.ellipticcurve)))
+            if not isogeny_class_cm(L.ellipticcurve):
+                info['friends'].append(
+                    ('Symmetric square L-function',
+                     url_for(".l_function_ec_sym_page", power='2',
+                             label=L.ellipticcurve)))
+                info['friends'].append(
+                    ('Symmetric cube L-function',
+                     url_for(".l_function_ec_sym_page", power='3',
+                             label=L.ellipticcurve)))
 
     elif L.Ltype() == 'hilbertmodularform':
         friendlink = '/'.join(friendlink.split('/')[:-1])
@@ -1158,7 +1159,7 @@ def processEllipticCurveNavigation(startCond, endCond):
     except:
         end = 100
 
-    iso_list = isogenyclasstable(N, end)
+    iso_list = isogeny_class_table(N, end)
     s = '<h5>Examples of L-functions attached to isogeny classes of elliptic curves</h5>'
     s += '<table>'
 
@@ -1254,7 +1255,7 @@ def processSymPowerEllipticCurveNavigation(startCond, endCond, power):
     except:
         end = 100
 
-    iso_list = isogenyclasstable(N, end)
+    iso_list = isogeny_class_table(N, end)
     if power == 2:
         powerName = 'square'
     elif power == 3:

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -7,6 +7,7 @@ import flask
 from sage.all import *
 import tempfile
 import os
+import re
 import sqlite3
 import numpy
 import pymongo
@@ -79,7 +80,10 @@ def l_function_degree4_browse_page():
 # Degree browsing page #########################################################
 @l_function_page.route("/<degree>/")
 def l_function_degree_page(degree):
-    degree = int(degree[6:])
+    res = re.match('degree[0-9]+',degree)
+    if not res:
+        return flask.abort(404)
+    degree = res.group(0).atoi()
     info = {"degree": degree}
     info["key"] = 777
     info["bread"] = get_bread(degree, [])

--- a/lmfdb/templates/404.html
+++ b/lmfdb/templates/404.html
@@ -15,7 +15,7 @@ If you think accessing "{{ request.referrer }}" is an error, please <a href="htt
 </div>
 {% else %}
 <div>
-Please <a href = "http://code.google.com/p/lmfdb/issues/list">report this problem</a> so we can improve the site.
+If you believe this page should be here, please <a href = "http://code.google.com/p/lmfdb/issues/list">report this problem</a> so we can improve the site.
 </div>
 {% endif %}
 


### PR DESCRIPTION
Attempting to access an L-function page with an invalid URL will now display a page not found error rather than causing an internal server error (fixes #1530).  To test visit

http://127.0.0.1:37777/L/nothinghere/

Addresses #1532 by only displaying symmetric power L-function links for elliptic modular forms that do not have CM.

Also changes LfunctionComp.py to use the db_ec() function in lmfdb.elliptic_curves.web_ec to access the elliptic curves database (so that it will correctly use the correct collection curves or curves2 and not break when/if this changes or one of them is removed) and improves code for computing isogeny class tables and counting curves in an isogeny class.

To test, check that all of the pages

http://127.0.0.1:37777/EllipticCurve/Q/11/a/
http://127.0.0.1:37777/EllipticCurve/Q/11/a/1
http://127.0.0.1:37777/L/EllipticCurve/Q/11.a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/11/2/1/a/
http://127.0.0.1:37777/L/ModularForm/GL2/Q/holomorphic/11/2/1/a/0/

show symmetric square and symmetric cube L-functions in the related objects box, but that this is not the case for the pages

http://127.0.0.1:37777/EllipticCurve/Q/27/a/
http://127.0.0.1:37777/EllipticCurve/Q/27/a/1
http://127.0.0.1:37777/L/EllipticCurve/Q/27.a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/27/2/1/a/
http://127.0.0.1:37777/L/ModularForm/GL2/Q/holomorphic/27/2/1/a/0/

To check that the isogeny class table code still works, visit

http://127.0.0.1:37777/L/degree2/EllipticCurve/

