### PR TITLE
Fix for #1587 and part of #1537

### DIFF
--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -49,13 +49,12 @@ def getEllipticCurveLData(label):
     
 def getGenus2Ldata(label,label_type="url"):
     connection = base.getDBConnection()
-#    g2 = connection.genus2_curves
     db = connection.Lfunctions
     try:
-    #    Ldata = g2.Lfunctions.find_one({'hash': hash})
-   #     Lpointer = db.instances.find_one({'url': label})
         if label_type == "url":
             Lpointer = db.instances.find_one({'url': label})
+            if not Lpointer:
+                return None
             Lhash = Lpointer['Lhash']
             Ldata = db.Lfunctions.find_one({'Lhash': Lhash})
         elif label_type == "Lhash":
@@ -112,7 +111,7 @@ def getGenus2Ldata(label,label_type="url"):
         Ldata['plot'] = neg_plot[:] + pos_plot[:]
         #print "Ldata['plot']",Ldata['plot']
 
-    except ValueError:
+    except ValueError as e:
         Ldata = None
     return Ldata
     

--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -49,12 +49,13 @@ def getEllipticCurveLData(label):
     
 def getGenus2Ldata(label,label_type="url"):
     connection = base.getDBConnection()
+#    g2 = connection.genus2_curves
     db = connection.Lfunctions
     try:
+    #    Ldata = g2.Lfunctions.find_one({'hash': hash})
+   #     Lpointer = db.instances.find_one({'url': label})
         if label_type == "url":
             Lpointer = db.instances.find_one({'url': label})
-            if not Lpointer:
-                return None
             Lhash = Lpointer['Lhash']
             Ldata = db.Lfunctions.find_one({'Lhash': Lhash})
         elif label_type == "Lhash":
@@ -111,7 +112,7 @@ def getGenus2Ldata(label,label_type="url"):
         Ldata['plot'] = neg_plot[:] + pos_plot[:]
         #print "Ldata['plot']",Ldata['plot']
 
-    except ValueError as e:
+    except ValueError:
         Ldata = None
     return Ldata
     

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -8,7 +8,7 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebN
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
 from lmfdb.characters.ListCharacters import get_character_modulus
 from lmfdb.lfunctions import logger
-from sage.all import prod
+from sage.all import prod, CC
 
 ###############################################################################
 # Maass form for GL(n) n>2
@@ -814,7 +814,7 @@ def paintCSHoloTMP(width, height, xMax, yMax, xfactor, yfactor, ticlength):
 
 def signtocolour(sign):
     import cmath
-    argument = cmath.phase(float(sign))
+    argument = cmath.phase(CC(str(sign)))
     r = int(255.0 * (math.cos((1.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
     g = int(255.0 * (math.cos((2.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
     b = int(255.0 * (math.cos(argument / 2.0)) ** 2)

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -57,6 +57,8 @@ def getAllMaassGraphHtml(degree):
         groups = [ ["GL3", [1 , 4] ] ] 
     elif degree == 4:
         groups = [ ["GSp4", [1]], ["GL4", [1]] ] 
+    else:
+        return ""
 
     ans = ""
     for i in range(0, len(groups)):

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -968,7 +968,6 @@ def render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ar
     ''' Renders the first few zeroes of the L-function with the given arguments.
     '''
     L = generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, to_dict(request.args))
-    print L
     if hasattr(L,"lfunc_data"):
         if L.lfunc_data is None:
             return "<span>" + L.zeros + "</span>"

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -968,7 +968,7 @@ def render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, ar
     ''' Renders the first few zeroes of the L-function with the given arguments.
     '''
     L = generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, to_dict(request.args))
-
+    print L
     if hasattr(L,"lfunc_data"):
         if L.lfunc_data is None:
             return "<span>" + L.zeros + "</span>"

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -25,6 +25,11 @@ import LfunctionDatabase
 from lmfdb import base
 from pymongo import ASCENDING
 
+def get_degree(degree_string):
+    if not re.match('degree[0-9]+',degree_string):
+        return -1
+    return int(degree_string[6:])
+
 ################################################################################
 #   Route functions, navigation pages
 ################################################################################
@@ -43,9 +48,6 @@ def l_function_history():
     bc = [('L-functions', url_for('.l_function_top_page')),
           (t, url_for('.l_function_history'))]
     return render_template(_single_knowl, title=t, kid='lfunction.history', body_class='', bread=bc)
-
-
-
 
 # Degree 1 L-functions browsing page ##############################################
 @l_function_page.route("/degree1/")
@@ -80,10 +82,9 @@ def l_function_degree4_browse_page():
 # Degree browsing page #########################################################
 @l_function_page.route("/<degree>/")
 def l_function_degree_page(degree):
-    res = re.match('degree[0-9]+',degree)
-    if not res:
+    degree = get_degree(degree)
+    if degree < 0:
         return flask.abort(404)
-    degree = res.group(0).atoi()
     info = {"degree": degree}
     info["key"] = 777
     info["bread"] = get_bread(degree, [])
@@ -118,10 +119,15 @@ def l_function_ec_browse_page():
 # L-function of GL(n) Maass forms browsing page ##############################################
 @l_function_page.route("/<degree>/MaassForm/")
 def l_function_maass_gln_browse_page(degree):
-    degree = int(degree[6:])
+    degree = get_degree(degree)
+    if degree < 0:
+        return flask.abort(404)
+    contents = LfunctionPlot.getAllMaassGraphHtml(degree)
+    if not contents:
+        return flask.abort(404)
     info = {"bread": get_bread(degree, [("MaassForm", url_for('.l_function_maass_gln_browse_page',
                                                               degree='degree' + str(degree)))])}
-    info["contents"] = LfunctionPlot.getAllMaassGraphHtml(degree)
+    info["contents"] = contents
     return render_template("MaassformGLn.html",
                            title='L-functions of GL(%s) Maass Forms' % degree, **info)
 

--- a/lmfdb/lfunctions/templates/DegreeNavigateL.html
+++ b/lmfdb/lfunctions/templates/DegreeNavigateL.html
@@ -83,7 +83,10 @@ By {{ KNOWL('lfunction.underlying_object', title='underlying object:')}}
 <h2>Search Degree 4 L-functions</h2>
 #}
 
+{% endif %}
 
+{% if degree > 4 %}
+There is currently no L-function data available for {{ KNOWL('lfunction.degree', title='degree')}} {{degree}} L-functions.  Click <a href="{{url_for('l_functions.l_function_top_page')}}">here</a> to return to the main L-functions page.
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This PR fixes #1587 and implements part of the fix for #1537 by providing better error handling on requests for L-functions of degree beyond the range in the LMFDB (e.g. the pages http://www.lmfdb.org/L/degree5/ and http://www.lmfdb.org/L/degree5/MaassForm currently produce server errors, whereas http://127.0.0.1:37777/L/degree5/ and http://127.0.0.1:37777/L/degree5/MaassForm/ do something more reasonable).

