### PR TITLE
Fix #1803

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
@@ -110,7 +110,7 @@ class WebMaassForm(object):
         ff = db.get_Maass_forms(id=self._maassid)
         # print "ff=",ff
         if len(ff) == 0:
-            return
+            raise KeyError("massid %s not found in database"%maassid)
         f = ff[0]
 
         # print "f here=",f

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -145,7 +145,10 @@ def render_one_maass_waveform(maass_id, **kwds):
         info.get('download', '') == 'all'):
         DB = connect_db()
         maass_id = info['maass_id']
-        f = WebMaassForm(DB, maass_id)
+        try:
+            f = WebMaassForm(DB, maass_id)
+        except KeyError:
+            flask.abort(404)
         filename = str(f._maassid) + '.txt'
         if info.get('download', '') == 'coefficients':
             res = f.coeffs
@@ -191,7 +194,11 @@ def render_one_maass_waveform_wp(info):
     DB = connect_db()
     maass_id = info['maass_id']
     mwf_logger.debug("id1={0}".format(maass_id))
-    info['MF'] = MF = WebMaassForm(DB, maass_id)
+    try:
+        MF = WebMaassForm(DB, maass_id)
+    except KeyError:
+        return flask.abort(404)
+    info['MF'] = MF
     info['title'] = "Maass form"
     info['bread'] = [('Modular forms', url_for('mf.modular_form_main_page')),
                      ('Maass waveforms', url_for('.render_maass_waveforms'))]

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -180,6 +180,8 @@ def plot_maassform(maass_id):
         return flask.abort(404)
     DB = connect_db()
     data = DB.get_maassform_plot_by_id(maass_id)
+    if not data:
+        return flask.abort(404)
     data = data['plot']
     response = make_response(loads(data))
     response.headers['Content-type'] = 'image/png'


### PR DESCRIPTION
This is a simple fix for #1803; it returns a 404 page not found error when a lookup for a maass form fails because the record is not present in the FS collection.

So the pages listed in #1803 will now all give a page not found error, compare:

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d

It does the same things for plot requests, compare:

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/plot/4f55571188aece241f00000d
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/plot/4f55571188aece241f00000d

And it will handle L-function errors (rather than displaying a page that looks quasi-reasonable at first glance but actually has no information in it other than a claim the level is 1, which has no basis, it will say the same thing for any string of 24 hex chars you type in for the object id)

http://www.lmfdb.org/L/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/4f55571188aece241f00000d

To see that maass forms that are in the database still display correctly (whether they have a plot or not), compare:

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032 (scroll down for plot)
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/53222e00acf7560f8ad4cd64 (no plot)
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/53222e00acf7560f8ad4cd64

You can also see that the scatter plots still work:

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/
http://www.lmfdb.org/ModularForm/GL2/Q/Maass/BrowseGraph/100/250/0/2/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/100/250/0/2/
http://www.lmfdb.org/ModularForm/GL2/Q/Maass/BrowseGraph/100/1000/0/1/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/BrowseGraph/100/1000/0/1/

And you can try creating a table (e.g. type in level 1) at

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/

