### PR TITLE
Modify higher genus w/automorphisms pages to align more closely with other future work.

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -4,21 +4,18 @@
 
 import re
 import pymongo
+import ast
 ASC = pymongo.ASCENDING
 import flask
 from lmfdb import base
 from lmfdb.base import app, getDBConnection
 from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
 from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, make_logger
-from lmfdb.search_parsing import parse_ints, parse_count, parse_bool, parse_start, parse_list, clean_input
+from lmfdb.search_parsing import *
 
 from sage.all import Permutation
-
 from lmfdb.higher_genus_w_automorphisms import higher_genus_w_automorphisms_page, logger
-
-from lmfdb.genus2_curves.data import group_dict
-
-
+from lmfdb.sato_tate_groups.main import *
 
 
 # Determining what kind of label
@@ -33,24 +30,11 @@ def label_is_one_passport(lab):
     return passport_label_regex.match(lab)
 
 
-
 def get_bread(breads=[]):
     bc = [("Higher Genus/C/aut", url_for(".index"))]
     for b in breads:
         bc.append(b)
     return bc
-
-
-#pretty printing functions 
-def groupid_to_meaningful(groupid):
-    if groupid[0] < 120:
-        return group_dict[str(groupid).replace(" ", "")]
-    elif groupid[0]==168 and groupid[1]==42:
-        return 'PSL(2,7)'
-    elif groupid[0]==120 and groupid[1]==34:
-        return 'S_5'
-    else:    
-        return str(groupid)
 
 def tfTOyn(bool):
     if bool:
@@ -58,11 +42,6 @@ def tfTOyn(bool):
     else:
         return "No"
     
-def group_display_shortC(C):
-    def gds(nt):
-        return group_display_short(nt[0], nt[1], C)
-    return gds
-
         
 def sign_display(L):
     sizeL = len(L)                
@@ -81,6 +60,74 @@ def cc_display(L):
     stg=stg+ str(L[sizeL-1])
     return stg
 
+
+#for splitting permutations cycles
+sep=' ' 
+
+def split_perm(strg):
+    startpoint = 0
+    for i in range(0,len(strg)):
+        if strg[i] == ")":
+            yield strg[startpoint:i+1]
+            startpoint = i+1
+
+def signature_to_list(L):
+    for i in range(0,len(L)):
+        if L[i] == ';':
+            newsig = L[:i] + "," + L[i+1:]
+            return newsig
+    return L
+
+#copied from parse_bracketed_posints,  but keeps outside brackets in string
+@search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_bracketed_posints2(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, check_divisibility=None):
+    if process is None: process = lambda x: x
+    if (not BRACKETED_POSINT_RE.match(inp) or
+        (maxlength is not None and inp.count(',') > maxlength - 1) or
+        (exactlength is not None and inp.count(',') != exactlength - 1) or
+        (exactlength is not None and inp == '[]' and exactlength > 0)):
+        if exactlength == 2:
+            lstr = "pair of integers"
+            example = "[2,3] or [3,3]"
+        elif exactlength == 1:
+            lstr = "list of 1 integer"
+            example = "[2]"
+        elif exactlength is not None:
+            lstr = "list of %s integers" % exactlength
+            example = str(range(2,exactlength+2)).replace(" ","") + " or " + str([3]*exactlength).replace(" ","")
+        elif maxlength is not None:
+            lstr = "list of at most %s integers" % maxlength
+            example = str(range(2,maxlength+2)).replace(" ","") + " or " + str([2]*max(1, maxlength-2)).replace(" ","")
+        else:
+            lstr = "list of integers"
+            example = "[1,2,3] or [5,6]"
+        raise ValueError("It needs to be a %s in square brackets, such as %s." % (lstr, example))
+    else:
+        if inp == '[]': # fixes bug in the code below (split never returns an empty list)
+            query[qfield] = []
+            return
+        if check_divisibility == 'decreasing':
+            # Check that each entry divides the previous
+            L = [int(a) for a in inp[1:-1].split(',')]
+            for i in range(len(L)-1):
+                if L[i] % L[i+1] != 0:
+                    raise ValueError("Each entry must divide the previous, such as [4,2].")
+        elif check_divisibility == 'increasing':
+            # Check that each entry divides the previous
+            L = [int(a) for a in inp[1:-1].split(',')]
+            for i in range(len(L)-1):
+                if L[i+1] % L[i] != 0:
+                    raise ValueError("Each entry must divide the next, such as [2,4].")
+        if split:
+#            query[qfield] = [process(int(a)) for a in inp[1:-1].split(',')]
+            query[qfield] = [process(int(a)) for a in inp.split(',')]
+        else:
+#            query[qfield] = inp[1:-1]
+            query[qfield] = inp
+
+
+
+
     
 @higher_genus_w_automorphisms_page.route("/")
 def index():
@@ -95,7 +142,7 @@ def index():
                 ('Source of the data', url_for(".how_computed_page")),
                 ('Labeling convention', url_for(".labels_page"))]
     
-    return render_template("hgcwa-index.html", title="Higher Genus Curves with Automorphisms", bread=bread, info=info, learnmore=learnmore)
+    return render_template("hgcwa-index.html", title="Families of Higher Genus Curves with Automorphisms", bread=bread, info=info, learnmore=learnmore)
 
 
 
@@ -110,7 +157,7 @@ def by_label(label):
     else:
         info = {}
         bread = get_bread([("Search error", url_for('.search'))])
-        info['err'] = "Higher Genus Curve with Automorphism " + label + " was not found in the database."
+        info['err'] = "No family with label " + label + " was found in the database."
         info['label'] = label
         return search_input_error(info, bread)
     
@@ -138,25 +185,41 @@ def higher_genus_w_automorphisms_search(**args):
     C = base.getDBConnection()
     query = {}
     if 'jump_to' in info:
-        return render_family({'label': info['jump_to']})
+        labs = info['jump_to']
+        if label_is_one_passport(labs):
+            return render_passport({'passport_label': labs})
+        elif label_is_one_family(labs):
+            return render_family({'label': labs})
+        else:
+            info['number'] = 0
+            info['label']=labs
+            info['err'] = "The label " + labs + " is not a legitimate label for this data."
+            return search_input_error(info, bread)
 
+#allows for ; in signature
+    if 'signature' in info:   
+        info.update({'signature': signature_to_list(info['signature'])})
+        
     try:
-        parse_list(info,query,'group', name='Group')
+        parse_bracketed_posints2(info,query,'group', split=False, exactlength=2, name='Group')
         parse_ints(info,query,'genus',name='Genus')
-        parse_list(info,query,'signature',name='Signature')
+        parse_bracketed_posints2(info,query,signature_to_list('signature'),split=False,name='Signature')
         parse_ints(info,query,'dim',name='Dimension of the family')
         if 'inc_hyper' in info:
             if info['inc_hyper'] == 'exclude':
                 query['hyperelliptic'] = False
             elif info['inc_hyper'] == 'only':
                 query['hyperelliptic'] = True
+            
+
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)
     start = parse_start(info)
     
     res = C.curve_automorphisms.passports.find(query).sort([(
-         'g', pymongo.ASCENDING), ('dim', pymongo.ASCENDING)])
+         'g', pymongo.ASCENDING), ('dim', pymongo.ASCENDING),
+        ('cc'[0],pymongo.ASCENDING)])
     nres = res.count()
     res = res.skip(start).limit(count)
 
@@ -165,9 +228,16 @@ def higher_genus_w_automorphisms_search(**args):
     if(start < 0):
         start = 0
 
-    info['fields'] = res
+        
+    L = [ ]    
+    for field in res:
+        field['signature'] = ast.literal_eval(field['signature'])    
+        L.append(field)
+        
+    info['fields'] = L    
     info['number'] = nres
-    info['group_display'] = group_display_shortC(C)
+    info['group_display'] = sg_pretty
+
     info['sign_display'] = sign_display
     info['start'] = start
     if nres == 1:
@@ -179,7 +249,7 @@ def higher_genus_w_automorphisms_search(**args):
         else:
             info['report'] = 'displaying all %s matches' % nres
 
-    return render_template("hgcwa-search.html", info=info, title="Higher Genus Curves with Automorphisms Search Result", bread=bread)
+    return render_template("hgcwa-search.html", info=info, title="Families of Higher Genus Curves with Automorphisms Search Result", bread=bread)
 
 
 
@@ -193,32 +263,33 @@ def render_family(args):
         dataz = C.curve_automorphisms.passports.find({'label': label})
         if dataz.count() is 0:
             bread = get_bread([("Search error", url_for('.search'))])
-            info['err'] = "Higher Genus Curve with Automorphism " + label + " was not found in the database."
+            info['err'] = "No family with label " + label + " was found in the database."
             info['label'] = label
             return search_input_error(info, bread)
         data=dataz[0]
         g = data['genus']
-        GG = data['group']
+        GG = ast.literal_eval(data['group'])
         gn = GG[0]
         gt = GG[1]
-    
 
-        group = groupid_to_meaningful(data['group'])
-        if group == str(GG) or group == "[" + str(gn)+","+str(gt)+"]":
+        gp_string=str(gn) + '.' + str(gt)
+        pretty_group=sg_pretty(gp_string)
+
+        if gp_string == pretty_group:
             spname=False
         else:
             spname=True
-        title = 'Family of genus ' + str(g) + ' curves with automorphism group $' + group +'$'
-        smallgroup="(" + str(gn) + "," +str(gt) +")"   
+        title = 'Family of genus ' + str(g) + ' curves with automorphism group $' + pretty_group +'$'
+        smallgroup="[" + str(gn) + "," +str(gt) +"]"   
 
         prop2 = [
             ('Genus', '\(%d\)' % g),
-            ('Small Group', '\(%s\)' %  smallgroup),
-            ('Signature', '\(%s\)' % sign_display(data['signature']))
+            ('Group', '\(%s\)' %  pretty_group),
+            ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature'])))
         ]
         info.update({'genus': data['genus'],
-                    'sign': sign_display(data['signature']),   
-                    'group': groupid_to_meaningful(data['group']),
+                    'sign': sign_display(ast.literal_eval(data['signature'])),   
+                     'group': pretty_group,
                     'g0':data['g0'],
                     'dim':data['dim'],
                     'r':data['r'],
@@ -232,10 +303,10 @@ def render_family(args):
         Lall=[]
         i=1
         for dat in dataz:
-            if dat['con'] not in Lcc:
+            if ast.literal_eval(dat['con']) not in Lcc:
                 urlstrng=dat['passport_label']
-                Lcc.append(dat['con'])
-                Lall.append([cc_display(dat['con']),dat['passport_label'],
+                Lcc.append(ast.literal_eval(dat['con']))
+                Lall.append([cc_display(ast.literal_eval(dat['con'])),dat['passport_label'],
                              urlstrng])
                 i=i+1
             
@@ -269,35 +340,41 @@ def render_passport(args):
         dataz = C.curve_automorphisms.passports.find({'passport_label': label})
         if dataz.count() is 0:
             bread = get_bread([("Search error", url_for('.search'))])
-            info['err'] = "Higher Genus Curve with Automorphism " + label + " was not found in the database."
+            info['err'] = "No passport with label " + label + " was found in the database."
             info['label'] = label
             return search_input_error(info, bread)
         data=dataz[0]
         g = data['genus']
-        GG = data['group']
+        GG = ast.literal_eval(data['group'])
         gn = GG[0]
         gt = GG[1]
-        numb = dataz.count()
 
+        gp_string=str(gn) + '.' + str(gt)
+        pretty_group=sg_pretty(gp_string)
 
-        group = groupid_to_meaningful(data['group'])
-        if group == str(GG) or group == "[" + str(gn)+","+str(gt)+"]":
+        if gp_string == pretty_group:
             spname=False
         else:
             spname=True
-        title = 'One passport of genus ' + str(g) + ' curves with automorphism group $' + group +'$'
-        smallgroup="(" + str(gn) + "," +str(gt) +")"   
+        title = 'Family of genus ' + str(g) + ' curves with automorphism group $' + pretty_group +'$'
+        smallgroup="[" + str(gn) + "," +str(gt) +"]"   
+
+        numb = dataz.count()
+
+
+        title = 'One passport of genus ' + str(g) + ' curves with automorphism group $' + pretty_group +'$'
+        smallgroup="[" + str(gn) + "," +str(gt) +"]"   
 
         prop2 = [
             ('Genus', '\(%d\)' % g),
-            ('Small Group', '\(%s\)' %  smallgroup),
-            ('Signature', '\(%s\)' % sign_display(data['signature'])),
+            ('Small Group', '\(%s\)' %  pretty_group),
+            ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature']))),
             ('Generating Vectors','\(%d\)' % numb)
         ]
         info.update({'genus': data['genus'],
                     'cc': cc_display(data['con']), 
-                    'sign': sign_display(data['signature']),   
-                    'group': groupid_to_meaningful(data['group']),
+                    'sign': sign_display(ast.literal_eval(data['signature'])),   
+                     'group': pretty_group,
                      'gpid': smallgroup
                    })
 
@@ -322,11 +399,11 @@ def render_passport(args):
             else:
                 x3=' '
 
-            x4=[]    
+            x4=[]
             for perm in dat['gen_vectors']:
                 cycperm=Permutation(perm).cycle_string()
-
-                x4.append(cycperm)
+                
+                x4.append(sep.join(split_perm(cycperm)))
                     
             Ldata.append([x1,x2,x3,x4])
 
@@ -334,30 +411,39 @@ def render_passport(args):
                 
         info.update({'genvects': Ldata, 'HypColumn' : HypColumn})
 
+        info.update({'passport_cc': cc_display(ast.literal_eval(dat['con']))})
+        
 
         if 'hyperelliptic' in data:
             info.update({'ishyp':  tfTOyn(data['hyperelliptic'])})
             
         if 'hyp_involution' in data:
-            info.update({'hypinv': data['hyp_involution']})
+            inv=Permutation(data['hyp_involution']).cycle_string()
+            info.update({'hypinv': sep.join(split_perm(inv))})
             
 
         if 'full_auto' in data:
-            info.update({'fullauto': groupid_to_meaningful(data['full_auto']),
-                         'signH':sign_display(data['signH']),
+            full_G=ast.literal_eval(data['full_auto'])
+            full_gn = full_G[0]
+            full_gt = full_G[1]
+
+            full_gp_string=str(full_gn) + '.' + str(full_gt)
+            full_pretty_group=sg_pretty(full_gp_string)
+            info.update({'fullauto': full_pretty_group,
+                         'signH':sign_display(ast.literal_eval(data['signH'])),
                          'higgenlabel' : data['full_label'] })
 
-
+        urlstrng =data['label'] 
+            
         if Lfriends:
            for Lf in Lfriends:
-              friends = [("Full Automorphism " + Lf, Lf) ]
+              friends = [("Full automorphism " + Lf, Lf),("Family containing this passport ",  urlstrng) ]
   
         else:    
-            friends = [ ]
+            friends = [("Family containing this passport",  urlstrng) ]    
+         
         
-
-        
-        bread = get_bread([(data['label'], ' '),(data['cc'][0], ' ')])
+        bread = get_bread([(data['label'], urlstrng),(data['cc'][0], ' ')])
         learnmore =[('Completeness of the data', url_for(".completeness_page")),
                 ('Source of the data', url_for(".how_computed_page")),
                 ('Labeling convention', url_for(".labels_page"))]
@@ -371,10 +457,8 @@ def render_passport(args):
 
 
     
-
-
 def search_input_error(info, bread):
-    return render_template("hgcwa-search.html", info=info, title='Higher Genus Curve Search Input Error', bread=bread)
+    return render_template("hgcwa-search.html", info=info, title='Families of Higher Genus Curve Search Input Error', bread=bread)
 
 
  

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -11,11 +11,12 @@ from lmfdb import base
 from lmfdb.base import app, getDBConnection
 from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
 from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, coeff_to_poly, pol_to_html, make_logger
-from lmfdb.search_parsing import *
+from lmfdb.search_parsing import search_parser, parse_ints, parse_count, parse_start, clean_input
+BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
 
 from sage.all import Permutation
 from lmfdb.higher_genus_w_automorphisms import higher_genus_w_automorphisms_page, logger
-from lmfdb.sato_tate_groups.main import *
+from lmfdb.sato_tate_groups.main import sg_pretty
 
 
 # Determining what kind of label

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -19,7 +19,7 @@ text-align:right;
       <h2>Browse {{KNOWL('g2c.aut_grp', title="automorphisms")}} of higher genus curves</h2>
 
 <p>
-By genus:
+By  {{KNOWL('ag.curve.genus',title='genus')}}:
 {% for gen in info.genus_list %}
 <a href="?genus={{gen}}">{{gen}}</a>
 {% endfor %}</p>
@@ -32,7 +32,7 @@ By genus:
 
 
 
-    <h2>Find specific automorphisms of higher genus curve</h2>
+    <h2>Find specific automorphisms of higher genus curves</h2>
 
     <form name="search" method = "get" action="{{search}}">
         <table class="">
@@ -46,7 +46,7 @@ By genus:
           <button type="submit" value="Find">Find</button>
 	      </td>
 	      <td>
-		<span class="formexample">family with automorphisms label, e.g. 2.12-4.0.2-2-2-3 </span>
+		<span class="formexample">family or passport label, e.g. 2.12-4.0.2-2-2-3 or 3.168-42.0.2-3-7.2 </span>
 	      </td>
 	    </tr>
 	  </table>
@@ -59,7 +59,7 @@ By genus:
         <table class="">
           <tr align=left>
             <td align=right>
-            Genus:
+             {{KNOWL('ag.curve.genus',title='Genus')}}:
             </td><td><input type="integer" name="genus" value=""
       placeholder="3"></td>
       <td>
@@ -78,9 +78,9 @@ By genus:
 	  <tr>
             <td align=right>
               {{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
-            </td><td><input type="list" name="signature" value="" placeholder="[0,2,3,3,6]"></td>
+            </td><td><input type="text" name="signature" value="" placeholder="[0,2,3,3,6]"></td>
       <td>
-	<span class="formexample">e.g. [0,2,3,3,6].</span>
+	<span class="formexample">e.g. [0,2,3,3,6] or [0;2,3,8]</span>
 	  </td> </tr>
 	 <tr><td align=right>
               {{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -26,7 +26,7 @@ By genus:
 
 <p>Hyperelliptic curves by genus:
 {% for gen in info.genus_list %}
-<a href="?genus={{gen}}&hyperelliptic=True">{{gen}}</a>
+<a href="?genus={{gen}}&inc_hyper=only">{{gen}}</a>
 {% endfor %} 
 </p>
 
@@ -90,7 +90,7 @@ By genus:
 	 </td> </tr>
               <tr>  <td align=right>
 	       Hyperelliptic Curve(s):
-            </td>  <td> <select name='hyperelliptic'>
+            </td>  <td> <select name='inc_hyper'>
                     <option value='include'>include </option>
 		    <option value='exclude'>exclude</option>
                     <option value='only'>only</option>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -9,7 +9,7 @@
 
 <tr>
 <td align=left> 
-Genus:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
+{{KNOWL('ag.curve.genus',title='Genus')}}:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
 </td>
 <td align=left> 
 Group: <td align=left> <input type="text" name="group" size="8" value="{{info.group}}" > 
@@ -75,7 +75,7 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 <td><button type='submit' value='Find'>Find</button></td>
 </tr>
 <tr>
-<td colspan="3" rowspan="2"><span class="formexample"> a higher genus curve with automorphisms label, e.g. 3.4-2.0.2-2-2-2-2-2</span></td>
+<td colspan="3" rowspan="2"><span class="formexample"> a higher genus curve with family label or passport label, e.g. 3.4-2.0.2-2-2-2-2-2 or 4.120-34.0.2-4-5.1"</span></td>
 </tr>
 </table>
 </form>
@@ -99,12 +99,11 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 <thead>
 <tr>
 
-  <th>Passport Label</th>
-  <th>Genus</th>
+  <th>{{KNOWL('dq.curve.highergenus.aut.label',title='Passport Label')}}</th>
+  <th>{{KNOWL('ag.curve.genus',title='Genus')}}</th>
   <th>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension')}}</th>
   <th>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma group')}}</th>
-  <th>Signature</th>
-<!--<th>{{KNOWL('lf.slope_content',title='label')}}</th>-->
+  <th>{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}</th>
 </tr>
 </thead>
 <tbody>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -99,7 +99,7 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 <thead>
 <tr>
 
-  <th>Label</th>
+  <th>Passport Label</th>
   <th>Genus</th>
   <th>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension')}}</th>
   <th>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma group')}}</th>
@@ -112,7 +112,7 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 {% for field in info.fields: %}
 <tr>
 
-  <td align='left'><a href="/HigherGenus/C/aut/{{field.label}}">{{field.label}}</a></td>
+  <td align='left'><a href="/HigherGenus/C/aut/{{field.passport_label}}">{{field.passport_label}}</a></td>
     <td>{{field.genus}}</td>
   <td>{{field.dim}}</td>
   <td>{{field.group}}</td>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
@@ -16,14 +16,14 @@ table,td {
 <p><h2> Family Information</h2>
 
   <table>
-      <tr><td> Genus:  </td><td> {{ info.genus }} </td></tr>
+      <tr><td> {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>
       <tr><td>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family:')}}</td><td> {{info.dim}} </td></tr>
     </table>
 </p>
 
 
 <h2>Cover</h2><table>
-      <tr><td> {{KNOWL('curve.highergenus.aut.quotient genus',title='Quotient genus')}}: </td> <td>{{info.g0}}</td></tr>
+      <tr><td> {{KNOWL('curve.highergenus.aut.quotientgenus',title='Quotient genus')}}: </td> <td>{{info.g0}}</td></tr>
       <tr><td> Number of {{ KNOWL('curve.highergenus.aut.branchpoints', title='branch points') }}: </td> <td>{{info.r}}</td></tr>
       <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
       </table> 
@@ -34,17 +34,17 @@ table,td {
    {% if info.specialname %}
    <tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr>
    {% endif %}
-     <tr><td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td><td>SmallGroup{{info.gpid}}</td></tr>
+     <tr><td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td><td>{{info.gpid}}</td></tr>
     </table>
 
 </p>
 
 
-<p> <h2> Conjugacy class(es) of passports </h2>
+<p> <h2> Conjugacy class(es) of {{KNOWL('curve.highergenus.aut.passport',title='Passports')}} </h2>
 
 <table>
   <tr>
-     <th>{{KNOWL('curve.highergenus.aut.passportlabel',title='Passport Label')}} </th>
+     <th>{{KNOWL('dq.curve.highergenus.aut.label',title='Passport Label')}} </th>
   <th>Lists of Conjugacy Classes</th>
  
 </tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
@@ -1,0 +1,65 @@
+{% extends "homepage.html" %}
+
+<!-- in templates -->
+
+{% block content %}
+
+<style>
+table,td {
+  border-right:solid 30px transparent;
+} 
+</style>
+
+
+
+
+<p><h2> Family Information</h2>
+
+  <table>
+      <tr><td> Genus:  </td><td> {{ info.genus }} </td></tr>
+      <tr><td>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family:')}}</td><td> {{info.dim}} </td></tr>
+    </table>
+</p>
+
+
+<h2>Cover</h2><table>
+      <tr><td> {{KNOWL('curve.highergenus.aut.quotient genus',title='Quotient genus')}}: </td> <td>{{info.g0}}</td></tr>
+      <tr><td> Number of {{ KNOWL('curve.highergenus.aut.branchpoints', title='branch points') }}: </td> <td>{{info.r}}</td></tr>
+      <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
+      </table> 
+
+
+<p> <h2>Group </h2>
+  <table>
+   {% if info.specialname %}
+   <tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr>
+   {% endif %}
+     <tr><td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td><td>SmallGroup{{info.gpid}}</td></tr>
+    </table>
+
+</p>
+
+
+<p> <h2> Conjugacy class(es) of passports </h2>
+
+<table>
+  <tr>
+     <th>{{KNOWL('curve.highergenus.aut.passportlabel',title='Passport Label')}} </th>
+  <th>Lists of Conjugacy Classes</th>
+ 
+</tr>
+{% for itm in info.passport %}
+<tr>
+  <td class="center"><a href="{{itm[2]}}">{{itm[1]}}</td>
+  <td class="center">{{itm[0]}}</td>
+
+</tr>
+{% endfor %}
+</table>
+  
+
+</p>
+
+
+  
+{% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -1,0 +1,65 @@
+{% extends "homepage.html" %}
+
+<!-- in templates -->
+
+{% block content %}
+
+<style>
+table,td {
+  border-right:solid 30px transparent;
+} 
+</style>
+
+
+
+
+<p><h2> Family Information</h2>
+
+  <table>
+      <tr><td> Genus:  </td><td> {{ info.genus }} </td></tr>    
+   {% if info.specialname %}
+   <tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr>
+   {% endif %}
+<tr>
+  <td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td>
+  <td>SmallGroup{{info.gpid}}</td></tr>
+  <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
+
+  </table></p>
+
+
+<p>  {% if info.fullauto  %}
+The full automorphism group for this family is ${{info.fullauto}}$ with signature ${{info.signH}}$.
+    {% endif %} 
+</p>
+
+{% if info.ishyp %}     
+
+  <p><h2>Other Data</h2>
+    <table>
+     <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
+   {% if info.hypinv  %}
+       <tr><td>Hyperelliptic involution:</td> <td>{{info.hypinv}}</td></tr>
+   {% endif %}  
+    </table>
+  </p>
+  
+
+ {% endif %}
+
+
+<p><h2>{{KNOWL('curve.highergenus.aut.groupnotation',title='Generating Vector(s)')}}</h2>
+
+ 
+    {% for cdata in info.genvects %}
+   {{cdata[0]}}
+     <table>{% for perm in cdata[3] %}
+	  <tr><td> &nbsp; </td><td>{{perm}}</td></tr>
+	  {% endfor %} </table> <br>
+    {% endfor %}
+</table>    
+
+</p>
+
+  
+{% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -16,15 +16,15 @@ table,td {
 <p><h2> Family Information</h2>
 
   <table>
-      <tr><td> Genus:  </td><td> {{ info.genus }} </td></tr>    
+      <tr><td>  {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>    
    {% if info.specialname %}
    <tr><td>Isomorphism class:</td> <td>${{info.group}}$</td></tr>
    {% endif %}
 <tr>
   <td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td>
-  <td>SmallGroup{{info.gpid}}</td></tr>
+  <td>{{info.gpid}}</td></tr>
   <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
-
+  <tr><td> Conjugacy classes for this  {{KNOWL('curve.curve.highergenus.aut.passport',title='passport')}}: </td><td>{{info.passport_cc}}</td></tr>
   </table></p>
 
 
@@ -48,7 +48,7 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
  {% endif %}
 
 
-<p><h2>{{KNOWL('curve.highergenus.aut.groupnotation',title='Generating Vector(s)')}}</h2>
+<p><h2>{{KNOWL('curve.highergenus.aut.generatingvector',title='Generating Vector(s)')}}</h2>
 
  
     {% for cdata in info.genvects %}

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -20,5 +20,5 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
 
 
     def test_search_genus_group(self):
-        L = self.tc.get('/HigherGenus/C/aut/?genus=2&group=%5B6%2C2%5D&signature=&count=20&Submit=Search')
+        L = self.tc.get('/HigherGenus/C/aut/?genus=2&group=%5B48%2C29%5D&signature=&dim=&hyperelliptic=include&count=20&Submit=Search')
         assert '2 matches' in L.data

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -15,7 +15,7 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
 
     def test_url_naturallabel(self):
 	L = self.tc.get('/HigherGenus/C/aut/junk')
-	assert 'No family with label junk was found in the database in L.data'
+	assert 'No family with label junk was found in the database' in L.data
     
 
 

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -15,7 +15,8 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
 
     def test_url_naturallabel(self):
 	L = self.tc.get('/HigherGenus/C/aut/junk')
-	assert 'was not found in the database' in L.data # error mesage
+	assert 'No family with label junk was found in the database in L.data'
+    
 
 
 


### PR DESCRIPTION
These are modified versions of the group actions pages based on conversations with @jvoight to try to align these pages more with future pages relating to Belyi maps.  The data is basically the same, but centered around conjugacy classes of elements in a group (so called passports), instead of the individual elements of the group.

The first commit is two new files.
(1) /higher_genus_w_automorphisms/templates/hgcwa-show-family.html
will give pages like: /HigherGenus/C/aut/3.8-3.0.2-2-4-4
where given a group and signature, all possible conjugacy classes of the group which satisfy the signature restrictions are listed.

(2) /higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
will give pages like: /HigherGenus/C/aut/3.8-3.0.2-2-4-4.1
where given a specific set of conjugacy classes from the pages in (1) will  give all generating vectors (up to conjugation by elements in G) and list properties like whether the family is hyperelliptic. 

The second commit is modifications to old files to support the changes above.

The download functionality is not coded yet.

Any and all feedback welcome.