### PR TITLE
add --dbmon flag to support mongo db call monitoring

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -36,6 +36,18 @@ _mongo_kwargs = None
 _mongo_user = None
 _mongo_pass = None
 
+# simple event logger that logs all interaction with mongo db
+# to activate set the mongo_kwargs to include event_listeners=[MongoEventLogger()]
+# see website.py --dblistener option where this is set
+from pymongo import monitoring
+class MongoEventLogger(monitoring.CommandListener):
+    def started(self, event):
+        logging.info("mongo db command %s(%x) on db %s with args %s sent"%(event.command_name,event.request_id,event.database_name,event.command))
+    def succeeded(self, event):
+        logging.info("mongo db command %s(%x) took %.3fs"%(event.command_name,event.request_id,event.duration_micros/1000000.0))
+    def failed(self, event):
+        logging.info("mongo db command %s(%x) failed after %.3fs, details: %s"%(event.command_name,event.request_id,event.duration_micros/1000000.0,event.failure))
+
 def getDBConnection():
     if not _mongo_C:
         makeDBConnection()

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -188,7 +188,7 @@ Usage: %s [OPTION]...
       --logfocus=NAME       name of a logger to focus on
       --debug               enable debug mode
       --dbport=NUM          bind the MongoDB to the given port (default base.DEFAULT_DB_PORT)
-      --dbmon=NAME          monitor MongoDB commands to the specified database (specify empty NAME to monitor everything)
+      --dbmon=NAME          monitor MongoDB commands to the specified database (use NAME=* to monitor everything, NAME=~DB to monitor all but DB)
       --help                show this help
 """ % sys.argv[0]
 

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -84,7 +84,7 @@ import sys
 import time
 import getopt
 from pymongo import ReadPreference
-from base import app, set_logfocus, get_logfocus, _init, MongoEventLogger
+from base import app, set_logfocus, get_logfocus, _init
 from flask import g, render_template, request, make_response, redirect, url_for, current_app, abort
 import sage
 
@@ -184,12 +184,12 @@ Usage: %s [OPTION]...
   -p, --port=NUM            bind to port NUM (default 37777)
   -h, --host=HOST           bind to host HOST (default "127.0.0.1")
   -l, --log=FILE            log to FILE (default "flasklog")
-      --dbport=NUM          bind the MongoDB to the given port (default base.DEFAULT_DB_PORT)
-      --debug               enable debug mode
-      --dbmon               if specified all MongoDB calls will be logged (with timings)
-      --logfocus=NAME       name of logger to focus on
-      --help                show this help
   -m, --mongo-client=FILE   config file for connecting to MongoDB (default is "mongoclient.config")
+      --logfocus=NAME       name of a logger to focus on
+      --debug               enable debug mode
+      --dbport=NUM          bind the MongoDB to the given port (default base.DEFAULT_DB_PORT)
+      --dbmon=NAME          monitor MongoDB commands to the specified database (specify empty NAME to monitor everything)
+      --help                show this help
 """ % sys.argv[0]
 
 def get_configuration():
@@ -218,7 +218,7 @@ def get_configuration():
                                            "dbport=", 
                                            "log=", 
                                            "logfocus=", 
-                                           "dbmon",
+                                           "dbmon=",
                                            "debug",
                                            "help", 
                                            "mongo-client=",
@@ -226,7 +226,7 @@ def get_configuration():
                                             "enable-reloader", "disable-reloader",
                                             "enable-debugger", "disable-debugger",
                                             "enable-profiler"
-                                            # no currently used
+                                            # not currently used
                                             "threading"
                                         ]
                                        )
@@ -249,7 +249,7 @@ def get_configuration():
             elif opt in ("--dbport"):
                 mongo_client_options["port"] = int(arg)
             elif opt in ("--dbmon"):
-                mongo_client_options["event_listeners"] = [MongoEventLogger()]
+                mongo_client_options["dbmon"] = arg
             elif opt == "--debug":
                 flask_options["debug"] = True
             elif opt == "--logfocus":


### PR DESCRIPTION
This PR adds a --dbmon=NAME command line option that you can specify when you start the LMFDB webserver to log (with timings) all calls to mongo db on the specified database.  To monitor everything, use --dbmon=* (or even just --dbmon=), and to monitor everything except the specified datbase, put a twiddle in front of it (e.g. --dbmon=~knowledge will not log knowl lookups).

This will be useful both for analyzing performance, and for debugging issues like #1533 and #1803, both of which are caused by problems with invalid or inconsistent data across multiple collections (and it is not always easy to tell from the code which collections are being accessed when).

To see it in action just add --dbmon=* to your usual lmfdb startup and visit some of your favorite pages

sage -python start-lmfdb.py --dbmon=*

To prevent being overwhelmed by messages about knowl lookups use

sage -python start-lmfdb.py --dbmon=~knowledge
