### PR TITLE
removed sage_eval from lmfdb/lfunctions/LfunctionPlot.py

### DIFF
--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -1,7 +1,6 @@
 # Code for creating plots for browsing L-functions
 
 import math
-import cmath
 import datetime
 from flask import url_for, make_response
 import lmfdb.base as base
@@ -228,8 +227,6 @@ def getWidthAndHeight(gls):
 
 
 def paintSvgFileAllNEW(glslist):  # list of group, level, and (maybe) sign
-    from sage.misc.sage_eval import sage_eval
-    
     xfactor = 20
     yfactor = 20
     extraSpace = 20
@@ -283,7 +280,7 @@ def paintSvgFileAllNEW(glslist):  # list of group, level, and (maybe) sign
             ans += "<circle cx='" + str(float(x) * xfactor)[0:7]
             ans += "' cy='" + str(height - float(y) * yfactor)[0:7]
             ans += "' r='" + str(radius)
-            ans += "' style='fill:" + signtocolour(sage_eval(sign)) + "'>"
+            ans += "' style='fill:" + signtocolour(sign) + "'>"
             ans += "<title>" + str((x, y)).replace("u", "").replace("'", "") + "</title>"
             ans += "</circle></a>\n"
 
@@ -291,7 +288,6 @@ def paintSvgFileAllNEW(glslist):  # list of group, level, and (maybe) sign
     return(ans)
 
 def paintSvgFileAll(glslist):  # list of group, level, and (maybe) sign
-    from sage.misc.sage_eval import sage_eval
     index1 = 2
     index2 = 3
 
@@ -341,7 +337,7 @@ def paintSvgFileAll(glslist):  # list of group, level, and (maybe) sign
         ans += "<circle cx='" + str(float(x) * xfactor)[0:7]
         ans += "' cy='" + str(height - float(y) * yfactor)[0:7]
         ans += "' r='" + str(radius)
-        ans += "' style='fill:" + signtocolour(sage_eval(sign)) + "'>"
+        ans += "' style='fill:" + signtocolour(sign) + "'>"
         ans += "<title>" + str((x, y)).replace("u", "").replace("'", "") + "</title>"
         ans += "</circle></a>\n"
 
@@ -815,7 +811,8 @@ def paintCSHoloTMP(width, height, xMax, yMax, xfactor, yfactor, ticlength):
 
 
 def signtocolour(sign):
-    argument = cmath.phase(sign)
+    import cmath
+    argument = cmath.phase(float(sign))
     r = int(255.0 * (math.cos((1.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
     g = int(255.0 * (math.cos((2.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
     b = int(255.0 * (math.cos(argument / 2.0)) ** 2)


### PR DESCRIPTION
This deals with 1 out of 3 things mentioned in Issue #1539.   Of the others, one is in Siegel MFs and the other is only one instance but that is in a general "python string to Sage" function called p2sage which is used in many places.  Personally I think it would be better to replace that function, which tries to do everything, with a small number of string parsing functions (most of which would be trivial) each being documented as to what input is expected and what output is required.  But this is a small start.