### PR TITLE
Added Qbar-simple to results and properties box for genus 2 curves

### DIFF
--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -294,7 +294,7 @@ def genus2_curve_search(**args):
         return render_template("search_results_g2.html", info=info, title='Genus 2 Curves Search Input Error', bread=bread, credit=credit_string)
     # Database query happens here
     info["query"] = query # save query for reuse in download_search
-    cursor = g2c_db_curves().find(query,{'_id':int(0),'label':int(1),'eqn':int(1),'st_group':int(1),'is_gl2_type':int(1),'analytic_rank':int(1)})
+    cursor = g2c_db_curves().find(query, {'_id':False, 'label':True, 'eqn':True, 'st_group':True, 'is_gl2_type':True, 'is_simple_geom':True, 'analytic_rank':True})
 
     count = parse_count(info, 50)
     start = parse_start(info)
@@ -321,7 +321,7 @@ def genus2_curve_search(**args):
         v_clean["label"] = v["label"]
         v_clean["class"] = class_from_curve_label(v["label"])
         v_clean["is_gl2_type"] = v["is_gl2_type"] 
-        v_clean["is_gl2_type_display"] = '&#10004;' if v["is_gl2_type"] else '' # display checkmark if true, blank otherwise
+        v_clean["is_simple_geom"] = v["is_simple_geom"] 
         v_clean["equation_formatted"] = list_to_min_eqn(literal_eval(v["eqn"]))
         v_clean["st_group_link"] = st_link_by_name(1,4,v['st_group'])
         v_clean["analytic_rank"] = v["analytic_rank"]

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -40,7 +40,7 @@
 <tr>
 <td><select name='is_gl2_type' style="width: 110px">
   <option ></option>
-{% if info.is_gl2_type=='True' %}
+{% if info.is_gl2_type == 'True' %}
   <option value="True" selected>True</option>
 {% else %}
   <option value="True">True</option>
@@ -98,7 +98,7 @@
 
 <td><select name='locally_solvable' style="width: 110px">
   <option ></option>
-{% if info.locally_solvable=='True' %}
+{% if info.locally_solvable == 'True' %}
   <option value="True" selected>True</option>
 {% else %}
   <option value="True">True</option>
@@ -112,7 +112,7 @@
 
 <td><select name='has_square_sha' style="width: 110px">
   <option ></option>
-{% if info.has_square_sha=='True' %}
+{% if info.has_square_sha == 'True' %}
   <option value="True" selected>True</option>
 {% else %}
   <option value="True">True</option>
@@ -134,7 +134,7 @@
 <td><button type='submit' value='refine' style="width: 110px">Search again</button></td>
 <td><select name='is_simple_geom' width="110" style="width: 110px">
   <option ></option>
-{% if info.is_simple_geom=='True' %}
+{% if info.is_simple_geom == 'True' %}
   <option value="True" selected>True</option>
 {% else %}
   <option value="True">True</option>
@@ -166,9 +166,10 @@
     <th>{{ KNOWL('g2c.label', title='Label') }}</th>
     <th>{{ KNOWL('g2c.isogeny_class', title='Class') }}</th>
     <th>{{ KNOWL('g2c.equation', title='Equation') }}</th>
-    <th>{{ KNOWL('g2c.st_group', title='Sato Tate') }}</th>
-    <th>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</th>
-    <th>{{ KNOWL('g2c.analytic_rank', title='rank*') }}</th>
+    <th>{{ KNOWL('g2c.st_group', title='Sato-Tate') }}</th>
+    <th>{{ KNOWL('ag.geom_simple', title='\(\overline{\Q}\)-simple') }}</th>
+    <th>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)') }}</th>
+    <th>{{ KNOWL('g2c.analytic_rank', title='Rank*') }}</th>
 </tr>
 {% for curve in info.curves: %}
 <tr>
@@ -176,7 +177,8 @@
     <td> <a href = "{{info.class_url(curve.class)}}"> {{curve.class}} </a> </td>
     <td> \({{curve.equation_formatted}}\) </td>
     <td align=center> {{curve.st_group_link|safe}} </td>
-    <td align=center> {{curve.is_gl2_type_display|safe}} </td>
+    <td align=center> {{('&#x2713;' if curve.is_simple_geom else '')|safe}} </td>
+    <td align=center> {{('&#x2713;' if curve.is_gl2_type else '')|safe}} </td>
     <td align=center> {{curve.analytic_rank}} </td>
 </tr>
 {% endfor %}

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -34,6 +34,9 @@ def g2c_db_isogeny_classes_count():
 # Pretty print functions
 ###############################################################################
 
+def bool_pretty(v):
+    return 'yes' if v else 'no'
+
 def intlist_to_poly(s):
     return latex(PolynomialRing(QQ, 'x')(s))
 
@@ -545,8 +548,6 @@ class WebG2C(object):
         data['st_group_link'] = st_link_by_name(1,4,data['st_group'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])
         data['is_gl2_type'] = curve['is_gl2_type']
-        data['is_gl2_type_name'] = 'yes' if data['is_gl2_type'] else 'no'
-        data['is_gl2_type_display'] = '&#x2713;' if data['is_gl2_type'] else ''
         data['root_number'] = ZZ(curve['root_number'])
         data['bad_lfactors'] = literal_eval(curve['bad_lfactors'])
         data['bad_lfactors_pretty'] = [ (c[0], list_to_factored_poly_otherorder(c[1])) for c in data['bad_lfactors']]
@@ -634,12 +635,12 @@ class WebG2C(object):
                 (None, plot_link),
                 ('Conductor',str(data['cond'])),
                 ('Discriminant', str(data['disc'])),
-                ('Invariants', '%s </br> %s </br> %s </br> %s' % tuple(data['igusa_clebsch']))
                 ]
         properties += [
             ('Sato-Tate group', data['st_group_link']),
             ('\(\\End(J_{\\overline{\\Q}}) \\otimes \\R\)', '\(%s\)' % data['real_geom_end_alg_name']),
-            ('\(\mathrm{GL}_2\)-type', data['is_gl2_type_name'])
+            ('\(\\overline{\\Q}\)-simple', bool_pretty(data['is_simple_geom'])),
+            ('\(\mathrm{GL}_2\)-type', bool_pretty(data['is_gl2_type'])),
             ]
 
         # Friends


### PR DESCRIPTION
The properties box and search results for genus 2 curves now indicate whether or not the Jacobian of the curve is geometrically simple.

This PR also removes Igusa-Clebsch invariants from the properties box to save space.  They are still clearly visible on the main page where one can choose which type of invariants to see and see them in factored form (which is much more useful for projective invariants).  These will become unwieldly to display in the properties box as we add more curves and the invariants get bigger.