### PR TITLE
Redirect number-field page lookups to show "official" URL

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -416,6 +416,9 @@ def format_coeffs(coeffs):
 @nf_page.route("/<label>")
 def by_label(label):
     try:
+        nflabel = nf_string_to_label(label)
+        if label != nflabel:
+            return redirect(url_for(".by_label", label=nflabel), 301)
         return render_field_webpage({'label': nf_string_to_label(label)})
     except ValueError as err:
         flash(Markup("Error: <span style='color:black'>%s</span> is not a valid number field. %s" % (label,err)), "error")

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -6,7 +6,7 @@ class NumberFieldTest(LmfdbTest):
     # All tests should pass
     
     def test_Q(self):
-        L = self.tc.get('/NumberField/Q')
+        L = self.tc.get('/NumberField/Q', follow_redirects=True)
         assert '\chi_{1}' in L.data
         L = self.tc.get('/NumberField/1.1.1.1')
         assert '\chi_{1}' in L.data
@@ -45,7 +45,7 @@ class NumberFieldTest(LmfdbTest):
         L = self.tc.get('/NumberField/2.2.5.1')
         assert '0.481211825059603' in L.data # regulator
 
-    def test_url_naturallabel(self):
+    def test_url_naturallabel(self, follow_redirects=True):
         L = self.tc.get('/NumberField/Qsqrt5')
         assert '0.481211825059603' in L.data # regulator
 

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -45,8 +45,8 @@ class NumberFieldTest(LmfdbTest):
         L = self.tc.get('/NumberField/2.2.5.1')
         assert '0.481211825059603' in L.data # regulator
 
-    def test_url_naturallabel(self, follow_redirects=True):
-        L = self.tc.get('/NumberField/Qsqrt5')
+    def test_url_naturallabel(self):
+        L = self.tc.get('/NumberField/Qsqrt5', follow_redirects=True)
         assert '0.481211825059603' in L.data # regulator
 
     def test_url_bad(self):


### PR DESCRIPTION
This very small change adds a redirect so that if you reach a number field page by looking it up via its defining polynomial (or via a "natural" label) the URL will be set to the "official" URL for the number field, e.g. the pages

http://www.lmfdb.org/NumberField/x^2-45 and http://www.lmfdb.org/NumberField/Qsqrt45

both redirect to http://www.lmfdb.org/NumberField/2.0.5.1 as usual, but now the URL will also be updated as well (and the same is true for all of the infinitely many other ways you could get to the page http://www.lmfdb.org/NumberField/2.0.5.1).

This is useful for people who are bookmarking or linking to pages they found by typing in a (not necessarily canonical) defining polynomial for a field and is consistent with how things work elsewhere in the LMFDB (e.g. if you lookup an elliptic curve by typing in its coefficients, when you get to its webpage the URL has the curve label in it, not the coefficients you typed in).
