### PR TITLE
Higher Genus  tiny changes and connect to genus2/Q pages

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -157,7 +157,10 @@ def index():
     bread = get_bread()
     if request.args:
         return higher_genus_w_automorphisms_search(**request.args)
-    genus_list = range(2,6)
+
+    C = base.getDBConnection()
+    genus_max = C.curve_automorphisms.passports.find().sort('genus', pymongo.DESCENDING).limit(1)[0]['genus']  + 1
+    genus_list = range(2,genus_max)
     info = {'count': 20,'genus_list': genus_list}
     
 
@@ -322,8 +325,13 @@ def render_family(args):
             
         info.update({'passport': Lall})
 
-            
-        friends = [ ]
+
+        g2List = ['[2,1]','[4,2]','[8,3]','[10,2]','[12,4]','[24,8]','[48,29]']
+        if g  == 2 and data['group'] in g2List:
+            g2url = "/Genus2Curve/Q/?geom_aut_grp_id=" + data['group']
+            friends = [("Family Over $\Q$", g2url ) ]
+        else:    
+            friends = [ ]
         
 
         br_g, br_gp, br_sign = split_family_label(label)

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -89,6 +89,11 @@ def signature_to_list(L):
     return L
 
 
+def sort_sign(L):
+    L1 = L[1:]
+    L1.sort()
+    return [L[0]] +L1
+
 def label_to_breadcrumbs(L):
     newsig = '['
     for i in range(0,len(L)):
@@ -214,13 +219,15 @@ def higher_genus_w_automorphisms_search(**args):
 
 
 #allows for ; in signature
-    if 'signature' in info:   
-        info.update({'signature': signature_to_list(info['signature'])})
-        
+    if 'signature' in info and info['signature'] != '':
+        sig_list = ast.literal_eval(signature_to_list(info['signature']))
+        sig =  sort_sign(sig_list)
+        info.update({'signature': str(sig)})
+            
     try:
         parse_bracketed_posints2(info,query,'group', split=False, exactlength=2, name='Group')
         parse_ints(info,query,'genus',name='Genus')
-        parse_bracketed_posints2(info,query,signature_to_list('signature'),split=False,name='Signature')
+        parse_bracketed_posints2(info,query,'signature',split=False,name='Signature')
         parse_ints(info,query,'dim',name='Dimension of the family')
         if 'inc_hyper' in info:
             if info['inc_hyper'] == 'exclude':

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -234,7 +234,8 @@ def higher_genus_w_automorphisms_search(**args):
                 query['hyperelliptic'] = False
             elif info['inc_hyper'] == 'only':
                 query['hyperelliptic'] = True
-            
+
+        query['cc.1'] = 1       
 
     except ValueError:
         return search_input_error(info, bread)
@@ -336,7 +337,7 @@ def render_family(args):
         g2List = ['[2,1]','[4,2]','[8,3]','[10,2]','[12,4]','[24,8]','[48,29]']
         if g  == 2 and data['group'] in g2List:
             g2url = "/Genus2Curve/Q/?geom_aut_grp_id=" + data['group']
-            friends = [("Family Over $\Q$", g2url ) ]
+            friends = [("Genus 2 curves over $\Q$", g2url ) ]
         else:    
             friends = [ ]
         

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -24,7 +24,7 @@ table,td {
   <td>{{KNOWL('curve.highergenus.aut.groupnotation',title='GAP/Magma notation')}}:</td>
   <td>{{info.gpid}}</td></tr>
   <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
-  <tr><td> Conjugacy classes for this {{KNOWL('curve.curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
+  <tr><td> Conjugacy classes for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
   </table></p>
 
 

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -26,7 +26,7 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
 
     def test_random(self):
         L = self.tc.get('/HigherGenus/C/Aut/random',follow_redirects=True)
-        assert 'Conjugacy classes for this   refined passport:' in L.data
+        assert 'Conjugacy classes for this' in L.data
 
     def test_magma_download(self):
         L = self.tc.get('/HigherGenus/C/Aut/5.32-27.0.2-2-2-4.1/download/magma')


### PR DESCRIPTION
1. Fixed a typo for calling one KNOWL on passport pages like
http://127.0.0.1:37777/HigherGenus/C/Aut/2.5-1.0.5-5-5.2
The "refined passport" KNOWL had the wrong name in the file /lmfdb/higher_genus_w_automorphisms/template/hgcwa-show-passport.html

This fix broke a test too, so small change to one test as well.

2. On the index page  http://127.0.0.1:37777/HigherGenus/C/Aut/ the highest genus listed for the browse options is now a variable which is found by query to the database to find the highest genus available (before it was just a static number).

3.  Added connections to the genus 2/Q data.  For example, there is now a friend here:
http://127.0.0.1:37777/HigherGenus/C/Aut/2.12-4.0.2-2-2-3 
which takes you to the search in the genus2/Q data for automorphism group over \bar{Q} of D_6.