### PR TITLE
fixes for #1537

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -926,10 +926,9 @@ class Lfunction_Maass(Lfunction):
         if self.fromDB:
             self.dbid = "ModularForm/%s/Q/Maass/%s/%s/%s/%s/" % (
                 self.group, self.level, self.char, self.R, self.ap_id)
-
             self.lfunc_data = LfunctionDatabase.getGenus2Ldata(self.dbid)
             if self.lfunc_data is None:
-                raise KeyError("No Maass L-function with that data in the database.")
+                raise KeyError("No L-function data for %s was found in the database." % self.dbid)
             
             makeLfromdata(self, fromdb=True)
             if not self.selfdual:
@@ -978,7 +977,7 @@ class Lfunction_Maass(Lfunction):
 
                 # Extract the L-function information from the Maass form object
                 self.symmetry = self.mf.symmetry
-                self.eigenvalue = float(self.mf.R)
+                self.eigenvalue = float(self.mf.R if self.mf.R else 0)
                 self.level = int(self.mf.level)
                 self.charactermodulus = self.level
                 self.weight = int(self.mf.weight)
@@ -996,7 +995,7 @@ class Lfunction_Maass(Lfunction):
 
                 # Todo: If self has dimension >1, link to specific L-functions
                 self.dirichlet_coefficients = self.mf.coeffs
-                if self.dirichlet_coefficients[0] == 0:
+                if 0 in self.dirichlet_coefficients and self.dirichlet_coefficients[0] == 0:
                     self.dirichlet_coefficients.pop(0)
 
                 # Set properties of the L-function
@@ -1038,7 +1037,7 @@ class Lfunction_Maass(Lfunction):
                               + "level %s and $R= %s$" % (
                               self.level, self.eigenvalue))
                 self.citation = ''
-                self.credit = self.mf.contributor_name
+                self.credit = self.mf.contributor_name if 'contributor_name' in dir(self.mf) else ''
 
             generateSageLfunction(self)
 

--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -49,15 +49,17 @@ def getEllipticCurveLData(label):
     
 def getGenus2Ldata(label,label_type="url"):
     connection = base.getDBConnection()
-#    g2 = connection.genus2_curves
     db = connection.Lfunctions
     try:
-    #    Ldata = g2.Lfunctions.find_one({'hash': hash})
-   #     Lpointer = db.instances.find_one({'url': label})
         if label_type == "url":
             Lpointer = db.instances.find_one({'url': label})
+            if not Lpointer:
+                return None
             Lhash = Lpointer['Lhash']
             Ldata = db.Lfunctions.find_one({'Lhash': Lhash})
+            # do not ignore this error, if the instances record exists the Lhash should be there and we want to know if it is not
+            if not Ldata:
+                raise KeyError("Lhash %s in instances record for URL %s not found in Lfunctions collection" % (label, Lhash))
         elif label_type == "Lhash":
             Ldata = db.Lfunctions.find_one({'Lhash': label})
             # just return what we have, because

--- a/lmfdb/lfunctions/LfunctionInject.py
+++ b/lmfdb/lfunctions/LfunctionInject.py
@@ -9,7 +9,7 @@
     # def inject_database(self, relevant_info, time_limit = None):
     #    #   relevant_methods are text strings
     #    #    desired_database_fields = [Lfunction.original_mathematical_object, Lfunction.level]
-    #    #    also zeroes, degree, conductor, type, real_coeff, rational_coeff, algebraic_coeff, critical_value, value_at_1, sign
+    #    #    also zeros, degree, conductor, type, real_coeff, rational_coeff, algebraic_coeff, critical_value, value_at_1, sign
     #    #    ok_methods = [Lfunction.math_id, Lfunction.level]
     #    #
     #    # Is used to inject the data in relevant_fields

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -270,7 +270,6 @@ def paintSvgFileAllNEW(glslist):  # list of group, level, and (maybe) sign
     height = yfactor * yMax + extraSpace
 
     ans += paintCS(width, height, xMax, yMax, xfactor, yfactor, ticlength)
-
     for (x, y, lid, group, level, char, R, ap_id, sign) in paralist:
         if float(x)>0 and float(y)>0:  #Only one of dual pair
             try:

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -24,6 +24,7 @@ from LfunctionComp import isogeny_class_table, isogeny_class_cm
 import LfunctionDatabase
 from lmfdb import base
 from pymongo import ASCENDING
+from flask import current_app
 
 def get_degree(degree_string):
     if not re.match('degree[0-9]+',degree_string):
@@ -384,25 +385,31 @@ def l_function_lcalc_page():
 ################################################################################
 #   Helper functions, individual L-function homepages
 ################################################################################
+
+def render_lfunction_exception(err):
+    if current_app.debug:
+        raise err
+    if err.args:
+        errmsg = "Unable to render L-function page due to the following problem(s):<br><ul>" + reduce(lambda x,y:x+"<li>"+y+"</li>",err.args) + "</ul>"
+    else:
+        errmsg = "Unable to render L-function page due to the following problem:<br><ul><li>%s</li></ul>"%err
+    info = {'content': errmsg, 'title': 'Error displaying L-function data'}
+    return render_template('LfunctionSimple.html', info=info, **info), 500
+
 def render_single_Lfunction(Lclass, args, request):
     temp_args = to_dict(request.args)
     logger.debug(args)
     logger.debug(temp_args)
 
-    L = Lclass(**args)
     try:
-        pass
-    except Exception as ex:
-        from flask import current_app
-        if not current_app.debug:
-            info = {'content': 'Sorry, there has been a problem: %s.'%str(ex.args), 'title': 'Error'}
-            return render_template('LfunctionSimple.html', info=info, **info), 500
-        else:
-            raise ex
+        # if you move L=Lclass outside the try for debugging, remember to put it back in before committing
+        L = Lclass(**args)
+    except Exception as err:
+        return render_lfunction_exception(err)
     try:
         if temp_args['download'] == 'lcalcfile':
             return render_lcalcfile(L, request.url)
-    except KeyError as ex:
+    except KeyError as err:
         pass # Do nothing
 
     info = initLfunction(L, temp_args, request)
@@ -529,9 +536,9 @@ def initLfunction(L, args, request):
 
     info['degree'] = int(L.degree)
 
-    info['zeroeslink'] = (request.url.replace('/L/', '/L/Zeros/').
+    info['zeroslink'] = (request.url.replace('/L/', '/L/Zeros/').
                           replace('/Lfunction/', '/L/Zeros/').
-                          replace('/L-function/', '/L/Zeros/'))  # url_for('zeroesLfunction',  **args)
+                          replace('/L-function/', '/L/Zeros/'))  # url_for('zerosLfunction',  **args)
 
     info['plotlink'] = (request.url.replace('/L/', '/L/Plot/').
                         replace('/Lfunction/', '/L/Plot/').
@@ -540,7 +547,7 @@ def initLfunction(L, args, request):
     if L.Ltype() == 'ellipticmodularform':
         if ( (L.number == 1 and (1 + L.level) * L.weight > 50) or 
                (L.number > 1 and L.level * L.weight > 50)):
-            info['zeroeslink'] = ""
+            info['zeroslink'] = ""
             info['plotlink'] = ""
 
 
@@ -558,7 +565,7 @@ def initLfunction(L, args, request):
             minNumberOfCoefficients = 100     # TODO: Fix this to take level into account
 
             if len(L.dirichlet_coefficients) < minNumberOfCoefficients:
-                info['zeroeslink'] = ''
+                info['zeroslink'] = ''
                 info['plotlink'] = ''
             info['bread'] = get_bread(2, [('Maass Form',
                                            url_for('.l_function_maass_browse_page')),
@@ -737,7 +744,7 @@ def initLfunction(L, args, request):
     elif L.Ltype() == "artin":
         info['friends'] = [('Artin representation', L.artin.url_for())]
         if L.sign == 0:           # The root number is now unknown
-            info['zeroeslink'] = ''
+            info['zeroslink'] = ''
             info['plotlink'] = ''
 
     elif L.Ltype() == "hgmQ":
@@ -816,7 +823,7 @@ def set_gaga_properties(L):
 
 
 ################################################################################
-#   Route functions, plotting L-function and displaying zeroes
+#   Route functions, plotting L-function and displaying zeros
 ################################################################################
 
 # L-function of Elliptic curve #################################################
@@ -851,12 +858,12 @@ def plotLfunction(arg1=None, arg2=None, arg3=None, arg4=None, arg5=None, arg6=No
 @l_function_page.route("/Zeros/<arg1>/<arg2>/<arg3>/<arg4>/<arg5>/<arg6>/<arg7>/")
 @l_function_page.route("/Zeros/<arg1>/<arg2>/<arg3>/<arg4>/<arg5>/<arg6>/<arg7>/<arg8>/")
 @l_function_page.route("/Zeros/<arg1>/<arg2>/<arg3>/<arg4>/<arg5>/<arg6>/<arg7>/<arg8>/<arg9>/")
-def zeroesLfunction(arg1=None, arg2=None, arg3=None, arg4=None, arg5=None, arg6=None, arg7=None, arg8=None, arg9=None):
-    return render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+def zerosLfunction(arg1=None, arg2=None, arg3=None, arg4=None, arg5=None, arg6=None, arg7=None, arg8=None, arg9=None):
+    return render_zerosLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 
 
 ################################################################################
-#   Render functions, plotting L-function and displaying zeroes
+#   Render functions, plotting L-function and displaying zeros
 ################################################################################
 def render_plotLfunction_from_db(db, dbTable, condition):
     data_location = os.path.expanduser(
@@ -908,10 +915,13 @@ def render_plotLfunction_from_db(db, dbTable, condition):
 
 
 def render_plotLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9):
-    data = getLfunctionPlot(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    try:
+        data = getLfunctionPlot(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    except Exception as err: # depending on the arguments, we may get an exception or we may get a null return, we need to handle both cases
+        return render_lfunction_exception(err)
     if not data:
         # see note about missing "hardy_z_function" in plotLfunction()
-        return flask.redirect(404)
+        return flask.abort(404)
     response = make_response(data)
     response.headers['Content-type'] = 'image/png'
     return response
@@ -920,7 +930,8 @@ def render_plotLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8
 def getLfunctionPlot(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9):
     pythonL = generateLfunctionFromUrl(
         arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, to_dict(request.args))
-
+    if not pythonL:
+        return ""
     plotrange = 30
     if hasattr(pythonL,"lfunc_data"):
         if pythonL.lfunc_data is None:
@@ -962,12 +973,16 @@ def styleLfunctionPlot(p, fontsize):
     p.axes_width(0.2)
 
 
-
-
-def render_zeroesLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9):
-    ''' Renders the first few zeroes of the L-function with the given arguments.
+def render_zerosLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9):
+    ''' Renders the first few zeros of the L-function with the given arguments.
     '''
-    L = generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, to_dict(request.args))
+    try:
+        L = generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, to_dict(request.args))
+    except Exception as err:
+        return render_lfunction_exception(err)
+        
+    if not L:
+        return flask.abort(404)
     if hasattr(L,"lfunc_data"):
         if L.lfunc_data is None:
             return "<span>" + L.zeros + "</span>"
@@ -1050,7 +1065,6 @@ def generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg
             return Lfunction_Maass(fromDB = True, group = arg2, level = arg5,
                 char = arg6, R = arg7, ap_id = arg8)
 
-
     elif arg1 == 'ModularForm' and arg2 == 'GSp' and arg3 == 'Q' and arg4 == 'Sp4Z' and arg5 == 'specimen':  # this should be changed when we fix the SMF urls
         return Lfunction_SMF2_scalar_valued(weight=arg6, orbit=arg7, number=arg8)
 
@@ -1076,7 +1090,7 @@ def generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg
         return Lfunction_lcalc(Ltype='lcalcurl', url=temp_args['url'])
 
     else:
-        return flask.redirect(403)
+        return None
 
 
 ################################################################################

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -304,8 +304,8 @@ table.ntdata tr.more:nth-child(2n) { background: {{color.table_ntdata_background
 
  <h2> Imaginary part of the first few zeros on the {{ KNOWL('lfunction.critical_line', title='critical line') }}</h2>
 
- {% if zeroeslink %}
-     <div><span id="zeroes"></span></div>
+ {% if zeroslink %}
+     <div><span id="zeros"></span></div>
  {% elif tpzeroslink %}
      {{zeroswarning}}.
      <div><span id="tpzeros">{{tpzeroslink|safe}}</span></div>
@@ -328,7 +328,7 @@ table.ntdata tr.more:nth-child(2n) { background: {{color.table_ntdata_background
 
 <script type="text/javascript">
   $(function() {
-      $("#zeroes").load("{{ zeroeslink|safe }}");
+      $("#zeros").load("{{ zeroslink|safe }}");
   });
   
 </script>

--- a/lmfdb/lfunctions/templates/LfunctionSimple.html
+++ b/lmfdb/lfunctions/templates/LfunctionSimple.html
@@ -2,11 +2,12 @@
 
 {% block content %}
 <div class="announce">
- {{ content|safe }}
-Please report it <a href="{{ feedbackpage }}" target=_blank>here</a>.
+<indent>
+{{ content|safe }}
+Please report this problem <a href="{{ feedbackpage }}" target=_blank>here</a>.
 </div>
-<div align="center">
-<input type=button value="Back" onClick="history.go(-1)">
+<div>
+<input type=button value="Return to previous page" onClick="history.go(-1)">
 </div>
 {% endblock %}
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
@@ -734,7 +734,7 @@ class WebNewForm(WebObject, CachedRepresentation):
           Reimplement the recursive algorithm in sage modular/hecke/module.py
           We do this because of a bug in sage with .eigenvalue()
         """
-        from sage.arith.all import factor
+        from sage.all import factor
         ev = self.eigenvalues
 
         c2 = self._coefficients.get(2)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
@@ -344,7 +344,11 @@ class MaassDB(object):
         r"""
         Find a Maass form matching the information in the dictionary data
         """
-        find_data = arg_to_search_parameters(data, **kwds)
+        from bson.errors import InvalidId
+        try:
+            find_data = arg_to_search_parameters(data, **kwds)
+        except InvalidId:
+            return []
         # print "find_data",find_data
         res = []
         for collection in self._show_collection:

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
@@ -101,7 +101,7 @@ class WebMaassForm(object):
         if not isinstance(maassid, (bson.objectid.ObjectId, str)):
             ids = db.find_Maass_form_id(id=maassid)
             if len(ids) == 0:
-                return
+                raise KeyError("maassid %s not found in database"%maassid)
             mwf_logger.debug("maassid is not an objectid! {0}".format(maassid))
             maassid = ids[0]
         self._maassid = bson.objectid.ObjectId(maassid)


### PR DESCRIPTION
This PR provides better error handling in the lfunctions code to address the remaining issues in #1537.  In particular, the page

http://www.lmfdb.org/L/Zeros/ModularForm/GL3/Q/Maass/4/1/15.04294_2.93986/-0.451767%20/

noted in #1537 now displays a more useful error message, see

http://localhost:37777/L/Zeros/ModularForm/GL3/Q/Maass/1/1/24.78828_6.590306/1.7780841/.

More generally, URLs that math a page route in lfunctions.main.py but for which there actually isn't a page to display are now handled in a more reasonable way, e.g. compare:

http://www.lmfdb.org/L/Zeros/zeta/
http://www.lmfdb.org/L/Plot/zeta/
http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/3/6/1/a/1/
http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/1/6/1/a/0/
http://www.lmfdb.org/L/ModularForm/GL3/Q/Maass/non-existent-Maass-form-id/

to

http:/localhost:37777/L/Zeros/zeta/
http:/localhost:37777/L/Plot/zeta/
http:/localhost:37777/L/ModularForm/GL2/Q/holomorphic/3/6/1/a/1/
http:/localhost:37777/L/ModularForm/GL2/Q/holomorphic/1/6/1/a/0/
http:/localhost:37777/L/ModularForm/GL3/Q/Maass/non-existent-Maass-form-id/

I also corrected some lingering inconsistent spellings of zeros as zeroes (we apparently even implemented a unit-test to check for this at some point), and changed all the flask.redirect(404)'s in the lfunctions code to flask.abort(404) -- see #1592.

All tests pass except for checking the sagemath link in box 6 (known problem).





