### PR TITLE
Handle non-existent elliptic curve isogeny class requests

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -290,8 +290,11 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     label = "-".join([nf_label, conductor_label, class_label])
     full_class_label = "-".join([conductor_label, class_label])
     cl = ECNF_isoclass.by_label(label)
-    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field)
     bread = [("Elliptic Curves", url_for(".index"))]
+    if not isinstance(cl, ECNF_isoclass):
+        info = {'query':{}, 'err':'No elliptic curve isogeny class in the database has label %s.' % label}
+        return search_input_error(info, bread)
+    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field)
     bread.append((cl.field, url_for(".show_ecnf1", nf=nf_label)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))


### PR DESCRIPTION
If you attempt to access a URL for an elliptic curve that is not in the database, e.g.

http://www.lmfdb.org/EllipticCurve/2.2.5.1/31.1/b/1

you get an error message explaining that no elliptic curve with this label is in the database.  But if you instead try to access the corresponding isogeny class, i.e.

http://www.lmfdb.org/EllipticCurve/2.2.5.1/31.1/b/

you get an internal server error.  This tiny PR fixes this by displaying an error message when the isogeny class is not found, similar to what is done when the elliptic curve is not found, see:

http://127.0.0.1:37777/EllipticCurve/2.2.5.1/31.1/b/

