### PR TITLE
Fix regex for checking artin rep labels.

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -44,7 +44,7 @@ def make_cond_key(D):
 
 def parse_artin_label(label):
     label = clean_input(label)
-    if re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+t\d+\.\d+c\d+$').match(label):
+    if re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+c\d+$').match(label):
         return label
     else:
         raise ValueError("Error parsing input %s.  It is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1"% label)

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -44,7 +44,7 @@ def make_cond_key(D):
 
 def parse_artin_label(label):
     label = clean_input(label)
-    if re.compile(r'^\d+\.\d+e\d+(_\d+e\d+)*\.\d+t\d\.\d+c\d+$').match(label):
+    if re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+t\d+\.\d+c\d+$').match(label):
         return label
     else:
         raise ValueError("Error parsing input %s.  It is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1"% label)

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -46,7 +46,7 @@ A <a href={{url_for('.random_representation')}}>random Artin representation</a> 
 <h2>Go to a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
 
 <div><form>
-Artin representation: <input type='text' name='natural' size='30' example='3.2e3_7e5.7t3.1c1'> <button type='submit' name='search' value='Go'>label</button> <span class="formexample">e.g., 3.2e3_7e5.7t3.1c1</span></form></div>
+Artin representation: <input type='text' name='natural' size='50' example='3.2e3_7e5.7t3.1c1'> <button type='submit' name='search' value='Go'>label</button> <span class="formexample">e.g., 3.2e3_7e5.7t3.1c1</span></form></div>
 
 
 <h2> Search for an Artin representation </h2>


### PR DESCRIPTION
The previous regex failed in two ways.  The "e" is optional in the conductor part (was manditory in the old regex), and T-numbers can have more than one digit in the Galois part.

To test, enter the following label into the corresponding search box: 2.2e2_3_11e2.12t12.2c1 .  The parts that didn't work before are the second 12 in 12t12 and the _3_ in the conductor part (2e2_3_11e2 means 2^2*3*11^2, and there is no exponent given for 3 since it is 1).
