### PR TITLE
Remove deprecated app routes in website.py, issue #1717

### DIFF
--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -169,7 +169,7 @@ def news():
 def varieties():
     t = 'Varieties'
     b = [(t, url_for('varieties'))]
-    lm = [('History of varieties', '/Variety/history')]
+    # lm = [('History of varieties', '/Variety/history')]
     return render_template('single.html', title=t, kid='varieties.about', bread=b) #, learnmore=lm)
 
 
@@ -192,7 +192,7 @@ def holomorphic_mf_history():
 def fields():
     t = 'Fields'
     b = [(t, url_for('fields'))]
-    lm = [('History of fields', '/Field/history')]
+    # lm = [('History of fields', '/Field/history')]
     return render_template('single.html', kid='field.about', title=t, body_class=_bc, bread=b) #, learnmore=lm)
 
 @app.route("/Field/history")
@@ -207,7 +207,7 @@ def fields_history():
 def representations():
     t = 'Representations'
     b = [(t, url_for('representations'))]
-    lm = [('History of representations', '/Representation/history')]
+    # lm = [('History of representations', '/Representation/history')]
     return render_template('single.html', kid='repn.about', title=t, body_class=_bc, bread=b) #, learnmore=lm)
 
 
@@ -224,7 +224,7 @@ def representations_history():
 def groups():
     t = 'Groups'
     b = [(t, url_for('groups'))]
-    lm = [('History of groups', '/Group/history')]
+    # lm = [('History of groups', '/Group/history')]
     return render_template('single.html', kid='group.about', title=t, body_class=_bc, bread=b) #, learnmore=lm)
 
 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -88,7 +88,7 @@ import os
 import sys
 import getopt
 from pymongo import ReadPreference
-from base import app, set_logfocus, _init
+from base import app, set_logfocus, get_logfocus, _init
 from flask import g, render_template, request, make_response, redirect, url_for, current_app, abort
 
 DEFAULT_DB_PORT = 37010
@@ -103,7 +103,7 @@ def not_found_500(error):
 
 @app.errorhandler(503)
 def not_found_503(error):
-    return render_template("503.html"), 500
+    return render_template("503.html"), 503
 
 #@app.route("/") is now handled in pages.py
 
@@ -327,6 +327,7 @@ if True:
     file_handler.setLevel(logging.WARNING)
     if 'logfocus' in configuration['logging_options']:
         set_logfocus(configuration['logging_options']['logfocus'])
+        logging.getLogger(get_logfocus()).setLevel(logging.DEBUG)
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -10,47 +10,79 @@
 start this via $ sage -python website.py --port <portnumber>
 add --debug if you are developing (auto-restart, full stacktrace in browser, ...)
 """
+
+# Import top-level modules that makeup the site
+# Note that this necessarily includes everything, even clode in still in an alpha state
 import pages
+assert pages
 import api
+assert api
 import hilbert_modular_forms
+assert hilbert_modular_forms
 import half_integral_weight_forms
+assert half_integral_weight_forms
 import siegel_modular_forms
+assert siegel_modular_forms
 import modular_forms
+assert modular_forms
 import elliptic_curves
+assert elliptic_curves
 import ecnf
+assert ecnf
 import quadratic_twists
+assert quadratic_twists
 import plot_example
+assert plot_example
 import number_fields
+assert number_fields
 import lfunction_db
+assert lfunction_db
 import lfunctions
-# import maass_form_picard
-# import maass_waveforms
+assert lfunctions
 import genus2_curves
+assert genus2_curves
 import sato_tate_groups
+assert sato_tate_groups
 import users
+assert users
 import knowledge
-#import upload
+assert knowledge
 import characters
+assert characters
 import local_fields
+assert local_fields
 import galois_groups
-# import number_field_galois_groups
+assert galois_groups
 import artin_representations
+assert artin_representations
 import tensor_products
+assert tensor_products
 import zeros
+assert zeros
 import crystals
+assert crystals
 import permutations
+assert permutations
 import hypergm
+assert hypergm
 import motives
+assert motives
 import riemann
-import logging
+assert riemann
 import lattice
+assert lattice
 import higher_genus_w_automorphisms
+assert higher_genus_w_automorphisms
 import modlmf
+assert modlmf
 import rep_galois_modl
+assert rep_galois_modl
+
+# Currently uploading is not supported
+# import upload
 
 
-import raw
-from modular_forms.maass_forms.picard import mwfp
+import logging
 
 import sys
 from base import app, set_logfocus, _init
@@ -165,20 +197,9 @@ Usage: %s [OPTION]...
 """ % sys.argv[0]
 
 def get_configuration():
-    global logfocus
-    # FIXME
-    # I don't think that this global variable does anything at all,
-    # but let's keep track of it anyway.
 
-    # default options to pass to the app.run()
-    flask_options = {"port": 37777, "host": "127.0.0.1", "debug": False}
-    # Default option to pass to _init
-    threading_opt = False 
-    # the logfocus can be set to the string-name of a logger you want
-    # follow on the debug level and all others will be set to warning
-    logfocus = None
-    #FIXME logfile isn't used
-    logfile = "flasklog"
+    # default flask options
+    flask_options = {"port": 37777, "host": "127.0.0.1", "debug": False, "logfile": "flasklog" }
 
     # default options to pass to the MongoClient
     from pymongo import ReadPreference
@@ -231,14 +252,13 @@ def get_configuration():
                 flask_options["host"] = arg
             #FIXME logfile isn't used
             elif opt in ("-l", "--log"):
-                logfile = arg
+                flask_options["logfile"] = arg
             elif opt in ("--dbport"):
                 mongo_client_options["port"] = int(arg)
             elif opt == "--debug":
                 flask_options["debug"] = True
             elif opt == "--logfocus":
-                logfocus = arg
-                logging.getLogger(arg).setLevel(logging.DEBUG)
+                flask_options["logfocus"] = arg
             elif opt in ("-m", "--mongo-client"):
                 if os.path.exists(arg):
                     mongo_client_config_filename = arg
@@ -321,9 +341,11 @@ def main():
 if True:
     # this bit is so that we can import website.py to use
     # with gunicorn.
-    logfile = "flasklog"
-    file_handler = logging.FileHandler(logfile)
+    file_handler = logging.FileHandler(configuration['flask_options']['logfile'])
     file_handler.setLevel(logging.WARNING)
+    logfocus = configuration['flask_options'].get('logfocus')
+    if logfocus:
+        logging.getLogger(logfocus).setLevel(logging.DEBUG)
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -202,14 +202,13 @@ def get_configuration():
     mongo_client_config_filename = "mongoclient.config"
     config_dir = '/'.join( os.path.dirname(os.path.abspath(__file__)).split('/')[0:-1])
     mongo_client_config_filename = '{0}/{1}'.format(config_dir,mongo_client_config_filename)
-    
-        
-    # deals with argv's
-    if not sys.argv[0].endswith('nosetests'):
+
+    if not 'sage' in sys.argv[0] and not sys.argv[0].endswith('nosetests'):
+        import getopt
         try:
             opts, args = getopt.getopt(
                                         sys.argv[1:],
-                                        "p:h:l:t:m:",
+                                        "p:h:l:tm:",
                                        [
                                            "port=",
                                            "host=", 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -97,24 +97,6 @@ def robots_txt():
     return "User-agent: *\nDisallow: / \n"
 
 
-# TODO what is that? we have git now btw ...
-@app.route("/hg/<arg>")
-def hg(arg):
-    if arg == "":
-        return "Use /hg/parent, /hg/log or /hg/identify"
-    import os
-    if arg == "parent":
-        f = os.popen("hg parent")
-    elif arg == "tip":
-        f = os.popen("hg tip")
-    elif arg == "identify":
-        f = os.popen("hg identify")
-    else:
-        return "Unrecognized command. Allowed are parent, tip and identify."
-    text = f.read()
-    return str(text)
-
-
 @app.route("/style.css")
 def css():
     from flask import make_response
@@ -147,51 +129,15 @@ def menutoggle(show):
     url = request.referrer or url_for('index')
     return redirect(url)
 
-@app.route('/a/<int:a>')
-def a(a):
-    from sage.all import Integer
-    a = Integer(a)
-    return r'\(' + str(a / (1 + a)) + r'\)'
-
-
-@app.route("/example/")
-@app.route("/example/<blah>")
-def example(blah=None):
-    return render_template("example.html", blah=blah)
-
-
-@app.route("/modular/")
-@app.route("/ModularForm/")
-@app.route("/AutomorphicForm/")
-def modular_form_toplevel():
-    from flask import redirect, url_for
-    return redirect(url_for("mf.render_modular_form_main_page"))
-    # return render_template("modular_form_space.html", info = { })
-
-
-@app.route("/calc")
-def calc():
-    return request.args['ep']
-
-
-@app.route("/form")
-def form_example():
-    sidebar = [('topic1', [("abc", "#"), ("def", "#")]), ("topic2", [("ghi", "#"), ("jkl", "#")])]
-    info = {'sidebar': sidebar}
-    return render_template("form.html", info=info)
-
-
 @app.route('/example_plot')
 def render_example_plot():
     return plot_example.render_plot(request.args)
-
 
 @app.route("/not_yet_implemented")
 def not_yet_implemented():
     return render_template("not_yet_implemented.html", title="Not Yet Implemented")
 
-# the checklist is for testing on a high-level
-
+# the checklist is used for human testing on a high-level, supplements test.sh
 
 @app.route("/checklist-list")
 def checklist_list():


### PR DESCRIPTION
This PR removes the routes identified in https://github.com/LMFDB/lmfdb/issues/1717#issuecomment-232139787.  Leaves in /example_plot (which I would still suggest removing).

Also cleans up website.py and pages.py so that pyflakes runs cleanly and streamlines configuration and setting of logging options.
