### PR TITLE
Fix for #1555

### DIFF
--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -48,13 +48,13 @@ def rescan_collection():
     global COLNS
     COLNS = colns
 
-@app.route('/ModularForm/GSp/Q/Sp4Z_j/<j>/<k>')
-@app.route('/ModularForm/GSp/Q/Sp4Z_j/<j>/<k>/')
+@app.route('/ModularForm/GSp/Q/Sp4Z_j/<k>/<j>')
+@app.route('/ModularForm/GSp/Q/Sp4Z_j/<k>/<j>/')
 def ModularForm_GSp4_Q_Sp4Z_j_space(j=4, k=4):
     bread = [("Modular Forms", url_for('mf.modular_form_main_page')),
              ('Siegel modular forms', url_for('ModularForm_GSp4_Q_top_level')),
              ('$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z})$', '/ModularForm/GSp/Q/Sp4Z_j'),
-             ('$M_{%s, %s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k,j), '/ModularForm/GSp/Q/Sp4Z_j/%s/%s'%(k,j))]
+             ('$M_{%s,%s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k,j), '/ModularForm/GSp/Q/Sp4Z_j/%s/%s'%(k,j))]
     # How to handle space decomposition: dict with keys and entries.
     #Then special case code here.
     j=int(j)
@@ -242,7 +242,7 @@ def prepare_collection_page( col, args, bread):
                           })
         except Exception as e:
             info.update( {'error': str(e)})            
-    bread.append( ('$'+col.latex_name()+'$', col.name()))
+    bread.append( ('$'+col.latex_name()+'$', ''))#col.name()))
     return render_template("ModularForm_GSp4_Q_collection.html",
                            title='Siegel modular forms $'+col.latex_name()+'$',
                            bread=bread, **info)
@@ -350,7 +350,8 @@ def prepare_sample_page( sam, args, bread):
                          ('Hecke Eigenform', "%s"%sam.is_eigenform()),
                          ('Degree of Field', "%s"%sam.field().degree())]
     
-    bread.append( (sam.collection()[0] + '.' + sam.name(), '/' + sam.collection()[0] + '.' + sam.name()))
+    bread.append( (sam.collection()[0] + '.' + sam.name(), ''))
+    #'/' + sam.collection()[0] + '.' + sam.name()))
     return render_template( "ModularForm_GSp4_Q_sample.html",
                             title='Siegel modular forms sample ' + sam.collection()[0] + '.'+ sam.name(),
                             bread=bread, **info)

--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_Sp4Zj.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_Sp4Zj.html
@@ -36,7 +36,7 @@
       {{ wt }}
     </th>
     {% for j in jrange %}
-    <td class="center">{% if dimtable[wt][j]>0 %} <a href="/ModularForm/GSp/Q/Sp4Z_j/{{j}}/{{wt}}/">{{dimtable[wt][j] }}</a> {% else %}
+    <td class="center">{% if dimtable[wt][j]>0 %} <a href="/ModularForm/GSp/Q/Sp4Z_j/{{wt}}/{{j}}/">{{dimtable[wt][j] }}</a> {% else %}
       0
 
       {% endif%}

--- a/lmfdb/siegel_modular_forms/test_siegel_modular_form_Browse.py
+++ b/lmfdb/siegel_modular_forms/test_siegel_modular_form_Browse.py
@@ -6,27 +6,27 @@ import unittest2
 
 class HomePageTest(LmfdbTest):
 
-    def check(self,homepage,path,text):
-        assert path in homepage
-        assert text in self.tc.get(path).data
+    def check(self,path,text):
+        data = self.tc.get(path).data
+        assert text in data
 
     # All tests should pass: these are all the links in the browse page 
     def test_Siegel_links_browse_page(self):
         r"""
         Check that the links work.
         """
-        homepage = self.tc.get("/ModularForm/GSp/Q/").data
-        self.check(homepage, "/ModularForm/GSp/Q/Sp4Z_j/",  'Upsilon')
-        self.check(homepage, "/ModularForm/GSp/Q/Kp/",  'in level 277, the')
-        self.check(homepage, "/ModularForm/GSp/Q/Sp6Z/",  'Miyawaki (1)')
-        self.check(homepage, "/ModularForm/GSp/Q/Sp8Z/",  'Other_II (2)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_2/",  'Gamma_0(2)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma1_2/",  'Gamma_1(2)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma_2/",  'Gamma(2)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_3/",  'Gamma_0(3)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_3_psi_3/",  'T.Ibukiyama:')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_4/",  'Gamma_0(4)')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_4_psi_4/",  'psi_4')
-        self.check(homepage, "/ModularForm/GSp/Q/Gamma0_4_half/",  'k-1/2')
+        self.check("/ModularForm/GSp/Q/Sp4Z_j/10/0/", 'M_{10,0}')
+        self.check("/ModularForm/GSp/Q/Sp4Z_j/",  'Upsilon')
+        self.check("/ModularForm/GSp/Q/Kp/",  'in level 277, the')
+        self.check("/ModularForm/GSp/Q/Sp6Z/",  'Miyawaki (1)')
+        self.check("/ModularForm/GSp/Q/Sp8Z/",  'Other_II (2)')
+        self.check("/ModularForm/GSp/Q/Gamma0_2/",  'Gamma_0(2)')
+        self.check("/ModularForm/GSp/Q/Gamma1_2/",  'Gamma_1(2)')
+        self.check("/ModularForm/GSp/Q/Gamma_2/",  'Gamma(2)')
+        self.check("/ModularForm/GSp/Q/Gamma0_3/",  'Gamma_0(3)')
+        self.check("/ModularForm/GSp/Q/Gamma0_3_psi_3/",  'T.Ibukiyama:')
+        self.check("/ModularForm/GSp/Q/Gamma0_4/",  'Gamma_0(4)')
+        self.check("/ModularForm/GSp/Q/Gamma0_4_psi_4/",  'psi_4')
+        self.check("/ModularForm/GSp/Q/Gamma0_4_half/",  'k-1/2')
 
 


### PR DESCRIPTION
In addition to fixing #1555, this fix swaps the order of j and k in the URLs previously written as

http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z_j/j/k/

to

localhost:37777/ModularForm/GSp/Q/Sp4Z_j/k/j/

which is now consistent with the displayed M_{k,j}.  This inconsistency is likely what caused the bug in the first place.  This does mean that external URLs linking to these pages could be broken.  If this is a concern, please say so and I will change it back to its previous inconsistent state (but still fix #1555).
