### PR TITLE
display detail on 404 errors

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -139,7 +139,7 @@ def by_url_isogeny_class_discriminant(cond, alpha, disc):
     clabel = str(cond)+"."+alpha
     # if the isogeny class is not present in the database, return a 404 (otherwise title and bread crumbs refer to a non-existent isogeny class)
     if not g2c_db_curves().find_one({'class':clabel},{'_id':True}):
-        return abort(404)
+        return abort(404, 'Genus 2 isogeny class %s not found in database.'%clabel)
     data['title'] = 'Genus 2 curves in isogeny class %s of discriminant %s' % (clabel,disc)
     data['bread'] = [('Genus 2 Curves', url_for(".index")),
         ('$\Q$', url_for(".index_Q")),
@@ -184,8 +184,8 @@ def by_label(label):
 def render_curve_webpage(label):
     try:
         g2c = WebG2C.by_label(label)
-    except (KeyError,ValueError):
-        return abort(404)
+    except (KeyError,ValueError) as err:
+        return abort(404,err.args[0])
     return render_template("g2c_curve.html",
                            properties2=g2c.properties,
                            credit=credit_string,
@@ -201,8 +201,8 @@ def render_curve_webpage(label):
 def render_isogeny_class_webpage(label):
     try:
         g2c = WebG2C.by_label(label)
-    except (KeyError,ValueError):
-        return abort(404)
+    except (KeyError,ValueError) as err:
+        return abort(404,err.args[0])
     return render_template("g2c_isogeny_class.html",
                            properties2=g2c.properties,
                            credit=credit_string,

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -514,18 +514,18 @@ class WebG2C(object):
             elif len(slabel) == 4:
                 curve = g2c_db_curves().find_one({"label" : label})
             else:
-                raise ValueError("Invalid genus 2 label %s" % label)
+                raise ValueError("Invalid genus 2 label %s." % label)
         except AttributeError:
-            raise ValueError("Invalid genus 2 label %s" % label)
+            raise ValueError("Invalid genus 2 label %s." % label)
         if not curve:
             if len(slabel) == 2:
-                raise KeyError("Genus 2 isogeny class %s not found in database" % label)
+                raise KeyError("Genus 2 isogeny class %s not found in the database." % label)
             else:
-                raise KeyError("Genus 2 curve %s not found in database" % label)
+                raise KeyError("Genus 2 curve %s not found in database." % label)
         endo = g2c_db_endomorphisms().find_one({"label" : curve['label']})
         if not endo:
-            g2c_logger.error("Genus 2 endomorphism data for curve %s not found in database" % label)
-            raise KeyError("Genus 2 endomorphism data for curve %s not found in database" % label)
+            g2c_logger.error("Endomorphism data for genus 2 curve %s not found in database." % label)
+            raise KeyError("Endomorphism data for genus 2 curve %s not found in database." % label)
         return WebG2C(curve, endo, is_curve=(len(slabel)==4))
 
     def make_object(self, curve, endo, is_curve):

--- a/lmfdb/templates/404.html
+++ b/lmfdb/templates/404.html
@@ -2,11 +2,11 @@
 {% block content %}
 
 <div class="announce red">
-<div>The page you are looking for does not exist. </div>
+<div>Unable to locate the page you requested.</div>
 <br>
 {% if message %}
 <div>
-  {{ message }}
+{{ message }}
 </div>
 <br>
 {% elif request.referrer %}
@@ -19,17 +19,13 @@ If you believe this page should be here, please <a href = "http://code.google.co
 </div>
 {% endif %}
 
-<br>
-<div>Thank you for your understanding!</div>
-
 {% if request.referrer %}
 <div>
 <br>
-You now have the option of <a href="{{ request.referrer }}">jumping back to your referring URL</a>.
+<a href="{{ request.referrer }}">Click here</a> to return to the referring URL.
 </div>
 {% endif %}
 
 </div>
-
 
 {% endblock %}

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -91,6 +91,9 @@ import sage
 DEFAULT_DB_PORT = 37010
 LMFDB_SAGE_VERSION = '7.1'
 
+def timestamp():
+    return '[%s UTC]'%time.strftime("%Y-%m-%d %H:%M:%S",time.gmtime())
+
 @app.before_request
 def redirect_nonwww():
     """Redirect lmfdb.org requests to www.lmfdb.org"""
@@ -102,12 +105,13 @@ def redirect_nonwww():
 
 @app.errorhandler(404)
 def not_found_404(error):
-    return render_template("404.html"), 404
+    app.logger.info('%s 404 error for URL %s %s'%(timestamp(),request.url,error.description))
+    return render_template("404.html", title='LMFDB page not found', message=error.description), 404
 
 @app.errorhandler(500)
 def not_found_500(error):
-    app.logger.error("[%s UTC] 500 error on URL %s"%(time.strftime("%Y-%m-%d %H:%M:%S",time.gmtime()),request.url))
-    return render_template("500.html"), 500
+    app.logger.error("%s 500 error on URL %s"%(timestamp(),request.url))
+    return render_template("500.html", title='LMFDB error', message=error.description), 500
 
 @app.errorhandler(503)
 def not_found_503(error):


### PR DESCRIPTION
As suggested in https://github.com/LMFDB/lmfdb/pull/1855#issuecomment-234063144, error detail on 404 errors is now displayed when specified (use flask.abort(404,errmsg)), and this is used in the genus 2 code.

old: http://www.lmfdb.org/Genus2Curve/Q/169/b/
new" http://127.0.0.1:37777/Genus2Curve/Q/169/b/

old: http://www.lmfdb.org/Genus2Curve/Q/169/a/169/2
new" http://127.0.0.1:37777/Genus2Curve/Q/169/a/169/2

