### PR TITLE
fix for #1561: ecnf Twists link

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -360,7 +360,7 @@ class ECNF(object):
 
         self.friends = []
         self.friends += [('Isogeny class ' + self.short_class_label, self.urls['class'])]
-        self.friends += [('Twists', url_for('ecnf.index', field_label=self.field_label, jinv=self.jinv))]
+        self.friends += [('Twists', url_for('ecnf.index', field=self.field_label, jinv=str(j)))]
         if totally_real:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
             self.friends += [('L-function', self.urls['Lfunction'])]


### PR DESCRIPTION
Two bugs in one line, both caused by the search-parsing code (this used to work, honest!):  a parameter name is 'field' and not 'field_label', and if you pass something like jinv=L as part of a **kwargs where L is a list, then it arrives as multiple arguements jinv=L[0], jinv-L[1], ... which fails.  This was fixed by passing in the j-invariant as a string representing a polynomial in the variable, which the parser converts to a coefficient list before looking in the database.