### PR TITLE
Clean submit

### DIFF
--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -1,6 +1,6 @@
 {% extends 'homepage.html' %}
-{% block content %}
 
+{% block content %}
 <p>
 The database currently contains {{info["counts"]["ncurves_c"]}} <a title="Genus 2 curves [g2c.g2curve]" knowl="g2c.g2curve" kwargs="">genus 2 curves</a> over $\Q$
 of <a title="Genus 2 curves [g2c.abs_discriminant]" knowl="g2c.abs_discriminant" kwargs="">absolute discriminant</a> up to {{info["counts"]["max_D_c"]}}.
@@ -40,7 +40,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 
 
 <h2> Search </h2>
-<form>
+<form id='search' onsubmit="cleanSubmit(this.id)">
 <table>
 <tr>
 <td>{{ KNOWL('ag.conductor', title='conductor') }}</td>

--- a/lmfdb/genus2_curves/templates/browse_search_g2.html
+++ b/lmfdb/genus2_curves/templates/browse_search_g2.html
@@ -1,6 +1,6 @@
 {% extends 'homepage.html' %}
-
 {% block content %}
+
 <p>
 The database currently contains {{info["counts"]["ncurves_c"]}} <a title="Genus 2 curves [g2c.g2curve]" knowl="g2c.g2curve" kwargs="">genus 2 curves</a> over $\Q$
 of <a title="Genus 2 curves [g2c.abs_discriminant]" knowl="g2c.abs_discriminant" kwargs="">absolute discriminant</a> up to {{info["counts"]["max_D_c"]}}.

--- a/lmfdb/genus2_curves/templates/search_results_g2.html
+++ b/lmfdb/genus2_curves/templates/search_results_g2.html
@@ -3,7 +3,7 @@
 
 <h2>Refine search </h2>
 
-<form id='re-search'>
+<form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
 

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -236,6 +236,21 @@
             {% endfor %}
         </div>
     {% endif %}
+    {% block content_js %}
+        <script type="text/javascript">
+        // strips empty input/select fields from query URLs.  To enable, put onsubmit="cleanSubmit(this.id)" in form tag (and give it an id).
+        function cleanSubmit(id)
+        {
+            var myForm = document.getElementById(id);
+            var allInputs = myForm.getElementsByTagName('input')
+            var allSelects = myForm.getElementsByTagName('select')
+            var item, i;
+
+            for(i = 0; item = allInputs[i]; i++) if(item.getAttribute('name') && !item.value) item.setAttribute('name', '');
+            for(i = 0; item = allSelects[i]; i++) if(item.getAttribute('name') && !item.value) item.setAttribute('name', '');
+        }
+        </script>
+    {% endblock content_js %}
     {% block content -%}
     There is nothing here. This is just a template.
     {%- endblock content %}


### PR DESCRIPTION
This is a very small change that adds a short javascript code snippet to homepage.html that can be used to strip empty parameters from URL strings in GET requests.  To use it in a search form, just add "onsubmit=cleanSubmit(this.id)" to your input form tag (and give it an id if it does not already have one).

This is useful for browse/search pages with many parameters (so many you cannot even see them all in the URL bar, which makes debugging a pain).  To compare, go to http://www.lmfdb.org/Genus2Curve/Q/ and click search and look at your URL bar.  Now go to http://127.0.0.1:37777/Genus2Curve/Q/ and do the same thing.