### PR TITLE
Logger colors

### DIFF
--- a/lmfdb/genus2_curves/__init__.py
+++ b/lmfdb/genus2_curves/__init__.py
@@ -6,7 +6,6 @@ from flask import Blueprint
 g2c_page = Blueprint("g2c", __name__, template_folder='templates',
         static_folder="static")
 g2c_logger = make_logger(g2c_page)
-g2c_logger.info("Initializing genus 2 curves blueprint")
 
 @g2c_page.context_processor
 def body_class():

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -103,9 +103,9 @@ class LmfdbFormatter(logging.Formatter):
         elif record.levelno >= logging.WARNING:
             self._fmt = '\033[33m' + self._fmt
         elif record.levelno <= logging.DEBUG:
-            self._fmt = '\033[32m' + self._fmt
-        elif record.levelno <= logging.INFO:
             self._fmt = '\033[34m' + self._fmt
+        elif record.levelno <= logging.INFO:
+            self._fmt = '\033[32m' + self._fmt
 
         # bold, if module name matches
         if record.name == self._hl:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -103,7 +103,7 @@ class LmfdbFormatter(logging.Formatter):
         elif record.levelno >= logging.WARNING:
             self._fmt = '\033[33m' + self._fmt
         elif record.levelno <= logging.DEBUG:
-            self._fmt = '\033[34m' + self._fmt
+            self._fmt = '\033[32m' + self._fmt
         elif record.levelno <= logging.INFO:
             self._fmt = '\033[34m' + self._fmt
 

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -97,13 +97,15 @@ class LmfdbFormatter(logging.Formatter):
 
         # some colors for severity level
         if record.levelno >= logging.CRITICAL:
-            self._fmt = '\033[91m' + self._fmt
+            self._fmt = '\033[31m' + self._fmt
+        elif record.levelno >= logging.ERROR:
+            self._fmt = '\033[35m' + self._fmt
         elif record.levelno >= logging.WARNING:
-            self._fmt = '\033[93m' + self._fmt
+            self._fmt = '\033[33m' + self._fmt
         elif record.levelno <= logging.DEBUG:
-            self._fmt = '\033[94m' + self._fmt
+            self._fmt = '\033[34m' + self._fmt
         elif record.levelno <= logging.INFO:
-            self._fmt = '\033[92m' + self._fmt
+            self._fmt = '\033[34m' + self._fmt
 
         # bold, if module name matches
         if record.name == self._hl:


### PR DESCRIPTION
Tweak logger colors to distinguish errors from warnings and not use bright mode (unless hl is set).