### PR TITLE
Fix internal server errors in L-function pages for scalar-valued SMFs

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1420,6 +1420,9 @@ class Lfunction_SMF2_scalar_valued(Lfunction):
         if not S:
             raise KeyError("Siegel modular form Sp4Z.%s not found in database." % name)
         self.field = S.field()
+        evlist = S.available_eigenvalues()
+        if len(evlist) < 3: # FIXME -- we should sanity check that we have enough eigenvalues for it make sense to display an L-function page (presumably 3 is not enough)
+            raise ValueError("Eigenvalue data for Siegel modular form Sp4Z.%s not available of insufficient." % name)
         self.evs = S.eigenvalues(S.available_eigenvalues())
         for ev in self.evs:
             self.evs[ev] = self.field(self.evs[ev])
@@ -1433,8 +1436,7 @@ class Lfunction_SMF2_scalar_valued(Lfunction):
 
         self.degree = 4
         roots = compute_local_roots_SMF2_scalar_valued(self.field, self.evs, self.weight, self.number)  # compute the roots of the Euler factors
-
-        self.numcoeff = max([a[0] for a in roots])  # include a_0 = 0
+        self.numcoeff = max([a[0] for a in roots])+1  # include a_0 = 0
         self.dirichlet_coefficients = compute_dirichlet_series(roots, self.numcoeff)  # these are in the analytic normalization, coeffs from Gamma(ks+lambda)
         self.selfdual = True
         if self.orbit[0] == 'U':  # if the form isn't a lift but is a cusp form
@@ -1444,17 +1446,17 @@ class Lfunction_SMF2_scalar_valued(Lfunction):
             self.primitive = True  # and primitive
         elif self.orbit[0] == 'E':  # if the function is an Eisenstein series
             self.poles = [float(3) / float(2)]
-            self.residues = [math.pi ** 2 / 6]  # fix this
+            self.residues = [math.pi ** 2 / 6]  # FIXME: fix this
             self.langlands = True
             self.primitive = False
         elif self.orbit[0] == 'M':  # if the function is a lift and a cusp form
             self.poles = [float(3) / float(2)]
-            self.residues = [math.pi ** 2 / 6]  # fix this
+            self.residues = [math.pi ** 2 / 6]  # FIXME: fix this
             self.langlands = True
             self.primitive = False
         elif self.orbit[0] == 'K':
             self.poles = [float(3) / float(2)]
-            self.residues = [math.pi ** 2 / 6]  # fix this
+            self.residues = [math.pi ** 2 / 6]  # FIXME: fix this
             self.langlands = True
             self.primitive = False
 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -920,13 +920,10 @@ def euler_p_factor(root_list, PREC):
     return ep + O(x ** (PREC + 1))
 
 
-def compute_local_roots_SMF2_scalar_valued(ev_data, k, embedding):
+def compute_local_roots_SMF2_scalar_valued(K, ev, k, embedding):
     ''' computes the dirichlet series for a Lfunction_SMF2_scalar_valued
     '''
 
-    logger.debug("Start SMF2")
-    K = ev_data[0].parent().fraction_field()  # field of definition for the eigenvalues
-    ev = ev_data[1]  # dict of eigenvalues
     L = ev.keys()
     m = ZZ(max(L)).isqrt() + 1
     ev2 = {}

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1069,8 +1069,8 @@ def generateLfunctionFromUrl(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg
             return Lfunction_Maass(fromDB = True, group = arg2, level = arg5,
                 char = arg6, R = arg7, ap_id = arg8)
 
-    elif arg1 == 'ModularForm' and arg2 == 'GSp' and arg3 == 'Q' and arg4 == 'Sp4Z' and arg5 == 'specimen':  # this should be changed when we fix the SMF urls
-        return Lfunction_SMF2_scalar_valued(weight=arg6, orbit=arg7, number=arg8)
+    elif arg1 == 'ModularForm' and arg2 == 'GSp' and arg3 == 'Q' and arg4 == 'Sp4Z':
+        return Lfunction_SMF2_scalar_valued(weight=arg5, orbit=arg6, number=arg7)
 
     elif arg1 == 'NumberField':
         return DedekindZeta(label=str(arg2))

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -331,6 +331,10 @@ def l_function_maass_gln_page_noDb(group, dbid):
 
 # L-function of Siegel modular form    #########################################
 @l_function_page.route("/ModularForm/GSp/Q/Sp4Z/specimen/<weight>/<orbit>/<number>/")
+def l_function_siegel_specimen_page(weight, orbit, number):
+    return flask.redirect(url_for('.l_function_siegel_page', weight=weight, orbit=orbit, number=number),301)
+
+@l_function_page.route("/ModularForm/GSp/Q/Sp4Z/<weight>/<orbit>/<number>/")
 def l_function_siegel_page(weight, orbit, number):
     args = {'weight': weight, 'orbit': orbit, 'number': number}
     return render_single_Lfunction(Lfunction_SMF2_scalar_valued, args, request)
@@ -378,7 +382,8 @@ def l_function_lcalc_page():
 ################################################################################
 
 def render_lfunction_exception(err):
-    #if current_app.debug:
+    # from flask import current_app
+    # if current_app.debug:
     #    raise err
     if err.args:
         errmsg = "Unable to render L-function page due to the following problem(s):<br><ul>" + reduce(lambda x,y:x+y,["<li>"+msg+"</li>" for msg in err.args]) + "</ul>"
@@ -737,9 +742,9 @@ def initLfunction(L, args, request):
                 info['friends'].append(('Symmetric %s' % ordinal(j), friendlink3))
 
     elif L.Ltype() == 'siegelnonlift' or L.Ltype() == 'siegeleisenstein' or L.Ltype() == 'siegelklingeneisenstein' or L.Ltype() == 'siegelmaasslift':
-        friendlink = friendlink.rpartition('/')[0] #strip off embedding number for L-function
         weight = str(L.weight)
-        info['friends'] = [('Siegel Modular Form ' + weight + '_' + L.orbit, friendlink)]
+        friendlink = '/'.join(friendlink.split('/')[:-3]) + '.' + weight + '_' + L.orbit
+        info['friends'] = [('Siegel Modular Form Sp4Z.' + weight + '_' + L.orbit, friendlink)]
 
     elif L.Ltype() == "artin":
         info['friends'] = [('Artin representation', L.artin.url_for())]

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -102,6 +102,12 @@ def Sp4Z_j_space(k,j):
 def Sp4Z_space(k):
     return redirect(url_for(".Sp4Z_j_space", k=k, j=0), 301)
 
+# handle URLs in scalar valued SMF L-function format
+@smf_page.route('/Sp4Z/<int:k>/<orbit>')
+def Sp4Z_form(k,orbit):
+    label = 'Sp4Z.%d_%s' % (k,orbit)
+    return redirect(url_for('.by_label',label=label))
+
 @smf_page.route('/Sp4Z_2/<int:k>')
 @smf_page.route('/Sp4Z_2/<int:k>/')
 def Sp4Z_2_space(k):


### PR DESCRIPTION
We have been getting lots of 500 errors in the flasklog for URLs that refer to L-functions of scalar-valued Siegel modular forms such as:

http://www.lmfdb.org/L/ModularForm/GSp/Q/Sp4Z/specimen/14/E/0/
http://www.lmfdb.org/L/ModularForm/GSp/Q/Sp4Z/specimen/48/Klingen/0/
http://www.lmfdb.org/L/ModularForm/GSp/Q/Sp4Z/specimen/30/Maass/0/
http://www.lmfdb.org/L/ModularForm/GSp/Q/Sp4Z/specimen/36/Ups/4/
http://www.lmfdb.org/L/ModularForm/GSp/Q/Sp4Z/specimen/26/Ups_II/0/

and many others.  These were caused by errors in the attempt to load eigenvalues for these forms as Sage objects from an external site (which was failing inside Sage load).  But the eigenvalue data for all these forms is in the LMFDB and is displayed on the corresponding SMF pages, e.g.

http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z.14_E
http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z.48_Klingen
http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z.30_Maass
http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z.36_Ups
http://www.lmfdb.org/ModularForm/GSp/Q/Sp4Z.26_Ups_II

This PR modifies the L-function code to read the eigenvalue data from the siegel_modular_forms database.  The pages now display without errors.  I have no idea if the data being displayed is actually correct, and I suspect that in many cases we simply don't have enough eigenvalues (e.g. just 4) for it to be reasonable to display an L-function page.  I will raise a separate issue about verifying this.  Currently the L-functions are not linked to on the SMF pages so they are only accessible to someone typing in a URL (or a robot that learned them from some previous incarnation of the LMFDB, which I suspect is what is actually hitting these pages).

I also added URL entry points in Lfunctions/main that do not include the word "specimen" which does not occur in the corresponding SMF URL (but the "specimen" L-function pages still work).  Additionally, I added URL entry points in the Siegel modular forms pages that matches the L-function URL format (i.e. with slashes in place of dots and underlines).  To see the new pages/urls in action, click on

http://127.0.0.1:37777/L/ModularForm/GSp/Q/Sp4Z/14/E/0/
http://127.0.0.1:37777/L/ModularForm/GSp/Q/Sp4Z/48/Klingen/0/
http://127.0.0.1:37777/L/ModularForm/GSp/Q/Sp4Z/30/Maass/0/
http://127.0.0.1:37777/L/ModularForm/GSp/Q/Sp4Z/36/Ups/4/
http://127.0.0.1:37777/L/ModularForm/GSp/Q/Sp4Z/26/Ups_II/0/

http://127.0.0.1:37777/ModularForm/GSp/Q/Sp4Z/14/E
http://127.0.0.1:37777/ModularForm/GSp/Q/Sp4Z/48/Klingen
http://127.0.0.1:37777/ModularForm/GSp/Q/Sp4Z/30/Maass
http://127.0.0.1:37777/ModularForm/GSp/Q/Sp4Z/36/Ups
http://127.0.0.1:37777/ModularForm/GSp/Q/Sp4Z/26/Ups_II

The friend links in the L-function pages to the SMF pages should work.  If and when someone tells me the L-function pages are correct (and I note there are still several "FIXME" comments in the constructor for the Lfunction_SMF2_scalar_valued class in Lfunctions.py), I will add L-function links to the SMF pages.





