### PR TITLE
gp code fix for ecnf (#1895)

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -505,10 +505,10 @@ class ECNF(object):
 
         gen = self.field.generator_name().replace("\\","") # phi not \phi
         for lang in ['sage', 'magma', 'pari']:
-            self._code['field'][lang] = self._code['field'][lang] % self.field.poly()
-            if gen != 'a':
-                self._code['field'][lang] = self._code['field'][lang].replace("<a>","<%s>" % gen)
-                self._code['field'][lang] = self._code['field'][lang].replace("a=","%s=" % gen)
+            pol = str(self.field.poly())
+            if lang=='pari':
+                pol = pol.replace('x',gen)
+            self._code['field'][lang] = (self._code['field'][lang] % pol).replace("<a>", "<%s>" % gen)
 
         for lang in ['sage', 'magma', 'pari']:
             self._code['curve'][lang] = self._code['curve'][lang] % self.ainvs

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -18,7 +18,7 @@ not-implemented:
 
 field:
   sage:  K.<a> = NumberField(%s)
-  pari: K = nfinit(%s); a=x
+  pari: K = nfinit(%s);
   magma: K<a> := NumberField(%s);
 
 curve:


### PR DESCRIPTION
Fixes #1895.  Test with curves over Q(i) and Q(sqrt(5)) and  a generic field to see all possibilities for teh generator name, e.g.
/EllipticCurve/2.0.4.1/65.18.1/a/6
/EllipticCurve/2.2.5.1/45.1/a/1
/EllipticCurve/3.3.148.1/356.1/a/1
and also test with all three language options to be sure that Magma and Sage are unchanged.