### PR TITLE
Interim partial fix for #1803

### DIFF
--- a/lmfdb/templates/problem.html
+++ b/lmfdb/templates/problem.html
@@ -1,0 +1,12 @@
+{% extends 'homepage.html' %}
+
+{% block content %}
+<div class="announce red">
+{{ explain | safe }}
+You may report this problem <a href="{{ feedbackpage }}" target=_blank>here</a>.
+</div>
+<div>
+<input type=button value="Return to previous page" onClick="history.go(-1)">
+</div>
+{% endblock %}
+


### PR DESCRIPTION
This PR is an initial attempt to address part of #1803 by displaying a meaningful error message to the user and giving them an opportunity to report the problem.  It also logs an error in the flasklog.

I added the template problem.html (which is essentially a copy of LfunctionSingle.html used by render_lfunction_exception in similar situations) which can be used to report problems where the application actually has some clue as to what the problem is (as opposed to a generic 404 or 500 errors).

To see it in action compare

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d

All modular forms tests that used to pass still pass.
