### PR TITLE
Remove siegel experimental

### DIFF
--- a/lmfdb/siegel_modular_forms/sample.py
+++ b/lmfdb/siegel_modular_forms/sample.py
@@ -21,24 +21,27 @@ class DataBase():
     def __init__( self, DB_URL = None):
         if DB_URL:
             self.__client = pymongo.MongoClient( DB_URL)
+            self.__db_prefix=""
         else:
             import lmfdb.base
             self.__client = lmfdb.base.getDBConnection()
-        self.__db = self.__client.siegel_modular_forms_experimental
-        # self.__db = self.__client.siegel_modular_forms
+        # just use one database, prefix collection name to distinguish experimental data
+        # so siegel_modular_forms_experimental.samples is now siegel_modular_forms.experimental_samples
+        # self.__db = self.__client.siegel_modular_forms_experimental
+        self.__db = self.__client.siegel_modular_forms
+        self.__db_prefix = "experimental"
         
     def find_one( self, *dct, **kwargs):
         collection = kwargs.get( 'collection', 'samples')
-        col = self.__db[collection]
+        col = self.__db[self.__db_prefix+collection]
         return col.find_one( *dct)
 
     def find( self, *dct, **kwargs):
         collection = kwargs.get( 'collection', 'samples')
-        col = self.__db[collection]
+        col = self.__db[self.__db_prefix+collection]
         return col.find( *dct)
 
     def __del__( self):
-#        self.__client.close()
         pass
 
 

--- a/lmfdb/siegel_modular_forms/sample.py
+++ b/lmfdb/siegel_modular_forms/sample.py
@@ -29,7 +29,7 @@ class DataBase():
         # so siegel_modular_forms_experimental.samples is now siegel_modular_forms.experimental_samples
         # self.__db = self.__client.siegel_modular_forms_experimental
         self.__db = self.__client.siegel_modular_forms
-        self.__db_prefix = "experimental"
+        self.__db_prefix = "experimental_"
         
     def find_one( self, *dct, **kwargs):
         collection = kwargs.get( 'collection', 'samples')


### PR DESCRIPTION
This PR enables the consolidation of the two mongo databases **siegel_modular_forms** and **siegel_modular_forms_experimental**.  The only collection **samples** in the database siegel_modular_forms_experimental has been moved to the collection **experimental_samples** in siegel_modular_forms.  The code has been changed so that all attempts to access a collection in siegel_modular_forms_experimental instead access a corresponding collection in siegel_modular_forms with the name prefixed by "experimental_".

For example, **siegel_modular_forms_experimental.samples** becomes **siegel_modular_forms.experimental_samples**.

Once this PR has been pushed to beta and prod the database siegel_modular_forms_experimental can be dropped from both the cloud and warwick mongo dbs.