### PR TITLE
Fix for #1006

### DIFF
--- a/lmfdb/siegel_modular_forms/collection.py
+++ b/lmfdb/siegel_modular_forms/collection.py
@@ -38,6 +38,7 @@ class Collection (SageObject):
         if not self.__latex_name:
             self.__latex_name =  Latex(self.name())
         self.__description = doc.get('description')
+        self.__degree = doc.get('degree')
         self.__dimension = doc.get('dimension')
         if self.__dimension:
             a,b,c = self.__dimension.rpartition('.')
@@ -64,6 +65,9 @@ class Collection (SageObject):
 
     def description(self):
         return self.__description
+        
+    def degree(self):
+        return self.__degree
 
     def computes_dimensions(self):
         return True if self.__dimension else False

--- a/lmfdb/siegel_modular_forms/static/Gamma0_2.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_2.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma0_2_basic.html",
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_2", 
     "dim_args_default": {"k": "4..24", "j": "2"},
     "latex_name": "M_{k,j}\\left(\\Gamma_0(2)\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Gamma0_3.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_3.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma0_3_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_3",
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left(\\Gamma_0(3)\\right)",

--- a/lmfdb/siegel_modular_forms/static/Gamma0_3_psi_3.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_3_psi_3.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma0_3_psi_3_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_3_psi_3",
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left(\\Gamma_0(3),\\psi_3\\right)",

--- a/lmfdb/siegel_modular_forms/static/Gamma0_4.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_4.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma0_4_basic.html",
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_4",
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left(\\Gamma_0(4)\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Gamma0_4_half.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_4_half.json
@@ -1,5 +1,6 @@
 {
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_4_half",
+    "degree": 2,
     "dim_args_default": { "k": "1..20" },
     "latex_name": "M_{k-1/2}\\left(\\Gamma_0(4)\\right)",
     "name": "Gamma0_4_half",

--- a/lmfdb/siegel_modular_forms/static/Gamma0_4_psi_4.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma0_4_psi_4.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma0_4_psi_4_basic.html",
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma0_4_psi_4",
     "dim_args_default": { "k": "0..40" },
     "latex_name": "M_k\\left(\\Gamma_0(4),\\psi_4\\right)",

--- a/lmfdb/siegel_modular_forms/static/Gamma1_2.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma1_2.json
@@ -1,5 +1,6 @@
 {
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma1_2",
+    "degree": 2,
     "dim_args_default": { "k": "4..10", "j": "2" },
     "latex_name": "M_{k,j}\\left(\\Gamma_1(2)\\right)", 
     "name": "Gamma1_2",

--- a/lmfdb/siegel_modular_forms/static/Gamma_2.json
+++ b/lmfdb/siegel_modular_forms/static/Gamma_2.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Gamma_2_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Gamma_2", 
     "dim_args_default": { "k": "4..10", "j": "2" },
     "latex_name": "M_{k,j}\\left(\\Gamma(2)\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Kp.json
+++ b/lmfdb/siegel_modular_forms/static/Kp.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Kp_basic.html", 
+    "degree": 2,
     "latex_name": "M_2\\left(K(p)\\right)", 
     "name": "Kp",
     "order": 110

--- a/lmfdb/siegel_modular_forms/static/Sp4Z.json
+++ b/lmfdb/siegel_modular_forms/static/Sp4Z.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Sp4Z_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Sp4Z", 
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left({\\textrm{Sp}}(4,\\mathbb{Z})\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Sp4Z_2.json
+++ b/lmfdb/siegel_modular_forms/static/Sp4Z_2.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Sp4Z_2_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Sp4Z_2", 
     "dim_args_default": { "k": "4..24" },
     "latex_name": "M_{k,2}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Sp4Z_j.json
+++ b/lmfdb/siegel_modular_forms/static/Sp4Z_j.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Sp4Z_j_basic.html", 
+    "degree": 2,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Sp4Z_j",
     "dim_args_default": { "k": "4..24", "j": "4" },
     "latex_name": "M_{k,j}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Sp6Z.json
+++ b/lmfdb/siegel_modular_forms/static/Sp6Z.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Sp6Z_basic.html",
+    "degree": 3,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Sp6Z",
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_{k}\\left(\\textrm{Sp}(6,\\mathbb{Z})\\right)", 

--- a/lmfdb/siegel_modular_forms/static/Sp8Z.json
+++ b/lmfdb/siegel_modular_forms/static/Sp8Z.json
@@ -1,5 +1,6 @@
 {
     "description": "includes/Sp8Z_basic.html", 
+    "degree": 4,
     "dimension": "lmfdb.siegel_modular_forms.dimensions.dimension_Sp8Z", 
     "dim_args_default": { "k": "0..16" },
     "latex_name": "M_k\\left(\\textrm{Sp}(8,\\mathbb{Z})\\right)", 

--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_collection.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_collection.html
@@ -1,14 +1,13 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-{% if (info.col.name() not in ["Gamma0_2", "Gamma1_2", "Gamma_2", "Gamma0_3", "Gamma0_3_psi_3", "Gamma0_4", "Gamma0_4_psi_4", "Gamma0_4_half"]) %}
+{% if info.forms|count > 0 %}
 <h2>Available samples</h2>
 {% include [['includes/avail/', info.col.name(), '_avail_forms.html']|join] %}
 {% endif %}
 
 {% if info.col.computes_dimensions() %}
-
-<!-- Display dimension table here -->
+<h2>Dimension table of spaces of {{KNOWL('mf.siegel.degree',title='degree '+info.col.degree()|string)}} {{KNOWL('mf.siegel',title='Siegel modular forms')}}</h2>
 {% include 'includes/dimension_table.html' %}
 
 <h4> Enter a new range of weights for dimension table:</h4>
@@ -28,7 +27,6 @@
 {% endif %}
 
 {% if (info.col.name() not in ["Gamma1_2", "Gamma0_4_half"]) %}
-<h2>Miscellaneous</h2>
 {% include [ ['',info.col.description()]|join, 'Not_available.html'] %}
 {% endif %}
 

--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_dimensions.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_dimensions.html
@@ -2,6 +2,7 @@
 {% block content %}
 
 {% if info.table %}
+<h2>Dimension table of spaces of {{KNOWL('mf.siegel.degree',title='degree '+info.col.degree()|string)}} {{KNOWL('mf.siegel',title='Siegel modular forms')}}</h2>
 {% include 'includes/dimension_table.html' %}
 {% endif %}
 

--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_index.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_index.html
@@ -2,7 +2,7 @@
 {% block content %}
 <p>
   The database contains information about {{ info.number_of_samples }} examples of scalar and vector
-  valued <a knowl="mf.siegel"> Siegel modular forms</a>, as well as
+  valued {{KNOWL('mf.siegel.degree',title='Siegel modular forms')}}, as well as
   dimension formulas for spaces of Siegel modular forms.  The examples
   not in the image of a lift from a lower rank group are almost all of
   the known examples in the literature, and most published dimension

--- a/lmfdb/siegel_modular_forms/templates/includes/Gamma_2_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Gamma_2_basic.html
@@ -1,5 +1,4 @@
-<h2>The ring of <a class="knowl-title" knowl="mf.siegel">
-    Siegel modular forms</a> of degree 2 with respect to the 
+<h2>The ring of Siegel modular forms of degree 2 with respect to the 
   the principal congruence subgroup of level 2</h2>
 
 

--- a/lmfdb/siegel_modular_forms/templates/includes/Sp4Z_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Sp4Z_basic.html
@@ -1,5 +1,4 @@
-<h2>The ring of <a class="knowl-title" knowl="mf.siegel">
-Siegel modular forms</a> of degree 2 with respect to the 
+<h2>The ring of Siegel modular forms of degree 2 with respect to the 
 <a class="knowl-title" knowl="group.sp2gr">full modular group</a></h2>
 
 <div class="literature">

--- a/lmfdb/siegel_modular_forms/templates/includes/Sp6Z_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Sp6Z_basic.html
@@ -1,5 +1,4 @@
-<h2>The ring of <a class="knowl-title" knowl="mf.siegel">
-Siegel modular forms</a> of degree 3 with respect to the 
+<h2>The ring of Siegel modular forms of degree 3 with respect to the 
 <a class="knowl-title" knowl="group.sp2gr">full modular group</a></h2>
 
 <div class="literature">

--- a/lmfdb/siegel_modular_forms/templates/includes/Sp8Z_basic.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/Sp8Z_basic.html
@@ -1,5 +1,4 @@
-<h2>The ring of <a class="knowl-title" knowl="mf.siegel">
-Siegel modular forms</a> of degree 4 with respect to the 
+<h2>The ring of Siegel modular forms of degree 4 with respect to the 
 <a class="knowl-title" knowl="group.sp2gr">full modular group</a></h2>
 
 <div class="literature">

--- a/lmfdb/siegel_modular_forms/templates/includes/dimension_table.html
+++ b/lmfdb/siegel_modular_forms/templates/includes/dimension_table.html
@@ -1,5 +1,3 @@
-<h2>Dimension Table</h2>
-
 {% if not info.error %}
 <p>
   The table below lists, for each bold value of $k$ in the header,  the dimensions of the following subspaces of ${{ info.col.latex_name() }}${% if 'j' in info.kwargs %} for $j={{ info.kwargs.j }}$: {% else %}:{% endif %}


### PR DESCRIPTION
This PR addresses #1006 by adding a degree attribute to families of Siegel modular forms that is then displayed whenever a dimension table is shown.  The word degree has a knowl link in it (the knowl can be created after this PR is merged), it refers to to the integer g for which the group G appearing in M_{k,j}(G) is a group of 2g x 2g matrices (currently g is 2, 3, or 4).

This meant touching a lot of files, but the changes are all very minor.
