### PR TITLE
Fix for issue #1619

### DIFF
--- a/lmfdb/lfunctions/LfunctionLcalc.py
+++ b/lmfdb/lfunctions/LfunctionLcalc.py
@@ -4,11 +4,11 @@ import math
 import time  # for printing the date on an lcalc file
 import socket  # for printing the machine used to generate the lcalc file
 from sage.all import Infinity, imag_part, real_part
-from Lfunctionutilities import splitcoeff, pair2complex, p2sage
+from Lfunctionutilities import splitcoeff, pair2complex, string2number
 
 
 def parse_complex_number(z):
-    zs = p2sage(z)
+    zs = string2number(z)
     z_parsed = "(" + str(real_part(zs)) + "," + str(imag_part(zs)) + ")"
     return z_parsed
 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -34,8 +34,16 @@ def p2sage(s):
 def string2number(s):
     # a start to replace p2sage (used for the paramters in the FE)
 
-    strs = str(s)
+    strs = str(s).replace(' ','')
     try:
+        if 'e' in strs:
+            # check for e(m/n) := exp(2*pi*i*m/n), used by Dirichlet characters, for example
+            r = re.match('^\$?e\\\\left\(\\\\frac\{(?P<num>\d+)\}\{(?P<den>\d+)\}\\\\right\)\$?$',strs)
+            if not r:
+                r = re.match('^e\((?P<num>\d+)/(?P<den>\d+)\)$',strs)
+            if r:
+                q = Rational(r.groupdict()['num'])/Rational(r.groupdict()['den'])
+                return CDF(exp(2*pi*I*q))
         if 'I' in strs:
             return CDF(strs)
         elif '/' in strs:


### PR DESCRIPTION
The problem was caused by parse_complex_number not handling dirichlet coefficients specified in the form e(m/n) (meaning exp(2*pi*i*m/n)).  The Lfunctionsutilites.py function string2number now handles this case (even in latex format), and lcalcfiles for Dirichlet characters now work again.