### PR TITLE
Better handling of L-function page errors

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -284,7 +284,7 @@ class Lfunction_EC_Q(Lfunction):
     #     field is Q
     def __init__(self, **args):
         constructor_logger(self, args)
-        validate_required_args('Unable to construct elliptic curve L-function', args, 'label')
+        validate_required_args('Unable to construct elliptic curve L-function.', args, 'label')
 
         self._Ltype = "ellipticcurveQ"
 
@@ -355,7 +355,7 @@ class Lfunction_EC_Q(Lfunction):
         db_label = "EllipticCurve/Q/" + label_slash
         self.lfunc_data = LfunctionDatabase.getGenus2Ldata(db_label)
         if not self.lfunc_data:
-                raise KeyError("No L-function instance data for %s was found in the database." % db_label)
+                raise KeyError('No L-function instance data for "%s" was found in the database.' % db_label)
 
         try:
             makeLfromdata(self)
@@ -546,7 +546,7 @@ class Lfunction_HMF(Lfunction):
         # Load form from database
         (f, F_hmf) = LfunctionDatabase.getHmfData(self.label)
         if f is None:
-            raise KeyError("No Hilbert modular form with label %s found in database."%self.label)
+            raise KeyError('No Hilbert modular form with label "%s" found in database.'%self.label)
 
         F = WebNumberField(f['field_label'])
         if not F or F.is_null():
@@ -554,7 +554,7 @@ class Lfunction_HMF(Lfunction):
 
         self.character = args['character']
         if self.character > 0:
-            raise KeyError("L-functions of Hilbert modular form with non-trivial character are not currently implemented.")
+            raise KeyError("L-functions of Hilbert modular forms with non-trivial character are not yet implemented.")
         self.number = int(args['number'])
 
         # It is a Sage int
@@ -815,7 +815,7 @@ class Lfunction_Dirichlet(Lfunction):
             db_label = "Character/Dirichlet/" + label_slash
             self.lfunc_data = LfunctionDatabase.getGenus2Ldata(db_label)
             if not self.lfunc_data:
-                raise KeyError('Unable to construct Dirichlet L-function.', 'No L-function data for the Dirichlet character $\chi_{%d}(%d,\cdot)$ was found in the database.'%(self.charactermodulus,self.characternumber))
+                raise KeyError('No L-function data for the Dirichlet character $\chi_{%d}(%d,\cdot)$ was found in the database.'%(self.charactermodulus,self.characternumber))
             makeLfromdata(self, fromdb=True)
             self.fromDB = True
             if not self.selfdual:  #TODO: This should be done on a general level
@@ -1058,7 +1058,7 @@ class DedekindZeta(Lfunction):   # added by DK
         # Fetch the polynomial of the field from the database
         wnf = WebNumberField(self.label)
         if not wnf or wnf.is_null():
-            raise KeyError('Unable to construct Dedekind zeta function.', 'No data for the number field %s was found in the database'%self.label)
+            raise KeyError('Unable to construct Dedekind zeta function.', 'No data for the number field "%s" was found in the database'%self.label)
         # poly_coeffs = wnf.coeffs()
 
         # Extract the L-function information from the polynomial
@@ -1174,7 +1174,7 @@ class HypergeometricMotiveLfunction(Lfunction):
         self.label = args["label"]
         self.motive = LfunctionDatabase.getHgmData(self.label)
         if not self.motive:
-            raise KeyError('No data for the hypergeometric motive %s was found in the database.'%self.label)
+            raise KeyError('No data for the hypergeometric motive "%s" was found in the database.'%self.label)
 
         self.conductor = self.motive["cond"]
 
@@ -1252,7 +1252,7 @@ class ArtinLfunction(Lfunction):
     """
     def __init__(self, **args):
         constructor_logger(self, args)
-        validate_required_args('Unable to construct Artin L-function', 'label')
+        validate_required_args('Unable to construct Artin L-function', args, 'label')
 
         self._Ltype = "artin"
         

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -11,12 +11,11 @@ import re
 
 from flask import url_for
 
-from Lfunctionutilities import (p2sage, string2number, seriescoeff,
+from Lfunctionutilities import (p2sage, string2number,
                                 compute_local_roots_SMF2_scalar_valued,
                                 compute_dirichlet_series,
-                                number_of_coefficients_needed,
                                 signOfEmfLfunction)
-from LfunctionComp import (nr_of_EC_in_isogeny_class, modform_from_EC,
+from LfunctionComp import (nr_of_EC_in_isogeny_class, modform_from_EC, 
                            EC_from_modform)
 import LfunctionDatabase
 import LfunctionLcalc
@@ -24,17 +23,15 @@ from Lfunction_base import Lfunction
 from lmfdb.lfunctions import logger
 from lmfdb.utils import web_latex
 
-from sage.all import *
+import sage
+from sage.all import ZZ, QQ, RR, CC, Integer, Rational, Reals, nth_prime, is_prime, factor, exp, log, real, pi, I, gcd, sqrt, prod, ceil, NaN, EllipticCurve, NumberField, load
 import sage.libs.lcalc.lcalc_Lfunction as lc
-from sage.rings.rational import Rational
 
 from lmfdb.WebCharacter import WebDirichletCharacter
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes \
-     import WebMaassForm
+from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes import WebMaassForm
 from lmfdb.sato_tate_groups.main import st_link_by_name
-from lmfdb.base import url_for
 
 def validate_required_args(errmsg, args, *keys):
     missing_keys = [key for key in keys if not key in args]
@@ -292,7 +289,6 @@ class Lfunction_EC_Q(Lfunction):
         self._Ltype = "ellipticcurveQ"
 
         # Initialize default values
-        max_height = 30
         modform_translation_limit = 101
 
         # Put the arguments into the object dictionary
@@ -426,7 +422,7 @@ class Lfunction_EMF(Lfunction):
 
         self._Ltype = "ellipticmodularform"
 
-        modform_translation_limit = 101
+        # modform_translation_limit = 101
 
         # Put the arguments into the object dictionary
         self.__dict__.update(args)
@@ -589,7 +585,7 @@ class Lfunction_HMF(Lfunction):
         R = QQ['x']
         (x,) = R._first_ngens(1)
         K = NumberField(R(str(f['hecke_polynomial']).replace('^', '**')), 'e')
-        e = K.gens()[0]
+        # e = K.gens()[0]
         iota = K.complex_embeddings()[self.number]
 
         if self.level == 1:  # For level 1, the sign is always plus
@@ -651,7 +647,7 @@ class Lfunction_HMF(Lfunction):
                 # prime power
                 p = nfact[0][0]
                 k = nfact[0][1]
-                S = [1] + [dcoeffs[p ** i] for i in range(1, k)]
+                # S = [1] + [dcoeffs[p ** i] for i in range(1, k)]
                 heckepol = heckepolsinv[ratl_primes.index(p)]
                 dcoeffs.append(heckepol[k])
             else:
@@ -1094,7 +1090,7 @@ class DedekindZeta(Lfunction):   # added by DK
         self.grh = wnf.used_grh()
         if self.degree > 1:
             if wnf.is_abelian() and len(wnf.dirichlet_group())>0:
-                cond = wnf.conductor()
+                # cond = wnf.conductor()
                 dir_group = wnf.dirichlet_group()
                 # Remove 1 from the list
                 j = 0
@@ -1210,7 +1206,7 @@ class HypergeometricMotiveLfunction(Lfunction):
             
         hodge = self.motive["hodge"]
         signature = self.motive["sig"]
-        hodge_index = lambda p: hodge[p]
+        # hodge_index = lambda p: hodge[p]
             # The hodge number p,q
         
         from lmfdb.hypergm.hodge import mu_nu
@@ -1417,8 +1413,8 @@ class SymmetricPowerLfunction(Lfunction):
         self.level = self.S.conductor
 
     def Lkey(self):
-        return {"power": power, "underlying_type": underlying_type,
-                "field": field}
+        return {"power": self.power, "underlying_type": self.underlying_type,
+                "field": self.field}
 
 #############################################################################
 
@@ -1530,87 +1526,86 @@ class Lfunction_SMF2_scalar_valued(Lfunction):
 
         generateSageLfunction(self)
 
-    def Lkey():
+    def Lkey(self):
         return {"weight": self.weight, "orbit": self.orbit}
 
 #############################################################################
 
+# this class it not used anywhere and does not yet appear to be functional (in particular, the function TensorProduct is not defined anywhere in the LMFDB)
+#~ class TensorProductLfunction(Lfunction):
+    #~ """
+    #~ Class representing the L-function of a tensor product
+    #~ (currently only of a elliptic curve with a Dirichlet character)
 
-class TensorProductLfunction(Lfunction):
-    """
-    Class representing the L-function of a tensor product
-    (currently only of a elliptic curve with a Dirichlet character)
+    #~ arguments are
 
-    arguments are
+    #~ - charactermodulus
+    #~ - characternumber
+    #~ - ellipticcurvelabel
 
-    - charactermodulus
-    - characternumber
-    - ellipticcurvelabel
+    #~ """
 
-    """
+    #~ def __init__(self, **args):
 
-    def __init__(self, **args):
+        #~ # Check for compulsory arguments
+        #~ validate_required_args('Unable to construct tensor product L-function.', args, 'charactermodulus', 'characternumber', 'ellipticcurvelabel')
 
-        # Check for compulsory arguments
-        validate_required_args('Unable to construct tensor product L-function.', args, 'charactermodulus', 'characternumber', 'ellipticcurvelabel')
+        #~ self._Ltype = "tensorproduct"
 
-        self._Ltype = "tensorproduct"
+        #~ # Put the arguments into the object dictionary
+        #~ self.__dict__.update(args)
+        #~ self.charactermodulus = int(self.charactermodulus)
+        #~ self.characternumber = int(self.characternumber)
+        #~ self.Elabel = self.ellipticcurvelabel
 
-        # Put the arguments into the object dictionary
-        self.__dict__.update(args)
-        self.charactermodulus = int(self.charactermodulus)
-        self.characternumber = int(self.characternumber)
-        self.Elabel = self.ellipticcurvelabel
+        #~ # Create the tensor product
+        #~ # try catch later
+        #~ self.tp = TensorProduct(self. Elabel, self.charactermodulus, self.characternumber)
+        #~ # chi = self.tp.chi
+        #~ # E = self.tp.E
 
-        # Create the tensor product
-        # try catch later
-        self.tp = TensorProduct(self. Elabel, self.charactermodulus,
-                                self.characternumber)
-        chi = self.tp.chi
-        E = self.tp.E
-
-        self.motivic_weight = 1
-        self.weight = 2
-        self.algebraic = True
-        self.poles = []
-        self.residues = []
-        self.langlands = True
-        self.primitive = True
-        self.degree = 2
-        self.quasidegree = 1
-        self.level = int(self.tp.conductor())
-        self.sign = self.tp.root_number()
-        self.coefficient_type = 3
-        self.coefficient_period = 0
+        #~ self.motivic_weight = 1
+        #~ self.weight = 2
+        #~ self.algebraic = True
+        #~ self.poles = []
+        #~ self.residues = []
+        #~ self.langlands = True
+        #~ self.primitive = True
+        #~ self.degree = 2
+        #~ self.quasidegree = 1
+        #~ self.level = int(self.tp.conductor())
+        #~ self.sign = self.tp.root_number()
+        #~ self.coefficient_type = 3
+        #~ self.coefficient_period = 0
 
 
-        # We may want to change this later to a better estimate.
-        self.numcoeff = 20 + ceil(sqrt(self.tp.conductor()))
+        #~ # We may want to change this later to a better estimate.
+        #~ self.numcoeff = 20 + ceil(sqrt(self.tp.conductor()))
 
-        self.mu_fe = []
-        self.nu_fe = [Rational('1/2')]
-        self.compute_kappa_lambda_Q_from_mu_nu()
+        #~ self.mu_fe = []
+        #~ self.nu_fe = [Rational('1/2')]
+        #~ self.compute_kappa_lambda_Q_from_mu_nu()
 
-        li = self.tp.an_list(upper_bound=self.numcoeff)
-        for n in range(1,len(li)):
-            # now renormalise it for s <-> 1-s as the functional equation
-            li[n] /= sqrt(float(n))
-        self.dirichlet_coefficients = li
+        #~ li = self.tp.an_list(upper_bound=self.numcoeff)
+        #~ for n in range(1,len(li)):
+            #~ # now renormalise it for s <-> 1-s as the functional equation
+            #~ li[n] /= sqrt(float(n))
+        #~ self.dirichlet_coefficients = li
 
-        self.texname = "L(s,E,\\chi)"
-        self.texnamecompleteds = "\\Lambda(s,E,\\chi)"
-        self.title = "$L(s,E,\\chi)$, where $E$ is the elliptic curve %s and $\\chi$ is the Dirichlet character of conductor %s, modulo %s, number %s"%(self.ellipticcurvelabel, self.tp.chi.conductor(), self.charactermodulus, self.characternumber)
+        #~ self.texname = "L(s,E,\\chi)"
+        #~ self.texnamecompleteds = "\\Lambda(s,E,\\chi)"
+        #~ self.title = "$L(s,E,\\chi)$, where $E$ is the elliptic curve %s and $\\chi$ is the Dirichlet character of conductor %s, modulo %s, number %s"%(self.ellipticcurvelabel, self.tp.chi.conductor(), self.charactermodulus, self.characternumber)
 
-        self.credit = 'Workshop in Besancon, 2014'
+        #~ self.credit = 'Workshop in Besancon, 2014'
 
-        generateSageLfunction(self)
+        #~ generateSageLfunction(self)
 
-        constructor_logger(self, args)
+        #~ constructor_logger(self, args)
 
-    def Lkey(self):
-        return {"ellipticcurvelabel": self.Elabel,
-                "charactermodulus": self.charactermodulus,
-                "characternumber": self.characternumber}
+    #~ def Lkey(self):
+        #~ return {"ellipticcurvelabel": self.Elabel,
+                #~ "charactermodulus": self.charactermodulus,
+                #~ "characternumber": self.characternumber}
 
 #############################################################################
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -390,7 +390,7 @@ def render_lfunction_exception(err):
     if current_app.debug:
         raise err
     if err.args:
-        errmsg = "Unable to render L-function page due to the following problem(s):<br><ul>" + reduce(lambda x,y:x+"<li>"+y+"</li>",err.args) + "</ul>"
+        errmsg = "Unable to render L-function page due to the following problem(s):<br><ul>" + reduce(lambda x,y:x+y,["<li>"+msg+"</li>" for msg in err.args]) + "</ul>"
     else:
         errmsg = "Unable to render L-function page due to the following problem:<br><ul><li>%s</li></ul>"%err
     info = {'content': errmsg, 'title': 'Error displaying L-function data'}
@@ -402,9 +402,9 @@ def render_single_Lfunction(Lclass, args, request):
     logger.debug(temp_args)
 
     try:
-        # if you move L=Lclass outside the try for debugging, remember to put it back in before committing
         L = Lclass(**args)
-    except Exception as err:
+        # if you move L=Lclass outside the try for debugging, remember to put it back in before committing
+    except (ValueError,KeyError) as err:  # do not trap all errors, if there is an assert error we want to see it in flasklog
         return render_lfunction_exception(err)
     try:
         if temp_args['download'] == 'lcalcfile':

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1,22 +1,20 @@
 # -*- coding: utf-8 -*-
-from lmfdb.base import *
-from flask import (Flask, session, g, render_template, url_for, request,
-                   make_response, abort)
+from lmfdb.base import getDBConnection
 import flask
+from flask import render_template, url_for, request, make_response
 
-from sage.all import *
+from sage.all import ZZ, is_prime, latex, factor, plot, srange, spline, line
 import tempfile
 import os
 import re
 import sqlite3
 import numpy
-import pymongo
-from Lfunction import *
+from Lfunction import Lfunction_Dirichlet, Lfunction_EC_Q, Lfunction_EMF, Lfunction_HMF, Lfunction_Maass, Lfunction_SMF2_scalar_valued
+from Lfunction import RiemannZeta, DedekindZeta, ArtinLfunction, SymmetricPowerLfunction, HypergeometricMotiveLfunction, Lfunction_genus2_Q, Lfunction_lcalc
 import LfunctionPlot as LfunctionPlot
 from lmfdb.utils import to_dict
 import bson
-from Lfunctionutilities import (p2sage, lfuncDShtml, lfuncEPtex, lfuncFEtex,
-                                truncatenumber, styleTheSign, specialValueString, specialValueTriple)
+from Lfunctionutilities import p2sage, lfuncDShtml, lfuncEPtex, lfuncFEtex, styleTheSign, specialValueString, specialValueTriple
 from lmfdb.WebCharacter import WebDirichlet
 from lmfdb.lfunctions import l_function_page, logger
 from lmfdb.elliptic_curves.web_ec import cremona_label_regex, lmfdb_label_regex
@@ -319,7 +317,7 @@ def l_function_hmf_redirect_2(field, label):
 def l_function_maass_page(dbid):
     try:
         args = {'dbid': bson.objectid.ObjectId(dbid), 'fromDB': False}
-    except Exception as ex:
+    except Exception:
         args = {'dbid': dbid, 'fromDB': False}
     return render_single_Lfunction(Lfunction_Maass, args, request)
 
@@ -738,7 +736,6 @@ def initLfunction(L, args, request):
     elif L.Ltype() == 'siegelnonlift' or L.Ltype() == 'siegeleisenstein' or L.Ltype() == 'siegelklingeneisenstein' or L.Ltype() == 'siegelmaasslift':
         friendlink = friendlink.rpartition('/')[0] #strip off embedding number for L-function
         weight = str(L.weight)
-        number = str(L.number)
         info['friends'] = [('Siegel Modular Form ' + weight + '_' + L.orbit, friendlink)]
 
     elif L.Ltype() == "artin":
@@ -803,21 +800,16 @@ def set_gaga_properties(L):
     ans.append(('Sign', "$"+styleTheSign(L.sign)+"$"))
 
     if L.selfdual:
- #       sd = 'Self-dual'
         ans.append(('Self-dual', "yes"))
     else:
- #       sd = 'Not self-dual'
         ans.append(('Self-dual', "no"))
- #   ans.append((None, sd))
 
     if L.algebraic:
         ans.append(('Motivic weight', str(L.motivic_weight)))
 
-    if L.primitive:
-        prim = 'Primitive'
-    else:
-        prim = 'Not primitive'
-#    ans.append((None,        prim))    Disabled until fixed
+    # Disable until fixed
+    # prim = 'Primitive' if L.primitive else 'Not primitive'
+    # ans.append((None,        prim))
 
     return ans
 
@@ -1053,7 +1045,7 @@ def generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg
         # logger.debug(db)
         try:
             dbid = bson.objectid.ObjectId(arg5)
-        except Exception as ex:
+        except Exception:
             dbid = arg5
         return Lfunction_Maass(dbid=dbid)
 

--- a/lmfdb/lfunctions/templates/LfunctionSimple.html
+++ b/lmfdb/lfunctions/templates/LfunctionSimple.html
@@ -4,7 +4,7 @@
 <div class="announce">
 <indent>
 {{ content|safe }}
-Please report this problem <a href="{{ feedbackpage }}" target=_blank>here</a>.
+You may report this problem <a href="{{ feedbackpage }}" target=_blank>here</a>.
 </div>
 <div>
 <input type=button value="Return to previous page" onClick="history.go(-1)">


### PR DESCRIPTION
This PR further extends the error-handling introduced in #1537 to display more informative (and less distressing) errors when something goes wrong in the construction of an L-page.  This partially addresses #1087: the page http://127.0.0.1:37777/L/Character/Dirichlet/7000/3 now displays a message saying that no L-function data for this Dirichlet character was found in the database (rather than raising an internal server error or displaying the error "'NoneType' object has no attribute '__getitem__'").

It also removes "import *" from main.py and Lfunctions.py (per #122).
