### PR TITLE
Set zeroslink/plotlink to null if not available

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -528,14 +528,23 @@ def initLfunction(L, args, request):
 
     info['degree'] = int(L.degree)
 
-    info['zeroslink'] = (request.url.replace('/L/', '/L/Zeros/').
-                          replace('/Lfunction/', '/L/Zeros/').
-                          replace('/L-function/', '/L/Zeros/'))  # url_for('zerosLfunction',  **args)
-
-    info['plotlink'] = (request.url.replace('/L/', '/L/Plot/').
-                        replace('/Lfunction/', '/L/Plot/').
-                        replace('/L-function/', '/L/Plot/'))  # info['plotlink'] = url_for('plotLfunction',  **args)
-#    # an inelegant way to remove the plot in certain cases
+    # AVS 07/10/2016
+    # only set zeroslink and plot if we actually have the ability to determine zeros and plot the Z function
+    # this could either be because we already know them (in which case lfunc_data is set), or we can compute them via sageLfunction)
+    # in the former case there is really no reason to use zeroslink at all, we could just fill them in now
+    # but keep it as is for the moment for backward compatibility
+    if hasattr(L,'lfunc_data') or (hasattr(L,'sageLfunction') and L.sageLfunction):
+        info['zeroslink'] = (request.url.replace('/L/', '/L/Zeros/').
+                              replace('/Lfunction/', '/L/Zeros/').
+                              replace('/L-function/', '/L/Zeros/'))  # url_for('zerosLfunction',  **args)
+        info['plotlink'] = (request.url.replace('/L/', '/L/Plot/').
+                            replace('/Lfunction/', '/L/Plot/').
+                            replace('/L-function/', '/L/Plot/'))  # info['plotlink'] = url_for('plotLfunction',  **args)
+    else:
+        info['zeroslink'] = ""
+        info['plotlink'] = ""
+                            
+#    # an inelegant way to remove zeros/plot in certain cases -- TODO: it would be better to do this by setting sageLFunction = None when L is created
     if L.Ltype() == 'ellipticmodularform':
         if ( (L.number == 1 and (1 + L.level) * L.weight > 50) or 
                (L.number > 1 and L.level * L.weight > 50)):


### PR DESCRIPTION
As discussed in #1691, this PR modifies lfunctions/main.py to only set the zeroslink and plotlink fields in cases where the zeros and plot are either stored in the database or can be computed using sageLfunction via the lcalc file.  When they are not set Lfunctions.html already displays a message saying that they are not available.

With this change the four Dedekind zeta functions identified in #1692 for which the class number and regulator are not available will now display a "Plot not available" message rather than a stub image that never gets filled in, compare:

http://www.lmfdb.org/L/NumberField/16.2.14383898168677573334952601242898232687.4/
http://www.lmfdb.org/L/NumberField/16.4.1055734705924451249419325715250393166653097913001.1/
http://www.lmfdb.org/L/NumberField/16.4.35504497706629289335330118915361516626281.21/
http://www.lmfdb.org/L/NumberField/16.0.1599229661124692101046354619853228081.5/

and

localhost:37777/16.2.14383898168677573334952601242898232687.4/
localhost:37777/16.4.1055734705924451249419325715250393166653097913001.1/
localhost:37777/16.4.35504497706629289335330118915361516626281.21/
localhost:37777/16.0.1599229661124692101046354619853228081.5/

If we address #1687 and #1691 by setting sageLfunction to None for Dedekind zeta functions of degree 4, this PR will ensure that suitable "Zeros not available" and "Plot not available" messages are displayed on the L-function page.
