### PR TITLE
fix #1766

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -354,7 +354,8 @@ class WebNumberField:
     def gpK(self):
         if not self.haskey('gpK'):
             Qx = PolynomialRing(QQ,'x')
-            basis = [Qx(el.replace('a','x')) for el in self.zk()]
+            # while [1] is a perfectly good basis for Z, gp seems to want []
+            basis = [Qx(el.replace('a','x')) for el in self.zk()] if self.degree() > 1 else []
             k1 = gp( "nfinit([%s,%s])" % (str(self.poly()),str(basis)) )
             self._data['gpK'] = k1
         return self._data['gpK']

--- a/lmfdb/number_fields/__init__.py
+++ b/lmfdb/number_fields/__init__.py
@@ -10,6 +10,7 @@ nf_logger = make_logger(nf_page)
 def body_class():
     return {'body_class': 'nf'}
 
-from number_field import *
+import number_field
+assert number_field
 
 app.register_blueprint(nf_page, url_prefix="/NumberField")

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -317,9 +317,12 @@ def render_field_webpage(args):
         pretty_label = "%s: %s" % (label, pretty_label)
 
     info.update(data)
-    gpK = nf.gpK()
-    rootof1coeff = gpK.nfrootsof1()[2]
-    rootofunity = Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))
+    if nf.degree() > 1:
+        gpK = nf.gpK()
+        rootof1coeff = gpK.nfrootsof1()[2]
+        rootofunity = Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))
+    else:
+        rootofunity = Ra('-1')
 
     info.update({
         'label': pretty_label,

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -1,44 +1,57 @@
 # -*- coding: utf8 -*-
 from lmfdb.base import LmfdbTest
-import math
-import unittest2
-
 
 class NumberFieldTest(LmfdbTest):
 
     # All tests should pass
-    #
+    
+    def test_Q(self):
+        L = self.tc.get('/NumberField/Q')
+        assert '\chi_{1}' in L.data
+        L = self.tc.get('/NumberField/1.1.1.1')
+        assert '\chi_{1}' in L.data
+
+    def test_hard_degree10(self):
+        L = self.tc.get('/NumberField/10.10.1107649855354064.1')
+        assert '10T36' in L.data
+        L = self.tc.get('/NumberField/10.10.138420300533025695415730492558689.1')
+        assert '10T38' in L.data
+
+    def test_hard_degree16(self):
+        L = self.tc.get('/NumberField/16.0.13307764731675384304522756096.1')
+        assert '16T1535' in L.data
+
     def test_search_ramif_cl_deg(self):
-		L = self.tc.get('/NumberField/?start=0&paging=0&degree=5&signature=&galois_group=&class_number=&class_group=[2%2C2]&ur_primes=7&discriminant=&ram_quantifier=some&ram_primes=2%2C3%2C5&count=20')
-		assert '5.1.27000000000.8' in L.data
+        L = self.tc.get('/NumberField/?start=0&paging=0&degree=5&signature=&galois_group=&class_number=&class_group=[2%2C2]&ur_primes=7&discriminant=&ram_quantifier=some&ram_primes=2%2C3%2C5&count=20')
+        assert '5.1.27000000000.8' in L.data
 
     def test_search_poly_mean2parser(self):
-		L = self.tc.get('/NumberField/?natural=X**3-4x%2B2&search=Go')
-		assert '148' in L.data # discriminant
+        L = self.tc.get('/NumberField/?natural=X**3-4x%2B2&search=Go')
+        assert '148' in L.data # discriminant
 
     def test_search_zeta(self):
-		L = self.tc.get('/NumberField/?natural=Qzeta23&search=Go', follow_redirects=True)
-		assert '[3]' in L.data # class group
+        L = self.tc.get('/NumberField/?natural=Qzeta23&search=Go', follow_redirects=True)
+        assert '[3]' in L.data # class group
 
     def test_search_sqrt(self):
-		L = self.tc.get('/NumberField/?natural=Qsqrt-163&search=Go', follow_redirects=True)
-		assert '41' in L.data # minpoly
+        L = self.tc.get('/NumberField/?natural=Qsqrt-163&search=Go', follow_redirects=True)
+        assert '41' in L.data # minpoly
 
     def test_search_disc(self):
-		L = self.tc.get('/NumberField/?start=&paging=0&degree=&signature=&galois_group=&class_number=&class_group=&ur_primes=&discriminant=1988-2014&ram_quantifier=all&ram_primes=&count=')
-		assert '401' in L.data # factor of one of the discriminants
+        L = self.tc.get('/NumberField/?start=&paging=0&degree=&signature=&galois_group=&class_number=&class_group=&ur_primes=&discriminant=1988-2014&ram_quantifier=all&ram_primes=&count=')
+        assert '401' in L.data # factor of one of the discriminants
 
     def test_url_label(self):
-		L = self.tc.get('/NumberField/2.2.5.1')
-		assert '0.481211825059603' in L.data # regulator
+        L = self.tc.get('/NumberField/2.2.5.1')
+        assert '0.481211825059603' in L.data # regulator
 
     def test_url_naturallabel(self):
-		L = self.tc.get('/NumberField/Qsqrt5')
-		assert '0.481211825059603' in L.data # regulator
+        L = self.tc.get('/NumberField/Qsqrt5')
+        assert '0.481211825059603' in L.data # regulator
 
-    def test_url_naturallabel(self):
-		L = self.tc.get('/NumberField/junk')
-		assert 'Error' in L.data # error mesage
+    def test_url_bad(self):
+        L = self.tc.get('/NumberField/junk')
+        assert 'Error' in L.data # error mesage
 
 
 


### PR DESCRIPTION
This fixes the critical issue #1766 (server errror the number field page for Q) by tweaking the call to pari nfinit when the degree is 1 and the computation of the rootsofunity when the degree is 1 (this fixes problems introduced in the recent PR #1744).  I also added a test for Q to test_numberfield.py, as well as tests for the recently fixed degree 10 and degree 16 number fields.

All tests pass (except for the usual failures in test_emf.py)

Given that this change only impacts number fields of degree 1 (i.e. Q), which currently do not work at all, I am going to merge this and push it to beta and prod.  @jwj61 please feel free to make any further changes you think are appropriate.
