### PR TITLE
Add st links

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -6,6 +6,7 @@ from sage.all import ZZ, var, PolynomialRing, QQ, GCD, RR, rainbow, implicit_plo
 from lmfdb.base import app, getDBConnection
 from lmfdb.utils import image_src, web_latex, web_latex_ideal_fact, encode_plot
 from lmfdb.WebNumberField import WebNumberField
+from lmfdb.sato_tate_groups.main import st_link_by_name
 from kraus import (non_minimal_primes, is_global_minimal_model, has_global_minimal_model, minimal_discriminant_ideal)
 
 ecnf = None
@@ -260,11 +261,11 @@ class ECNF(object):
             # The line below will need to change once we have curves over non-quadratic fields
             # that contain the Hilbert class field of an imaginary quadratic field
             if self.signature == [0,1] and ZZ(-self.abs_disc*self.cm).is_square():
-                self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.U(1)'),'\\mathrm{U}(1)')
+                self.ST = st_link_by_name(1,2,'U(1)')
             else:
-                self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.N(U(1))'),'N(\\mathrm{U}(1))')
+                self.ST = st_link_by_name(1,2,'N(U(1))')
         else:
-            self.ST = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.SU(2)'),'\\mathrm{SU}(2)')
+            self.ST = st_link_by_name(1,2,'SU(2)')
 
         # Q-curve / Base change
         self.qc = "no"

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -10,6 +10,7 @@ from lmfdb.utils import comma, make_logger, web_latex, encode_plot
 from lmfdb.search_parsing import split_list
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label, is_newform_in_db
+from lmfdb.sato_tate_groups.main import st_link_by_name
 import sage.all
 from sage.all import EllipticCurve, latex, matrix, ZZ, QQ, prod, Factorization, PowerSeriesRing
 
@@ -308,9 +309,9 @@ class WebEC(object):
                 data['EndE'] = "\(\Z[\sqrt{%s}]\)" % d4
             else:
                 data['EndE'] = "\(\Z[(1+\sqrt{%s})/2]\)" % data['CMD']
-            data['ST'] = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.N(U(1))'),'N(\\mathrm{U}(1))')
+            data['ST'] = st_link_by_name(1,2,'N(U(1))')
         else:
-            data['ST'] = '<a href="%s">$%s$</a>' % (url_for('st.by_label', label='1.2.SU(2)'),'\\mathrm{SU}(2)')
+            data['ST'] = st_link_by_name(1,2,'SU(2)')
 
         data['p_adic_primes'] = [p for i,p in enumerate(sage.all.prime_range(5, 100))
                                  if (N*data['ap'][i]) %p !=0]

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -13,7 +13,8 @@ from lmfdb.utils import to_dict, comma, random_value_from_collection
 from lmfdb.search_parsing import parse_bool, parse_ints, parse_signed_ints, parse_bracketed_posints, parse_count, parse_start
 from lmfdb.number_fields.number_field import make_disc_key
 from lmfdb.genus2_curves import g2c_page, g2c_logger
-from lmfdb.genus2_curves.web_g2c import WebG2C, g2c_db_curves, g2c_db_isogeny_classes_count, list_to_min_eqn, st0_group_name, st_group_name, st_group_href
+from lmfdb.genus2_curves.web_g2c import WebG2C, g2c_db_curves, g2c_db_isogeny_classes_count, list_to_min_eqn, st0_group_name
+from lmfdb.sato_tate_groups.main import st_link_by_name
 
 import sage.all
 from sage.all import ZZ, QQ, latex, matrix, srange
@@ -321,8 +322,7 @@ def genus2_curve_search(**args):
         v_clean["is_gl2_type"] = v["is_gl2_type"] 
         v_clean["is_gl2_type_display"] = '&#10004;' if v["is_gl2_type"] else '' # display checkmark if true, blank otherwise
         v_clean["equation_formatted"] = list_to_min_eqn(v["min_eqn"])
-        v_clean["st_group_name"] = st_group_name(v['st_group'])
-        v_clean["st_group_href"] = st_group_href(v['st_group'])
+        v_clean["st_group_link"] = st_link_by_name(1,4,v['st_group'])
         v_clean["analytic_rank"] = v["analytic_rank"]
         res_clean.append(v_clean)
 
@@ -350,6 +350,9 @@ def aut_grp_name(id):
 
 def geom_aut_grp_name(id):
     return geom_aut_grp_dict[id]
+
+def st_group_name(name):
+    return st_group_link(1,4,name)
 
 stats_attribute_list = [
     {'name':'num_rat_wpts','top_title':'rational Weierstrass points','row_title':'Weierstrass points','knowl':'g2c.num_rat_wpts','avg':True},

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -342,29 +342,32 @@ def genus2_curve_search(**args):
 # Statistics
 ################################################################################
 
-def boolean_name(value):
-    return '\\mathrm{True}' if value else '\\mathrm{False}'
+def boolean_format(value):
+    return 'True' if value else 'False'
 
-def aut_grp_name(id):
-    return aut_grp_dict[id]
+def aut_grp_format(id):
+    return "\("+aut_grp_dict[id]+"\)"
 
-def geom_aut_grp_name(id):
-    return geom_aut_grp_dict[id]
+def geom_aut_grp_format(id):
+    return "\("+geom_aut_grp_dict[id]+"\)"
 
-def st_group_name(name):
-    return st_group_link(1,4,name)
+def st0_group_format(name):
+    return "\("+st0_group_name(name)+"\)"
+
+def st_group_format(name):
+    return st_link_by_name(1,4,name)
 
 stats_attribute_list = [
     {'name':'num_rat_wpts','top_title':'rational Weierstrass points','row_title':'Weierstrass points','knowl':'g2c.num_rat_wpts','avg':True},
-    {'name':'aut_grp_id','top_title':'$\mathrm{Aut}(X)$','row_title':'automorphism group','knowl':'g2c.aut_grp','format':aut_grp_name},
-    {'name':'geom_aut_grp_id','top_title':'$\mathrm{Aut}(X_{\mathbb{Q}})$','row_title':'automorphism group','knowl':'g2c.geom_aut_grp','format':geom_aut_grp_name},
+    {'name':'aut_grp_id','top_title':'$\mathrm{Aut}(X)$','row_title':'automorphism group','knowl':'g2c.aut_grp','format':aut_grp_format},
+    {'name':'geom_aut_grp_id','top_title':'$\mathrm{Aut}(X_{\mathbb{Q}})$','row_title':'automorphism group','knowl':'g2c.geom_aut_grp','format':geom_aut_grp_format},
     {'name':'analytic_rank','top_title':'analytic ranks','row_title':'analytic rank','knowl':'g2c.analytic_rank','avg':True},
     {'name':'two_selmer_rank','top_title':'2-Selmer ranks','row_title':'2-Selmer rank','knowl':'g2c.two_selmer_rank','avg':True},
-    {'name':'has_square_sha','top_title':'squareness of &#1064;','row_title':'has square Sha','knowl':'g2c.has_square_sha', 'format':boolean_name},
-    {'name':'locally_solvable','top_title':'local solvability','row_title':'locally solvable','knowl':'g2c.locally_solvable', 'format':boolean_name},
-    {'name':'is_gl2_type','top_title':'$\mathrm{GL}_2$-type','row_title':'is of GL2-type','knowl':'g2c.gl2type', 'format':boolean_name},
-    {'name':'real_geom_end_alg','top_title':'Sato-Tate group identity components','row_title':'identity component','knowl':'g2c.st_group_identity_component', 'format':st0_group_name},
-    {'name':'st_group','top_title':'Sato-Tate groups','row_title':'Sato-Tate groups','knowl':'g2c.st_group', 'format':st_group_name},
+    {'name':'has_square_sha','top_title':'squareness of &#1064;','row_title':'has square Sha','knowl':'g2c.has_square_sha', 'format':boolean_format},
+    {'name':'locally_solvable','top_title':'local solvability','row_title':'locally solvable','knowl':'g2c.locally_solvable', 'format':boolean_format},
+    {'name':'is_gl2_type','top_title':'$\mathrm{GL}_2$-type','row_title':'is of GL2-type','knowl':'g2c.gl2type', 'format':boolean_format},
+    {'name':'real_geom_end_alg','top_title':'Sato-Tate group identity components','row_title':'identity component','knowl':'g2c.st_group_identity_component', 'format':st0_group_format},
+    {'name':'st_group','top_title':'Sato-Tate groups','row_title':'Sato-Tate groups','knowl':'g2c.st_group', 'format':st_group_format},
     {'name':'torsion_order','top_title':'torsion subgroup orders','row_title':'torsion order','knowl':'g2c.torsion_order','avg':True},
 ]
 
@@ -434,7 +437,7 @@ class G2C_stats(object):
             if len(vcounts):
                 rows.append(vcounts)
             if 'avg' in attr and attr['avg']:
-                vcounts.append({'value':'\\mathrm{avg}\\ %.2f'%(float(avg)/total), 'curves':total, 'query':url_for(".index_Q") +'?'+attr['name'],'proportion':format_percentage(1,1)})
+                vcounts.append({'value':'\(\\mathrm{avg}\\ %.2f\)'%(float(avg)/total), 'curves':total, 'query':url_for(".index_Q") +'?'+attr['name'],'proportion':format_percentage(1,1)})
             dists.append({'attribute':attr,'rows':rows})
         stats["distributions"] = dists
         self._stats = stats

--- a/lmfdb/genus2_curves/templates/curve_g2.html
+++ b/lmfdb/genus2_curves/templates/curve_g2.html
@@ -231,7 +231,7 @@ function show_invs(invstyle) {
 
 <table>
     <tr>
-        <td>\(\mathrm{ST}\)</td><td>\(\simeq\)</td> <td>{{ data.st_group_href|safe}}</td>
+        <td>\(\mathrm{ST}\)</td><td>\(\simeq\)</td> <td>{{ data.st_group_link|safe}}</td>
     </tr>
     <tr>
         <td>\(\mathrm{ST}^0\)</td><td>\(\simeq\)</td> <td>\({{ data.st0_group_name}}\) </td>

--- a/lmfdb/genus2_curves/templates/isogeny_class_g2.html
+++ b/lmfdb/genus2_curves/templates/isogeny_class_g2.html
@@ -53,9 +53,9 @@ text-align: center;
 <h2>{{ KNOWL('g2c.st_group', title='Sato-Tate group')}}</h2>
 <p>
 {% if data.st_group == 'USp(4)'%}
-\(\mathrm{ST} =\) {{ data.st_group_href|safe }}
+\(\mathrm{ST} =\) {{ data.st_group_link|safe }}
 {% else %}
-\(\mathrm{ST} =\) {{ data.st_group_href|safe }}, \(\quad \mathrm{ST}^0 = {{ data.st0_group_name}}\)
+\(\mathrm{ST} =\) {{ data.st_group_link|safe }}, \(\quad \mathrm{ST}^0 = {{ data.st0_group_name}}\)
 {% endif %}
 </p>
 

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -164,9 +164,9 @@
 <table class="ntdata">
 <tr>
     <th>{{ KNOWL('g2c.label', title='Label') }}</th>
-    <th>{{ KNOWL('g2c.isogeny_class', title='Isogeny class') }}</th>
+    <th>{{ KNOWL('g2c.isogeny_class', title='Class') }}</th>
     <th>{{ KNOWL('g2c.equation', title='Equation') }}</th>
-    <th>{{ KNOWL('g2c.st_group', title='Sato Tate group') }}</th>
+    <th>{{ KNOWL('g2c.st_group', title='Sato Tate') }}</th>
     <th>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</th>
     <th>{{ KNOWL('g2c.analytic_rank', title='rank*') }}</th>
 </tr>
@@ -175,8 +175,8 @@
     <td> <a href = "{{info.curve_url(curve.label)}}"> {{curve.label}} </a> </td>
     <td> <a href = "{{info.class_url(curve.class)}}"> {{curve.class}} </a> </td>
     <td> \({{curve.equation_formatted}}\) </td>
-    <td align=center> {{curve.st_group_href|safe}} </td>
-    <td align=center> {{curve.is_gl2_type_display | safe}} </td>
+    <td align=center> {{curve.st_group_link|safe}} </td>
+    <td align=center> {{curve.is_gl2_type_display|safe}} </td>
     <td align=center> {{curve.analytic_rank}} </td>
 </tr>
 {% endfor %}

--- a/lmfdb/genus2_curves/templates/statistics_g2.html
+++ b/lmfdb/genus2_curves/templates/statistics_g2.html
@@ -14,7 +14,7 @@ with {{ KNOWL('g2c.abs_discriminant',title = "absolute discriminant")}} at most 
 <tr>
 <th>{{d.attribute['row_title']}}</th>
 {% for c in r %}
-<td>\({{c.value}}\)</td>
+<td>{{c.value|safe}}</td>
 {% endfor %}
 </tr>
 <tr>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -6,6 +6,7 @@ from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.sato_tate_groups.main import st_link_by_name
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, real, sqrt, var, expand
 from sage.plot.text import text
 from flask import url_for
@@ -113,15 +114,6 @@ def ring_pretty(L, f):
     if f % 2 == 0:
         return r'\Z [' + (str(f//2) if f != 2 else "") + r'\sqrt{' + str(D) + r'}]'
     return r'\Z [\frac{1 +' + str(f) + r'\sqrt{' + str(D) + r'}}{2}]'
-
-def st_group_name(st_group):
-    return '\\mathrm{USp}(4)' if st_group == 'USp(4)' else st_group
-
-def url_for_st_group(st_group):
-    return url_for('st.by_label', label='1.4.'+st_group)
-    
-def st_group_href(st_group):
-    return '<a href="%s">$%s$</a>' % (url_for_st_group(st_group),st_group_name(st_group))
 
 # currently galois functionality is not used here, but it is used in lfunctions so don't delete it
 def list_to_factored_poly_otherorder(s, galois=False):
@@ -408,7 +400,7 @@ def end_field_statement(field_label, poly):
         Galois number field \(K = \Q (a)\) with defining polynomial \(%s\)""" % poly
 
 def st_group_statement(group):
-    return """Sato-Tate group: \(%s\)""" % group
+    return """Sato-Tate group: <a href=%s> \(%s\) </a>""" % (group, url_for_st_group(group))
 
 def end_lattice_statement(lattice):
     statement = ''
@@ -424,7 +416,7 @@ def end_lattice_statement(lattice):
                 % (strlist_to_nfelt(ED[0][2], 'a'), intlist_to_poly(ED[0][1]))
         statement += """:<br>"""
         statement += end_statement(ED[1], ED[2], field=r'F', ring=ED[3])
-        statement += st_group_statement(ED[4])
+        statement += """Sato Tate group: %s""" % st_link_by_name(1,4,ED[4])
         statement += """<br>"""
         statement += gl2_simple_statement(ED[1], ED[2])
         statement += """<p></p>"""
@@ -549,8 +541,8 @@ class WebG2C(object):
         data['cond'] = ZZ(curve['cond'])
         data['cond_factor_latex'] = web_latex(factor(int(data['cond'])))
         data['analytic_rank'] = ZZ(curve['analytic_rank'])
-        data['st_group_name'] = st_group_name(curve['st_group'])
-        data['st_group_href'] = st_group_href(curve['st_group'])
+        data['st_group'] = curve['st_group']
+        data['st_group_link'] = st_link_by_name(1,4,data['st_group'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])
         data['is_gl2_type'] = curve['is_gl2_type']
         data['is_gl2_type_name'] = 'yes' if data['is_gl2_type'] else 'no'
@@ -645,7 +637,7 @@ class WebG2C(object):
                 ('Invariants', '%s </br> %s </br> %s </br> %s' % tuple(data['igusa_clebsch']))
                 ]
         properties += [
-            ('Sato-Tate group', data['st_group_href']),
+            ('Sato-Tate group', data['st_group_link']),
             ('\(\\End(J_{\\overline{\\Q}}) \\otimes \\R\)', '\(%s\)' % data['real_geom_end_alg_name']),
             ('\(\mathrm{GL}_2\)-type', data['is_gl2_type_name'])
             ]

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -33,6 +33,7 @@ from lmfdb.WebNumberField import WebNumberField
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes \
      import WebMaassForm
+from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.base import url_for
 
 def constructor_logger(object, args):
@@ -79,6 +80,7 @@ def makeLfromdata(L, fromdb=False):
         L.motivic_weight = data['motivic_weight']
     else:
         L.motivic_weight = ''
+    L.st_link = st_link_by_name(L.motivic_weight,L.degree,L.st_group)
 
     L.selfdual = data['self_dual']
     if 'credit' in data.keys():

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -490,6 +490,7 @@ def initLfunction(L, args, request):
         info['sv_edge_arithmetic'] = [svt_edge[1], svt_edge[2]]
 
         info['st_group'] = L.st_group
+        info['st_link'] = L.st_link
         info['rank'] = L.order_of_vanishing
         info['motivic_weight'] = L.motivic_weight
 

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -137,7 +137,7 @@ table.ntdata tr.more:nth-child(2n) { background: {{color.table_ntdata_background
         <tr>
         <td> {{ KNOWL('g2c.st_group', title="Sato-Tate") }} </td>
         <td>&nbsp;:&nbsp;</td>
-        <td> {{ st_group }}
+        <td> {{ st_link | safe}}
         </td>
         </tr>
 

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -91,7 +91,21 @@ def sg_pretty(sg_label):
     if data and 'pretty' in data:
         return data['pretty']
     return sg_label
+    
+# dictionary for quick and dirty prettification that does not access the database
+st_pretty_dict = {
+    'USp(4)':'\\mathrm{USp}(4)',
+    'SU(2)':'\\mathrm{SU}(2)',
+    'U(1)':'\\mathrm{U}(1)',
+    'N(U(1))':'N(\\mathrm{U}(1))'
+}
 
+def st_pretty(st_name):
+    return st_pretty_dict.get(st_name,st_name)
+
+def st_link_by_name(weight,degree,name):
+    return '<a href="%s">\(%s\)</a>' % (url_for('st.by_label', label="%s.%s.%s"%(weight,degree,name)), st_pretty(name))
+    
 ###############################################################################
 # Learnmore display functions
 ###############################################################################

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -149,26 +149,25 @@ def by_label(label):
 # Searching
 ###############################################################################
 
-ec_groups = { 'U(1)':'1.2.1.1.1a', 'N(U(1))':'1.2.1.2.1a', 'SU(2)':'1.2.3.1.1a' }
-
 def search_by_label(label):
-    label_regex = re.compile(r'\d+.\d+.\d+.\d+.\d+[a-z]+$')
-    if label_regex.match(label.strip()):
-        return render_by_label(label.strip())
-    label_regex = re.compile(r'\d+.\d+.\d+.\d+.\d+$')
-    if label_regex.match(label.strip()):
-        return render_by_label(label.strip()+'a')
-    # backward compatibility for old labels coming from ec or g2c
-    name = label.strip().split('.')[-1]
-    if name in ec_groups:
-        return render_by_label(ec_groups[name])
+    label = label.strip()
+    if re.match(r'\d+.\d+.\d+.\d+.\d+[a-z]+$', label):
+        return render_by_label(label)
+    if re.match(r'\d+.\d+.\d+.\d+.\d+$', label):
+        return render_by_label(label+'a')
+    # check for labels of the form w.d.name
+    data = {}
+    if re.match(r'\d+.\d+.[a-zA-z0-9\{\}\(\)\[\]\_\,]+',label):
+        slabel = label.split('.')
+        try:
+            data = st_groups().find_one({'weight':int(slabel[0]),'degree':int(slabel[1]),'name':slabel[2]},{'_id':False,'label':True})
+        except ValueError:
+            data = {}
+    if not data:
+        flash(Markup("Error: <span style='color:black'>%s</span> is not the label or name of a Sato-Tate group currently in the database" % label),"error")
+        return redirect(url_for(".index"))
     else:
-        data = st_groups().find_one({'weight':int(1),'degree':int(4),'name':name})
-        if not data:
-            flash(Markup("Error: <span style='color:black'>%s</span> is not the label or name of a Sato-Tate group currently in the database" % label),"error")
-            return redirect(url_for(".index"))
-        else:
-            return render_by_label(data['label'])
+        return redirect(url_for('.by_label', label=data['label']))
 
 def search(**args):
     info = to_dict(args)

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -47,6 +47,8 @@ class SatoTateGroupTest(LmfdbTest):
         print ""
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=2')
         assert '3 matches' in L.data
+        data = stdb.find({'weight':int(1),'degree':int(2)})
+        assert data.count() == 3
         for r in data:
             print 'Checking Sato-Tate group ' + r['label']
             L = self.tc.get('/SatoTateGroup/?label='+r['label'])

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -14,8 +14,10 @@ class SatoTateGroupTest(LmfdbTest):
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')
         assert 'USp(4)' in L.data
-        L = self.tc.get('/SatoTateGroup/?label=USp%284%29')
-        assert 'USp(4)' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)')
+        assert '1.4.10.1.1a' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))')
+        assert '1.2.1.2.1a' in L.data
         
     def test_direct_access(self):
         L = self.tc.get('/SatoTateGroup/1.4.G_{3,3}')
@@ -45,12 +47,10 @@ class SatoTateGroupTest(LmfdbTest):
         print ""
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=2')
         assert '3 matches' in L.data
-        L = self.tc.get('/SatoTateGroup/U(1)')
-        assert '1.2.1.1.1a' in L.data
-        L = self.tc.get('/SatoTateGroup/N(U(1))')
-        assert '1.2.1.2.1a' in L.data
-        L = self.tc.get('/SatoTateGroup/SU(2)')
-        assert '1.2.3.1.1a' in L.data
+        for r in data:
+            print 'Checking Sato-Tate group ' + r['label']
+            L = self.tc.get('/SatoTateGroup/?label='+r['label'])
+            assert r['label'] in L.data and 'Moment Statistics' in L.data
         stdb = getDBConnection().sato_tate_groups.st_groups
         data = stdb.find({'weight':int(1),'degree':int(2)})
         assert data.count() == 3

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -44,16 +44,16 @@ class SatoTateGroupTest(LmfdbTest):
         assert '33' in L.data
 
     def test_completeness(self):
-        print ""
+        stdb = getDBConnection().sato_tate_groups.st_groups
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=2')
         assert '3 matches' in L.data
         data = stdb.find({'weight':int(1),'degree':int(2)})
         assert data.count() == 3
+        print ""
         for r in data:
             print 'Checking Sato-Tate group ' + r['label']
             L = self.tc.get('/SatoTateGroup/?label='+r['label'])
             assert r['label'] in L.data and 'Moment Statistics' in L.data
-        stdb = getDBConnection().sato_tate_groups.st_groups
         data = stdb.find({'weight':int(1),'degree':int(2)})
         assert data.count() == 3
         for r in data:


### PR DESCRIPTION
This PR adds links to appropriate Sato-Tate group pages to L-function pages, e.g., compare

http://www.lmfdb.org/L/EllipticCurve/Q/11.a/
http://localhost:37777/L/EllipticCurve/Q/11.a/

http://www.lmfdb.org/L/Genus2Curve/Q/336/a/
http://localhost:37777/L/Genus2Curve/Q/336/a/

and also to endomorphism lattice pages, e.g., compare (after scrolling down)

http://www.lmfdb.org/Genus2Curve/Q/4608/c/27648/1
http://localhost:37777/Genus2Curve/Q/4608/c/27648/1

Additionally, it standardizes Sato-Tate group page link formatting (anyone who wants to display a Sato-Tate link should use lmfdb.sato_tate_groups.st_link_by_name) and always redirects to page with the full Sato-Tate group label in the URL.

All tests in test.sh pass.
