### PR TITLE
Fix for #1687 and #1691

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -833,8 +833,7 @@ class Lfunction_Dirichlet(Lfunction):
             if self.selfdual:
                 self.coefficient_type = 2
                 for n in range(0, self.numcoeff - 1):
-                    self.dirichlet_coefficients[n] = int(
-                        round(real(self.dirichlet_coefficients[n])))
+                    self.dirichlet_coefficients[n] = int(round(real(self.dirichlet_coefficients[n])))
             else:
                 self.coefficient_type = 3
 
@@ -1151,7 +1150,8 @@ class DedekindZeta(Lfunction):   # added by DK
         self.citation = ''
         
         # If we know the residue create a Sage L-function we can call to compute values
-        if self.res:
+        # But only when the degree is at most 4, due to bugs in the Sage lcalc library (see issues #1687 and #1691)
+        if self.res and self.degree <= 4:
             generateSageLfunction(self)
         else:
             self.sageLfunction = None


### PR DESCRIPTION
This is a one-line change to address issues #1687 and #1691 by disabling the use of sageLfunction for Dedekind Zeta functions of number fields of degree > 4.  In particular, all the URLs listed [here](https://github.com/LMFDB/lmfdb/issues/1687#issuecomment-231550693), which crash the LMFD server on www.lmfdb.org load without problems with this PR (special values are simply listed as "not computed" and the zeros and Z-plot are shown as "not available").  Compare:

http://127.0.0.1:37777/L/NumberField/5.5.2337227518904161.1/
http://127.0.0.1:37777/L/NumberField/10.0.162778775259375.1/

and

http://www.lmfdb.org/L/NumberField/5.5.2337227518904161.1/
http://www.lmfdb.org/L/NumberField/10.0.162778775259375.1/

for example.  The L/Zeros/... listed [here](https://github.com/LMFDB/lmfdb/issues/1691#issuecomment-231556070) now simply return "not available" rather than a server error (except for the two cases of degree 2 which are unaffected by this change, they result in timeouts).

Merging this change will allow #1687 and #1691 to be closed (the first is tagged as critical because it is related to the www.lmfdb.org outage caused (we believe) by a robot hitting a long list of URLs that crash sage).  In the longer term, we can again make special value, zeros, and Z-plots available for Dedekind Zeta functions once they are stored in the database (this is issue #1700).
