### PR TITLE
fix empty nf search label bug

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -450,7 +450,7 @@ def number_field_search(**args):
         query = {'label_orig': info['natural']}
         try:
             parse_nf_string(info,query,'natural',name="Label",qfield='label')
-            return redirect(url_for(".by_label", label= clean_input(query['label'])))
+            return redirect(url_for(".by_label", label= clean_input(query['label_orig'])))
         except ValueError:
             query['err'] = info['err']
             return search_input_error(query, bread)

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -26,7 +26,7 @@ class NumberFieldTest(LmfdbTest):
         assert '5.1.27000000000.8' in L.data
 
     def test_search_poly_mean2parser(self):
-        L = self.tc.get('/NumberField/?natural=X**3-4x%2B2&search=Go')
+        L = self.tc.get('/NumberField/?natural=X**3-4x%2B2&search=Go', follow_redirects=True)
         assert '148' in L.data # discriminant
 
     def test_search_zeta(self):


### PR DESCRIPTION
A tiny fix this:  go to http://www.lmfdb.org/NumberField/ and click on the Go button without entering anything, and you get a server error, because of a small error which this fixes.  Now you just get the same page back again which seems OK to me.