### PR TITLE
fixed encf twist link for fields with name not a

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -30,6 +30,12 @@ special_names = {'2.0.4.1': 'i',
                  '4.0.125.1': 'zeta5',
                  }
 
+def rename_j(j):
+    sj = str(j)
+    for name in ['zeta5', 'phi', 'i']:
+        sj = sj.replace(name,'a')
+    return sj
+
 field_list = {}  # cached collection of enhanced WebNumberFields, keyed by label
 
 def FIELD(label):
@@ -361,7 +367,7 @@ class ECNF(object):
 
         self.friends = []
         self.friends += [('Isogeny class ' + self.short_class_label, self.urls['class'])]
-        self.friends += [('Twists', url_for('ecnf.index', field=self.field_label, jinv=str(j)))]
+        self.friends += [('Twists', url_for('ecnf.index', field=self.field_label, jinv=rename_j(j)))]
         if totally_real:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
             self.friends += [('L-function', self.urls['Lfunction'])]


### PR DESCRIPTION
This fixes issue #1618.   The parse_nf_elt function should be given an extra 'var' parameter which it would pass to the pol_string_to_list() function which already has one, so that we could parse input of number field elements written with any generator name.  But for this case it was simpler to use the known list of special names to convert the name back to the default  'a' before creating the link.

Test on curves over Q(sqrt(5)), Q(sqrt(-1)) and a field of larger degree (to see that if the name appears more than once, all are converted).