### PR TITLE
tensor product cleanup

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1530,81 +1530,84 @@ class Lfunction_SMF2_scalar_valued(Lfunction):
 
 #############################################################################
 
-# this class it not used anywhere and does not yet appear to be functional (in particular, the function TensorProduct is not defined anywhere in the LMFDB)
-#~ class TensorProductLfunction(Lfunction):
-    #~ """
-    #~ Class representing the L-function of a tensor product
-    #~ (currently only of a elliptic curve with a Dirichlet character)
+# This class it not used anywhere and has not been touched since January 2014.  The key function TensorProduct is not defined anywhere, so it won't work
+# There is closely related code in lmfdb/tensor_products that perhaps is meant to supersed this?
+# This should either be fully implemented or removed when #500 is addressed (Release 2.0)
 
-    #~ arguments are
+class TensorProductLfunction(Lfunction):
+    """
+    Class representing the L-function of a tensor product
+    (currently only of a elliptic curve with a Dirichlet character)
 
-    #~ - charactermodulus
-    #~ - characternumber
-    #~ - ellipticcurvelabel
+    arguments are
 
-    #~ """
+    - charactermodulus
+    - characternumber
+    - ellipticcurvelabel
 
-    #~ def __init__(self, **args):
+    """
 
-        #~ # Check for compulsory arguments
-        #~ validate_required_args('Unable to construct tensor product L-function.', args, 'charactermodulus', 'characternumber', 'ellipticcurvelabel')
+    def __init__(self, **args):
 
-        #~ self._Ltype = "tensorproduct"
+        # Check for compulsory arguments
+        validate_required_args('Unable to construct tensor product L-function.', args, 'charactermodulus', 'characternumber', 'ellipticcurvelabel')
 
-        #~ # Put the arguments into the object dictionary
-        #~ self.__dict__.update(args)
-        #~ self.charactermodulus = int(self.charactermodulus)
-        #~ self.characternumber = int(self.characternumber)
-        #~ self.Elabel = self.ellipticcurvelabel
+        self._Ltype = "tensorproduct"
 
-        #~ # Create the tensor product
-        #~ # try catch later
-        #~ self.tp = TensorProduct(self. Elabel, self.charactermodulus, self.characternumber)
-        #~ # chi = self.tp.chi
-        #~ # E = self.tp.E
+        # Put the arguments into the object dictionary
+        self.__dict__.update(args)
+        self.charactermodulus = int(self.charactermodulus)
+        self.characternumber = int(self.characternumber)
+        self.Elabel = self.ellipticcurvelabel
 
-        #~ self.motivic_weight = 1
-        #~ self.weight = 2
-        #~ self.algebraic = True
-        #~ self.poles = []
-        #~ self.residues = []
-        #~ self.langlands = True
-        #~ self.primitive = True
-        #~ self.degree = 2
-        #~ self.quasidegree = 1
-        #~ self.level = int(self.tp.conductor())
-        #~ self.sign = self.tp.root_number()
-        #~ self.coefficient_type = 3
-        #~ self.coefficient_period = 0
+        # Create the tensor product
+        # try catch later
+        self.tp = TensorProduct(self. Elabel, self.charactermodulus, self.characternumber)
+        # chi = self.tp.chi
+        # E = self.tp.E
+
+        self.motivic_weight = 1
+        self.weight = 2
+        self.algebraic = True
+        self.poles = []
+        self.residues = []
+        self.langlands = True
+        self.primitive = True
+        self.degree = 2
+        self.quasidegree = 1
+        self.level = int(self.tp.conductor())
+        self.sign = self.tp.root_number()
+        self.coefficient_type = 3
+        self.coefficient_period = 0
 
 
-        #~ # We may want to change this later to a better estimate.
-        #~ self.numcoeff = 20 + ceil(sqrt(self.tp.conductor()))
+        # We may want to change this later to a better estimate.
+        self.numcoeff = 20 + ceil(sqrt(self.tp.conductor()))
 
-        #~ self.mu_fe = []
-        #~ self.nu_fe = [Rational('1/2')]
-        #~ self.compute_kappa_lambda_Q_from_mu_nu()
+        self.mu_fe = []
+        self.nu_fe = [Rational('1/2')]
+        self.compute_kappa_lambda_Q_from_mu_nu()
 
-        #~ li = self.tp.an_list(upper_bound=self.numcoeff)
-        #~ for n in range(1,len(li)):
-            #~ # now renormalise it for s <-> 1-s as the functional equation
-            #~ li[n] /= sqrt(float(n))
-        #~ self.dirichlet_coefficients = li
+        li = self.tp.an_list(upper_bound=self.numcoeff)
+        for n in range(1,len(li)):
+            # now renormalise it for s <-> 1-s as the functional equation
+            li[n] /= sqrt(float(n))
+        self.dirichlet_coefficients = li
 
-        #~ self.texname = "L(s,E,\\chi)"
-        #~ self.texnamecompleteds = "\\Lambda(s,E,\\chi)"
-        #~ self.title = "$L(s,E,\\chi)$, where $E$ is the elliptic curve %s and $\\chi$ is the Dirichlet character of conductor %s, modulo %s, number %s"%(self.ellipticcurvelabel, self.tp.chi.conductor(), self.charactermodulus, self.characternumber)
+        self.texname = "L(s,E,\\chi)"
+        self.texnamecompleteds = "\\Lambda(s,E,\\chi)"
+        self.title = "$L(s,E,\\chi)$, where $E$ is the elliptic curve %s and $\\chi$ is the Dirichlet character of conductor %s, modulo %s, number %s"%(self.ellipticcurvelabel, self.tp.chi.conductor(), self.charactermodulus, self.characternumber)
 
-        #~ self.credit = 'Workshop in Besancon, 2014'
+        self.credit = 'Workshop in Besancon, 2014'
 
-        #~ generateSageLfunction(self)
+        generateSageLfunction(self)
 
-        #~ constructor_logger(self, args)
+        constructor_logger(self, args)
 
-    #~ def Lkey(self):
-        #~ return {"ellipticcurvelabel": self.Elabel,
-                #~ "charactermodulus": self.charactermodulus,
-                #~ "characternumber": self.characternumber}
+    def Lkey(self):
+        return {"ellipticcurvelabel": self.Elabel,
+                "charactermodulus": self.charactermodulus,
+                "characternumber": self.characternumber}
 
 #############################################################################
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -231,13 +231,6 @@ def l_function_dirichlet_page(modulus, number):
     return render_single_Lfunction(Lfunction_Dirichlet, args, request)
 
 
-# L-function of tensor product #################################################
-# Not yet implemented
-# @l_function_page.route("/TensorProduct/")
-# def l_function_tensor_product_page(galoisrep):
-#    args = {}
-#    return render_single_Lfunction(GaloisRepresentationLfunction, args, request)
-
 # L-function of Elliptic curve #################################################
 @l_function_page.route("/EllipticCurve/Q/<label>/")
 def l_function_ec_page(label):

--- a/lmfdb/tensor_products/__init__.py
+++ b/lmfdb/tensor_products/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from lmfdb.base import app, getDBConnection
+from lmfdb.base import app
 from lmfdb.utils import make_logger
 from flask import Blueprint
 

--- a/lmfdb/tensor_products/galois_reps.py
+++ b/lmfdb/tensor_products/galois_reps.py
@@ -93,16 +93,11 @@ sage: VW.algebraic_coefficients(38)[36] == -38
 #import weakref
 
 import lmfdb.base
-from lmfdb.WebCharacter import * #WebDirichletCharacter
 from lmfdb.lfunctions.Lfunction_base import Lfunction
 from lmfdb.lfunctions.HodgeTransformations import selberg_to_hodge, root_number_at_oo, hodge_to_selberg, tensor_hodge, gamma_factors
 
-from sage.structure.sage_object import SageObject
-from sage.rings.integer_ring import ZZ
-from sage.rings.complex_field import ComplexField
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
-from sage.rings.power_series_ring import PowerSeriesRing
-from sage.rings.fast_arith import prime_range
+import sage
+from sage.all import ZZ, QQ, RealField, ComplexField, PolynomialRing, PowerSeriesRing, I, sqrt, prime_range, Dokchitser, O
 
 class GaloisRepresentation( Lfunction):
 
@@ -132,7 +127,7 @@ class GaloisRepresentation( Lfunction):
 
         elif (isinstance(thingy, list) and
               len(thingy) == 2 and
-              isinstance(thingy[0],lmfdb.modular_forms.elliptic_modular_forms.backend.web_modforms.WebNewForm_class) and
+              isinstance(thingy[0],lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms.WebNewForm) and
               isinstance(thingy[1],sage.rings.integer.Integer) ):
             self.init_elliptic_modular_form(thingy[0],thingy[1])
 
@@ -690,14 +685,14 @@ def tensor_get_an_no_deg1(L1, L2, d1, d2, BadPrimeInfo):
                 E2.append(L2[q-1])
             e1 = list_to_euler_factor(E1,f+1)
             e2 = list_to_euler_factor(E2,f+1)
-            ld1 = d1
-            ld2 = d2
+            # ld1 = d1 # not used
+            # ld2 = d2 # not used
         else: # either convolve, or have one input be the answer and other 1-t
             i = BadPrimes.index(p)
             e1 = BadPrimeInfo[i][1]
             e2 = BadPrimeInfo[i][2]
-            ld1 = e1.degree()
-            ld2 = e2.degree()
+            # ld1 = e1.degree() # not used
+            # ld2 = e2.degree() # not used
             F = e1.list()[0].parent().fraction_field()
             R = PowerSeriesRing(F, "T", default_prec=f+1)
             e1 = R(e1)
@@ -812,7 +807,7 @@ def list_to_euler_factor(L,d):
     else:
         K = L[0].parent()
     R = PowerSeriesRing(K, "T")
-    T = R.gens()[0]
+    # T = R.gens()[0]
     f =  1/ R([1]+L)
     f = f.add_bigoh(d+1)
     return f

--- a/lmfdb/tensor_products/main.py
+++ b/lmfdb/tensor_products/main.py
@@ -4,26 +4,16 @@
 
 import pymongo
 ASC = pymongo.ASCENDING
-import flask
-from lmfdb.base import app, getDBConnection
-from flask import render_template, render_template_string, request, abort, Blueprint, url_for, make_response
-from lmfdb.tensor_products import tensor_products_page, tensor_products_logger 
-from lmfdb.utils import to_dict
-from lmfdb.transitive_group import *
-from string import split
-from sets import Set
-from sage.all import *
-
-from lmfdb.math_classes import *
-from lmfdb.WebNumberField import *
-from lmfdb.lfunctions.Lfunctionutilities import *
-from lmfdb.lfunctions import *
+from lmfdb.base import  getDBConnection
+from flask import render_template, request, url_for
+from lmfdb.tensor_products import tensor_products_page 
 
 from galois_reps import GaloisRepresentation
-from sage.schemes.elliptic_curves.constructor import EllipticCurve
-from lmfdb.WebCharacter import *
+from sage.all import ZZ, EllipticCurve
+from lmfdb.artin_representations.main import ArtinRepresentation
+from lmfdb.WebCharacter import WebDirichletCharacter
 from lmfdb.modular_forms.elliptic_modular_forms import WebNewForm
-from lmfdb.lfunctions import *
+from lmfdb.lfunctions.Lfunctionutilities import lfuncDShtml, lfuncEPtex, lfuncFEtex, specialValueString
 
 # The method "show" shows the page for the Lfunction of a tensor product object.  This is registered on to the tensor_products_page blueprint rather than going via the l_function blueprint, hence the idiosyncrasies.  Sorry about that.  The reason is due to a difference in implementation; the tensor products are not (currently) in the database and the current L functions framewo  
 
@@ -51,7 +41,6 @@ def navigate():
 @tensor_products_page.route("/show/")
 def show():
     args = request.args
-    bread = get_bread()
 
     objLinks = args # an immutable dict of links to objects to tp
 
@@ -68,10 +57,11 @@ def show():
         gr.lfunction()
 
         info = {}
-        info['dirichlet'] = lfuncDShtml(tp, "analytic")
-        info['eulerproduct'] = lfuncEPtex(tp, "abstract")
-        info['functionalequation'] = lfuncFEtex(tp, "analytic")
-        info['functionalequationSelberg'] = lfuncFEtex(tp, "selberg")
+        info['dirichlet'] = lfuncDShtml(gr, "analytic")
+        info['eulerproduct'] = lfuncEPtex(gr, "abstract")
+        info['functionalequation'] = lfuncFEtex(gr, "analytic")
+        info['functionalequationSelberg'] = lfuncFEtex(gr, "selberg")
+        info['bread'] = get_bread()
 
         return render_template('Lfunction.html', **info)
 
@@ -110,7 +100,7 @@ def show():
 #            info['friends'] = friends
 
             info['eulerproduct'] = 'L(s, V \otimes W) = \prod_{p} \det(1 - Frob_p p^{-s} | (V \otimes W)^{I_p})^{-1}'
-
+            info['bread'] = get_bread()
             return render_template('Lfunction.html', **info)
         except Exception as ex:
             info = {'content': 'Sorry, there was a problem: ' + str(ex.args), 'title':'Error'}
@@ -145,10 +135,10 @@ def zeros(L):
 
 def galois_rep_from_path(p):
     C = getDBConnection()
-
+    print p
     if p[0]=='EllipticCurve':
         # create the sage elliptic curve then create Galois rep object
-        data = C.elliptic_curves.curves.find_one({'lmfdb_label':p[2]})
+        data = C.elliptic_curves.curves.find_one({'lmfdb_label':p[2]+"."+p[3]+p[4]})
         ainvs = [int(a) for a in data['ainvs']]
         E = EllipticCurve(ainvs)
         return GaloisRepresentation(E)


### PR DESCRIPTION
This PR removes import *'s from tensor_products code (per #112) and fixes a few obvious bugs so that beta.lmfdb.org/TensorProducts (which is hidden) now at least does something.  Per issue #500, tensor products are not yet functional and are scheduled for Release 2.0, this PR is not meant to make them functional, just to clean up the code.