### PR TITLE
Fix for #1209

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -10,9 +10,9 @@
 import os
 import logging
 from time import sleep
-from flask import Flask, g, url_for, abort, render_template, request
+from flask import Flask, g, url_for, abort
 import pymongo
-from pymongo import MongoClient, MongoReplicaSetClient, Connection
+from pymongo import MongoClient, MongoReplicaSetClient
 from pymongo.cursor import Cursor
 from pymongo.errors import AutoReconnect
 from os.path import dirname, join
@@ -141,8 +141,6 @@ def _db_reconnect(func):
 
 # disabling this reconnect thing, doesn't really help anyways
 Cursor._Cursor__send_message = _db_reconnect(Cursor._Cursor__send_message)
-Connection._send_message = _db_reconnect(Connection._send_message)
-Connection._send_message_with_response = _db_reconnect(Connection._send_message_with_response)
 
 def _init(port, **kwargs):
     configureDBConnection(port, **kwargs)

--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -7,15 +7,15 @@
 # License as published by the Free Software Foundation; either
 # version 2 of the License, or (at your option) any later version.
 
-import sys
+import os
 import logging
 from time import sleep
-from flask import Flask, session, g, render_template, url_for, request, redirect
+from flask import Flask, g, url_for, abort, render_template, request
+import pymongo
+from pymongo import MongoClient, MongoReplicaSetClient, Connection
 from pymongo.cursor import Cursor
 from pymongo.errors import AutoReconnect
-from sage.all import *
-from functools import wraps
-from werkzeug.contrib.cache import SimpleCache
+from os.path import dirname, join
 
 # logfocus
 logfocus = None
@@ -26,47 +26,85 @@ def set_logfocus(lf):
 
 
 def get_logfocus():
-    global logfocus
     return logfocus
 
 # global db connection instance (will be set by the first call to
 # getDBConnection() and should always be obtained from that)
-_C = None
-
-#FIXME perhaps the globals dbport and DEFAULT_DB_PORT should be removed?
-#we could had it a default argument to makeDBConnection
-DEFAULT_DB_PORT = 37010
-dbport = DEFAULT_DB_PORT
-
+_mongo_C = None
+_mongo_port = None
+_mongo_kwargs = None
+_mongo_user = None
+_mongo_pass = None
 
 def getDBConnection():
-    return _C
+    if not _mongo_C:
+        makeDBConnection()
+        if not _mongo_C:
+            abort(503)
+    return _mongo_C
 
-def makeDBConnection(port, **kwargs):
-    global _C
-    if not _C:
-        logging.info("establishing db connection at port %s ..." % port)
-        import pymongo
-        logging.info("using pymongo version %s" % pymongo.version)
-        if pymongo.version_tuple[0] >= 3 or kwargs.get("replicaset",None) is None:
-            from pymongo import MongoClient
-            _C = MongoClient(port = port,  **kwargs)
+def configureDBConnection(port, **kwargs):
+    global _mongo_port, _mongo_kwargs, _mongo_user, _mongo_pass
+
+    _mongo_port = port
+    _mongo_kwargs = kwargs
+    pw_filename = join(dirname(dirname(__file__)), "password")
+    try:
+        _mongo_user = "webserver"
+        _mongo_pass = open(pw_filename, "r").readlines()[0].strip()
+    except:
+        # file not found or any other problem
+        # this is read-only everywhere
+        logging.warning("authentication: no password -- fallback to read-only access")
+        _mongo_user = "lmfdb"
+        _mongo_pass = "lmfdb"
+
+def makeDBConnection():
+    global _mongo_C
+
+    logging.info("attempting to establish mongo db connection on port %s ..." % _mongo_port)
+    logging.info("using pymongo version %s" % pymongo.version)
+    try:
+        if pymongo.version_tuple[0] >= 3 or _mongo_kwargs.get("replicaset",None) is None:
+            _mongo_C = MongoClient(port = _mongo_port,  **_mongo_kwargs)
         else:
-            from pymongo import MongoReplicaSetClient
-            _C = MongoReplicaSetClient(port = port,  **kwargs)
-        mongo_info = _C.server_info()
+            _mongo_C = MongoReplicaSetClient(port = _mongo_port,  **_mongo_kwargs)
+        mongo_info = _mongo_C.server_info()
         logging.info("mongodb version: %s" % mongo_info["version"])
-        logging.info("_C = %s", (_C,) )
+        logging.info("_mongo_C = %s", (_mongo_C,) )
         #the reads are not necessarily from host/address
         #those depend on the cursor, and can be checked with cursor.conn_id or cursor.address 
         if pymongo.version_tuple[0] >= 3:
-            logging.info("_C.address = %s" % (_C.address,) )
+            logging.info("_mongo_C.address = %s" % (_mongo_C.address,) )
         else:
-            logging.info("_C.host = %s" % (_C.host,) )
+            logging.info("_mongo_C.host = %s" % (_mongo_C.host,) )
 
-        logging.info("_C.nodes = %s" %  (_C.nodes,) )
-        logging.info("_C.read_preference = %s" %  (_C.read_preference,) )
+        logging.info("_mongo_C.nodes = %s" %  (_mongo_C.nodes,) )
+        logging.info("_mongo_C.read_preference = %s" %  (_mongo_C.read_preference,) )
 
+        try:
+            _mongo_C["admin"].authenticate(_mongo_user, _mongo_pass)
+            if _mongo_user == "webserver":
+                logging.info("authentication: partial read-write access enabled")
+        except pymongo.errors.PyMongoError as err:
+            logging.error("authentication: FAILED -- aborting")
+            raise err
+        #read something from the db    
+        #and check from where was it read
+        if pymongo.version_tuple[0] >= 3:
+            cursor = _mongo_C.userdb.users.find({},{'_id':True}).limit(-1)
+            list(cursor)
+            logging.info("MongoClient conection is reading from: %s" % (cursor.address,));
+        elif _mongo_kwargs.get("replicaset",None) is not None:
+            cursor = _mongo_C.userdb.users.find({},{'_id':True}).limit(-1)
+            list(cursor)
+            logging.info("MongoReplicaSetClient connection is reading from: %s" % (cursor.conn_id,));
+        else:
+            logging.info("MongoClient conection is reading from: %s" % (_mongo_C.host,));
+    except Exception as err:
+        logging.info("connection attempt failed: %s", err)
+        _mongo_C = None
+        return
 
 
 # Global to track of many auto reconnect attempts for _db_reconnect
@@ -75,14 +113,13 @@ AUTO_RECONNECT_ATTEMPTS = 0
 def _db_reconnect(func):
     """
     Wrapper to automatically reconnect when mongodb throws a AutoReconnect exception.
-
     See
       * http://stackoverflow.com/questions/5287621/occasional-connectionerror-cannot-connect-to-the-database-to-mongo
       * http://paste.pocoo.org/show/224441/
     and similar workarounds
     """
-    # maximal number of auto reconnect attempts
-    AUTO_RECONNECT_MAX = 10
+    # maximum number of auto reconnect attempts
+    AUTO_RECONNECT_MAX = 3 # there is no reason to make this large, if the database is down we may as well wait for the user to hit refresh or click on something before trying again
     # delay between attempts
     AUTO_RECONNECT_DELAY = 1
 
@@ -95,57 +132,21 @@ def _db_reconnect(func):
                 AUTO_RECONNECT_ATTEMPTS += 1
                 if AUTO_RECONNECT_ATTEMPTS > AUTO_RECONNECT_MAX:
                     AUTO_RECONNECT_ATTEMPTS = 0
-                    import flask
-                    flask.flash("AutoReconnect failed to reconnect", "error")
-                    raise
+                    abort(503)
                 logging.warning(
                     'AutoReconnect #%d - %s raised [%s]' % (AUTO_RECONNECT_ATTEMPTS, func.__name__, e))
                 sleep(AUTO_RECONNECT_DELAY)
+                makeDBConnection()
     return retry
 
 # disabling this reconnect thing, doesn't really help anyways
-# Cursor._Cursor__send_message = _db_reconnect(Cursor._Cursor__send_message)
-# Connection._send_message = _db_reconnect(Connection._send_message)
-# Connection._send_message_with_response =
-# _db_reconnect(Connection._send_message_with_response)
-
+Cursor._Cursor__send_message = _db_reconnect(Cursor._Cursor__send_message)
+Connection._send_message = _db_reconnect(Connection._send_message)
+Connection._send_message_with_response = _db_reconnect(Connection._send_message_with_response)
 
 def _init(port, **kwargs):
-    import pymongo
-    makeDBConnection(port = port, **kwargs)
-    C = getDBConnection()
-
-    from os.path import dirname, join
-    pw_filename = join(dirname(dirname(__file__)), "password")
-    try:
-        username = "webserver"
-        password = open(pw_filename, "r").readlines()[0].strip()
-    except:
-        # file not found or any other problem
-        # this is read-only everywhere
-        logging.warning("authentication: no password -- fallback to read-only access")
-        username = "lmfdb"
-        password = "lmfdb"
-
-    try:
-        C["admin"].authenticate(username, password)
-        if username == "webserver":
-            logging.info("authentication: partial read-write access enabled")
-    except pymongo.errors.PyMongoError as err:
-        logging.error("authentication: FAILED -- aborting")
-        raise err
-    #read something from the db    
-    #and check from where was it read
-    if pymongo.version_tuple[0] >= 3:
-        cursor = C.test.test.find().limit(-1)
-        list(cursor)
-        logging.info("MongoClient conection is reading from: %s" % (cursor.address,));
-    elif kwargs.get("replicaset",None) is not None:
-        cursor = C.test.test.find().limit(-1)
-        list(cursor)
-        logging.info("MongoReplicaSetClient connection is reading from: %s" % (cursor.conn_id,));
-    else:
-        logging.info("MongoClient conection is reading from: %s" % (C.host,));
+    configureDBConnection(port, **kwargs)
+    makeDBConnection()
 
 app = Flask(__name__)
 
@@ -200,7 +201,6 @@ def ctx_proc_userdata():
     vars['title'] = r'LMFDB'
 
     # meta_description appears in the meta tag "description"
-    import knowledge
     vars['meta_description'] = r'Welcome to the LMFDB, the database of L-functions, modular forms, and related objects. These pages are intended to be a modern handbook including tables, formulas, links, and references for L-functions and their underlying objects.'
     vars['shortthanks'] = r'This project is supported by <a href="%s">grants</a> from the US National Science Foundation and the UK Engineering and Physical Sciences Research Council.' % (url_for('acknowledgment') + "#sponsors")
 #    vars['feedbackpage'] = url_for('contact')
@@ -258,7 +258,7 @@ def git_infos():
         rev = Popen([git_rev_cmd], shell=True, stdout=PIPE).communicate()[0]
         date = Popen([git_date_cmd], shell=True, stdout=PIPE).communicate()[0]
         cmd_output = rev, date
-    except e:
+    except:
         cmd_output = '-', '-'
     return cmd_output
 
@@ -323,4 +323,5 @@ class LmfdbTest(unittest2.TestCase):
         self.app = app
         self.tc = app.test_client()
         import lmfdb.website
+        assert lmfdb.website
         self.C = getDBConnection()

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -10,18 +10,7 @@ DSC = pymongo.DESCENDING
 
 def get_knowls():
     _C = getDBConnection()
-    knowls = _C.knowledge.knowls
-# See issue #1169
-#    try:
-#        knowls.ensure_index('authors')
-#        # _keywords is used for the full text search
-#        knowls.ensure_index('title')
-#        knowls.ensure_index('cat')
-#        knowls.ensure_index('_keywords')
-#    except pymongo.errors.OperationFailure:
-#        pass
-    return knowls
-
+    return _C.knowledge.knowls
 
 def get_meta():
     """
@@ -46,8 +35,6 @@ def save_history(knowl, who):
     TODO also calculate a diff with python's difflib and store it here.
     """
     history = getDBConnection().knowledge.history
-#   See issue #1169
-#   history.ensure_index("time")
     h_item = {'_id': knowl.id,
               'title': knowl.title,
               'time': datetime.utcnow(),
@@ -88,8 +75,6 @@ def set_locked(knowl, who):
     when a knowl is edited, a lock is created. who is the user id.
     """
     history = getDBConnection().knowledge.history
-# See issue #1169
-#   history.ensure_index("time")
     lock_item = {'_id': knowl.id,
                  'title': knowl.title,
                  'time': datetime.utcnow(),
@@ -99,7 +84,6 @@ def set_locked(knowl, who):
 
 
 def get_knowl(ID, fields={"history": 0, "_keywords": 0}):
-    print "get_knowl", ID
     return get_knowls().find_one({'_id': ID}, fields)
 
 

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -99,6 +99,7 @@ def set_locked(knowl, who):
 
 
 def get_knowl(ID, fields={"history": 0, "_keywords": 0}):
+    print "get_knowl", ID
     return get_knowls().find_one({'_id': ID}, fields)
 
 

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -424,7 +424,8 @@ def render(ID, footer=None, kwargs=None, raw=False):
         k = Knowl(ID)
     except:
         logger.critical("Failed to render knowl %s"%ID)
-        return make_response("Sorry, the knowledge database is currently unavailable.")
+        errmsg = "Sorry, the knowledge database is currently unavailable."
+        return errmsg if raw else make_response(errmsg)
 
     # logger.debug("kwargs: %s", request.args)
     kwargs = kwargs or dict(((k, v) for k, v in request.args.iteritems()))

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -420,7 +420,11 @@ def render(ID, footer=None, kwargs=None, raw=False):
     the keyword 'raw' is used in knowledge.show and knowl_inc to
     include *just* the string and not the response object.
     """
-    k = Knowl(ID)
+    try:
+        k = Knowl(ID)
+    except:
+        logger.critical("Failed to render knowl %s"%ID)
+        return make_response("Sorry, the knowledge database is currently unavailable.")
 
     # logger.debug("kwargs: %s", request.args)
     kwargs = kwargs or dict(((k, v) for k, v in request.args.iteritems()))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -21,9 +21,10 @@ AUTHORS:
  - Stephan Ehlen
 
 """
-from flask import render_template, url_for, request, redirect, make_response, send_file, send_from_directory,flash
-import os
-from lmfdb.base import app, db, getDBConnection
+from flask import url_for, request, redirect, make_response, send_from_directory,flash
+import os, tempfile
+import sage
+from lmfdb.base import getDBConnection
 from lmfdb.modular_forms.backend.mf_utils import my_get
 from lmfdb.utils import to_dict, random_object_from_collection
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf

--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -27,7 +27,7 @@ def alive():
         conn = getDBConnection()
         assert conn.userdb.users.count()
     except:
-        abort(501)
+        abort(503)
     return "LMFDB!"
 
 @app.route("/acknowledgment")

--- a/lmfdb/templates/503.html
+++ b/lmfdb/templates/503.html
@@ -3,7 +3,7 @@
 
 <h3>The LMFDB is currently unavailable.</h3>
 <p>
-{% if 'warwick' in request.url_root %}
+{% if 'warwick' in request.url_root  or 'beta' in request.url_root %}
 You can visit our main site at
 <a href="http://www.lmfdb.org">www.lmfdb.org</a>.
 {% else %}

--- a/lmfdb/templates/503.html
+++ b/lmfdb/templates/503.html
@@ -1,0 +1,8 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<h3>
+The LMFDB is currently unavailable, please try again later.
+</h3>
+
+{% endblock %}

--- a/lmfdb/templates/503.html
+++ b/lmfdb/templates/503.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <h3>
-The LMFDB is currently unavailable, please try again later.
+The LMFDB is currently unavailable, please try again later.  You can contact us <a href="/contact">here</a>.
 </h3>
 
 {% endblock %}

--- a/lmfdb/templates/503.html
+++ b/lmfdb/templates/503.html
@@ -1,8 +1,18 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<h3>
-The LMFDB is currently unavailable, please try again later.  You can contact us <a href="/contact">here</a>.
-</h3>
+<h3>The LMFDB is currently unavailable.</h3>
+<p>
+{% if 'warwick' in request.url_root %}
+You can visit our main site at
+<a href="http://www.lmfdb.org">www.lmfdb.org</a>.
+{% else %}
+You can visit our alternate site at
+<a href="http://lmfdb.warwick.ac.uk">lmfdb.warwick.ac.uk</a>.
+{% endif %}
+</p>
+<p>
+You can contact us <a href="/contact">here</a>.
+</p>
 
 {% endblock %}

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -53,8 +53,8 @@ import raw
 from modular_forms.maass_forms.picard import mwfp
 
 import sys
-#import base
-from base import app, render_template, request, set_logfocus, _init
+from base import app, set_logfocus, _init
+from flask import render_template, request
 
 DEFAULT_DB_PORT = 37010
 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -54,16 +54,21 @@ from modular_forms.maass_forms.picard import mwfp
 
 import sys
 #import base
-from base import app, render_template, request, DEFAULT_DB_PORT, set_logfocus, _init
+from base import app, render_template, request, set_logfocus, _init
+
+DEFAULT_DB_PORT = 37010
 
 @app.errorhandler(404)
 def not_found_404(error):
     return render_template("404.html"), 404
 
-
 @app.errorhandler(500)
 def not_found_500(error):
     return render_template("500.html"), 500
+
+@app.errorhandler(503)
+def not_found_503(error):
+    return render_template("503.html"), 500
 
 #@app.route("/") is now handled in pages.py
 
@@ -160,6 +165,7 @@ def example(blah=None):
 @app.route("/AutomorphicForm/")
 def modular_form_toplevel():
     from flask import redirect, url_for
+    print "hi there"
     return redirect(url_for("mf.render_modular_form_main_page"))
     # return render_template("modular_form_space.html", info = { })
 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -165,7 +165,6 @@ def example(blah=None):
 @app.route("/AutomorphicForm/")
 def modular_form_toplevel():
     from flask import redirect, url_for
-    print "hi there"
     return redirect(url_for("mf.render_modular_form_main_page"))
     # return render_template("modular_form_space.html", info = { })
 


### PR DESCRIPTION
This PR addresses #1209 by allowing the LMFDB application to stay up when mongo db goes down.  If/when this happens, the user will see the main page (with sidebar and title) with a message indicating that the LMFDB is unavailable and the option to visit an alternate site (e.g. lmfdb.warwick.ac.uk) or to contact us (the contact page does not require mongo db).

While mongo db is down, clicking on any sidebar links (or directly trying to visit any URL) will take the use to the same front page (with a 503 status returned to the browser).  If/when the mongo db becomes available again, everything will start working again, no restart is required.

To test this, its best to run warwick.sh in a terminal where you can easily stop and start it.  Try starting the lmfdb without the tunnel to the mongo db at warwick in place, then run warwick.sh and see that everything works, then stop warwick.sh in the middle of something and see what happens.

