### PR TITLE
added display of local root numbers to elliptic curves /Q

### DIFF
--- a/lmfdb/elliptic_curves/templates/curve.html
+++ b/lmfdb/elliptic_curves/templates/curve.html
@@ -331,6 +331,7 @@ text-align: center;
 <th>{{KNOWL('ec.q.tamagawa_numbers', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
+<th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
 <th>{{KNOWL('ec.conductor_valuation', title='ord(\(N\))')}}</th>
 <th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\Delta\))')}}</th>
 <th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
@@ -349,6 +350,7 @@ text-align: center;
    Non-split multiplicative
 {% endif %}
 </td>
+<td>{{pr.rootno}}</td>
 <td>{{pr.ord_cond}}</td>
 <td>{{pr.ord_disc}}</td>
 <td>{{pr.ord_den_j}}</td>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -266,12 +266,30 @@ class WebEC(object):
                 local_data_p['cp'] = ld.tamagawa_number()
                 local_data_p['kod'] = web_latex(ld.kodaira_symbol()).replace('$', '')
                 local_data_p['red'] = ld.bad_reduction_type()
+                rootno = -ld.bad_reduction_type()
+                if rootno==0:
+                    rootno = self.E.root_number(p)
+                local_data_p['rootno'] = rootno
                 local_data_p['ord_cond'] = ld.conductor_valuation()
                 local_data_p['ord_disc'] = ld.discriminant_valuation()
                 local_data_p['ord_den_j'] = max(0,-self.E.j_invariant().valuation(p))
                 local_data.append(local_data_p)
 
         jfac = Factorization([(ZZ(ld['p']),ld['ord_den_j']) for ld in local_data])
+
+        # If we got the data from the database, the root numbers may
+        # not have been stored there, so we have to compute them.  If
+        # there are additive primes this means constructing the curve.
+        for ld in self.local_data:
+            if not 'rootno' in ld:
+                rootno = -ld['red']
+                if rootno==0:
+                    try:
+                        E = self.E
+                    except AttributeError:
+                        self.E = E = EllipticCurve(data['ainvs'])
+                    rootno = E.root_number(ld['p'])
+                ld['rootno'] = rootno
 
         minq_N, minq_iso, minq_number = split_lmfdb_label(data['minq_label'])
 


### PR DESCRIPTION
See Issue #1548.  This shows local root numbers for elliptic curves over Q (and adds a knowl saying what they are).
Since these are not currently stored in the database for primes of additive reduction, they are currently computed on the fly if (and only if) needed.  I will also add the additional data to the database, but that is a separate operation, and this will work both with and without that being done.

A similar thing will be done for elliptic curves over number fields, which are having a data update anyway.