### PR TITLE
Cleanup maass form imports, fixes #122

### DIFF
--- a/lmfdb/modular_forms/backend/__init__.py
+++ b/lmfdb/modular_forms/backend/__init__.py
@@ -1,4 +1,6 @@
-# from mf_utils import ModularFormDisplay
-from mf_classes import MFDataTable
+# -*- coding: utf-8 -*-
+
 import mf_classes
+assert mf_classes
 import mf_utils
+assert mf_utils

--- a/lmfdb/modular_forms/backend/mf_classes.py
+++ b/lmfdb/modular_forms/backend/mf_classes.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from lmfdb.base import getDBConnection
 from lmfdb.modular_forms import mf_logger
 
@@ -97,7 +99,7 @@ class MFDisplay(object):
         self.table = {}
 
     def connect(self):
-        self.db = base.getDBConnection()[dbname]
+        self.db = getDBConnection()[self._dbname]
 
     def set_table(self):
         raise NotImplementedError("Needs to be overwritten in subclasses!")

--- a/lmfdb/modular_forms/maass_forms/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/__init__.py
@@ -1,4 +1,4 @@
-# /modular_forms/maass_forms/__init__.py
+# -*- coding: utf-8 -*-
 
 from lmfdb.utils import make_logger
 from flask import Blueprint
@@ -8,5 +8,6 @@ maassf = Blueprint(MAASSF, __name__, template_folder="views/templates")
 maassf_logger = make_logger(maassf)
 
 import maass_waveforms
-from maass_waveforms import *
+assert maass_waveforms
 import picard
+assert picard

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from lmfdb.utils import make_logger
 from flask import Blueprint
 
@@ -6,6 +8,6 @@ mwf = Blueprint(MWF, __name__, template_folder="views/templates", static_folder=
 mwf_logger = make_logger(mwf)
 
 import backend
+assert backend
 import views
-from backend import *
-from views import *
+assert views

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/__init__.py
@@ -1,3 +1,8 @@
-from web_maassforms import WebMaassFormSpace, WebMaassForm
-from mwf_utils import *
-from mwf_classes import *
+# -*- coding: utf-8 -*-
+
+import web_maassforms
+assert web_maassforms
+import mwf_utils
+assert mwf_utils
+import mwf_classes
+assert mwf_classes

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
@@ -284,7 +284,7 @@ class MaassDB(object):
             date_begun = ff['date']
             now = bson.datetime.datetime.utcnow()
             elapsed = now - date_begun
-            # FIXME: date_begnus is never used
+            # FIXME: date_beguns is never used
             # date_beguns = ff['date'].strftime("%d:%m:%y %H:%M:%s")
             if self._verbose > 0:
                 print "Removing N,weight,ch,R1,R2".format(ff.get('Level'), ff.get('Weight'), ff.get('Character'), ff.get('R1'), ff.get('R2'))

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/maass_forms_db.py
@@ -5,6 +5,8 @@
 import pymongo
 import gridfs
 import bson
+from copy import copy
+from sage.all import RR, real, imag
 from sage.symbolic.expression import Expression
 import datetime
 from lmfdb import base
@@ -13,10 +15,9 @@ from lmfdb.modular_forms.maass_forms.maass_waveforms import mwf_logger
 import math
 logger = mwf_logger
 try:
-    from dirichlet_conrey import *
+    from dirichlet_conrey import DirichletGroup_conrey
 except:
     logger.critical("dirichlet_conrey.pyx cython file is not available ...")
-import cython
 
 
 class MaassDB(object):
@@ -155,7 +156,7 @@ class MaassDB(object):
         mwf_logger.debug("Is in database:".format(isin))
         if not data.get('Conrey', False):
             # Then we have to convert the character to Conrey's label
-            ch = db.getDircharConrey(level, ch)
+            ch = self.getDircharConrey(level, ch)
         insert_data = {'Level': level, 'Weight': weight,
                        'Character': ch, 'Symmetry': sym_type,
                        'Error': err,
@@ -179,7 +180,7 @@ class MaassDB(object):
                 idd = idd0
         # See if we have coefficients to insert as well.
         if F is None:
-            coeffs = []
+            C = []
             numc = 0
         else:
             if hasattr(F, "is_automorphic_form"):
@@ -283,7 +284,8 @@ class MaassDB(object):
             date_begun = ff['date']
             now = bson.datetime.datetime.utcnow()
             elapsed = now - date_begun
-            date_beguns = ff['date'].strftime("%d:%m:%y %H:%M:%s")
+            # FIXME: date_begnus is never used
+            # date_beguns = ff['date'].strftime("%d:%m:%y %H:%M:%s")
             if self._verbose > 0:
                 print "Removing N,weight,ch,R1,R2".format(ff.get('Level'), ff.get('Weight'), ff.get('Character'), ff.get('R1'), ff.get('R2'))
                 print "Work took time:".format(elapsed)
@@ -310,8 +312,8 @@ class MaassDB(object):
                      'Eigenvalue': data.get('Eigenvalue', 0)}
         if verbose > 0:
             s = "Register coefficient computation:"
-            s += "N,weight,ch,R=", level, weight, ch, R
-            s += " in range NA,NB=", NA, NB
+            s += "N,weight,ch,R=", find_data['Level'], find_data['Weight'], find_data['Character'], find_data['Eigenvalue']
+            s += " in range NA,NB=", find_data['NA'], find_data['NB']
             print s
         try:
             t0 = self._collection_progress.find(data)
@@ -359,7 +361,7 @@ class MaassDB(object):
                     if not xid:
                         if self._verbose > 0:
                             mwf_logger.debug("Error: got record without id:{0}".format(x))
-                            mwf_logger.debug("coeffid={0}".format(coeff_id))
+                            mwf_logger.debug("coeffid={0}".format(x.get('coeff_id')))
                     res.append(x['_id'])
         return res
 
@@ -517,6 +519,7 @@ class MaassDB(object):
                     C1 = fn.get('Coefficients', [])
                     if C1 != []:
                         if get_filename != '':
+                            R = fn.get('Eigenvalue') # AVS July 18, 2016: set undefined R to what I believe was intended (without this the line below will always fail)
                             Rst = str(R).split(".")
                             Rst = (Rst[0] + "." + Rst[1][0:10])[0:12]
                             fname = '{0}-{1}-{2}-{3}-{4}'.format(
@@ -617,9 +620,9 @@ class MaassDB(object):
         s += "Nr.\tLevel \tWeight \tChar\tR1 \tR2 \tStart time \tStop time \tTotal time\n"
         j = 0
         for f in prog:
-            date_begun = f['start_time']
+            # date_begun = f['start_time']
             # elapsed_t = bson.datetime.datetime.utcnow() - date_begun
-            elapsed_t = f['elapsed']
+            # elapsed_t = f['elapsed']
             s += str(j) + "\t" + self.display_one_job_record(f)
 # s+="{0}\t{1}\t{2}\t{3}\t{4}\t{6}\t{7}
 # \n".format(j,f['Level'],f['Weight'],f['Char'],f['R1'],f['R2'],f['date'],elapsed_t)
@@ -651,9 +654,8 @@ class MaassDB(object):
         ## Reset and repopulate in case we want to remove one of these
         self._list_of_jobs = {}
         for f in prog:
-            date_begun = f['date']
-            elapsed_t = bson.datetime.datetime.utcnow() - date_begun
-
+            # date_begun = f['date']
+            # elapsed_t = bson.datetime.datetime.utcnow() - date_begun
             s += str(j) + "\t" + self.display_one_progress_record(f)
 # s+="{0}\t{1}\t{2}\t{3}\t{4}\t{6}\t{7}
 # \n".format(j,f['Level'],f['Weight'],f['Char'],f['R1'],f['R2'],f['date'],elapsed_t)
@@ -679,7 +681,7 @@ class MaassDB(object):
         if isinstance(jobnr, bson.objectid.ObjectId):
             self._collection_progress.deregister_work({'_id': jobnr})
         elif isinstance(jobnr, dict):  # treat job as a search pattern
-            f = self._collection_progress.find(job)
+            f = self._collection_progress.find(jobnr)
             for x in f:
                 print "Removing: \n"
                 print self.display_one_progress_record(x)
@@ -756,7 +758,6 @@ class MaassDB(object):
         for c in DC:
             if c.sage_character() == x:
                 return c.number()
-    from sage.all import euler_phi
 
     @cached_method
     def getDircharSageFromConrey(self, N, j):
@@ -841,8 +842,8 @@ class MaassDB(object):
         if html == 1:
             tr0 = "<tr>"
             tr1 = "</tr>"
-            td0 = "<td>"
-            td1 = "</td>"
+            # td0 = "<td>"  # unused
+            # td1 = "</td>" # unused
             th0 = "<th>"
             th1 = "</th>"
             tstart = "<table>"
@@ -850,8 +851,8 @@ class MaassDB(object):
         else:
             tr0 = ""
             tr1 = ""
-            td0 = ""
-            td1 = ""
+            # td0 = "" # unused
+            # td1 = "" # unused
             th0 = ""
             th1 = ""
             tstart = ""
@@ -953,23 +954,22 @@ class MaassDB(object):
                         date = prob.get("date", "")
                         message = prob.get("Message", "")
                         s = "{0} \ t {1} \t {2} \t {3} \t {4} \t {5}".format(N, x, R1, R2, date, message)
-                        level = x.get('Level', '')
+                        # level = x.get('Level', '') # unused
 
-                    res[k][N][x] = numr
+                    # FIXME: numr is not defined and it is not clear what is intended
+                    # res[k][N][x] = numr
 
             lN = res[k].keys()
             lN.sort()
             for N in lN:
                 s += str(N) + "\t"
-                lx = res[k][N].keys()
+                lx = res[k][N].keys() # FIXME: this will be an empty list until FIXME above is addressed
                 lx.sort()
                 for x in lx:
                     s += "\t " + str(x) + ":" + str(res[k][N][x])
                 s += "\n"
             s += "=============================================== \n"
             print s
-
-        # pri#nt N
 
     def show_eigenvalues(self, data={}, **kwds):
         verbose = kwds.get('verbose', 0)
@@ -1059,7 +1059,7 @@ class MaassDB(object):
                        'Message': message
                        }
         mwf_logger.debug("inserting:", insert_data)
-        idd = self._collection_problems.insert(insert_data)
+        self._collection_problems.insert(insert_data)
 
     def sync_dbs(self, other, search={}, update=False, verbose=0):
         r"""
@@ -1127,7 +1127,7 @@ class MaassDB(object):
             data['Conrey'] = conrey
             data['Dim'] = dim
             data['_id'] = idd
-            data['Contributor'] = Contr
+            data['Contributor'] = Contributor
             coeff_id = None
             f = None
             ff = other.find_Maass_form_id({'_id': idd})  # find_data)
@@ -1144,7 +1144,7 @@ class MaassDB(object):
                 else:
                     # if other._collection.find(key).count()==0:
                     raise ArithmeticError(
-                        "Insertion unsuccessful!\n key={0}, inserts={1}, ind:{2}".format(key, data, ins))
+                        "Insertion unsuccessful!\n key={0}, inserts={1}, ind:{2}".format(idd, data, ins))
                         # print "Insertion unsuccessful! ins:{0}".format(ins)
                 ncnew = 0
                 idnew = ins
@@ -1231,28 +1231,27 @@ class MaassDB(object):
 ## Default to this if we don't have a mongodb connection?
 # DB=None
 
+#~ def setup_sqldb():
+    #~ table_skeleton = {
+        #~ 'R': {'sql': 'REAL', 'index': True},
+        #~ 'ch': {'sql': 'INTEGER', 'index': True},
+        #~ 'level': {'sql': 'INTEGER', 'index': True, 'primary_key': False},
+        #~ 'id': {'sql': 'INTEGER', 'index': True, 'primary_key': True},
+        #~ 'file': {'sql': 'TEXT'}
+    #~ }
 
-def setup_sqldb():
-    table_skeleton = {
-        'R': {'sql': 'REAL', 'index': True},
-        'ch': {'sql': 'INTEGER', 'index': True},
-        'level': {'sql': 'INTEGER', 'index': True, 'primary_key': False},
-        'id': {'sql': 'INTEGER', 'index': True, 'primary_key': True},
-        'file': {'sql': 'TEXT'}
-    }
-
-    if not DB:
-        DB = SQLDatabase()  # filename="maasstable.db")
-        DB.create_table('maass_forms', table_skeleton)
-    DB.show('maass_forms')
-    Q = SQLQuery(
-        DB, {'table_name': 'maass_forms', 'display_cols': ['level'], 'expression': ['level', '=', 1]})
+    #~ if not DB:
+        #~ DB = SQLDatabase()  # filename="maasstable.db")
+        #~ DB.create_table('maass_forms', table_skeleton)
+    #~ DB.show('maass_forms')
+    #~ Q = SQLQuery(
+        #~ DB, {'table_name': 'maass_forms', 'display_cols': ['level'], 'expression': ['level', '=', 1]})
 
 
-def get_Maass(N, R1, R2, verbose=0):
-    G = MySubgroup(Gamma0(N))
-    find_Maass_for_one_N(G, R1, R2, char='all', verbose=verbose, db=DB)
-    DB.save("maasstable.db")
+#~ def get_Maass(N, R1, R2, verbose=0):
+    #~ G = MySubgroup(Gamma0(N))
+    #~ find_Maass_for_one_N(G, R1, R2, char='all', verbose=verbose, db=DB)
+    #~ DB.save("maasstable.db")
 
 
 def mongify_dict(data, lowercase=False):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+
 import mwf_main
+assert mwf_main

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -20,24 +20,22 @@ AUTHORS:
 
 
 """
-import lmfdb.base
-from lmfdb.base import app
-from flask import render_template, url_for, request, redirect, make_response, send_file
+
+import flask
+from flask import render_template, url_for, request, make_response, send_file
 import bson
 import StringIO
-import pymongo
-from sage.all import is_odd, is_even, dumps, loads
-# mwf = flask.Blueprint('mwf', __name__, template_folder="templates",static_folder="static")
+from sage.all import loads
 from lmfdb.modular_forms.maass_forms.maass_waveforms import MWF, mwf_logger, mwf
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_utils import *
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes import MaassFormTable, WebMaassForm
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db import MaassDB
-from mwf_upload_data import *
+from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_utils import get_args_mwf, get_search_parameters, connect_db, get_collections_info
+from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes import WebMaassForm
+# from mwf_upload_data import *
 from mwf_plot import paintSvgMaass
 logger = mwf_logger
 import json
 try:
-    from dirichlet_conrey import *
+    # from dirichlet_conrey import *
+    pass
 except:
     mwf_logger.critical("Could not import dirichlet_conrey!")
 
@@ -79,7 +77,9 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
 
     DB = connect_db()
     if not info['collection'] or info['collection'] == 'all':
-        md = get_collections_info()
+        # FIXME: metadata returned by get_collections_info is never used, only side effect appears to be logging messages
+        # md = get_collections_info()
+        get_collections_info()
     info['cur_character'] = character
     if level > 0:
         info['maass_weight'] = DB.weights(int(level))
@@ -217,7 +217,7 @@ def render_one_maass_waveform_wp(info):
 
     level = info['MF'].level
     dim = info['MF'].dim
-    numc = info['MF'].num_coeff
+    # numc = info['MF'].num_coeff # never used
     if info['MF'].has_plot(): # and level == 1: # Bara level = 1 har rätt format för tillfället //Lemurell
         info['plotlink'] = url_for('mwf.plot_maassform', maass_id=maass_id)
     # Create the link to the L-function (put in '/L' at the beginning and '/' before '?'
@@ -247,21 +247,21 @@ def render_one_maass_waveform_wp(info):
                           ('All coefficients of the form',
                            url_for('mwf.render_one_maass_waveform', maass_id=maass_id,
                                    download='coefficients')) ]
-    lenc = 20
     mwf_logger.debug("count={0}".format(DB.count()))
     ch = info['MF'].character
     s = "\( \chi_{" + str(level) + "}(" + str(ch) + ",\cdot) \)"
-    # is it possible to get the knowls into the properties?
-    knowls = knowls = {'level': 'mf.maass.mwf.level',
-                       'weight': 'mf.maass.mwf.weight',
-                       'char': 'mf.maass.mwf.character',
-                       'R': 'mf.maass.mwf.eigenvalue',
-                       'sym': 'mf.maass.mwf.symmetry',
-                       'prec': 'mf.maass.mwf.precision',
-                       'mult': 'mf.maass.mwf.dimension',
-                       'ncoeff': 'mf.maass.mwf.ncoefficients',
-                       'fricke': 'mf.maass.mwf.fricke',
-                       'atkinlehner': 'mf.maass.mwf.atkinlehner'}
+    # Q: Is it possible to get the knowls into the properties?
+    # A: Not in a nice way and this is not done elsewhere in the LMFDB; the knowls should appear on labels in the template
+    # knowls = {'level': 'mf.maass.mwf.level',
+    #                   'weight': 'mf.maass.mwf.weight',
+    #                   'char': 'mf.maass.mwf.character',
+    #                   'R': 'mf.maass.mwf.eigenvalue',
+    #                   'sym': 'mf.maass.mwf.symmetry',
+    #                   'prec': 'mf.maass.mwf.precision',
+    #                   'mult': 'mf.maass.mwf.dimension',
+    #                   'ncoeff': 'mf.maass.mwf.ncoefficients',
+    #                   'fricke': 'mf.maass.mwf.fricke',
+    #                   'atkinlehner': 'mf.maass.mwf.atkinlehner'}
     properties = [('Level', [info['MF'].level]),
                   ('Symmetry', [info['MF'].even_odd()]),
                   ('Weight', [info['MF'].the_weight()]),
@@ -303,7 +303,6 @@ def render_search_results_wp(info, search):
     """
     mwf_logger.debug("in render_search_results. info1={0}".format(info))
     mwf_logger.debug("Search:{0}".format(search))
-    evs = {'table': {}}
     if not isinstance(search, dict):
         search = {}
     if 'limit' not in search:
@@ -598,7 +597,4 @@ def evs_table(search, twodarray=False):
 
 
 def conrey_character_name(N, chi):
-    return "\chi_{" + str(self._N) + "}(" + strIO(chi.number()) + ",\cdot)"
-
-
-
+    return "\chi_{" + str(N) + "}(" + str(chi.number()) + ",\cdot)"

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -29,15 +29,9 @@ from sage.all import loads
 from lmfdb.modular_forms.maass_forms.maass_waveforms import MWF, mwf_logger, mwf
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_utils import get_args_mwf, get_search_parameters, connect_db, get_collections_info
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes import WebMaassForm
-# from mwf_upload_data import *
 from mwf_plot import paintSvgMaass
 logger = mwf_logger
 import json
-try:
-    # from dirichlet_conrey import *
-    pass
-except:
-    mwf_logger.critical("Could not import dirichlet_conrey!")
 
 
 # this is a blueprint specific default for the tempate system.

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_upload_data.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_upload_data.py
@@ -1,16 +1,11 @@
+# -*- coding: utf-8 -*-
 r"""
 Upload data and insert into database for Maass waveforms.
 
 
 """
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_utils import *
-
-import flask
-from flask import render_template, url_for, request, redirect, make_response, send_file
-import bson
-from sets import Set
-import pymongo
-from sage.all import is_odd, is_even
+from lmfdb.utils import to_dict
+from flask import request
 
 # Make a list of the entries which we allow to be put in the database
 # Hardcoded for simplicity
@@ -43,11 +38,8 @@ def check_data(info):
         s += "<td>%s </td>" % name
     for l in f:
         print l
-        data = l.split(' ')
-
-
+        # data = l.split(' ')
         ## Try to parse the file with info['format'] as keys
-
     # datafiles.save(f)
 
 def get_format_for_file_to_db(info):

--- a/lmfdb/modular_forms/maass_forms/picard/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/picard/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from lmfdb.utils import make_logger
 from flask import Blueprint
 
@@ -7,4 +9,6 @@ mwfp_logger = make_logger(mwfp)
 mwfp_dbname = 'HTPicard'
 
 import views
+assert views
 import backend
+assert backend

--- a/lmfdb/modular_forms/maass_forms/picard/backend/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/picard/backend/__init__.py
@@ -1,1 +1,4 @@
-from mwfp_classes import PicardDataTable, PicardFormTable
+# -*- coding: utf-8 -*-
+
+import mwfp_classes
+assert mwfp_classes

--- a/lmfdb/modular_forms/maass_forms/picard/backend/mwfp_classes.py
+++ b/lmfdb/modular_forms/maass_forms/picard/backend/mwfp_classes.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from lmfdb.modular_forms.maass_forms.picard import mwfp_logger
-# from lmfdb.modular_forms.backend.mf_utils import *
 from lmfdb.modular_forms.backend.mf_classes import MFDataTable
 from flask import url_for
 

--- a/lmfdb/modular_forms/maass_forms/picard/backend/mwfp_classes.py
+++ b/lmfdb/modular_forms/maass_forms/picard/backend/mwfp_classes.py
@@ -1,6 +1,7 @@
-# from utils import *
-from lmfdb.modular_forms.maass_forms.picard import *  # MWFP,mwfp_logger, mwfp
-from lmfdb.modular_forms.backend.mf_utils import *
+# -*- coding: utf-8 -*-
+
+from lmfdb.modular_forms.maass_forms.picard import mwfp_logger
+# from lmfdb.modular_forms.backend.mf_utils import *
 from lmfdb.modular_forms.backend.mf_classes import MFDataTable
 from flask import url_for
 
@@ -77,8 +78,6 @@ class PicardFormTable(MFDataTable):
         self._props['ev'] = f['ev']
         self._props['sym'] = f['sym']
         self._props['prec'] = f['prec']
-        i = 0
-        coeffs = list()
         self._row_heads = []
         self._col_heads = []
         row_min = self._nrows * skip

--- a/lmfdb/modular_forms/maass_forms/picard/views/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/picard/views/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+
 import mwfp_main
+assert mwfp_main

--- a/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
+++ b/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
@@ -3,7 +3,7 @@
 from flask import render_template, url_for, request
 from lmfdb.modular_forms.maass_forms.picard import mwfp, mwfp_logger, mwfp_dbname
 from lmfdb.modular_forms.maass_forms.picard.backend.mwfp_classes import PicardFormTable, PicardDataTable
-from lmfdb.modular_forms.maass_forms.maass_waveforms.backend import connect_db
+from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_utils import connect_db
 
 # see main mwfp blueprint for details
 

--- a/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
+++ b/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
@@ -1,28 +1,15 @@
-import flask
-from flask import render_template, url_for, request, render_template_string
-# import bson
-# import base
-# from base import app
-# from  modular_forms.maass_forms.picard import MWFP,mwfp,mwfp_logger
-# logger = mwfp_logger
-# from  modular_forms.maass_forms.maass_waveform import MWFTable
-# import modular_forms.maass_forms
-# from modular_forms.maass_forms.picard.backend.mwfp_utils import *
-from lmfdb.modular_forms.maass_forms.picard.backend.mwfp_classes import *
-# import jinja2
-from flask import Blueprint
+# -*- coding: utf-8 -*-
 
+from flask import render_template, url_for, request
+from lmfdb.modular_forms.maass_forms.picard import mwfp, mwfp_logger, mwfp_dbname
+from lmfdb.modular_forms.maass_forms.picard.backend.mwfp_classes import PicardFormTable, PicardDataTable
+from lmfdb.modular_forms.maass_forms.maass_waveforms.backend import connect_db
 
-# app.register_blueprint(mwfp, url_prefix="/ModularForm/GL2/C/Maass")
+# see main mwfp blueprint for details
 
-# app.register_blueprint(mwfp, url_prefix="/ModularForm/GL2/C/Maass")
-
-# see main mwf blueprint for details
 @mwfp.context_processor
 def body_class():
     return {'body_class': 'mwfp'}
-
-#@base.app.route("/ModularForm/GL2/C/Maass/")
 
 
 @mwfp.route("/", methods=['GET', 'POST'])

--- a/lmfdb/modular_forms/maass_forms/views/__init__.py
+++ b/lmfdb/modular_forms/maass_forms/views/__init__.py
@@ -1,8 +1,4 @@
-from lmfdb.base import app
-from lmfdb.utils import make_logger
-import flask
+# -*- coding: utf-8 -*-
 
-### The different kinds of Maass forms we have.
 import maassf_main
-# app.register_blueprint(views.mwf_main.mwf, url_prefix="/ModularForm/GL2/Q/Maass")
-# app.register_blueprint(views.mwfp_main.mwfp, url_prefix="/ModularForm/GL2/C/Maass")
+assert maassf_main

--- a/lmfdb/modular_forms/maass_forms/views/maassf_main.py
+++ b/lmfdb/modular_forms/maass_forms/views/maassf_main.py
@@ -1,19 +1,15 @@
-import lmfdb.base
-from lmfdb.base import app
+# -*- coding: utf-8 -*-
 
 from flask import render_template, url_for
-# from modular_forms.maass_forms import maassf,MAASSF,maassf_logger
-from lmfdb.modular_forms.maass_forms import maassf, MAASSF, maassf_logger
-
+from lmfdb.modular_forms.maass_forms import maassf, MAASSF
 
 @maassf.context_processor
 def body_class():
     return {'body_class': MAASSF}
-
 
 @maassf.route("/")
 def maass_forms_main_page():
     info = dict()
     title = "Maass Forms"
     bread = [('Modular Forms', url_for('modular_form_toplevel'))]
-    return render_template("maass_forms_navigation.html", info=info, title=title)
+    return render_template("maass_forms_navigation.html", info=info, title=title, bread=bread)


### PR DESCRIPTION
This PR is a pyflakes cleanup of the modular_forms/maass_forms/* subtree of the LMFDB that removes the last remaining import *'s in the LMFDB codebase (thereby allowing us close #122).

It uncovered many bugs due to references to misspelled or never defined variables; these all appear to be in code branches that are not (typically) executed or in functions that are not called anywhere in the LMFDB (a disturbing number of them were in maass_forms_db.py which is used and is the source of a few open production issues).

Where it was possible to discern the intent, I fixed these bugs, and where it was not I commented out the broken code and added a FIXME comment.  I also commented out some code that requires SQL imports and a SQL database to run (this code has not been touched in 4 years and appears not to be used).

All tests runs successful (except the known test_galois_conjugates errors) and browsing through the pages under  http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/ did not reveal any changes -- everything that works on www.lmfdb.org appears to still work, and everything that is broken on www.lmfdb.org is still broken (but hopefully will now be easier to fix).

Pages I checked include:
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032/
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032/?download=lcalcfile
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/1/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000031
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/100/250/0/2/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/100/1000/0/1/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/53234e85acf756120945d7d0
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/53234e85acf756120945d7d0/
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/53234e85acf756120945d7d0/?download=lcalcfile
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/997/

I also checked that prev/next and download links (both of them) on Maass form pages still work.
