### PR TITLE
Avoid server errors on number field download queries

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -594,7 +594,7 @@ def frobs(nf):
 
 
 def download_search(info, res):
-    dltype = info['Submit']
+    dltype = info.get('Submit')
     delim = 'bracket'
     com = r'\\'  # single line comment start
     com1 = ''  # multiline comment start


### PR DESCRIPTION
This is similar to (but even simpler than) #1792, which was about avoiding server errors on malformed elliptic curve download requests.

If you enter the URL
http://www.lmfdb.org/NumberField/?degree=13&download=1
you get a server error (several of these have shown up in the flasklog).

But the URL
http://www.lmfdb.org/NumberField/?degree=13&download=1&Submit=
works fine.

This PR changes line 597 of number_field.py to use info.get('Submit') rather than info['Submit'] so that you can leave off the Submit and it will still work, e.g.

http://127.0.0.1:37777/NumberField/?degree=13&download=1
http://127.0.0.1:37777/NumberField/?degree=13&download=1&Submit=

both do the same thing (generate a download in the default format).


