### PR TITLE
Avoid sage nf

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -343,10 +343,21 @@ class WebNumberField:
         t = self.galois_t()
         return modules2string(n, t, ugm)
 
+    # Sage version of K -- should be avoided since it can be slow
+    # in extreme cases
     def K(self):
         if not self.haskey('K'):
             self._data['K'] = NumberField(self.poly(), self.gen_name)
         return self._data['K']
+
+    # pari version of K
+    def gpK(self):
+        if not self.haskey('gpK'):
+            Qx = PolynomialRing(QQ,'x')
+            basis = [Qx(el.replace('a','x')) for el in self.zk()]
+            k1 = gp( "nfinit([%s,%s])" % (str(self.poly()),str(basis)) )
+            self._data['gpK'] = k1
+        return self._data['gpK']
 
     def generator_name(self):
         #Add special case code for the generator if desired:

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -3,7 +3,8 @@ from flask import url_for
 import lmfdb.base
 from lmfdb.utils import make_logger, web_latex, encode_plot
 from lmfdb.ecnf.WebEllipticCurve import web_ainvs
-from lmfdb.number_fields.number_field import field_pretty, nf_display_knowl
+#from lmfdb.number_fields.number_field import field_pretty, nf_display_knowl
+from lmfdb.WebNumberField import field_pretty, nf_display_knowl
 
 import sage.all
 from sage.all import latex, matrix

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -5,7 +5,7 @@ from lmfdb.lfunctions import logger
 import math
 from sage.all import ZZ, QQ, CC, Rational, RationalField, ComplexField, PolynomialRing, LaurentSeriesRing, O, Integer, Primes, primes, CDF, I, real_part, imag_part, latex, factor, prime_divisors, prime_pi, log, exp, pi, prod, floor
 from lmfdb.genus2_curves.web_g2c import list_to_factored_poly_otherorder
-from lmfdb.number_fields import group_display_knowl
+from lmfdb.transitive_group import group_display_knowl
 from lmfdb.base import getDBConnection
 
 ###############################################################

--- a/lmfdb/math_classes.py
+++ b/lmfdb/math_classes.py
@@ -605,18 +605,24 @@ class NumberFieldGaloisGroup(object):
 	PP = PolynomialRing(QQ, 'x')
     	return PP(self.polynomial())._latex_()
 
+    # WebNumberField of the object
+    def wnf(self):
+        return WebNumberField.from_polredabs(self.polredabs())
+
     def polredabs(self):
-        if "polredabs" in self._data.keys():
-            return self._data["polredabs"]
-        else:
-            pol = PolynomialRing(QQ, 'x')(map(str,self.polynomial()))
-            # Need to map because the coefficients are given as unicode, which does not convert to QQ
-            pol *= pol.denominator()
-            R = pol.parent()
-            from sage.all import pari
-            pol = R(pari(pol).polredabs())
-            self._data["polredabs"] = pol
-            return pol
+        # polynomials are all polredabs'ed now
+        return PolynomialRing(QQ, 'x')(map(str,self.polynomial()))
+        #if "polredabs" in self._data.keys():
+        #    return self._data["polredabs"]
+        #else:
+        #    pol = PolynomialRing(QQ, 'x')(map(str,self.polynomial()))
+        #    # Need to map because the coefficients are given as unicode, which does not convert to QQ
+        #    pol *= pol.denominator()
+        #    R = pol.parent()
+        #    from sage.all import pari
+        #    pol = R(pari(pol).polredabs())
+        #    self._data["polredabs"] = pol
+        #    return pol
 
     def polredabslatex(self):
         return self.polredabs()._latex_()
@@ -631,7 +637,7 @@ class NumberFieldGaloisGroup(object):
             #from number_fields.number_field import poly_to_field_label
             #pol = PolynomialRing(QQ, 'x')(map(str,self.polynomial()))
             #label = poly_to_field_label(pol)
-	    label = WebNumberField.from_coeffs(self._data["Polynomial"]).get_label()
+            label = WebNumberField.from_coeffs(self._data["Polynomial"]).get_label()
             if label:
                 self._data["label"] = label
             return label
@@ -655,7 +661,6 @@ class NumberFieldGaloisGroup(object):
         """
         More-or-less standardized name of the abstract group
         """
-        from WebNumberField import WebNumberField
         import re
         wnf = WebNumberField.from_polredabs(self.polredabs())
         if not wnf.is_null():
@@ -766,7 +771,7 @@ class NumberFieldGaloisGroup(object):
             return self._residue_field_degrees(p)
         except AttributeError:
             from number_fields.number_field import residue_field_degrees_function
-            fn_with_pari_output = residue_field_degrees_function(self.sage_object())
+            fn_with_pari_output = residue_field_degrees_function(self.wnf())
             self._residue_field_degrees = lambda p: map(Integer, fn_with_pari_output(p))
             # This function is better, becuase its output has entries in Integer
             return self._residue_field_degrees(p)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -28,7 +28,9 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import
 from lmfdb.utils import to_dict,ajax_more
 from lmfdb.modular_forms.backend.mf_utils import my_get
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, default_prec, default_bprec, default_display_bprec, EMF_TOP, default_max_height
-from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty, nf_display_knowl
+from lmfdb.number_fields.number_field import poly_to_field_label
+#from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty, nf_display_knowl
+from lmfdb.WebNumberField import field_pretty, nf_display_knowl
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_object import web_latex_poly
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label
 from lmfdb.base import getDBConnection

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -263,7 +263,6 @@ def render_field_webpage(args):
         return search_input_error(info, bread)
 
     info['wnf'] = nf
-    #from lmfdb.WebNumberField import nf_display_knowl
     data['degree'] = nf.degree()
     data['class_number'] = nf.class_number()
     t = nf.galois_t()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -327,7 +327,7 @@ def render_field_webpage(args):
         'integral_basis': zk,
         'regulator': web_latex(nf.regulator()),
         'unit_rank': nf.unit_rank(),
-        'root_of_unity': web_latex(rootofunity), #web_latex(nf.K().primitive_root_of_unity()),
+        'root_of_unity': web_latex(rootofunity),
         'fund_units': nf.units(),
         'grh_label': grh_label
     })


### PR DESCRIPTION
This fixes issue #1662 .  The issue lists the field which used to timeout.

The problem was that several parts of displaying a number field created a sage number field.  If the polynomial discriminant is too large, this can take too long.  For number field pages, we avoid this by creating a pari number field instead (feeding it our precomputed integral basis lets it run quickly).

This also makes pyflakes run cleanly on number_field.py.  Hopefully it doesn't break other parts of the web site.  This pull request changes other files which were importing functions from number_field.py when they probably shouldn't have (the functions are defined elsewhere and used to be imported into number_field.py).
