### PR TITLE
Switch to new ec/Q collection

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -61,7 +61,12 @@ def db_ec():
     global ecdb
     if ecdb is None:
         ec = lmfdb.base.getDBConnection().elliptic_curves
-        ecdb = ec.curves
+        if "new_curves" in ec.collection_names():
+            logger.info("Using collection new_curves")
+            ecdb = ec.new_curves
+        else:
+            logger.info("Using collection curves")
+            ecdb = ec.curves
     return ecdb
 
 def padic_db():


### PR DESCRIPTION
There is a new version of the collection curves in database elliptic_curves, called new_curves.  Two differences: (1) local data now includes root numbers, which are already displayed but now require no computation on the fly; (2) updated minimal quadratic twist information, following a well-defined definition (documented elsewhere) rather than the current Sage version which, when there is more than one twist of the same minimal conductor picks one essentially at random, and also, when the current curve is already of minimal conductor, use itself.  The new scheme sort first by conductor, then by abs value of discriminant, and finally (there can be at most 2 remaining candidates, which are -1-twists of each other) picks the one with positive c6.

Most of the new code here is in the import script which was run once-only to create the new database using the rewrite_collection function.  Otherwise all it does is make sure that the collection new_curves is used when present, but it should work fine when not present (please check that part of the code to make sure).  When this is on beta (resp. prod) we can do the usual: rename 'curves' to 'old_curves' and 'new_curves' to 'curves'; then drop 'old_curves'.