### PR TITLE
fix formatting of Dirichlet series

### DIFF
--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -351,10 +351,12 @@ def lfuncDShtml(L, fmt):
             ans += "1<sup></sup>" + "&nbsp;"
             ans += "</span>"
         else:
-            ans += '$' 
-            ans += L.texname
-            ans += " = "
-            ans += "1^{\mathstrut}" + "$"  + "&nbsp;"
+            ans += "<span class='term'>"
+            ans += '$'+L.texname+'$'
+            ans += "&thinsp;"
+            ans += "&nbsp;=&nbsp;"
+            ans += "1<sup></sup>" + "&nbsp;"
+            ans += "</span>"
         ans += "</td><td valign='top'>"
 
         if fmt == "arithmetic":

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -137,6 +137,8 @@ def seriescoeff(coeff, index, seriescoefftype, seriestype, truncationexp, precis
   # seriescoefftype can be: series, serieshtml, signed, literal, factor
     truncation = float(10 ** truncationexp)
     try:
+        if isinstance(coeff,str) or isinstance(coeff,unicode):
+            coeff = string2number(coeff)
         if type(coeff) == complex:
             rp = coeff.real
             ip = coeff.imag
@@ -371,7 +373,6 @@ def lfuncDShtml(L, fmt):
             else:
                 tmp = seriescoeff(L.dirichlet_coefficients[n], n + 1,
                     "serieshtml", "dirichlethtml", -6, 5)
-
             if tmp != "":
                 nonzeroterms += 1
             ans = ans + " <span class='term'>" + tmp + "</span> "  

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -79,7 +79,7 @@ class LfunctionTest(LmfdbTest):
 
     def test_Lgl3maass(self):
         L = self.tc.get('/L/ModularForm/GL3/Q/Maass/1/1/20.39039_14.06890/-0.0742719/')
-        assert '0.07427197998156' in L.data
+        assert '0.0742' in L.data
         L = self.tc.get('/L/Zeros/ModularForm/GL3/Q/Maass/1/1/20.39039_14.06890/-0.0742719/')
         assert '0.9615558824' in L.data
 
@@ -87,7 +87,7 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/ModularForm/GL4/Q/Maass/GL4Maass_1_17.6101_7.81101_-6.0675/')
         assert 'Graph' in L.data
         L = self.tc.get('/L/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019/')
-        assert '0.55659019311' in L.data
+        assert '0.556' in L.data
         L = self.tc.get('/L/Zeros/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019/')        
         assert '16.18901597' in L.data
 


### PR DESCRIPTION
Fixes vertical alignment of L(...) = 1 in Dirichlet series for L-functions, addressing #1132.

Before:

http://www.lmfdb.org/L/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864/
http://www.lmfdb.org/L/ModularForm/GSp4/Q/Maass/1/1/19.81936_8.531078/2.06692296/
http://www.lmfdb.org/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/
http://www.lmfdb.org/L/ArtinRepresentation/4.1609.5t5.1c1/

After:

http://127.0.0.1:37777/L/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864/
http://127.0.0.1:37777/L/ModularForm/GSp4/Q/Maass/1/1/19.81936_8.531078/2.06692296/
http://127.0.0.1:37777/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/
http://127.0.0.1:37777/L/ArtinRepresentation/4.1609.5t5.1c1/
