### PR TITLE
Avoid server errors on EC download queries

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -344,8 +344,8 @@ def show_ecnf(nf, conductor_label, class_label, number):
 
 
 def elliptic_curve_search(info):
-    
-    if 'download' in info and info['download'] != 0:
+
+    if info.get('download') == '1' and info.get('Submit') and info.get('query'):
         return download_search(info)
 
     if not 'query' in info:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -159,7 +159,7 @@ def elliptic_curve_jump_error(label, args, wellformed_label=False, cremona_label
 
 def elliptic_curve_search(info):
 
-    if 'download' in info and info['download'] != '0':
+    if info.get('download') == '1' and info.get('Submit') and info.get('query'):
         return download_search(info)
 
     if 'SearchAgain' in info:


### PR DESCRIPTION
Recently we have seeing a lot of errors in the flasklog of the form:

Failed URL: http://www.lmfdb.org/EllipticCurve/2.2.229.1/?download=1&query={'field_label': '2.2.229.1'}
Failed URL: http://www.lmfdb.org/EllipticCurve/Q/21780/?download=1&query={'conductor': 21780}
Failed URL: http://www.lmfdb.org/EllipticCurve/2.2.17.1/136.1/?download=1&query={'field_label': '2.2.17.1', 'conductor_label': '136.1', 'conductor_norm': 136}
Failed URL: http://www.lmfdb.org/EllipticCurve/Q/14/?download=1&query={'conductor': 14}
...
I'm not sure where these are coming from (they don't look like a robot), but they cause a server error because the "Submit" parameter is not set.  This PR makes a one line change in two places to verify that all the arguments the download_search function requires are actually present before attempting the download (otherwise it just treats the request as it usually would).
