### PR TITLE
Fix #1285

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -192,6 +192,7 @@ def md_latex_accents(text):
     knowl_content = re.sub(r"\\'{([a-zA-Z])}",r"&\1acute;",knowl_content)
     knowl_content = re.sub(r"\\`([a-zA-Z])",r"&\1grave;",knowl_content)
     knowl_content = re.sub(r"\\`{([a-zA-Z])}",r"&\1grave;",knowl_content)
+    knowl_content = re.sub(r"``(?P<a>[^\"]*)''", r"&ldquo;\1&rdquo;", knowl_content)
 
     return knowl_content
 

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -192,7 +192,7 @@ def md_latex_accents(text):
     knowl_content = re.sub(r"\\'{([a-zA-Z])}",r"&\1acute;",knowl_content)
     knowl_content = re.sub(r"\\`([a-zA-Z])",r"&\1grave;",knowl_content)
     knowl_content = re.sub(r"\\`{([a-zA-Z])}",r"&\1grave;",knowl_content)
-    knowl_content = re.sub(r"``(?P<a>[^\"]*)''", r"&ldquo;\1&rdquo;", knowl_content)
+    knowl_content = re.sub(r"``(?P<a>[\S\s]*?)''", r"&ldquo;\1&rdquo;", knowl_content)
 
     return knowl_content
 


### PR DESCRIPTION
This PR addresses #1285 adds one additional re.sub to the knowl md_latex_accents preprocssing code to replace any occurence of ``something'' with &ldquo;something&rdquo; (i.e. enclose something in HTML left and right double quotes).  To see the difference, compare the first sentence following the heading "Reimann's Memoir" in

Before: http://www.lmfdb.org/L/history
After: http://127.0.0.1:37777/L/history

(you may have to zoom in to see that they really are left and right double quotes).

Per the discussion in #1285, this only matches the "official" latex syntax, i.e. two left single quotes followed by something followed by two single quotes.
