### PR TITLE
Fix #928

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -20,15 +20,6 @@ from sage.all import ZZ
 import re, random
 
 
-def initialize_indices():
-    try:
-#        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor_plus", ASC),("galorbit", ASC)])
-#        ArtinRepresentation.collection().ensure_index([("Dim", ASC), ("Conductor", ASC)])
-#        ArtinRepresentation.collection().ensure_index([("Conductor", ASC), ("Dim", ASC)])
-	pass
-    except pymongo.errors.OperationFailure:
-        pass
-
 def get_bread(breads=[]):
     bc = [("Artin Representations", url_for(".index"))]
     for b in breads:
@@ -72,7 +63,7 @@ def artin_representation_search(**args):
             flash(Markup("Error: %s" % (err)), "error")
             bread = get_bread([('Search results','')])
             return search_input_error({'err':''}, bread)
-        return render_artin_representation_webpage(label)
+        return redirect(url_for(".render_artin_representation_webpage", label=label), 301)
 
     title = 'Artin representation search results'
     bread = [('Artin representation', url_for(".index")), ('Search results', ' ')]
@@ -177,7 +168,7 @@ def render_artin_representation_webpage(label):
     friends = []
     nf_url = the_nf.url_for()
     if nf_url:
-    	friends.append(("Artin Field", nf_url))
+        friends.append(("Artin Field", nf_url))
     cc = the_rep.central_character()
     if cc is not None:
         if cc.modulus <= 100000: 

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -135,7 +135,9 @@ def render_artin_representation_webpage(label):
 
     # label=dim.cond.nTt.indexcj, c is literal, j is index in conj class
     # Should we have a big try around this to catch bad labels?
-    label = clean_input(label)
+    clean_label = clean_input(label)
+    if clean_label != label:
+        return redirect(url_for('.render_artin_representation_webpage', label=clean_label), 301)
     try:
         the_rep = ArtinRepresentation(label)
     except:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -384,7 +384,7 @@ def elliptic_curve_search(info):
             info['err'] = ''
             return search_input_error(info, bread)
 
-        return show_ecnf(nf, cond_label, iso_label, number)
+        return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
 
     query = {}
 

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -85,7 +85,7 @@ LIST_RE = re.compile(r'^(\d+|(\d+-\d+))(,(\d+|(\d+-\d+)))*$')
 
 @galois_groups_page.route("/<label>")
 def by_label(label):
-    clean_label = label.replace(' ','')
+    clean_label = clean_input(label)
     if clean_label != label:
         return redirect(url_for('.by_label', label=clean_label), 301)
     return render_group_webpage({'label': label})

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -85,6 +85,9 @@ LIST_RE = re.compile(r'^(\d+|(\d+-\d+))(,(\d+|(\d+-\d+)))*$')
 
 @galois_groups_page.route("/<label>")
 def by_label(label):
+    clean_label = label.replace(' ','')
+    if clean_label != label:
+        return redirect(url_for('.by_label', label=clean_label), 301)
     return render_group_webpage({'label': label})
 
 
@@ -116,11 +119,11 @@ def index():
 
 def galois_group_search(**args):
     info = to_dict(args)
+    if info.get('jump_to'):
+        return redirect(url_for('.by_label', label=info['jump_to']).strip(), 301)
     bread = get_bread([("Search results", ' ')])
     C = base.getDBConnection()
     query = {}
-    if 'jump_to' in info:
-        return render_group_webpage({'label': info['jump_to']})
 
     def includes_composite(s):
         s = s.replace(' ','').replace('..','-')

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -14,7 +14,7 @@ from sage.all import ZZ, QQ, PolynomialRing, latex, matrix, PowerSeriesRing, sqr
 
 from lmfdb.lattice import lattice_page
 from lmfdb.lattice.lattice_stats import get_stats
-from lmfdb.search_parsing import parse_ints, parse_list, parse_count, parse_start
+from lmfdb.search_parsing import parse_ints, parse_list, parse_count, parse_start, clean_input
 from lmfdb.lattice.isom import isom
 
 from markupsafe import Markup
@@ -234,7 +234,9 @@ def render_lattice_webpage(**args):
     C = getDBConnection()
     data = None
     if 'label' in args:
-        lab = args.get('label')
+        lab = clean_input(args.get('label'))
+        if lab != args.get('label'):
+            return redirect(url_for('.render_lattice_webpage', label=lab), 301)
         data = C.Lattices.lat.find_one({'$or':[{'label': lab }, {'name': lab }]})
     if data is None:
         t = "Integral Lattices Search Error"

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -79,28 +79,18 @@ def index():
 
 @local_fields_page.route("/<label>")
 def by_label(label):
-    return render_field_webpage({'label': label})
-
-# FIXME: delete or fix this code
-# Apparently obsolete code that causes a server error if executed
-#@local_fields_page.route("/search", methods=["GET", "POST"])
-#def search():
-#    if request.method == "GET":
-#        val = request.args.get("val", "no value")
-#        bread = get_bread([("Search for '%s'" % val, url_for('.search'))])
-#        return render_template("lf-search.html", title="Local Number Field Search", bread=bread, val=val)
-#    elif request.method == "POST":
-#        return "ERROR: we always do http get to explicitly display the search parameters"
-#    else:
-#        return flask.abort(404)
+    clean_label = label.replace(' ','')
+    if label != clean_label:
+        return redirect(url_for('.by_label',label=clean_label), 301)
+    return render_field_webpage({'label': clean_label})
 
 def local_field_search(**args):
     info = to_dict(args)
     bread = get_bread([("Search results", ' ')])
     C = base.getDBConnection()
     query = {}
-    if 'jump_to' in info:
-        return render_field_webpage({'label': info['jump_to']})
+    if info.get('jump_to'):
+        return redirect(url_for(".by_label",label=info['jump_to']), 301)
 
     try:
         parse_galgrp(info,query,'gal', use_bson=False)

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -143,7 +143,7 @@ def render_field_webpage(args):
             info['err'] = "Field " + label + " was not found in the database."
             info['label'] = label
             return search_input_error(info, bread)
-        title = 'Local Number Field:' + label
+        title = 'Local Number Field ' + label
         polynomial = coeff_to_poly(data['coeffs'])
         p = data['p']
         e = data['e']

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -79,10 +79,10 @@ def index():
 
 @local_fields_page.route("/<label>")
 def by_label(label):
-    clean_label = label.replace(' ','')
+    clean_label = clean_input(label)
     if label != clean_label:
         return redirect(url_for('.by_label',label=clean_label), 301)
-    return render_field_webpage({'label': clean_label})
+    return render_field_webpage({'label': label})
 
 def local_field_search(**args):
     info = to_dict(args)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -416,7 +416,7 @@ def format_coeffs(coeffs):
 @nf_page.route("/<label>")
 def by_label(label):
     try:
-        nflabel = nf_string_to_label(label.replace(' ',''))
+        nflabel = nf_string_to_label(clean_input(label))
         if label != nflabel:
             return redirect(url_for(".by_label", label=nflabel), 301)
         return render_field_webpage({'label': nf_string_to_label(label)})

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -416,7 +416,7 @@ def format_coeffs(coeffs):
 @nf_page.route("/<label>")
 def by_label(label):
     try:
-        nflabel = nf_string_to_label(label)
+        nflabel = nf_string_to_label(label.replace(' ',''))
         if label != nflabel:
             return redirect(url_for(".by_label", label=nflabel), 301)
         return render_field_webpage({'label': nf_string_to_label(label)})

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -156,7 +156,10 @@ def random():
 
 @st_page.route('/<label>')
 def by_label(label):
-    return search_by_label(label)
+    clean_label = label.replace(' ','')
+    if clean_label != label:
+        return redirect(url_for('.by_label', label=clean_label), 301)
+    return search_by_label(clean_label)
 
 ###############################################################################
 # Searching
@@ -164,7 +167,7 @@ def by_label(label):
 
 def search_by_label(label):
     """ search for Sato-Tate group by label and render if found """
-    label = label.strip()
+
     if re.match(ST_LABEL_RE, label):
         return render_by_label(label)
     if re.match(ST_LABEL_SHORT_RE, label):

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -6,7 +6,7 @@ from flask import render_template, url_for, redirect, request
 from lmfdb.sato_tate_groups import st_page
 from lmfdb.utils import to_dict, random_object_from_collection, encode_plot, flash_error
 from lmfdb.base import getDBConnection
-from lmfdb.search_parsing import parse_ints, parse_rational, parse_count, parse_start, parse_ints_to_list_flash
+from lmfdb.search_parsing import parse_ints, parse_rational, parse_count, parse_start, parse_ints_to_list_flash, clean_input
 
 from sage.all import ZZ, cos, sin, pi, list_plot, circle
 
@@ -156,10 +156,10 @@ def random():
 
 @st_page.route('/<label>')
 def by_label(label):
-    clean_label = label.replace(' ','')
+    clean_label = clean_input(label)
     if clean_label != label:
         return redirect(url_for('.by_label', label=clean_label), 301)
-    return search_by_label(clean_label)
+    return search_by_label(label)
 
 ###############################################################################
 # Searching


### PR DESCRIPTION
This PR addresses issue #928, which is concerned with cleaning up URLs that contain labels with spaces in them; in short, whether you type a label into a form or include it in a URL, and spaces it contains should be removed and when you land on the specified page the spaces should not be in the URL.  The issue specifically mentioned ecnf, number fields, local fields, galois groups and lattices, but the same problem also affects artin representations and Sato-Tate groups.  This PR addresses all of these (I also check elliptic curves over Q, genus 2 curves over Q, and Dirichlet characters; the problem does not occur for these pages).

To see the changes, click on the following URLs:

Before:

http://www.lmfdb.org/EllipticCurve/?label=%20%202.2.5.1-31.1-a1%20%20&jump=label
http://www.lmfdb.org/NumberField/?natural=%20%20X%5E2%2B4%20&search=Go
http://www.lmfdb.org/NumberField/%202.0.4.1%20
http://www.lmfdb.org/LocalNumberField/?jump_to=%20%202.4.6.7%20%20
http://www.lmfdb.org/LocalNumberField/%20%202.4.6.7%20%20
http://www.lmfdb.org/GaloisGroup/?jump_to=%20%208T14%20%20
http://www.lmfdb.org/GaloisGroup/%20%208T14%20%20
http://www.lmfdb.org/Lattice/%20%203.4.8.1.2%20%20
http://www.lmfdb.org/ArtinRepresentation/?natural=%205.29077e4.12t183.1c1%20&search=Go
http://www.lmfdb.org/ArtinRepresentation/%20%205.29077e4.12t183.1c1%20
http://www.lmfdb.org/SatoTateGroup/%20%201.4.10.1.1a%20%20

After:

http://127.0.0.1:37777/EllipticCurve/?label=%20%202.2.5.1-31.1-a1%20%20&jump=label
http://127.0.0.1:37777/NumberField/?natural=%20%20X%5E2%2B4%20&search=Go
http://127.0.0.1:37777/NumberField/%202.0.4.1%20
http://127.0.0.1:37777/LocalNumberField/?jump_to=%20%202.4.6.7%20%20
http://127.0.0.1:37777/LocalNumberField/%20%202.4.6.7%20%20
http://127.0.0.1:37777/GaloisGroup/?jump_to=%20%208T14%20%20
http://127.0.0.1:37777/GaloisGroup/%20%208T14%20%20
http://127.0.0.1:37777/Lattice/%20%203.4.8.1.2%20%20
http://127.0.0.1:37777/ArtinRepresentation/?natural=%205.29077e4.12t183.1c1%20&search=Go
http://127.0.0.1:37777/ArtinRepresentation/%20%205.29077e4.12t183.1c1%20
http://127.0.0.1:37777/SatoTateGroup/%20%201.4.10.1.1a%20%20

All tests pass (except for the usual errors in classical modular forms).






