### PR TITLE
fix gp code for ecnf

### DIFF
--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -25,7 +25,7 @@ curve:
   sage: |
     E = EllipticCurve(%s)
   pari: |
-    E = ellinit(%s)
+    E = ellinit(%s,K)
   magma: |
     E := EllipticCurve(%s);
 


### PR DESCRIPTION
The number field was missing in the arguments of the initialization of elliptic curves over number fields.

Example:
/EllipticCurve/3.3.148.1/356.1/a/1
(click on show commands for pari/gp)