### PR TITLE
add pyflakes to requirements.txt and test.sh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask-login==0.2.11
 flask-markdown
 pymongo
 pyyaml
+pyflakes
 unittest2
 coverage
 nose

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,10 @@ else
   WHAT="$@"
 fi
 
+echo "Running pyflakes..."
+find $WHAT | grep "\.py$" | xargs pyflakes
+echo "pyflakes check complete"
+
 ARGS='-v -s --testmatch="(?:^|\/)[Tt]est_"'
 
 SAGE_COMMAND=$SAGE

--- a/test.sh
+++ b/test.sh
@@ -5,11 +5,12 @@
 
 # Note: to run the tests, sage must be in your path.  If necessary do
 # export PATH=$PATH:/path/to/sage
-# To run it, first install or upgrade "nose", "unittest2" and "coverage".
-# e.g. $ pip install --user -U nose coverage unittest2
+# To run it, first install or upgrade "nose", "unittest2" "coverage" and "pyflakes".
+# e.g. $ pip install --user -U nose coverage unittest2 pyflakes
 # or inside the Sage environment: $ easy_install -U nose
 #                                 $ easy_install -U coverage
 #                                 $ easy_install -U unittest2
+#                                 $ easy_install -U pyflakes
 # Second, call it in three ways, either
 # $ ./test.sh to test all
 # or


### PR DESCRIPTION
This PR adds a pyflakes check to test.sh that is run on all the python files in the specified subtree (or the entire codebase if the "coverage" option is used or no directory is specified -- this only takes 2-3 seconds).

To see it in action, from the top level lmfdb directory (where test.sh lives) try

./test.sh lmfdb
./test.sh lmfdb/elliptic_curves (this will only check *.py files in elliptic curves)

This PR also adds pyflakes to requirements.txt where it will get pip installed along with everything else.