### PR TITLE
Hide *.chunks, *.rand, *.stats, ..., collections by default

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -71,6 +71,7 @@ def get_database_info(show_hidden=False):
     for db in C.database_names():
         if not censored_db(db):
             info[db] = sorted([(c, C[db][c].count()) for c in C[db].collection_names() if not censored_collection(c) and (show_hidden or not hidden_collection(c))])
+            print db, info[db]
     return info
 
 @api_page.route("/")

--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -71,7 +71,6 @@ def get_database_info(show_hidden=False):
     for db in C.database_names():
         if not censored_db(db):
             info[db] = sorted([(c, C[db][c].count()) for c in C[db].collection_names() if not censored_collection(c) and (show_hidden or not hidden_collection(c))])
-            print db, info[db]
     return info
 
 @api_page.route("/")


### PR DESCRIPTION
This PR hides certain collections in the api interface by default, including those that end in ".rand", ".chunks", ".old", and ".new", and those that begin with "test".  You can still access the full list of uncensored collections via /api/all, and the /api/stats page still shows all uncensored collections.

To see the difference, compare:

http://beta.lmfdb.org/api
http://127.0.0.1:37777/api
http://127.0.0.1:37777/api/all

The ".old" and ".new" suffixes are recommended for use when updating a collection using rewrite.py -- naming the new collection blah.new will keep it from being visible while it is being written, and after renaming blah to blah.old and blah.new to blah, the new collection will be visible and the old one will not be visible (but still available in case you want to revert).  This convention is also used when copying collections from Warwick to the cloud.


