### PR TITLE
Fix EC breadcrumbs (issue #1472)

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -52,16 +52,27 @@ def string2list(s):
         return []
     return [int(a) for a in s.split(',')]
 
+def is_fundamental_discriminant(d):
+    if d in [0, 1]:
+        return False
+    if d.is_squarefree():
+        return d % 4 == 1
+    else:
+        return d % 16 in [8, 12] and (d // 4).is_squarefree()
+
 @cached_function
 def field_pretty(label):
     d, r, D, i = label.split('.')
     if d == '1':  # Q
         return '\(\Q\)'
     if d == '2':  # quadratic field
-        D = ZZ(int(D)).squarefree_part()
+        D = ZZ(int(D))
         if r == '0':
             D = -D
-        return '\(\Q(\sqrt{' + str(D) + '}) \)'
+        # Don't prettify invalid quadratic field labels
+        if not is_fundamental_discriminant(D):
+            return label
+        return '\(\Q(\sqrt{' + str(D if D%4 else D/4) + '}) \)'
     if label in cycloinfo:
         return '\(\Q(\zeta_{%d})\)' % cycloinfo[label]
     if d == '4':

--- a/lmfdb/ecnf/hmf_check_find.py
+++ b/lmfdb/ecnf/hmf_check_find.py
@@ -11,6 +11,7 @@ import os
 import random
 import glob
 import pymongo
+from lmfdb.WebNumberField import is_fundamental_discriminant
 from lmfdb.base import _init as init
 from lmfdb.base import getDBConnection
 from sage.rings.all import ZZ, QQ
@@ -777,15 +778,6 @@ def export_magma_output(infilename, outfilename=None, verbose=False):
         ec['cm'] = '?'
         ec['base_change'] = []
         output(make_curves_line(ec) + "\n")
-
-
-def is_fundamental_discriminant(d):
-    if d in [0, 1]:
-        return False
-    if d.is_squarefree():
-        return d % 4 == 1
-    else:
-        return d % 16 in [8, 12] and (d // 4).is_squarefree()
 
 
 def rqf_iterator(d1, d2):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -243,6 +243,8 @@ def show_ecnf1(nf):
         nf_label, nf_pretty = get_nf_info(nf)
     except ValueError:
         return search_input_error()
+    if nf_label == '1.1.1.1':
+        return redirect(url_for("ec.rational_elliptic_curves", **request.args), 301)
     info = to_dict(request.args)
     info['title'] = 'Elliptic Curves over %s' % nf_pretty
     info['bread'] = [('Elliptic Curves', url_for(".index")), (nf_pretty, url_for(".show_ecnf1", nf=nf))]
@@ -375,6 +377,9 @@ def elliptic_curve_search(info):
             query['torsion_order'] = reduce(mul,[int(n) for n in query['torsion_structure']],1)
     except ValueError:
         return search_input_error(info, bread)
+        
+    if query.get('field_label') == '1.1.1.1':
+        return redirect(url_for("ec.rational_elliptic_curves", **request.args), 301)
         
     if 'include_isogenous' in info and info['include_isogenous'] == 'off':
         info['number'] = 1

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -257,6 +257,7 @@ def show_ecnf1(nf):
 
 @ecnf_page.route("/<nf>/<conductor_label>/")
 def show_ecnf_conductor(nf, conductor_label):
+    conductor_label = unquote(conductor_label)
     try:
         nf_label, nf_pretty = get_nf_info(nf)
         conductor_norm = conductor_label_norm(conductor_label)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -309,6 +309,7 @@ def show_ecnf(nf, conductor_label, class_label, number):
         nf_label = nf_string_to_label(nf)
     except ValueError:
         return search_input_error()
+    conductor_label = unquote(conductor_label)
     label = "".join(["-".join([nf_label, conductor_label, class_label]), number])
     ec = ECNF.by_label(label)
     bread = [("Elliptic Curves", url_for(".index"))]
@@ -323,6 +324,7 @@ def show_ecnf(nf, conductor_label, class_label, number):
     bread.append((ec.conductor_label, ec.urls['conductor']))
     bread.append((ec.iso_label, ec.urls['class']))
     bread.append((ec.number, ec.urls['curve']))
+    print ec.urls
     code = ec.code()
     code['show'] = {'magma':'','pari':'','sage':''} # use default show names
     info = {}

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -128,16 +128,16 @@ def statistics():
 
 @ec_page.route("/<int:conductor>/")
 def by_conductor(conductor):
+    info = to_dict(request.args)
+    info['bread'] = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', url_for(".rational_elliptic_curves")), ('%s' % conductor, url_for(".by_conductor", conductor=conductor))]
+    info['title'] = 'Elliptic Curves over $\Q$ of conductor %s' % conductor
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'conductor' in request.args and request.args['conductor'] != str(conductor):
             return redirect (url_for(".rational_elliptic_curves", **request.args), 301)
-        info = to_dict(request.args)
-        info['title'] = 'Elliptic Curves over $\Q$ search results for conductor %s' % conductor
-    else:
-        info = {'title':'Elliptic Curves over $\Q$ of conductor %s' % conductor }
+        info['title'] += ' search results'
+        info['bread'].append(('search results',''))
     info['conductor'] = conductor
-    info['bread'] = (('Elliptic curves', url_for("ecnf.index")), ('$\Q$', url_for(".rational_elliptic_curves")), ('%s' % conductor, '.'))
     return elliptic_curve_search(info)
 
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -2,24 +2,24 @@
 import re
 import time
 import ast
-from pymongo import ASCENDING, DESCENDING
+from pymongo import ASCENDING
 from operator import mul
 import lmfdb.base
 from lmfdb.base import app
-from flask import Flask, session, g, render_template, url_for, request, redirect, make_response, send_file
+from flask import render_template, url_for, request, redirect, make_response, send_file
 import tempfile
 import os
 import StringIO
 
-from lmfdb.utils import ajax_more, image_src, web_latex, to_dict, web_latex_split_on_pm, comma, random_object_from_collection
+from lmfdb.utils import web_latex, to_dict, web_latex_split_on_pm, random_object_from_collection
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.ec_stats import get_stats
 from lmfdb.elliptic_curves.isog_class import ECisog_class
-from lmfdb.elliptic_curves.web_ec import WebEC, parse_points, match_lmfdb_label, match_lmfdb_iso_label, match_cremona_label, split_lmfdb_label, split_lmfdb_iso_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, class_cremona_label, curve_lmfdb_label, curve_cremona_label, ecdb, db_ec
-from lmfdb.search_parsing import split_list, parse_rational, parse_ints, parse_bracketed_posints, parse_primes, parse_count, parse_start
+from lmfdb.elliptic_curves.web_ec import WebEC, match_lmfdb_label, match_cremona_label, split_lmfdb_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, curve_lmfdb_label, db_ec
+from lmfdb.search_parsing import parse_rational, parse_ints, parse_bracketed_posints, parse_primes, parse_count, parse_start
 
 import sage.all
-from sage.all import ZZ, QQ, EllipticCurve, latex, matrix, srange
+from sage.all import ZZ, QQ, EllipticCurve
 q = ZZ['x'].gen()
 
 #########################

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -128,15 +128,16 @@ def statistics():
 
 @ec_page.route("/<int:conductor>/")
 def by_conductor(conductor):
-    info = {}
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'conductor' in request.args and request.args['conductor'] != str(conductor):
             return redirect (url_for(".rational_elliptic_curves", **request.args), 301)
         info = to_dict(request.args)
+        info['title'] = 'Elliptic Curves over $\Q$ search results for conductor %s' % conductor
+    else:
+        info = {'title':'Elliptic Curves over $\Q$ of conductor %s' % conductor }
     info['conductor'] = conductor
     info['bread'] = (('Elliptic curves', url_for("ecnf.index")), ('$\Q$', url_for(".rational_elliptic_curves")), ('%s' % conductor, '.'))
-    info['title'] = 'Elliptic Curves search results for conductor %s' % conductor
     return elliptic_curve_search(info)
 
 

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -136,14 +136,16 @@ def by_url_curve_label(cond, alpha, disc, num):
 
 @g2c_page.route("/Q/<int:cond>/<alpha>/<int:disc>/")
 def by_url_isogeny_class_discriminant(cond, alpha, disc):
-    data = {}
+    clabel = str(cond)+"."+alpha
     if len(request.args) > 0:
         # if conductor or discriminant changed, fall back to a general search
         if ('cond' in request.args and request.args['cond'] != str(cond)) or \
            ('abs_disc' in request.args and request.args['abs_disc'] != str(disc)):
             return redirect (url_for(".index", **request.args), 301)
         data = to_dict(request.args)
-    clabel = str(cond)+"."+alpha
+        data['title'] = 'Genus 2 curves search results for isogeny class %s and discriminant %s' % (clabel,disc)
+    else:
+        data['title'] = 'Genus 2 curves in isogeny class %s of discriminant %s' % (clabel,disc)
     data['cond'] = cond
     data['class'] = clabel
     data['abs_disc'] = disc
@@ -152,7 +154,6 @@ def by_url_isogeny_class_discriminant(cond, alpha, disc):
         ('%s' % cond, url_for(".by_conductor", cond=cond)),
         ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
         ('%s' % disc, '.'))
-    data['title'] = 'Genus 2 Curve search results for isogeny class %s and discriminant %s' % (clabel,disc)
     return genus2_curve_search(data)
 
 @g2c_page.route("/Q/<int:cond>/<alpha>/")
@@ -161,15 +162,17 @@ def by_url_isogeny_class_label(cond, alpha):
 
 @g2c_page.route("/Q/<int:cond>/")
 def by_conductor(cond):
-    data = {}
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'cond' in request.args and request.args['cond'] != str(cond):
             return redirect (url_for(".index", **request.args), 301)
         data = to_dict(request.args)
+        data['title'] = 'Genus 2 curves search results for conductor %s' % cond
+    else:
+        data = {'title':'Genus 2 curves of conductor %s' % cond }
     data['cond'] = cond
     data['bread'] = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('%s' % cond, '.'))
-    data['title'] = 'Genus 2 Curve search results for conductor %s' % cond
+    data['title'] = 'Genus 2 curve search results for conductor %s' % cond
     print "by_conductor",cond,data
     return genus2_curve_search(data)
 

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -136,24 +136,24 @@ def by_url_curve_label(cond, alpha, disc, num):
 
 @g2c_page.route("/Q/<int:cond>/<alpha>/<int:disc>/")
 def by_url_isogeny_class_discriminant(cond, alpha, disc):
+    data = to_dict(request.args)
     clabel = str(cond)+"."+alpha
+    data['title'] = 'Genus 2 curves in isogeny class %s of discriminant %s' % (clabel,disc)
+    data['bread'] = [('Genus 2 Curves', url_for(".index")),
+        ('$\Q$', url_for(".index_Q")),
+        ('%s' % cond, url_for(".by_conductor", cond=cond)),
+        ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
+        ('%s' % disc, url_for(".by_url_isogeny_class_discriminant", cond=cond, alpha=alpha, disc=disc))]
     if len(request.args) > 0:
         # if conductor or discriminant changed, fall back to a general search
         if ('cond' in request.args and request.args['cond'] != str(cond)) or \
            ('abs_disc' in request.args and request.args['abs_disc'] != str(disc)):
             return redirect (url_for(".index", **request.args), 301)
-        data = to_dict(request.args)
-        data['title'] = 'Genus 2 curves search results for isogeny class %s and discriminant %s' % (clabel,disc)
-    else:
-        data['title'] = 'Genus 2 curves in isogeny class %s of discriminant %s' % (clabel,disc)
+        data['title'] += ' search results'
+        data['bread'].append(('search results',''))
     data['cond'] = cond
     data['class'] = clabel
     data['abs_disc'] = disc
-    data['bread'] = (('Genus 2 Curves', url_for(".index")),
-        ('$\Q$', url_for(".index_Q")),
-        ('%s' % cond, url_for(".by_conductor", cond=cond)),
-        ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
-        ('%s' % disc, '.'))
     return genus2_curve_search(data)
 
 @g2c_page.route("/Q/<int:cond>/<alpha>/")
@@ -162,18 +162,16 @@ def by_url_isogeny_class_label(cond, alpha):
 
 @g2c_page.route("/Q/<int:cond>/")
 def by_conductor(cond):
+    data = to_dict(request.args)
+    data['title'] = 'Genus 2 curves of conductor %s' % cond
+    data['bread'] = [('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('%s' % cond, url_for(".by_conductor", cond=cond))]
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'cond' in request.args and request.args['cond'] != str(cond):
             return redirect (url_for(".index", **request.args), 301)
-        data = to_dict(request.args)
-        data['title'] = 'Genus 2 curves search results for conductor %s' % cond
-    else:
-        data = {'title':'Genus 2 curves of conductor %s' % cond }
+        data['title'] += ' search results'
+        data['bread'].append(('search results',''))
     data['cond'] = cond
-    data['bread'] = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('%s' % cond, '.'))
-    data['title'] = 'Genus 2 curve search results for conductor %s' % cond
-    print "by_conductor",cond,data
     return genus2_curve_search(data)
 
 @g2c_page.route("/Q/<label>")
@@ -232,10 +230,9 @@ def class_from_curve_label(label):
 ################################################################################
 
 def genus2_curve_search(info):
-    print info
     if 'jump' in info:
         jump = info["jump"].strip()
-        if re.match(r'\d+\.[a-z]+.\d+.\d+$',jump):
+        if re.match(r'\d+\.[a-z]+\.\d+\.\d+$',jump):
             return redirect(url_for_curve_label(jump), 301)
         else:
             if re.match(r'\d+\.[a-z]+$', jump):

--- a/lmfdb/genus2_curves/genus2_curve.py
+++ b/lmfdb/genus2_curves/genus2_curve.py
@@ -93,7 +93,7 @@ def index():
 @g2c_page.route("/Q/")
 def index_Q():
     if len(request.args) > 0:
-        return genus2_curve_search(data=request.args)
+        return genus2_curve_search(to_dict(request.args))
     info = {'counts' : g2cstats().counts()}
     info["stats_url"] = url_for(".statistics")
     info["curve_url"] =  lambda label: url_for_curve_label(label)
@@ -138,7 +138,7 @@ def by_url_curve_label(cond, alpha, disc, num):
 def by_url_isogeny_class_discriminant(cond, alpha, disc):
     data = {}
     if len(request.args) > 0:
-        # if changed conductor or discriminat, fall back to a general search
+        # if conductor or discriminant changed, fall back to a general search
         if ('cond' in request.args and request.args['cond'] != str(cond)) or \
            ('abs_disc' in request.args and request.args['abs_disc'] != str(disc)):
             return redirect (url_for(".index", **request.args), 301)
@@ -153,7 +153,7 @@ def by_url_isogeny_class_discriminant(cond, alpha, disc):
         ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
         ('%s' % disc, '.'))
     data['title'] = 'Genus 2 Curve search results for isogeny class %s and discriminant %s' % (clabel,disc)
-    return genus2_curve_search(data=data, **request.args)
+    return genus2_curve_search(data)
 
 @g2c_page.route("/Q/<int:cond>/<alpha>/")
 def by_url_isogeny_class_label(cond, alpha):
@@ -163,19 +163,20 @@ def by_url_isogeny_class_label(cond, alpha):
 def by_conductor(cond):
     data = {}
     if len(request.args) > 0:
-        # if changed conductor or discriminat, fall back to a general search
+        # if conductor changed, fall back to a general search
         if 'cond' in request.args and request.args['cond'] != str(cond):
             return redirect (url_for(".index", **request.args), 301)
         data = to_dict(request.args)
     data['cond'] = cond
     data['bread'] = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index_Q")), ('%s' % cond, '.'))
     data['title'] = 'Genus 2 Curve search results for conductor %s' % cond
-    return genus2_curve_search(data=data, **request.args)
+    print "by_conductor",cond,data
+    return genus2_curve_search(data)
 
 @g2c_page.route("/Q/<label>")
 def by_label(label):
     # handles curve, isogeny class, and Lhash labels
-    return genus2_curve_search(data={'jump':label}, **request.args)
+    return genus2_curve_search({'jump':label})
 
 def render_curve_webpage(label):
     g2c = WebG2C.by_label(label)
@@ -227,8 +228,8 @@ def class_from_curve_label(label):
 # Searching
 ################################################################################
 
-def genus2_curve_search(**args):
-    info = to_dict(args['data'])
+def genus2_curve_search(info):
+    print info
     if 'jump' in info:
         jump = info["jump"].strip()
         if re.match(r'\d+\.[a-z]+.\d+.\d+$',jump):

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -6,10 +6,12 @@ import time
 import flask
 import lmfdb.base as base
 from lmfdb.base import app, getDBConnection, url_for
-from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response, redirect, g, session, Flask, send_file
+from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response, redirect, g, session, Flask, send_file, flash
 import StringIO
 from lmfdb.number_fields import nf_page, nf_logger
 from lmfdb.WebNumberField import *
+
+from markupsafe import Markup
 
 import re
 
@@ -255,7 +257,7 @@ def render_field_webpage(args):
     data = {}
     if nf.is_null():
         bread.append(('Search results', ' '))
-        info['err'] = 'There is no field with label %s in the database' % label2
+        info['err'] = 'There is no field with label %s in the database' % label
         info['label'] = args['label_orig'] if 'label_orig' in args else args['label']
         return search_input_error(info, bread)
 
@@ -407,7 +409,8 @@ def format_coeffs(coeffs):
 def by_label(label):
     try:
         return render_field_webpage({'label': nf_string_to_label(label)})
-    except ValueError:
+    except ValueError as err:
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid number field. %s" % (label,err)), "error")
         bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Search results', ' ')]
         return search_input_error({'err':''}, bread)
 

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -382,8 +382,7 @@ def nf_string_to_label(F):  # parse Q, Qsqrt2, Qsqrt-4, Qzeta5, etc
         raise ValueError("Entry for the field was left blank.  You need to enter a field label, field name, or a polynomial.")
     if F[0] == 'Q':
         if '(' in F and ')' in F:
-            F.replace('(','')
-            F.replace(')','')
+            F=F.replace('(','').replace(')','')
         if F[1:5] in ['sqrt', 'root']:
             try:
                 d = ZZ(str(F[5:])).squarefree_part()
@@ -401,6 +400,8 @@ def nf_string_to_label(F):  # parse Q, Qsqrt2, Qsqrt-4, Qzeta5, etc
             s = 0 if D < 0 else 2
             return '2.%s.%s.1' % (s, str(absD))
         if F[1:5] == 'zeta':
+            if '_' in F:
+                F = F.replace('_','')
             try:
                 d = ZZ(str(F[5:]))
             except ValueError:


### PR DESCRIPTION
This PR addresses issue #1472.  To see it in action:

* Go to http://www.lmfdb.org/EllipticCurve/Q/11/ and click search and get a server error.  Now go to http://127.0.0.1:37777/EllipticCurve/Q/11/ and do the same thing.
* Go to http://www.lmfdb.org/EllipticCurve/2.2.5.1/76.1/ and notice that the list includes curves over Q(sqrt(17)); type in conductor norm 77 and notice nothing changes.  Now got to http://127.0.0.1:37777/EllipticCurve/2.2.5.1/76.1/ and do the same thing.
* Go to http://www.lmfdb.org/EllipticCurve/2.2.5.1/?conductor_norm=76 and notice that it includes curves over Q(sqrt(17)).  Now go to http:127.0.0.1:37777/EllipticCurve/2.2.5.1/?conductor_norm=76 and compare.
* Go to http://www.lmfdb.org/EllipticCurve/2.0.3.1/%5B2268%2C36%2C18%5D/a/1 and click on the last bread crumb and get a search error.  Now go to http://127.0.0.1:37777/EllipticCurve/2.0.3.1/%5B2268%2C36%2C18%5D/a/1 and do the same thing.

In general, if you are at a nf bread crumb or a conductor bread crumb you are on a search page where you can refine your search.  If your refinement does not change the nf or conductor, it will treat is a search extending the bread crumb trail, but if your refinement conflicts with your bread crumb trail it will treat it as a general search.  For example, got to http://127.0.0.1:37777/EllipticCurve/2.2.5.1/ or http://127.0.0.1:37777/EllipticCurve/2.2.5.1/76.1/ and enter in torsion order 1 in the search results.  Now try instead changing the field label to 2.0.3.1 or the conductor norm to 77.

I also fixed a few bugs in nf_string_to_label, and you can now enter URLs like

http://127.0.0.1:37777/EllipticCurve/Qzeta3/
http://127.0.0.1:37777/EllipticCurve/Q(zeta3)/
http://127.0.0.1:37777/EllipticCurve/Q(zeta_3)/
http://127.0.0.1:37777/EllipticCurve/Qsqrt5/
http://127.0.0.1:37777/EllipticCurve/Q(sqrt5))/
http://127.0.0.1:37777/EllipticCurve/Q(sqrt(5))/

If you specify a field equivalent to Q, e.g. http://127.0.0.1:37777/EllipticCurve/Q(zeta_2)/ http://127.0.0.1:37777/EllipticCurve/Q(sqrt(4))/ it will redirect to EllitpicCurve/Q.   It also does this if you set the field label to 1.1.1.1 when searching.

This PR also contains a few conforming changes to Genus2Curves so that bread crumbs and searching work the same in both EllipticCurves and Genus2Curves.

@JohnCremona, please review and if you see anything you don't like, tell me and I will change it.










