### PR TITLE
don't raise error in render_lfunction_exception in debug mode

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -379,8 +379,8 @@ def l_function_lcalc_page():
 ################################################################################
 
 def render_lfunction_exception(err):
-    if current_app.debug:
-        raise err
+    #if current_app.debug:
+    #    raise err
     if err.args:
         errmsg = "Unable to render L-function page due to the following problem(s):<br><ul>" + reduce(lambda x,y:x+y,["<li>"+msg+"</li>" for msg in err.args]) + "</ul>"
     else:


### PR DESCRIPTION
@JohnCremona I commented out the two lines in render_lfunction_exception that raise an error in debug mode -- anyone who wants to use them while testing can always uncomment them.