### PR TITLE
Fix #1771

### DIFF
--- a/lmfdb/modular_forms/__init__.py
+++ b/lmfdb/modular_forms/__init__.py
@@ -1,6 +1,5 @@
 # / modular_forms/__init__.py
-import lmfdb.base
-import lmfdb.utils
+import lmfdb
 from lmfdb.utils import make_logger
 import flask
 
@@ -9,12 +8,13 @@ MF = "mf"
 mf = flask.Blueprint(MF, __name__, template_folder="views/templates", static_folder="views/static")
 mf_logger = make_logger(mf)
 
-import views
-import backend
 import elliptic_modular_forms
+assert elliptic_modular_forms
 import maass_forms
-from elliptic_modular_forms import *
-from maass_forms import *
+assert maass_forms
+import views
+assert views
+
 lmfdb.base.app.register_blueprint(mf, url_prefix="/ModularForm/")
 lmfdb.base.app.register_blueprint(mf, url_prefix="/AutomorphicForm/")
 lmfdb.base.app.register_blueprint(elliptic_modular_forms.emf, url_prefix="/ModularForm/GL2/Q/holomorphic")

--- a/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
@@ -39,4 +39,5 @@ use_cache = False
 import views
 assert views
 import backend
+assert backend
 from backend import WebNewForm, WebModFormSpace

--- a/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
@@ -38,6 +38,5 @@ use_cache = False
 
 import views
 assert views
-import backend
-assert backend
 from backend import WebNewForm, WebModFormSpace
+assert WebNewForm and WebModFormSpace

--- a/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
@@ -17,7 +17,7 @@ version_major, version_minor = [int(x) for x in SAGE_VERSION.split('.')[:2]]
 #    emf_version = 1.1
 emf_version = 1.3
 
-EMF_TOP = "Holomorphic Modular Forms"  # The name to use for the top of this catergory
+EMF_TOP = "Holomorphic Cusp Forms"  # The name to use for the top of this catergory
 EMF = "emf"  # The current blueprint name
 emf = flask.Blueprint(EMF, __name__, template_folder="views/templates", static_folder="views/static")
 emf_logger = make_logger(emf)
@@ -36,7 +36,7 @@ N_max_extra_comp = 500
 ## https://github.com/LMFDB/lmfdb/pull/1409#issuecomment-220733555
 use_cache = False
 
-
 import views
+assert views
 import backend
-from backend import *
+from backend import WebNewForm, WebModFormSpace

--- a/lmfdb/modular_forms/elliptic_modular_forms/emf_test_pages.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/emf_test_pages.py
@@ -1,11 +1,7 @@
+# -*- coding: utf-8 -*-
 
 from lmfdb.base import LmfdbTest, getDBConnection
 
-from flask import request
-import unittest2
-import sys
-
-from views.emf_main import *
 from . import emf_logger
 emf_logger.setLevel(100)
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/test_emf.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/test_emf.py
@@ -1,10 +1,8 @@
+# -*- coding: utf-8 -*-
 
 from lmfdb.base import LmfdbTest
-
-from flask import request
 import unittest2
 
-from views.emf_main import *
 from . import emf_logger
 emf_logger.setLevel(100)
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/__init__.py
@@ -1,1 +1,2 @@
-from emf_main import *
+import emf_main
+assert emf_main

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -25,9 +25,10 @@ from flask import url_for, request, redirect, make_response, send_from_directory
 import os, tempfile
 import sage
 from lmfdb.base import getDBConnection
+from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.backend.mf_utils import my_get
 from lmfdb.utils import to_dict, random_object_from_collection
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf
+from lmfdb.modular_forms.elliptic_modular_forms import EMF, EMF_TOP, emf_logger, emf
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import (
     render_fd_plot,
@@ -79,8 +80,8 @@ def browse_web_modform_spaces_in_ranges(**kwds):
 
 @emf.route("/history")
 def holomorphic_mf_history():
-    b = [("Modular forms", url_for('mf.modular_form_main_page'))]
-    b.append(('Holomorphic', url_for(".render_elliptic_modular_forms")))
+    b = [(MF_TOP, url_for('mf.modular_form_main_page'))]
+    b.append((EMF_TOP, url_for(".render_elliptic_modular_forms")))
     b.append(('History', url_for(".holomorphic_mf_history")))
     return render_template("single.html", title="A brief history of holomorphic GL(2) modular forms", kid='mf.gl2.history', bread=b)
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -21,7 +21,7 @@ AUTHORS:
  - Stephan Ehlen
 
 """
-from flask import url_for, request, redirect, make_response, send_from_directory,flash
+from flask import url_for, request, redirect, make_response, send_from_directory,flash, render_template
 import os, tempfile
 import sage
 from lmfdb.base import getDBConnection
@@ -77,6 +77,12 @@ def browse_web_modform_spaces_in_ranges(**kwds):
     group=request.args.getlist('group')
     return render_elliptic_modular_form_navigation_wp(level=level,weight=weight,group=group)
 
+@emf.route("/history")
+def holomorphic_mf_history():
+    b = [("Modular forms", url_for('mf.modular_form_main_page'))]
+    b.append(('Holomorphic', url_for(".render_elliptic_modular_forms")))
+    b.append(('History', url_for(".holomorphic_mf_history")))
+    return render_template("single.html", title="A brief history of holomorphic GL(2) modular forms", kid='mf.gl2.history', bread=b)
 
 @emf.route("/", methods=met)
 @emf.route("/<level>/", methods=met)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -123,4 +123,5 @@ def render_elliptic_modular_form_navigation_wp(**args):
             info['table'][N][k]['in_db'] = indb
     info['col_heads'] = level_range
     info['row_heads'] = weight_range
-    return render_template("emf_browse_spaces.html", info=info, title=title, bread=bread)
+    lm = [('History of holomorphic modular forms', url_for(".holomorphic_mf_history"))]
+    return render_template("emf_browse_spaces.html", info=info, title=title, bread=bread, learnmore=lm)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -14,7 +14,6 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import extract
 def render_elliptic_modular_form_navigation_wp(**args):
     r"""
     Renders the webpage for the navigational page.
-
     """
     from sage.all import is_even
     from lmfdb.modular_forms.elliptic_modular_forms import WebModFormSpace
@@ -37,22 +36,25 @@ def render_elliptic_modular_form_navigation_wp(**args):
     is_set['level'] = False
     limits_weight = extract_limits_as_tuple(info, 'weight')
     limits_level = extract_limits_as_tuple(info, 'level')
-    if isinstance(weight,int) and weight > 0:
-        is_set['weight'] = True
-        weight = int(weight)
-    else:
-       weight = None
-       info.pop('weight',None)
+    title = "Holomorphic Cusp Forms"
+    bread = [(MF_TOP, url_for('mf.modular_form_main_page')), (EMF_TOP, url_for('.render_elliptic_modular_forms'))]
     if isinstance(level,int) and level > 0:
         is_set['level'] = True
         level = int(level)
+        bread.append(('Level %d'%level, url_for('emf.render_elliptic_modular_forms', level=level)))
+        title += " of level %d"%level 
     else:
         level = None
         info.pop('level',None)
+    if isinstance(weight,int) and weight > 0:
+        is_set['weight'] = True
+        weight = int(weight)
+        bread.append(('Weight %d'%weight, url_for('emf.render_elliptic_modular_forms', level=level, weight=weight)))
+        title += " of weight %d"%weight
+    else:
+       weight = None
+       info.pop('weight',None)
     ## This is the list of weights we initially put on the form
-    title = "Holomorphic Cusp Forms"
-    bread = [(MF_TOP, url_for('mf.modular_form_main_page'))]
-    bread.append((EMF_TOP, url_for('.render_elliptic_modular_forms')))
     if is_set['weight']:
         limits_weight = (weight, weight)
     elif limits_weight is None:

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -8,7 +8,7 @@ from lmfdb.search_parsing import parse_range
 from lmfdb.base import getDBConnection
 from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.backend.mf_utils import my_get
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf,EMF_TOP,emf_version
+from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP, emf_version
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import extract_limits_as_tuple
 
 def render_elliptic_modular_form_navigation_wp(**args):
@@ -123,5 +123,5 @@ def render_elliptic_modular_form_navigation_wp(**args):
             info['table'][N][k]['in_db'] = indb
     info['col_heads'] = level_range
     info['row_heads'] = weight_range
-    lm = [('History of holomorphic modular forms', url_for(".holomorphic_mf_history"))]
+    lm = [('History of modular forms', url_for(".holomorphic_mf_history"))]
     return render_template("emf_browse_spaces.html", info=info, title=title, bread=bread, learnmore=lm)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -1,15 +1,14 @@
+# -*- coding: utf-8 -*-
 r"""
 Routines for rendering the navigation.
 """
-import json
 from flask import url_for,render_template,request,redirect
 from lmfdb.utils import to_dict
-from lmfdb.search_parsing import parse_range
 from lmfdb.base import getDBConnection
 from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.backend.mf_utils import my_get
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP, emf_version
-from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import extract_limits_as_tuple
+from lmfdb.modular_forms.elliptic_modular_forms import emf_logger, EMF_TOP
+from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import extract_limits_as_tuple, render_fd_plot
 
 def render_elliptic_modular_form_navigation_wp(**args):
     r"""
@@ -27,9 +26,9 @@ def render_elliptic_modular_form_navigation_wp(**args):
     emf_logger.debug("render_c_m_f_n_wp info={0}".format(info))
     level = my_get(info, 'level', None, int)
     weight = my_get(info, 'weight', None, int)
-    character = my_get(info, 'character', 1, int)
-    label = info.get('label', '')
-    if('plot' in info and level is not None):
+    # character = my_get(info, 'character', 1, int) # not used
+    # label = info.get('label', '') # not used
+    if('plot' in info and isinstance(level,int) and level > 0):
         return render_fd_plot(level, info)
     is_set = dict()
     is_set['weight'] = False
@@ -90,8 +89,6 @@ def render_elliptic_modular_form_navigation_wp(**args):
         s['cchi']=int(1)
     else:
         s['gamma1_label']={"$exists":True}
-    # g = db_dim.find(s).sort([('level',int(1)),('weight',int(1))]) never used
-    table = {}
     info['table'] = {}
     level_range = range(limits_level[0],limits_level[1]+1)
     weight_range = range(limits_weight[0],limits_weight[1]+1)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -102,7 +102,7 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
             if not rep is None and not rep['cchi'] == character: # don't link back to myself!
                 info['wmfs_rep_url'] = url_for('emf.render_elliptic_modular_forms', level=level, weight=weight, character=rep['cchi'])
                 info['wmfs_rep_number'] =  rep['cchi']
-        # FIXME WNF is never defined above
+        # FIXME: the variable WNF is not defined above, so the code below cannot work (I don't think it is ever used)
         # if 'download' in info and 'tempfile' in info:
         #     save(WNF,info['tempfile'])
         #     info['filename'] = str(weight) + '-' + str(level) + '-' + str(character) + '-' + label + '.sobj'

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -19,16 +19,14 @@ Routines for rendering webpages for holomorphic modular forms on GL(2,Q)
 AUTHOR: Fredrik Strömberg  <fredrik314@gmail.com>
 
 """
-from flask import render_template, url_for, send_file,flash
+from flask import render_template, url_for, send_file,flash, redirect
 from lmfdb.utils import to_dict
 from lmfdb.base import getDBConnection
 from sage.all import uniq
 from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached, WebModFormSpace
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP, default_max_height
-from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty
-###
-###
+from lmfdb.modular_forms.elliptic_modular_forms import emf_logger, EMF_TOP, default_max_height
+
 
 def render_web_modform_space(level=None, weight=None, character=None, label=None, **kwds):
     r"""
@@ -43,7 +41,7 @@ def render_web_modform_space(level=None, weight=None, character=None, label=None
     info['character'] = character
     try:
         info = set_info_for_modular_form_space(**info)
-    except RuntimeError as e:
+    except RuntimeError:
         errst = "The space {0}.{1}.{2} is not in the database!".format(level,weight,character)
         flash(errst,'error')
         info = {'error': ''}
@@ -104,10 +102,11 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
             if not rep is None and not rep['cchi'] == character: # don't link back to myself!
                 info['wmfs_rep_url'] = url_for('emf.render_elliptic_modular_forms', level=level, weight=weight, character=rep['cchi'])
                 info['wmfs_rep_number'] =  rep['cchi']
-        if 'download' in info and 'tempfile' in info:
-            save(WNF,info['tempfile'])
-            info['filename'] = str(weight) + '-' + str(level) + '-' + str(character) + '-' + label + '.sobj'
-            return info
+        # FIXME WNF is never defined above
+        # if 'download' in info and 'tempfile' in info:
+        #     save(WNF,info['tempfile'])
+        #     info['filename'] = str(weight) + '-' + str(level) + '-' + str(character) + '-' + label + '.sobj'
+        #     return info
     except ValueError as e:
         emf_logger.debug(e)
         emf_logger.debug(e.message)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -23,6 +23,7 @@ from flask import render_template, url_for, send_file,flash
 from lmfdb.utils import to_dict
 from lmfdb.base import getDBConnection
 from sage.all import uniq
+from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached, WebModFormSpace
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP, default_max_height
 from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty
@@ -60,7 +61,7 @@ def render_web_modform_space(level=None, weight=None, character=None, label=None
         info['title'] = "Newforms of weight %s for \(\Gamma_{0}(%s)\) with character \(\chi_{%s}(%s, \cdot)\)" % (weight, level, level, character)
     else:
         info['title'] = "Newforms of weight %s for \(\Gamma_{0}(%s)\)" % (weight, level)
-    bread = [(EMF_TOP, url_for('emf.render_elliptic_modular_forms'))]
+    bread = [(MF_TOP, url_for('mf.modular_form_main_page')), (EMF_TOP, url_for('emf.render_elliptic_modular_forms'))]
     bread.append(("Level %s" % level, url_for('emf.render_elliptic_modular_forms', level=level)))
     bread.append(
         ("Weight %s" % weight, url_for('emf.render_elliptic_modular_forms', level=level, weight=weight)))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -68,7 +68,7 @@ def render_web_modform_space(level=None, weight=None, character=None, label=None
         ("Character \(\chi_{%s}(%s, \cdot)\)" % (level, character), url_for('emf.render_elliptic_modular_forms', level=level, weight=weight, character=character)))
     # emf_logger.debug("friends={0}".format(friends))
     info['bread'] = bread
-    info['learnmore'] = [('History of Modular forms', url_for('holomorphic_mf_history'))]
+    info['learnmore'] = [('History of modular forms', url_for('.holomorphic_mf_history'))]
     emf_logger.debug("info={0}".format(info))
     if info.has_key('space'):
         emf_logger.debug("space={0}".format(info['space']))        

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
@@ -22,12 +22,11 @@ AUTHOR: Fredrik Strömberg <fredrik314@gmail.com>
 from flask import render_template, url_for, send_file,flash
 from lmfdb.utils import to_dict 
 from sage.all import uniq
+from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP
-#from lmfdb.modular_forms.elliptic_modular_forms.backend.cached_interfaces import WebModFormSpace_cached
 from lmfdb.WebCharacter import ConreyCharacter
-###
-###
+
 
 def render_web_modform_space_gamma1(level=None, weight=None, character=None, label=None, **kwds):
     r"""
@@ -41,7 +40,7 @@ def render_web_modform_space_gamma1(level=None, weight=None, character=None, lab
     info['weight'] = weight
     info['character'] = character
     title = "Newforms of weight {0} for \(\Gamma_1({1})\)".format(weight, level)
-    bread = [(EMF_TOP, url_for('emf.render_elliptic_modular_forms'))]
+    bread = [(MF_TOP, url_for('mf.modular_form_main_page')), (EMF_TOP, url_for('emf.render_elliptic_modular_forms'))]
     bread.append(("Level %s" % level, url_for("emf.render_elliptic_modular_forms", level=level)))
     bread.append(
         ("Weight %s" % weight, url_for("emf.render_elliptic_modular_forms", level=level, weight=weight)))
@@ -53,6 +52,7 @@ def render_web_modform_space_gamma1(level=None, weight=None, character=None, lab
     else:
         info['table'] = table 
     info['bread'] = bread
+    info['learnmore'] = [('History of modular forms', url_for('.holomorphic_mf_history'))]
     info['title'] = title
     info['showGaloisOrbits']=1
     emf_logger.debug("info={0}".format(info))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
@@ -19,13 +19,13 @@ Routines for rendering webpages for holomorphic modular forms on GL(2,Q)
 AUTHOR: Fredrik Strömberg <fredrik314@gmail.com>
 
 """
-from flask import render_template, url_for, send_file,flash
+from flask import render_template, url_for, flash
+from  lmfdb.base import getDBConnection
 from lmfdb.utils import to_dict 
-from sage.all import uniq
 from lmfdb.modular_forms import MF_TOP
-from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP
+from lmfdb.modular_forms.elliptic_modular_forms import emf_logger, EMF_TOP
 from lmfdb.WebCharacter import ConreyCharacter
+from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
 
 
 def render_web_modform_space_gamma1(level=None, weight=None, character=None, label=None, **kwds):
@@ -60,21 +60,15 @@ def render_web_modform_space_gamma1(level=None, weight=None, character=None, lab
 
 
 def set_info_for_gamma1(level,weight,weight2=None):
-    from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import dimension_from_db,dirichlet_character_conrey_galois_orbits_reps,conrey_character_from_number
-    
-    from sage.all import DirichletGroup,dimension_new_cusp_forms
-    from dirichlet_conrey import DirichletGroup_conrey
-    from lmfdb.modular_forms.elliptic_modular_forms import WebModFormSpace
+    # from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import dimension_from_db
+    # dim_table = dimension_from_db(level,weight,chi='all',group='gamma1') # never used
     dimension_table_name = WebModFormSpace._dimension_table_name
-    dim_table = dimension_from_db(level,weight,chi='all',group='gamma1')
     if weight != None and weight2>weight:
         w1 = weight; w2 = weight2
     else:
         w1 = weight; w2 = weight
     table = {'galois_orbit':{},'galois_orbits_reps':{},'cells':{}}
     table['weights']=range(w1,w2+1)
-    max_gal_count = 0
-    from  lmfdb.base import getDBConnection
     emf_logger.debug("dimension table name={0}".format(dimension_table_name))
     db_dim = getDBConnection()['modularforms2'][dimension_table_name]
     s = {'level':int(level),'weight':{"$lt":int(w2+1),"$gt":int(w1-1)},'cchi':{"$exists":True}}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -103,7 +103,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     if WNF.dimension==0 and not info.has_key('error'):
         info['error'] = "This space is empty!"
     info['title'] = 'Newform ' + WNF.hecke_orbit_label
-    info['learnmore'] = [('History of Modular forms', url_for('holomorphic_mf_history'))]    
+    info['learnmore'] = [('History of modular forms', url_for('.holomorphic_mf_history'))]    
     if 'error' in info:
         return info
     ## Until we have figured out how to do the embeddings correctly we don't display the Satake

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -26,6 +26,7 @@ from sage.all import version,uniq,ZZ,Cusp,Infinity,latex,QQ
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached, WebNewForm
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
 from lmfdb.utils import to_dict,ajax_more
+from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.backend.mf_utils import my_get
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, default_prec, default_bprec, default_display_bprec, EMF_TOP, default_max_height
 from lmfdb.number_fields.number_field import poly_to_field_label
@@ -78,11 +79,12 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
         emf_logger.debug("defined webnewform for rendering!")
     except IndexError as e:
         info['error'] = e.message
+    url0 = url_for("mf.modular_form_main_page")
     url1 = url_for("emf.render_elliptic_modular_forms")
     url2 = url_for("emf.render_elliptic_modular_forms", level=level)
     url3 = url_for("emf.render_elliptic_modular_forms", level=level, weight=weight)
     url4 = url_for("emf.render_elliptic_modular_forms", level=level, weight=weight, character=character)
-    bread = [(EMF_TOP, url1)]
+    bread = [(MF_TOP, url0), (EMF_TOP, url1)]
     bread.append(("Level %s" % level, url2))
     bread.append(("Weight %s" % weight, url3))
     bread.append(("Character \( %s \)" % (WNF.character.latex_name), url4))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -22,14 +22,12 @@ AUTHORS:
 
 """
 from flask import render_template, url_for,  send_file
-from sage.all import version,uniq,ZZ,Cusp,Infinity,latex,QQ
-from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached, WebNewForm
-from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
-from lmfdb.utils import to_dict,ajax_more
+from sage.all import uniq,ZZ,latex,QQ
+from lmfdb.utils import to_dict
 from lmfdb.modular_forms import MF_TOP
 from lmfdb.modular_forms.backend.mf_utils import my_get
-from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, default_prec, default_bprec, default_display_bprec, EMF_TOP, default_max_height
-from lmfdb.number_fields.number_field import poly_to_field_label
+from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached
+from lmfdb.modular_forms.elliptic_modular_forms import emf_logger, default_prec, default_display_bprec, EMF_TOP, default_max_height
 #from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty, nf_display_knowl
 from lmfdb.WebNumberField import field_pretty, nf_display_knowl
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_object import web_latex_poly
@@ -41,10 +39,9 @@ def render_web_newform(level, weight, character, label, **kwds):
     Renders the webpage for one elliptic modular form.
 
     """
-    citation = ['Sage:' + version()]
+    # citation = ['Sage:' + version()] # never used
     info = set_info_for_web_newform(level, weight, character, label, **kwds)
     emf_logger.debug("info={0}".format(info.keys()))
-    err = info.get('error', '')
     ## Check if we want to download either file of the function or Fourier coefficients
     if 'download' in info and 'error' not in info:
         return send_file(info['tempfile'], as_attachment=True, attachment_filename=info['filename'])
@@ -298,8 +295,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
                     s+="E_4^{{ {0} }}E_6^{{ {1} }}".format(a,b)
                 info['explicit_formulas'] += s
             info['explicit_formulas'] += " \)"            
-    cur_url = '?&level=' + str(level) + '&weight=' + str(weight) + '&character=' + str(character) + \
-        '&label=' + str(label)
+    # cur_url = '?&level=' + str(level) + '&weight=' + str(weight) + '&character=' + str(character) + '&label=' + str(label) # never used
     if len(WNF.parent.hecke_orbits) > 1:
         for label_other in WNF.parent.hecke_orbits.keys():
             if(label_other != label):
@@ -340,5 +336,3 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     info['friends'] = friends
     info['max_cn'] = WNF.max_available_prec()
     return info
-
-import flask

--- a/lmfdb/modular_forms/views/__init__.py
+++ b/lmfdb/modular_forms/views/__init__.py
@@ -1,1 +1,2 @@
-from mf_main import *
+import mf_main
+assert mf_main

--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -182,7 +182,7 @@ def varieties_history():
 
 @app.route("/ModularForm/GL2/Q/holomorphic/history")
 def holomorphic_mf_history():
-    b = [("Modular forms", url_for('modular_form_toplevel'))]
+    b = [("Modular forms", url_for('mf.modular_form_main_page'))]
     b.append(('Holomorphic', url_for("emf.render_elliptic_modular_forms")))
     b.append(('History', url_for("holomorphic_mf_history")))
     return render_template(_single_knowl, title="A brief history of holomorphic GL(2) modular forms", kid='mf.gl2.history', body_class=_bc, bread=b)

--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -180,13 +180,6 @@ def varieties_history():
     b.append(('History', url_for("varieties_history")))
     return render_template(_single_knowl, title="A brief history of varieties", kid='ag.variety.history', body_class=_bc, bread=b)
 
-@app.route("/ModularForm/GL2/Q/holomorphic/history")
-def holomorphic_mf_history():
-    b = [("Modular forms", url_for('mf.modular_form_main_page'))]
-    b.append(('Holomorphic', url_for("emf.render_elliptic_modular_forms")))
-    b.append(('History', url_for("holomorphic_mf_history")))
-    return render_template(_single_knowl, title="A brief history of holomorphic GL(2) modular forms", kid='mf.gl2.history', body_class=_bc, bread=b)
-
 
 @app.route('/Field')
 def fields():

--- a/lmfdb/tensor_products/main.py
+++ b/lmfdb/tensor_products/main.py
@@ -12,7 +12,7 @@ from galois_reps import GaloisRepresentation
 from sage.all import ZZ, EllipticCurve
 from lmfdb.artin_representations.main import ArtinRepresentation
 from lmfdb.WebCharacter import WebDirichletCharacter
-from lmfdb.modular_forms.elliptic_modular_forms import WebNewForm
+from lmfdb.modular_forms.elliptic_modular_forms.backend import WebNewForm
 from lmfdb.lfunctions.Lfunctionutilities import lfuncDShtml, lfuncEPtex, lfuncFEtex, specialValueString
 from lmfdb.lfunctions.main import render_lfunction_exception
 


### PR DESCRIPTION
This PR fixes #1771 by moving mf_holomorphic_history out of pages.py into modular_forms/elliptic_modular_forms and fixing the URL links in its bread.  I also made changes to ensure it appears in the learnmore box on all the GL2/Holomorphic pages (previously it appeared on the form and space pages, but not the browse pages), and cleaned up some inconsistencies in the bread.

This PR also cleans up a bunch of import *'s in the elliptic_modular_forms pages (per #122).  There are still plenty left in the backend files, I only cleaned up those in the files I was touching (using pyflakes).  This revealed a few bugs in code which I either fixed or commented out (these all appear to be in code branches that do not get hit in the production system).

All tests pass except for the known problem in test_galois_conjugate.