### PR TITLE
removed references to now-redundant curves2 collection

### DIFF
--- a/lmfdb/elliptic_curves/import_ec_data.py
+++ b/lmfdb/elliptic_curves/import_ec_data.py
@@ -89,10 +89,8 @@ pw_dict = yaml.load(open(os.path.join(os.getcwd(), os.extsep, os.extsep, os.exts
 username = pw_dict['data']['username']
 password = pw_dict['data']['password']
 C['elliptic_curves'].authenticate(username, password)
-print "setting curves and curves2"
+print "setting curves"
 curves = C.elliptic_curves.curves
-curves2 = C.elliptic_curves.curves2
-
 
 def parse_tgens(s):
     r"""
@@ -601,8 +599,10 @@ def make_extra_data(label,number,ainvs,gens):
     return data
 
 def add_extra_data(N1,N2,store=False):
-    """
-    Add these fields to curves in the db with conductors from N1 to N2:
+    """Add these fields to curves in the db with conductors from N1 to
+    N2: NB This referes to a new collection 'curves2' which was
+    created temporarily when upgrading the data stored, and no longer
+    exists.
 
    - 'xainvs': (string) '[a1,a2,a3,a4,a6]' (will replace 'ainvs' in due course)
    - 'equation': (string)

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -61,12 +61,7 @@ def db_ec():
     global ecdb
     if ecdb is None:
         ec = lmfdb.base.getDBConnection().elliptic_curves
-        if 'curves2' in ec.collection_names():
-            #print("Using new collection curves2")
-            ecdb = ec.curves2
-        else:
-            #print("Using old collection curves")
-            ecbd = ec.curves
+        ecdb = ec.curves
     return ecdb
 
 def padic_db():


### PR DESCRIPTION
This code change is **necessary** for the website to work with no curves2 collection, only the curve collection.  It will make beta work again, and is **necessary** that it is pushed to prod before the production database is updated.

Apologies for this not being as smooth as it should have been, owing to a typo introduced a few months ago which means that (without this change) it does not work to have curves2 existing but not curves.