### PR TITLE
redirects lmfdb.org to www.lmfdb.org

### DIFF
--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -56,6 +56,16 @@ import sys
 #import base
 from base import app, render_template, request, DEFAULT_DB_PORT, set_logfocus, _init
 
+@app.before_request
+def redirect_nonwww():
+    """Redirect lmfdb.org requests to www.lmfdb.org"""
+    from urlparse import urlparse, urlunparse
+    urlparts = urlparse(request.url)
+    if urlparts.netloc == 'lmfdb.org':
+        urlparts._replace(netloc='www.lmfdb.org')
+        from flask import redirect
+        return redirect(urlunparse(urlparts), code=301)
+
 @app.errorhandler(404)
 def not_found_404(error):
     return render_template("404.html"), 404


### PR DESCRIPTION
Hello,

I added a hook to redirect requests from "lmfdb.org" to "www.lmfdb.org".

There is really way for me to test this until it gets to prod, thus please double check.

I'm using the code 301, which means, permanent redirect, see: https://en.wikipedia.org/wiki/HTTP_301 .

Best,
Edgar