### PR TITLE
Fix for #1620

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -151,7 +151,7 @@ def index():
 @st_page.route('/random')
 def random():
     data = random_object_from_collection(st_groups())
-    return redirect(url_for('.by_label', label=data['label']))
+    return redirect(url_for('.by_label', label=data['label']), 301)
 
 @st_page.route('/<label>')
 def by_label(label):
@@ -186,14 +186,16 @@ def search_by_label(label):
         flash_error("%s is not the label or name of a Sato-Tate group currently in the database", label)
         return redirect(url_for(".index"))
     else:
-        return redirect(url_for('.by_label', label=data['label']))
+        return redirect(url_for('.by_label', label=data['label']), 301)
 
 def search(**args):
     """ query processing for Sato-Tate groups -- returns rendered results page """
 
     info = to_dict(args)
+    if 'jump' in info:
+        return redirect(url_for('.by_label', label=info['jump']), 301)
     if 'label' in info:
-        return search_by_label(info['label'])
+        return redirect(url_for('.by_label', label=info['label']), 301)
     bread = [('Sato-Tate groups', url_for('.index')),('Search Results', '.')]
     count = parse_count(info, 25)
     start = parse_start(info)

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
+import re, itertools
 from pymongo import ASCENDING
 from flask import render_template, url_for, redirect, request
 from lmfdb.sato_tate_groups import st_page
@@ -7,7 +7,7 @@ from lmfdb.utils import to_dict, random_object_from_collection, encode_plot, fla
 from lmfdb.base import getDBConnection
 from lmfdb.search_parsing import parse_ints, parse_rational, parse_count, parse_start, parse_ints_to_list_flash
 
-from sage.all import ZZ, cos, sin, pi, list_plot, circle
+from sage.all import ZZ, QQ, cos, sin, pi, list_plot, circle
 
 ###############################################################################
 # Globals
@@ -18,12 +18,14 @@ MU_LABEL_NAME_RE = r'^0\.1\.mu\([1-9][0-9]*\)$'
 ST_LABEL_RE = '^\d+\.\d+\.\d+\.\d+\.\d+[a-z]+$'
 ST_LABEL_SHORT_RE = '^\d+\.\d+\.\d+\.\d+\.\d+$'
 ST_LABEL_NAME_RE = r'^\d+\.\d+\.[a-zA-z0-9\{\}\(\)\[\]\_\,]+'
+INFINITY = -1
 
 credit_string = 'Andrew Sutherland'
 
 # use a list and a dictionary (for pretty printing) so that we can control the display order (switch to ordered dictionary once everyone is on python 3.1)
-st0_list = ( 'U(1)', 'SU(2)', 'U(1)_2', 'SU(2)_2','U(1)xU(1)', 'U(1)xSU(2)','SU(2)xSU(2)','USp(4)' )
+st0_list = ( 'SO(1)', 'U(1)', 'SU(2)', 'U(1)_2', 'SU(2)_2','U(1)xU(1)', 'U(1)xSU(2)','SU(2)xSU(2)','USp(4)' )
 st0_dict = {
+    'SO(1)':'\\mathrm{SO}(1)',
     'U(1)':'\\mathrm{U}(1)',
     'SU(2)':'\\mathrm{SU}(2)',
     'U(1)_2':'\\mathrm{U}(1)_2',
@@ -91,7 +93,7 @@ def trace_moments(moments):
 
 def st0_pretty(st0_name):
     if re.match('SO\(1\)\_\d+', st0_name):
-        return '\\mathrm{SO}(1)_{%s}' % st0_name.splilt('_')[1]
+        return '\\mathrm{SO}(1)_{%s}' % st0_name.split('_')[1]
     return st0_dict.get(st0_name,st0_name)
 
 def sg_pretty(sg_label):
@@ -137,7 +139,7 @@ def learnmore_list_remove(matchstring):
 def index():
     if len(request.args) != 0:
         return search(**request.args)
-    weight_list= [1]
+    weight_list= [0, 1]
     degree_list=range(1, 5, 1)
     group_list = [ '1.2.1.2.1a','1.2.3.1.1a', '1.4.1.12.4d', '1.4.3.6.2a', '1.4.6.1.1a', '1.4.10.1.1a' ]
     group_dict = { '1.2.1.2.1a':'N(\\mathrm{U}(1))','1.2.3.1.1a':'\\mathrm{SU}(2)', '1.4.1.12.4d':'D_{6,2}','1.4.3.6.2a':'E_6', '1.4.6.1.1a':'G_{3,3}', '1.4.10.1.1a':'\\mathrm{USp}(4)' }
@@ -195,76 +197,73 @@ def search(**args):
     bread = [('Sato-Tate groups', url_for('.index')),('Search Results', '.')]
     count = parse_count(info, 25)
     start = parse_start(info)
-    query = {}
-    if info.get('rational','1') == '1':
-        # Lookup rational ST groups in database
-        try:
-            parse_ints(info,query,'weight','weight')
-            parse_ints(info,query,'degree','degree')
-            if info.get('identity_component'):
-                query['identity_component'] = info['identity_component']
-            parse_ints(info,query,'components','components')
-            parse_rational(info,query,'trace_zero_density','trace zero density')
-        except ValueError as err:
-            info['err'] = str(err)
-            return render_template('results.html', info=info, title='Sato-Tate groups search input error', bread=bread, credit=credit_string)
-        cursor = st_groups().find(query)
-        nres = cursor.count()
-        if (start >= nres):
-            start -= (1 + (start - nres) / count) * count
-        if (start < 0):
-            start = 0
-        res = cursor.sort([('degree', ASCENDING), ('real_dimension', ASCENDING), ('identity_component', ASCENDING), ('name', ASCENDING)]).skip(start).limit(count)
-        nres = res.count()
-        results = []
-        for v in res:
-            v_clean = {}
-            v_clean['label'] = v['label']
-            v_clean['weight'] = v['weight']
-            v_clean['degree'] = v['degree']
-            v_clean['real_dimension'] = v['real_dimension']
-            v_clean['identity_component'] = st0_pretty(v['identity_component'])
-            v_clean['name'] = v['name']
-            v_clean['pretty'] = v['pretty']
-            v_clean['components'] = v['components']
-            v_clean['component_group'] = sg_pretty(v['component_group'])
-            v_clean['trace_zero_density'] = v['trace_zero_density']
-            v_clean['trace_moments'] = trace_moments(v['moments'])
-            results.append(v_clean)
+    # if user clicked refine search always restart at 0
+    if 'refine' in info:
+        start = 0
+    ratonly = True if info.get('rational_only','no').strip().lower() == 'yes' else False
+    query = {'rational':True} if ratonly else {}
+    try:
+        parse_ints(info,query,'weight','weight')
+        if 'weight' in query:
+            weight_list = parse_ints_to_list_flash(info.get('weight'),'weight')
+        parse_ints(info,query,'degree','degree')
+        if 'degree' in query:
+            degree_list = parse_ints_to_list_flash(info.get('degree'),'degree')
+        if info.get('identity_component'):
+            query['identity_component'] = info['identity_component']
+        parse_ints(info,query,'components','components')
+        if 'components' in query:
+            components_list = parse_ints_to_list_flash(info.get('components'), 'components')
+        parse_rational(info,query,'trace_zero_density','trace zero density')
+    except ValueError as err:
+        info['err'] = str(err)
+        return render_template('results.html', info=info, title='Sato-Tate groups search input error', bread=bread, credit=credit_string)
+
+    # Check mu(n) groups first (these are not stored in the database)
+    results = []
+    print info
+    if (not 'weight' in query or 0 in weight_list) and \
+       (not 'degree' in query or 1 in degree_list) and \
+       (not 'identity_component' in query or query['identity_component'] == 'SO(1)') and \
+       (not 'trace_zero_density' in query or query['trace_zero_density'] == '0'):
+        if not 'components' in query:
+            components_list = xrange(1,3 if ratonly else start+count+1)
+        elif ratonly:
+            components_list = [n for n in range(1,3) if n in components_list]
+        nres = len(components_list) if 'components' in query or ratonly else INFINITY
+        for n in itertools.islice(components_list,start,start+count):
+            results.append(mu_info(n))
     else:
-        # Irrational ST groups are currently limited to weight 0 degree 1 (mu(n) for n > 2)
-        try:
-            query['weight'] = parse_ints_to_list_flash(info.get('weight'),'weight')
-            query['degree'] = parse_ints_to_list_flash(info.get('degree'),'degree')
-            query['components'] = parse_ints_to_list_flash(info.get('components'),'components')
-            parse_rational(info,query,'trace_zero_density', 'trace zero density')
-        except ValueError as err:
-            info['err'] = str(err)
-            return render_template('results.html', info=info, title='Sato-Tate groups search input error', bread=bread, credit=credit_string)
-        if (query['weight'] and not 0 in query['weight']) or \
-           (query['degree'] and not 1 in query['degree']) or \
-           (query.get('trace_zero_density') and query['trace_zero_density'] != 0):
-            res = []
-        else:
-            nres = len(query['components']) if query.get('components') else -1
-            if not query.get('components'):
-                query['components'] = xrange(3,3+start+count)
-            results = []
-            i = 0
-            for n in query['components']:
-                if n >= 2:
-                    i += 1
-                    if i >= start:
-                        results.append(mu_info(n))
-                        if len(results) == count:
-                            break
+        nres = 0
+
+    # Now lookup other (rational) ST groups in database
+    if nres != INFINITY:
+        cursor = st_groups().find(query)
+        start2 = start - nres if start > nres else 0
+        nres += cursor.count()
+        if start < nres and len(results) < count:
+            res = cursor.sort([('weight',ASCENDING), ('degree', ASCENDING), ('real_dimension', ASCENDING), ('identity_component', ASCENDING), ('name', ASCENDING)]).skip(start2).limit(count-len(results))
+            for v in res:
+                v_clean = {}
+                v_clean['label'] = v['label']
+                v_clean['weight'] = v['weight']
+                v_clean['degree'] = v['degree']
+                v_clean['real_dimension'] = v['real_dimension']
+                v_clean['identity_component'] = st0_pretty(v['identity_component'])
+                v_clean['name'] = v['name']
+                v_clean['pretty'] = v['pretty']
+                v_clean['components'] = v['components']
+                v_clean['component_group'] = sg_pretty(v['component_group'])
+                v_clean['trace_zero_density'] = v['trace_zero_density']
+                v_clean['trace_moments'] = trace_moments(v['moments'])
+                results.append(v_clean)
     if nres == 0:
         info['report'] = 'no matches'
     elif nres == 1:
         info['report'] = 'unique match'
     else:
-        if nres < 0 or nres > count or start > 0:
-            info['report'] = 'displaying matches %d-%d %s' % (start + 1, start + len(results), "of %d"%nres if nres > 0 else "")
+        if nres == INFINITY or nres > count or start > 0:
+            info['report'] = 'displaying matches %d-%d %s' % (start + 1, start + len(results), "of %d"%nres if nres != INFINITY else "")
         else:
             info['report'] = 'displaying all %s matches' % nres
 
@@ -289,12 +288,12 @@ def mu_info(n):
     rec['label'] = "0.1.%d"%n
     rec['weight'] = 0
     rec['degree'] = 1
-    rec['rational'] = boolean_name(True if n < 3 else False)
+    rec['rational'] = boolean_name(True if n <= 2 else False)
     rec['name'] = 'mu(%d)'%n
     rec['pretty'] = '\mu(%d)'%n
     rec['real_dimension'] = 0
     rec['components'] = int(n)
-    rec['ambient'] = '\mathrm{O}(1)'
+    rec['ambient'] = '\mathrm{O}(1)' if n <= 2 else '\mathrm{U}(1)'
     rec['connected'] = boolean_name(rec['components'] == 1)
     rec['st0_name'] = '\mathrm{SO}(1)'
     rec['identity_component'] = st0_pretty(rec['st0_name'])
@@ -307,10 +306,17 @@ def mu_info(n):
     rec['gens'] = r'\left[\zeta_{%d}\right]'%n
     rec['numgens'] = 1
     rec['subgroups'] = comma_separated_list([st_link("0.1.%d"%(n/p)) for p in n.prime_factors()])
-    rec['supgroups'] = comma_separated_list([st_link("0.1.%d"%(p*n)) for p in [2,3,5]] + ["$\ldots$"])
+    # only list supgroups with the same ambient (i.e.if mu(n) lies in O(1) don't list supgroups that are not)
+    if n == 1:
+        rec['supgroups'] = st_link("0.1.2")
+    elif n > 2:
+        rec['supgroups'] = comma_separated_list([st_link("0.1.%d"%(p*n)) for p in [2,3,5]] + ["$\ldots$"])
     rec['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%m for m in range(13)]]
     rec['moments'] += [['a_1'] + ['1' if m % n == 0  else '0' for m in range(13)]]
     rec['trace_moments'] = trace_moments(rec['moments'])
+    rational_traces = [1] if n%2 else [1,-1]
+    rec['counts'] = [['a_1', [[t,1] for t in rational_traces]]]
+    rec['probabilities'] = [['\\mathrm{P}[a_1=%d]=\\frac{1}{%d}'%(m,n)] for m in rational_traces]
     return rec
 
 def mu_portrait(n):
@@ -379,11 +385,10 @@ def render_st_group(info, portrait=None):
         ('Identity Component', '\(%s\)'%info['st0_name']),
         ('Component group', '\(%s\)'%info['component_group']),
     ]
-    rational_filter = '&rational=0' if info.get('rational') == boolean_name(False) else ''
     bread = [
         ('Sato-Tate groups', url_for('.index')),
-        ('Weight %d'% info['weight'], url_for('.index')+'?weight='+str(info['weight']) + rational_filter),
-        ('Degree %d'% info['degree'], url_for('.index')+'?weight='+str(info['weight'])+'&degree='+str(info['degree']) + rational_filter),
+        ('Weight %d'% info['weight'], url_for('.index')+'?weight='+str(info['weight'])),
+        ('Degree %d'% info['degree'], url_for('.index')+'?weight='+str(info['weight'])+'&degree='+str(info['degree'])),
         (info['name'], '')
     ]
     title = 'Sato-Tate group \(' + info['pretty'] + '\) of weight %d'% info['weight'] + ' and degree %d'% info['degree']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -7,7 +7,7 @@ from lmfdb.utils import to_dict, random_object_from_collection, encode_plot, fla
 from lmfdb.base import getDBConnection
 from lmfdb.search_parsing import parse_ints, parse_rational, parse_count, parse_start, parse_ints_to_list_flash
 
-from sage.all import ZZ, QQ, cos, sin, pi, list_plot, circle
+from sage.all import ZZ, cos, sin, pi, list_plot, circle
 
 ###############################################################################
 # Globals

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -221,7 +221,6 @@ def search(**args):
 
     # Check mu(n) groups first (these are not stored in the database)
     results = []
-    print info
     if (not 'weight' in query or 0 in weight_list) and \
        (not 'degree' in query or 1 in degree_list) and \
        (not 'identity_component' in query or query['identity_component'] == 'SO(1)') and \

--- a/lmfdb/sato_tate_groups/templates/browse.html
+++ b/lmfdb/sato_tate_groups/templates/browse.html
@@ -8,19 +8,19 @@
 <h2> Browse {{ KNOWL('st_group.definition', title='Sato-Tate groups') }}</h2>
 
 <p>
-By {{ KNOWL('st_group.weight', title='Weight') }}: 
+By {{ KNOWL('st_group.weight', title='weight') }}: 
 {% for r in info.weight_list %}
     <a href="?weight={{r}}">{{r}}</a>
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('st_group.degree', title='Degree') }}:
+By {{ KNOWL('st_group.degree', title='degree') }}:
 {% for r in info.degree_list %}
     <a href="?degree={{r}}">{{r}}</a>
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('st_group.identity_component', title='Identity component') }}: 
+By {{ KNOWL('st_group.identity_component', title='identity component') }}: 
 {% for r in info.st0_list %}
     &nbsp;<a href="?identity_component={{r}}">${{info.st0_dict[r]}}$</a>
 {% endfor %}
@@ -59,10 +59,10 @@ Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') 
 <td><span class="formexample"> e.g. 4 or 1-6</td>
 </tr>
 <tr>
-<td>{{KNOWL('st_group.rational',title='Rational')}}</td>
-<td><select name='rational' width="122" style="width: 122px">
-        <option value='1'>yes</option>
-        <option value='0'>no</option>
+<td>{{KNOWL('st_group.rational',title='Rational only')}}</td>
+<td><select name='rational_only' width="122" style="width: 122px">
+        <option value='yes' selected>yes</option>
+        <option value='no'>no</option>
 </select></td>
 <td><span class="formexample"> e.g. yes or no</td>
 </tr>

--- a/lmfdb/sato_tate_groups/templates/browse.html
+++ b/lmfdb/sato_tate_groups/templates/browse.html
@@ -38,9 +38,9 @@ Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') 
 <h2> Find a specific {{ KNOWL('st_group.definition', title='Sato-Tate group') }} by {{KNOWL('st_group.label', title='label')}} or by {{KNOWL('st_group.name', title='name')}}</h2>
 
 <form>
-<input type='text' name='label' placeholder='USp(4)'>
+<input type='text' name='label' placeholder='1.4.USp(4)'>
 <button type='submit'>Search by label</button>
-<br><span class="formexample">e.g. 1.2.1.2.1a or N(U(1)), or 1.4.10.1.1a or USp(4)</span>
+<br><span class="formexample">e.g. 0.1.3 or 0.1.mu(3), or 1.2.1.2.1a or N(U(1)), or 1.4.10.1.1a or 1.4.USp(4)</span>
 </form>
 
 <h2> Search </h2>

--- a/lmfdb/sato_tate_groups/templates/browse.html
+++ b/lmfdb/sato_tate_groups/templates/browse.html
@@ -46,46 +46,53 @@ Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') 
 <h2> Search </h2>
 
 <p>Please enter a value or leave blank:</p>
-<form>
+<form id='search' onsubmit="cleanSubmit(this.id)">
 <table>
 <tr>
 <td>{{ KNOWL('st_group.weight', title='Weight') }}:</td>
-<td><input type='text' name='weight' placeholder='1' size=10>
+<td><input type='text' name='weight' placeholder='1' size=10></td>
 <td><span class="formexample"> e.g. 1 or 0-3</td>
 </tr>
 <tr>
 <td>{{ KNOWL('st_group.degree', title='Degree') }}:</td>
-<td><input type='text' name='degree' placeholder='4' size=10>
+<td><input type='text' name='degree' placeholder='4' size=10></td>
 <td><span class="formexample"> e.g. 4 or 1-6</td>
 </tr>
 <tr>
-<td>{{KNOWL('st_group.identity_component',title='Sato-Tate identity component')}}</td>
+<td>{{KNOWL('st_group.rational',title='Rational')}}</td>
+<td><select name='rational' width="122" style="width: 122px">
+        <option value='1'>yes</option>
+        <option value='0'>no</option>
+</select></td>
+<td><span class="formexample"> e.g. yes or no</td>
+</tr>
+<tr>
+<td>{{KNOWL('st_group.identity_component',title='Identity component')}}</td>
 <td><select name='identity_component' width="122" style="width: 122px">
         <option ></option>
     {% for r in info.st0_list %}
         <option value='{{r}}'>{{r}}</option>
     {% endfor %}
-<td><span class="formexample"> e.g. U(1) or USp(4)</td>
 </select></td>
-
+<td><span class="formexample"> e.g. U(1) or USp(4)</td>
 </tr>
 <tr>
 <td>{{ KNOWL('st_group.components', title='Components') }}:</td>
-<td><input type='text' name='components' placeholder='1' size=10>
+<td><input type='text' name='components' placeholder='1' size=10></td>
 <td><span class="formexample"> e.g. 1 (connected) or 4-12</td>
 </tr>
 <tr>
 <td>{{ KNOWL('st_group.trace_zero_density', title='Trace zero density')}}:</td>
-<td><input type='text' name='trace_zero_density' placeholder='1/2' size=10>
+<td><input type='text' name='trace_zero_density' placeholder='1/2' size=10></td>
 <td><span class="formexample"> e.g. 0, 1/2, or 3/8</td>
 </tr>
-
-<tr><td colspan='3'>Maximum number of results to display &nbsp; <input type='text' name='count' value=50 size='5' />
-</td>
+<tr
+><td>Results to display:</td>
+<td><input type='text' name='count' value=25 size=10 /></td>
+<td><span class="formexample"> e.g. 25 or 50</td>
 </tr>
-
 <tr>
-<td colspan=3><button type='submit' value='Search'>Search</button>
+<td><button type='submit' value='Search'>Search</button>
 </td>
 </tr>
 </table>

--- a/lmfdb/sato_tate_groups/templates/display.html
+++ b/lmfdb/sato_tate_groups/templates/display.html
@@ -6,12 +6,12 @@
 
 <h2> {{ KNOWL('st_group.invariants', title='Invariants') }} </h2>
 <table>
-    <tr><td>{{ KNOWL('st_group.name', title='Label') }}:</td><td>{{info['label']}}</td></tr>
     <tr><td>{{ KNOWL('st_group.weight', title='Weight') }}:</td><td>${{info['weight']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.degree', title='Degree') }}:</td><td>${{info['degree']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.real_dimension', title='$\mathbb{R}$-dimension') }}:</td><td>${{info['real_dimension']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.components', title='Components') }}:</td><td>${{info['components']}}$</td></tr>
     <tr><td>{{ KNOWL('st_group.ambient', title='Contained in') }}:</td><td>${{info['ambient']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.rational', title='Rational') }}:</td><td>${{info['rational']}}$</td></tr>
 </table>
 
 <h2> {{ KNOWL('st_group.identity_component', title='Identity Component') }} </h2>

--- a/lmfdb/sato_tate_groups/templates/display.html
+++ b/lmfdb/sato_tate_groups/templates/display.html
@@ -34,7 +34,7 @@
 </table>
 {% endif %}
 
-{% if info['subsups'] > 1 %}
+{% if info['subgroups']|count or info['supgroups']|count %}
 <h2> {{ KNOWL('st_group.subsupgroups', title='Subgoups and Supergroups') }} </h2>
 <table>
     <tr><td>{{ KNOWL('st_group.subgroups', title='Maximal Subgroups') }}:</td><td>{{info['subgroups']|safe}}</td></tr>
@@ -42,7 +42,7 @@
 </table>
 {% endif %}
 
-{% if info['moments'] != [] %}
+{% if info['moments'] %}
 <h2> {{ KNOWL('st_group.moments', title='Moment Statistics') }} </h2>
 <table border=1>
     {% for m in info['moments'] %}
@@ -59,7 +59,7 @@
 </table>
 {% endif %}
 
-{% if info['probabilities'] != [] %}
+{% if info['probabilities'] %}
 <h2> {{ KNOWL('st_group.probabilities', title='Event Probabilities') }} </h2>
 <table border=1>
     {% for m in info['probabilities'] %}

--- a/lmfdb/sato_tate_groups/templates/results.html
+++ b/lmfdb/sato_tate_groups/templates/results.html
@@ -3,21 +3,31 @@
 
 <h2>Refine search </h2>
 
-<form id='re-search'>
+<form id='re-search' onsubmit='cleanSubmit(this.id)'>
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
 
 <table>
 <td>{{ KNOWL('st_group.weight', title='weight') }}</td>
 <td>{{ KNOWL('st_group.degree', title='degree')}}</td>
-<td>{{ KNOWL('st_group.identity_component', title='\(\mathrm{ST}^0\)') }}</td>
+<td>{{ KNOWL('st_group.rational', title='rational') }}</td>
+<td>{{ KNOWL('st_group.identity_component', title='$\mathrm{ST}^0$') }}</td>
 <td>{{ KNOWL('st_group.components', title='components')}}</td>
-<td>{{ KNOWL('st_group.trace_zero_density', title='\(\mathrm{P}[a_1=0]\)')}}</td>
+<td>{{ KNOWL('st_group.trace_zero_density', title='$\mathrm{P}[a_1=0]$')}}</td>
 </tr>
 
 <tr>
 <td><input type='text' name='weight' placeholder='1' style="width: 100px" value="{{info.weight}}"></td>
 <td><input type='text' name='degree' placeholder='4' style="width: 100px" value="{{info.degree}}"></td>
+<td><select name='rational' style="width: 110px" >
+    {% if info.rational == '0' %}
+        <option value='1'>yes</option>
+        <option value='0' selected>no</option>
+    {% else %}
+        <option value='1' selected>yes</option>
+        <option value='0'>no</option>
+    {% endif %}
+</select></td>
 <td><select name='identity_component' style="width: 110px" >
     <option ></option>
     {% for G in info.st0_list %}
@@ -35,7 +45,7 @@
 <td>&nbsp;</td>
 </tr>
 <tr>
-<td><button type='submit' value='refine'  style="width: 110px">Search again</button></td>
+<td><button type='submit' name='refine' value='1' style="width: 110px">Search again</button></td>
 </tr>
 
 </table>
@@ -57,13 +67,13 @@
     <th>{{ KNOWL('st_group.label', title='label') }}</th>
     <th>{{ KNOWL('st_group.weight', title='wt') }}</th>
     <th>{{ KNOWL('st_group.degree', title='deg') }}</th>
-    <th>{{ KNOWL('st_group.real_dimension', title='\(\mathrm{dim}_{\mathbb{R}}\)') }}</th>
-    <th>{{ KNOWL('st_group.identity_component', title='\(\mathrm{G}^0\)') }}</th>
+    <th>{{ KNOWL('st_group.real_dimension', title='$\mathrm{dim}_{\mathbb{R}}$') }}</th>
+    <th>{{ KNOWL('st_group.identity_component', title='$\mathrm{G}^0$') }}</th>
     <th>{{ KNOWL('st_group.name', title='name') }}</th>
-    <th>{{ KNOWL('st_group.component_group', title='\(\mathrm{G}/\mathrm{G}^0\)') }}</th>
-    <th>{{ KNOWL('st_group.components', title='\(\#\mathrm{G}/\mathrm{G^0}\)') }}</th>
-    <th>{{ KNOWL('st_group.trace_zero_density', title='\(\mathrm{P}[t\!=\!0]\)') }}</th>
-    <th colspan="11">{{ KNOWL('st_group.trace_moments', title='trace moments') }} \(M_0\ \ldots\ M_8\)</th>
+    <th>{{ KNOWL('st_group.component_group', title='$\mathrm{G}/\mathrm{G}^0$') }}</th>
+    <th>{{ KNOWL('st_group.components', title='$\#\mathrm{G}/\mathrm{G^0}$') }}</th>
+    <th>{{ KNOWL('st_group.trace_zero_density', title='$\mathrm{P}[t\!=\!0]$') }}</th>
+    <th colspan="11">{{ KNOWL('st_group.trace_moments', title='trace moments') }}</th>
 </tr>
 {% for group in info.stgroups: %}
 <tr>

--- a/lmfdb/sato_tate_groups/templates/results.html
+++ b/lmfdb/sato_tate_groups/templates/results.html
@@ -10,7 +10,7 @@
 <table>
 <td>{{ KNOWL('st_group.weight', title='weight') }}</td>
 <td>{{ KNOWL('st_group.degree', title='degree')}}</td>
-<td>{{ KNOWL('st_group.rational', title='rational') }}</td>
+<td>{{ KNOWL('st_group.rational', title='rational only') }}</td>
 <td>{{ KNOWL('st_group.identity_component', title='$\mathrm{ST}^0$') }}</td>
 <td>{{ KNOWL('st_group.components', title='components')}}</td>
 <td>{{ KNOWL('st_group.trace_zero_density', title='$\mathrm{P}[a_1=0]$')}}</td>
@@ -19,13 +19,13 @@
 <tr>
 <td><input type='text' name='weight' placeholder='1' style="width: 100px" value="{{info.weight}}"></td>
 <td><input type='text' name='degree' placeholder='4' style="width: 100px" value="{{info.degree}}"></td>
-<td><select name='rational' style="width: 110px" >
-    {% if info.rational == '0' %}
-        <option value='1'>yes</option>
-        <option value='0' selected>no</option>
+<td><select name='rational_only' style="width: 110px" >
+    {% if info.rational_only == 'yes' %}
+        <option value='yes' selected>yes</option>
+        <option value='no'>no</option>
     {% else %}
-        <option value='1' selected>yes</option>
-        <option value='0'>no</option>
+        <option value='yes'>yes</option>
+        <option value='no' selected>no</option>
     {% endif %}
 </select></td>
 <td><select name='identity_component' style="width: 110px" >

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -82,7 +82,7 @@ class SatoTateGroupTest(LmfdbTest):
             L = self.tc.get('/SatoTateGroup/?label='+r['label'])
             assert r['label'] in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?components=999999999')
-        assert 'unique match'  in L.data and 'mu(999999999)' in L.data and 'mu(333333333)' in L.data
+        assert 'unique match'  in L.data and 'mu(999999999)' in L.data
         
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -10,16 +10,16 @@ class SatoTateGroupTest(LmfdbTest):
         assert 'Browse' in L.data and 'SO(1)' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
         
     def test_by_label(self):
-        L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')
-        assert 'USp(4)' in L.data and 'Moment Statistics' in L.data
-        L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)')
-        assert '1.4.10.1.1a' in L.data and 'Moment Statistics' in L.data
-        L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))')
-        assert '1.2.1.2.1a' in L.data and 'Moment Statistics' in L.data
-        L = self.tc.get('/SatoTateGroup/?label=0.1.37')
-        assert '0.1.37' in L.data and 'Moment Statistics' in L.data
-        L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)')
-        assert '0.1.37' in L.data and 'Moment Statistics' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=1.4.10.1.1a', follow_redirects=True)
+        assert 'USp(4)' in L.data and '223412' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)', follow_redirects=True)
+        assert '1.4.10.1.1a' in L.data and '223412' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))', follow_redirects=True)
+        assert '1.2.1.2.1a' in L.data and '462' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=0.1.37', follow_redirects=True)
+        assert '0.1.37' in L.data and 'mu(185)' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)', follow_redirects=True)
+        assert '0.1.37' in L.data and 'mu(185)' in L.data
         
         
     def test_direct_access(self):
@@ -82,7 +82,7 @@ class SatoTateGroupTest(LmfdbTest):
             L = self.tc.get('/SatoTateGroup/?label='+r['label'])
             assert r['label'] in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?components=999999999')
-        assert 'unique match'  in L.data and 'mu(999999999)' in L.data
+        assert 'unique match'  in L.data and 'mu(999999999)' in L.data and 'mu(333333333)' in L.data
         
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -7,7 +7,7 @@ class SatoTateGroupTest(LmfdbTest):
     #
     def test_main(self):
         L = self.tc.get('/SatoTateGroup/')
-        assert 'Browse' in L.data and 'SO(1)' in L.data 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
+        assert 'Browse' in L.data and 'SO(1)' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -11,15 +11,15 @@ class SatoTateGroupTest(LmfdbTest):
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')
-        assert 'USp(4)' in L.data and 'Moments' in L.data
+        assert 'USp(4)' in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)')
-        assert '1.4.10.1.1a' in L.data and 'Moments' in L.data
+        assert '1.4.10.1.1a' in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))')
-        assert '1.2.1.2.1a' in L.data and 'Moments' in L.data
+        assert '1.2.1.2.1a' in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?label=0.1.37')
-        assert '0.1.37' in L.data and 'Moments' in L.data
+        assert '0.1.37' in L.data and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)')
-        assert '0.1.37' in L.data and 'Moments' in L.data
+        assert '0.1.37' in L.data and 'Moment Statistics' in L.data
         
         
     def test_direct_access(self):

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -11,23 +11,38 @@ class SatoTateGroupTest(LmfdbTest):
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')
-        assert 'USp(4)' in L.data
+        assert 'USp(4)' in L.data and 'Moments' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)')
-        assert '1.4.10.1.1a' in L.data
+        assert '1.4.10.1.1a' in L.data and 'Moments' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))')
-        assert '1.2.1.2.1a' in L.data
+        assert '1.2.1.2.1a' in L.data and 'Moments' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=0.1.37')
+        assert '0.1.37' in L.data and 'Moments' in L.data
+        L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)')
+        assert '0.1.37' in L.data and 'Moments' in L.data
+        
         
     def test_direct_access(self):
-        L = self.tc.get('/SatoTateGroup/1.4.G_{3,3}')
+        L = self.tc.get('/SatoTateGroup/1.4.G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
         assert 'G_{3,3}' in L.data
+        L = self.tc.get('/SatoTateGroup/0.1.mu(37)', follow_redirects=True)
+        assert '0.1.37' in L.data
+        L = self.tc.get('/SatoTateGroup/0.1.37')
+        assert 'mu(37)' in L.data
         
     def test_browse(self):
         L = self.tc.get('/SatoTateGroup/?identity_component=U(1)')
         assert 'all 2 matches' in L.data
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=4&&components=48')
         assert 'unique match' in L.data
+        L = self.tc.get('SatoTateGroup/?components=48')
+        assert 'all 2 matches' in L.data
+        L = self.tc.get('SatoTateGroup/?degree=1&start=1000&count=25')
+        assert 'matches 1001-1025' in L.data
+        L = self.tc.get('SatoTateGroup/?degree=1&rational_only=yes')
+        assert 'all 2 matches' in L.data
 
     def test_moments(self):
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
@@ -66,6 +81,8 @@ class SatoTateGroupTest(LmfdbTest):
             print 'Checking Sato-Tate group ' + r['label']
             L = self.tc.get('/SatoTateGroup/?label='+r['label'])
             assert r['label'] in L.data and 'Moment Statistics' in L.data
+        L = self.tc.get('/SatoTateGroup/?components=999999999')
+        assert 'unique match'  in L.data and 'mu(999999999)' in L.data
         
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -7,7 +7,7 @@ class SatoTateGroupTest(LmfdbTest):
     #
     def test_main(self):
         L = self.tc.get('/SatoTateGroup/')
-        assert 'Browse' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Maximum number' in L.data
+        assert 'Browse' in L.data and 'SO(1)' in L.data 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/1.4.10.1.1a')

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -28,7 +28,7 @@ from sage.all import latex
 
 def flash_error(errmsg, *args):
     """ flash errmsg in red with args in black; errmsg may contain markup, including latex math mode"""
-    flash(Markup("Error: %s"%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args))),"error")
+    flash(Markup("Error: %s"%(errmsg%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args)))),"error")
 
 def random_object_from_collection(collection):
     """ retrieves a random object from mongo db collection; uses collection.rand to improve performance if present """

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -15,8 +15,14 @@ from werkzeug.contrib.cache import SimpleCache
 from copy import copy
 from werkzeug import cached_property
 from flask import url_for
+from markupsafe import Markup
+
+def flash_error(errmsg, *args):
+    """ flash errmsg in red with args in black; errmsg may contain markup, including latex math mode"""
+    flash(Markup("Error: %s"%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args)),"error")
 
 def random_object_from_collection(collection):
+    """ retrieves a random object from mongo db collection; uses collection.rand to improve performance if present """
     import pymongo
     n = collection.rand.count()
     if n:
@@ -28,6 +34,7 @@ def random_object_from_collection(collection):
         return collection.aggregate([{ '$sample': { 'size': int(1) } } ]).next()
 
 def random_value_from_collection(collection,attribute):
+    """ retrieves the value of attribute (e.g. label) from a random object in mongo db collection; uses collection.rand to improve performance if present """
     import pymongo
     n = collection.rand.count()
     if n:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -3,23 +3,32 @@
 # @app.route(....)
 # @cached()
 # def func(): ...
-import logging
 
+import logging
 import re
+import tempfile
+import random
+import os
+import time
+import sage
 
 from random import randint
-from flask import request, make_response
+from flask import request, make_response, flash, url_for, current_app
 from functools import wraps
 from werkzeug.contrib.cache import SimpleCache
 
 from copy import copy
 from werkzeug import cached_property
-from flask import url_for
 from markupsafe import Markup
+
+from lmfdb.base import app
+
+from sage.all import latex
+
 
 def flash_error(errmsg, *args):
     """ flash errmsg in red with args in black; errmsg may contain markup, including latex math mode"""
-    flash(Markup("Error: %s"%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args)),"error")
+    flash(Markup("Error: %s"%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args))),"error")
 
 def random_object_from_collection(collection):
     """ retrieves a random object from mongo db collection; uses collection.rand to improve performance if present """
@@ -197,16 +206,6 @@ def orddict_to_strlist(v):
 
 
 ### this was formerly in utilities.py
-import tempfile
-import random
-import os
-import re
-import time
-
-from lmfdb.base import app
-from flask import url_for, make_response
-import sage.all
-
 def to_dict(args):
     d = {}
     for key in args:
@@ -242,7 +241,6 @@ def an_list(euler_factor_polynomial_fn, upperbound=100000, base_field=sage.rings
     from math import ceil, log
     PP = PowerSeriesRing(base_field, 'x', 1 + ceil(log(upperbound) / log(2.)))
 
-    x = PP('x')
     prime_l = prime_range(upperbound + 1)
     result = [1 for i in range(upperbound)]
     for p in prime_l:
@@ -290,7 +288,7 @@ def web_latex(x):
     if isinstance(x, (str, unicode)):
         return x
     else:
-        return "\( %s \)" % sage.all.latex(x)
+        return "\( %s \)" % latex(x)
 
 # if you just use web_latex(x) where x is a factored ideal then the
 # parentheses are doubled which does not look good!
@@ -304,7 +302,7 @@ def web_latex_split_on(x, on=['+', '-']):
     if isinstance(x, (str, unicode)):
         return x
     else:
-        A = "\( %s \)" % sage.all.latex(x)
+        A = "\( %s \)" % latex(x)
         for s in on:
             A = A.replace(s, '\) ' + s + ' \( ')
     return A
@@ -312,11 +310,11 @@ def web_latex_split_on(x, on=['+', '-']):
 # web_latex_split_on was not splitting polynomials, so we make an expanded version
 def web_latex_split_on_pm(x):
     on = ['+', '-']
- #   A = "\( %s \)" % sage.all.latex(x)
+ #   A = "\( %s \)" % latex(x)
     try:
         A = "\(" + x + "\)"  # assume we are given LaTeX to split on
     except:
-        A = "\( %s \)" % sage.all.latex(x)
+        A = "\( %s \)" % latex(x)
 
        # need a more clever split_on_pm that inserts left and right properly
     A = A.replace("\\left","")
@@ -348,7 +346,7 @@ def web_latex_split_on_re(x, r = '(q[^+-]*[+-])'):
     if isinstance(x, (str, unicode)):
         return x
     else:
-        A = "\( %s \)" % sage.all.latex(x)
+        A = "\( %s \)" % latex(x)
         c = re.compile(r)
         A = A.replace('+', '\) \( {}+ ')
         A = A.replace('-', '\) \( {}- ')
@@ -555,9 +553,6 @@ def comma(x):
 def coeff_to_poly(c):
     from sage.all import PolynomialRing, QQ
     return PolynomialRing(QQ, 'x')(c)
-
-from flask import current_app
-
 
 def debug():
     """


### PR DESCRIPTION
This PR fixes issue #1620 by adding the Sato-Tate groups mu(n) (weight 0 degree 1).  These are computed on the fly rather than being stored in the database, as there are infinitely many of these.  A new "rational" attribute has been added to distinguish those that correspond to motive whose L-functions whose Euler factors have rational coefficients (just mu(1) and mu(2)).  There are links to corresponding knowls that I will update once this PR has been merged and pushed to beta (along with the extent knowl).