### PR TITLE
sort databases/collections/fields in api html interface

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -160,7 +160,7 @@ def api_query(db, collection, id = None):
             document["_id"] = "ObjectId('%s')" % oid
         elif isinstance(oid, basestring):
             document["_id"] = str(oid)
-        
+
     # preparing the datastructure
     start = offset
     next_req = dict(request.args)

--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from flask import render_template, request, make_response, url_for
 from lmfdb.api import api_page, api_logger
 from bson.objectid import ObjectId
-from collections import OrderedDict
 
 # caches the database information
 _databases = None

--- a/lmfdb/api/templates/api.html
+++ b/lmfdb/api/templates/api.html
@@ -90,7 +90,7 @@ where the prefix "-" indicates to sort in descending order.
 
 <h3>Available Collections</h3>
 <ul class="api-entries">
-{% for db, collections in databases.iteritems() %}
+{% for db, collections in databases.iteritems()|sort %}
   <li>
     <b>{{ db }}</b>
     (<a href="https://github.com/LMFDB/lmfdb-inventory/blob/master/db-{{ db }}.md"

--- a/lmfdb/api/templates/collection.html
+++ b/lmfdb/api/templates/collection.html
@@ -9,8 +9,8 @@
 <div>
 Formats:
 - <a href="{{ url }}">HTML</a>
-- <a href="{{ url_for(".api_query", db=database, collection=collection, _format = "yaml", **url_args) }}">YAML</a>
-- <a href="{{ url_for(".api_query", db=database, collection=collection, _format = "json", **url_args) }}">JSON</a>
+- <a href="{{ url_for('.api_query', db=database, collection=collection, _format = 'yaml', **url_args) }}">YAML</a>
+- <a href="{{ url_for('.api_query', db=database, collection=collection, _format = 'json', **url_args) }}">JSON</a>
 - {{ timestamp }}
 {% if not single_object %}
 - <a href="{{ next }}">next page</a>
@@ -22,13 +22,13 @@ Query: <code><a href="{{ query }}">{{ query_unquote }}</a></code>
 
 {% if single_object %}
 <br/>
-<code>{{ data[0] }}</code>
+<code>{{ pretty(data[0]) }}</code>
 {% else %}
 <ol class="api-entries" start="{{ start }}">
 {% for entry in data %}
   <li>
-    <a href="{{ url_for(".api_query_id", db=database, collection=collection, id=entry["_id"]) }}">{{ entry["_id"] }}</a><br/>
-    <code>{{ entry }}</code>
+    <a href="{{ url_for('.api_query_id', db=database, collection=collection, id=entry['_id']) }}">{{ entry['_id'] }}</a><br/>
+    <code>{{ pretty(entry,id=False) }}</code>
   </li>
 {% endfor %}
 </ol>


### PR DESCRIPTION
Small change to the api web pages so that the databases and collection lists on http://127.0.0.1:37779/api/ or now sorted (as opposed to http://www.lmfdb.org/api/).

On the html pages for individual collections and documents, document attributes are now sorted by key name.  This only affects the html display, the yaml and json formats already get sorted this way.
