### PR TITLE
Fix for #1692

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1077,15 +1077,19 @@ class DedekindZeta(Lfunction):   # added by DK
         self.compute_kappa_lambda_Q_from_mu_nu()
         
         self.langlands = True
-        # self.degree = self.signature[0] + 2 * self.signature[1] # N = r1 +2r2
         self.degree = self.degreeofN
         self.dirichlet_coefficients = [Integer(x) for x in
                                        self.NF.zeta_coefficients(5000)]
         self.h = wnf.class_number()  # self.NF.class_number()
         self.R = wnf.regulator()  # self.NF.regulator()
         self.w = len(self.NF.roots_of_unity())
-        # r1 = self.signature[0]
-        self.res = RR(2 ** self.signature[0] * self.h * self.R) / self.w
+        # We can only compute the reside if we know the class number and regulator (not always the case)
+        if self.h == "Not computed" or self.R == "Not computed":
+            self.res = self.residues = 0
+        else:
+            self.res = RR(2 ** self.signature[0] * self.h * self.R) / self.w
+            self.residues = [self.res, -self.res]
+        
         self.grh = wnf.used_grh()
         if self.degree > 1:
             if wnf.is_abelian() and len(wnf.dirichlet_group())>0:
@@ -1126,7 +1130,6 @@ class DedekindZeta(Lfunction):   # added by DK
                             self.factorization += right
 
         self.poles = [1, 0]  # poles of the Lambda(s) function
-        self.residues = [self.res, -self.res] #residues of Lambda(s) function
 
         self.poles_L = [1]  # poles of L(s) used by createLcalcfile_ver2
         self.residues_L = [1234]
@@ -1146,8 +1149,13 @@ class DedekindZeta(Lfunction):   # added by DK
         self.title = "Dedekind zeta-function: $\\zeta_K(s)$, where $K$ is the number field with defining polynomial %s" %  web_latex(self.NF.defining_polynomial())
         self.credit = 'Sage'
         self.citation = ''
-
-        generateSageLfunction(self)
+        
+        # If we know the residue create a Sage L-function we can call to compute values
+        if self.res:
+            generateSageLfunction(self)
+        else:
+            self.sageLfunction = None
+            
 
     def Lkey(self):
         return {"label": self.label}

--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -99,7 +99,8 @@ class Lfunction:
             allZeros = self.compute_checked_zeros(**kwargs)
 
         # Sort the zeros and divide them into negative and positive ones
-        allZeros.sort()
+        if not isinstance(allZeros,str):
+            allZeros.sort()
         return allZeros
 
     def compute_checked_zeros(self, count = None, do_negative = False, **kwargs):
@@ -129,12 +130,16 @@ class Lfunction:
             do_negative = kwargs["do_negative"]
             if self.fromDB:
                 return "not available"
+            if not self.sageLfunction:
+                return "not available"
             return self.sageLfunction.find_zeros_via_N(count, do_negative)
         else:
             T1 = kwargs["lower_bound"]
             T2 = kwargs["upper_bound"]
             stepsize = kwargs["step_size"]
             if self.fromDB:
+                return "not available"
+            if not self.sageLfunction:
                 return "not available"
             return self.sageLfunction.find_zeros(T1, T2, stepsize)
     

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -980,6 +980,10 @@ def render_zerosLfunction(request, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg
         # Allow 10 seconds
         website_zeros = L.compute_web_zeros(time_allowed = 10)
 
+    # Handle cases where zeros are not available
+    if isinstance(website_zeros, str):
+        return website_zeros
+    
     positiveZeros = []
     negativeZeros = []
 


### PR DESCRIPTION
This PR addresses #1692 by modifying the code for creating Dedekind zeta functions to handle situations in which the class number and/or regulator are not known.  In this case it no longer attempts to create a sageLfunction for computing values/zeros and instead sets it to None.  The /Zeros page simply returns "not available" in this case, and the /Plot page will return a 404 (getLfunctionPlot already handles situations where the plot cannot be computed and did not need to be modified).