### PR TITLE
Genus2 error handling

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -6,7 +6,7 @@ import re
 import time
 from pymongo import ASCENDING, DESCENDING
 from operator import mul
-from flask import render_template, url_for, request, redirect, send_file
+from flask import render_template, url_for, request, redirect, send_file, abort
 from sage.all import ZZ
 
 from lmfdb.utils import to_dict, comma, random_value_from_collection, attribute_value_counts, flash_error
@@ -179,11 +179,10 @@ def by_label(label):
     return genus2_curve_search({'jump':label})
 
 def render_curve_webpage(label):
-    g2c = WebG2C.by_label(label)
-    if not g2c:
-        return "Error constructing genus 2 curve with label " + label
-    if isinstance(g2c,str):
-        return g2c
+    try:
+        g2c = WebG2C.by_label(label)
+    except (KeyError,ValueError):
+        return abort(404)
     return render_template("g2c_curve.html",
                            properties2=g2c.properties,
                            credit=credit_string,
@@ -197,11 +196,10 @@ def render_curve_webpage(label):
                            #downloads=g2c.downloads)
 
 def render_isogeny_class_webpage(label):
-    g2c = WebG2C.by_label(label)
-    if not g2c:
-        return "Error constructing genus 2 isogeny class with label " + label
-    if isinstance(g2c,str):
-        return g2c
+    try:
+        g2c = WebG2C.by_label(label)
+    except (KeyError,ValueError):
+        return abort(404)
     return render_template("g2c_isogeny_class.html",
                            properties2=g2c.properties,
                            credit=credit_string,
@@ -211,7 +209,6 @@ def render_isogeny_class_webpage(label):
                            title=g2c.title,
                            friends=g2c.friends)
                            #downloads=class_data.downloads)
-                           
 
 def url_for_curve_label(label):
     slabel = label.split(".")

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -137,6 +137,9 @@ def by_url_curve_label(cond, alpha, disc, num):
 def by_url_isogeny_class_discriminant(cond, alpha, disc):
     data = to_dict(request.args)
     clabel = str(cond)+"."+alpha
+    # if the isogeny class is not present in the database, return a 404 (otherwise title and bread crumbs refer to a non-existent isogeny class)
+    if not g2c_db_curves().find_one({'class':clabel},{'_id':True}):
+        return abort(404)
     data['title'] = 'Genus 2 curves in isogeny class %s of discriminant %s' % (clabel,disc)
     data['bread'] = [('Genus 2 Curves', url_for(".index")),
         ('$\Q$', url_for(".index_Q")),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -524,7 +524,7 @@ class WebG2C(object):
                 raise KeyError("Genus 2 curve %s not found in database" % label)
         endo = g2c_db_endomorphisms().find_one({"label" : curve['label']})
         if not endo:
-            gc2_logger.error("Genus 2 endomorphism data for curve %s not found in database" % label)
+            g2c_logger.error("Genus 2 endomorphism data for curve %s not found in database" % label)
             raise KeyError("Genus 2 endomorphism data for curve %s not found in database" % label)
         return WebG2C(curve, endo, is_curve=(len(slabel)==4))
 


### PR DESCRIPTION
Fix internal server error on pages like http://www.lmfdb.org/Genus2Curve/Q/123/a/ and http://www.lmfdb.org/Genus2Curve/Q/123/a/456/1 that refer to genus 2 isogeny classes or curves that do not exist (@JohnCremona - FYI, this was caused by code not properly checking the return type of a class constructor that returned an error message as a **unicode string** not a string -- another reason to actually raise errors in this situation, which the code now does).

All genus2 tests pass.  To see the difference compare

http://www.lmfdb.org/Genus2Curve/Q/123/a
http://127.0.0.1:37777/Genus2Curve/Q/123/a

http://www.lmfdb.org/Genus2Curve/Q/123/a/456/1
http://127.0.0.1:37777/Genus2Curve/Q/123/a/456/1

There is also a change to

http://www.lmfdb.org/Genus2Curve/Q/123/a/456/
http://127.0.0.1:37777/Genus2Curve/Q/123/a/456/

The old version looks reasonable at first glance, but in fact the title refers to an isogeny class that does not exist and the bread crumb for the isogeny class will throw a server error if you click on it; the new version returns a 404, which makes more sense in this situation (the URL includes an isogeny class that does not exist).

