### PR TITLE
Fix for bug in Artin representations caused by recent removal of construction of sage number fields.

### DIFF
--- a/lmfdb/math_classes.py
+++ b/lmfdb/math_classes.py
@@ -770,8 +770,14 @@ class NumberFieldGaloisGroup(object):
         try:
             return self._residue_field_degrees(p)
         except AttributeError:
-            from number_fields.number_field import residue_field_degrees_function
-            fn_with_pari_output = residue_field_degrees_function(self.wnf())
+            # Try to make WebNumberField, but only helps if the field is in our database
+            wnf = self.wnf()
+            if wnf._data is None:
+                from number_fields.number_field import sage_residue_field_degrees_function
+                fn_with_pari_output = sage_residue_field_degrees_function(self.sage_object())
+            else:
+                from number_fields.number_field import residue_field_degrees_function
+                fn_with_pari_output = residue_field_degrees_function(wnf)
             self._residue_field_degrees = lambda p: map(Integer, fn_with_pari_output(p))
             # This function is better, becuase its output has entries in Integer
             return self._residue_field_degrees(p)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -538,11 +538,23 @@ def residue_field_degrees_function(nf):
     """
     k1 = nf.gpK()
     D = nf.disc()
+    return main_work(k1,D,'pari')
 
+def sage_residue_field_degrees_function(nf):
+    """ Version of above which takes a sage number field
+        Used by Artin representation code when the Artin field is not
+        in the database.
+    """
+    D = nf.disc()
+    return main_work(pari(nf),D,'sage')
+
+def main_work(k1, D, typ):
+    # Difference for sage vs pari array indexing
+    ind = 3 if typ is 'sage' else 4
     def decomposition(p):
         if not ZZ(p).divides(D):
             dec = k1.idealprimedec(p)
-            dec = [z[4] for z in dec]
+            dec = [z[ind] for z in dec]
             return dec
         else:
             raise ValueError("Expecting a prime not dividing D")


### PR DESCRIPTION
The recent change to avoid constructing sage number fields overlooked the case where an artin representation needs a field which is not in the database.  Then we need to construct it, which leads to other changes to accomodate both cases.

Artin representation 2.3e3_11e2.12t12.2c1 is an example which currently crashes beta and prod.  To see other cases which involves this code, try NumberField/x%5E4-2 (i.e., x^4-2) and see that Frobenius splittings at the bottom are still ok, and the Artin representations linked to at the bottom still work.