### PR TITLE
Higher Genus added some equations and cyclic trigonal

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/code.yaml
+++ b/lmfdb/higher_genus_w_automorphisms/code.yaml
@@ -15,7 +15,7 @@ not-implemented:
 
 top_matter:
   gap:  "# WARNING: The conjugacy class numbers may not be the same as those listed in lmfdb.org, as numberings in Magma and GAP may differ. If you need to connect this data to that posted on lmfdb.org, compare the variables 'passport_label' and 'gen_vector_labels'."
-  magma:  RecFormat:=recformat<group,gp_id, signature,gen_vectors,conj_classes,genus,dimension,r,g0, passport_label,gen_vect_label, is_hyperelliptic, hyp_involution, full_auto, full_sign>;
+  magma:  RecFormat:=recformat<group,gp_id, signature,gen_vectors,conj_classes,genus,dimension,r,g0, passport_label,gen_vect_label, is_hyperelliptic, hyp_involution, is_cyclic_trigonal,cyc_auto,full_auto, full_sign>;
 
 
 
@@ -96,6 +96,17 @@ hyp_inv_last:
    gap: ");\n"
    magma: ";\n"
 
+
+cyc:
+  gap: is_cyclic_trigonal:=
+  magma: is_cyclic_trigonal:=
+
+cyc_auto:
+   gap:  cyc_auto:=PermList(
+   magma: cyc_auto:=S!
+
+
+
 full_auto:
    gap:  full_auto:=
    magma: full_auto:=
@@ -123,12 +134,19 @@ gen_vect_label:
 
 add_to_total_basic:
    gap:  "Add( result_record, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list, genus:=genus, dimension:=dim, r:=r, g0:=g0,  passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic) ); "
-   magma: "Append(~result_record, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic >);"
+   magma: "Append(~result_record, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic,is_cyclic_trigonal:=is_cyclic_trigonal >);"
 
 
 add_to_total_hyp:
-   gap:  "Add( result_record, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list,genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, hyp_involution:=hyp_involution) ); "
-   magma: "Append(~result_record, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, hyp_involution:=hyp_involution >);"
+   gap:  "Add( result_record, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list,genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, hyp_involution:=hyp_involution,is_cyclic_trigonal:=is_cyclic_trigonal) ); "
+   magma: "Append(~result_record, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, hyp_involution:=hyp_involution,is_cyclic_trigonal:=is_cyclic_trigonal >);"
+
+
+add_to_total_cyc_trig:
+   gap:  "Add( result_record, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list,genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label,is_hyperelliptic:=is_hyperelliptic, is_cyclic_trigonal:=is_cyclic_trigonal, cyc_auto:=cyc_auto) ); "
+   magma: "Append(~result_record, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, is_cyclic_trigonal:=is_cyclic_trigonal, cyc_auto:=cyc_auto >);"
+
+
 
 
 add_to_total_full:

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -177,6 +177,11 @@ def higher_genus_w_automorphisms_search(**args):
                 query['cyclic_trigonal'] = False
             elif info['inc_cyc_trig'] == 'only':
                 query['cyclic_trigonal'] = True
+        if 'inc_full' in info:
+            if info['inc_full'] == 'exclude':
+                query['full_auto'] = {'$exists': True} 
+            elif info['inc_full'] == 'only':
+                query['full_auto'] = {'$exists': False}
                                 
         query['cc.1'] = 1
 

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -321,7 +321,7 @@ def render_passport(args):
         GG = ast.literal_eval(data['group'])
         gn = GG[0]
         gt = GG[1]
-
+        
         gp_string=str(gn) + '.' + str(gt)
         pretty_group=sg_pretty(gp_string)
 
@@ -381,9 +381,11 @@ def render_passport(args):
                 
         info.update({'genvects': Ldata, 'HypColumn' : HypColumn})
 
-        info.update({'passport_cc': cc_display(ast.literal_eval(dat['con']))})
+        info.update({'passport_cc': cc_display(ast.literal_eval(data['con']))})
 
-
+        if 'eqn' in data:
+           info.update({'eqns': data['eqn']})
+        
         other_data = False
 
         if 'hyperelliptic' in data:

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -529,7 +529,7 @@ def hgcwa_code(**args):
     
     # extended formatting template for when signH is present
     signHfmt = stdfmt
-    signHfmt = code_list['full_auto'][lang] + '{full_auto}' + ';\n'
+    signHfmt += code_list['full_auto'][lang] + '{full_auto}' + ';\n'
     signHfmt += code_list['full_sign'][lang] + '{signH}' + ';\n'        
     signHfmt += code_list['add_to_total_full'][lang] + '\n'
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -91,7 +91,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	<span class="formexample">e.g. 1, or a range like 0..2</span>
 	 </td> </tr>
               <tr>  <td align=right>
-	       Hyperelliptic Curve(s):
+	       Hyperelliptic curve(s):
             </td>  <td> <select name='inc_hyper'>
                     <option value='include'>include </option>
 		    <option value='exclude'>exclude</option>
@@ -103,7 +103,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	 </td></tr>
 
 	  <tr>  <td align=right>
-	       Cyclic Trigonal Curve(s):
+	       Cyclic trigonal curve(s):
             </td>  <td> <select name='inc_cyc_trig'>
                     <option value='include'>include </option>
 		    <option value='exclude'>exclude</option>
@@ -113,7 +113,19 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
                 </td>  <td>
 	<span class="formexample"></span>
 	 </td></tr>
-	      
+
+ <tr>  <td align=right>
+      Full automorphism group:
+            </td>  <td> <select name='inc_full'>
+                    <option value='include'>include </option>
+		    <option value='exclude'>exclude</option>
+                    <option value='only'>only</option>
+                 
+                  </select>
+                </td>  <td>
+	<span class="formexample"></span>
+	 </td></tr>
+	  
           <tr>
           <td align=right>
               Maximum number of families to display:

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -101,7 +101,19 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
                 </td>  <td>
 	<span class="formexample"></span>
 	 </td></tr>
-	 
+
+	  <tr>  <td align=right>
+	       Cyclic Trigonal Curve(s):
+            </td>  <td> <select name='inc_cyc_trig'>
+                    <option value='include'>include </option>
+		    <option value='exclude'>exclude</option>
+                    <option value='only'>only</option>
+                 
+                  </select>
+                </td>  <td>
+	<span class="formexample"></span>
+	 </td></tr>
+	      
           <tr>
           <td align=right>
               Maximum number of families to display:

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -20,15 +20,8 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 
 </tr>
 
-<tr>
-  
-  <td align=left> 
-{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
-<td align=left> <input type="text" name="dim" size="5" value="{{info.dim}}" > 
-
-
-<td align=right>
-	       Hyperelliptic Curve(s):
+<tr><td>
+	       Hyperelliptic curve(s):
 </td>
 
   <td> <select name='inc_hyper'>
@@ -49,8 +42,8 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 {% endif %}
 </td> 
 
-<td align=right>
-	      Cyclic Trigonal Curve(s):
+<td >
+	      Cyclic trigonal curve(s):
 </td>
 
   <td> <select name='inc_cyc_trig'>
@@ -71,10 +64,39 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 {% endif %}
 </td> 
 
+
+<td>
+	      Full automorphism group:
+</td>
+
+  <td> <select name='inc_full'>
+{% if info.inc_full == "only" %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% else %}
+{% if info.inc_full == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% endif %}
+{% endif %}
+</td> 
+  
   
 </tr>
 
 <tr>
+
+ <td align=left> 
+{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
+<td align=left> <input type="text" name="dim" size="5" value="{{info.dim}}" > </td>
+
+  
 <td align='left' colspan='4'>Maximum number of families to display: <input type='text' name='count' value="{{info.count}}" size='10'>
 </td>
 </tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -49,7 +49,29 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 {% endif %}
 </td> 
 
+<td align=right>
+	      Cyclic Trigonal Curve(s):
+</td>
 
+  <td> <select name='inc_cyc_trig'>
+{% if info.inc_cyc_trig == "only" %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% else %}
+{% if info.inc_cyc_trig == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% endif %}
+{% endif %}
+</td> 
+
+  
 </tr>
 
 <tr>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -33,15 +33,21 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     {% endif %} 
 </p>
 
-{% if info.ishyp %}     
+{% if info.other_data %}     
 
   <p><h2>Other Data</h2>
     <table>
-     <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
-   {% if info.hypinv  %}
+      {% if info.ishyp %}     
+      <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
+      {% if info.hypinv  %}
        <tr><td>Hyperelliptic involution:</td> <td>{{info.hypinv}}</td></tr>
-   {% endif %}  
-    </table>
+       {% endif %}  {% endif %}
+      {% if info.iscyctrig %}     
+      <tr><td>Cyclic trigonal curve(s):</td><td>{{info.iscyctrig}}</td></tr>
+      {% if info.cinv  %}
+       <tr><td>Trigonal automorphism:</td> <td>{{info.cinv}}</td></tr>
+       {% endif %}  {% endif %}
+     </table>
   </p>
   
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -47,7 +47,15 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
       {% if info.cinv  %}
        <tr><td>Trigonal automorphism:</td> <td>{{info.cinv}}</td></tr>
        {% endif %}  {% endif %}
-     </table>
+    </table>
+
+    {% if info.eqns %}
+    <br>
+    Equations(s) of curve(s) in this refined passport:
+       <table>{% for eqn in info.eqns %}
+	  <tr><td> &nbsp; </td><td>${{eqn}}$</td></tr>
+	  {% endfor %} </table> <br>
+     {% endif %}
   </p>
   
 


### PR DESCRIPTION
Commits:

(1) I missed one case when I tested #1867 for the Magma downloads.  A tiny error with a missing '+'

(2) The data now includes a test of whether the curve(s) are cyclic trigonal.  This now shows up on refined passport pages of full automorphism like:
http://127.0.0.1:37777/HigherGenus/C/Aut/3.9-1.0.3-9-9.1
Also added a search Inc/Exc/Only for cyclic trigonal:
http://127.0.0.1:37777/HigherGenus/C/Aut/
Also changed the download files to include this information.

(3) I am updating the data with known equations (particularly hyperelliptic curves) so I have added a spot for this on the refined passport pages under "Other Data", if the data includes it.  See for example:
http://127.0.0.1:37777/HigherGenus/C/Aut/5.48-30.0.3-4-4.1

(4) Added a search Inc/Exc/Only for whether the automorphism group is the full automorphism for that family. Again see:
http://127.0.0.1:37777/HigherGenus/C/Aut/