### PR TITLE
make Higher Genus w/autos data available on beta sidebar

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/__init__.py
+++ b/lmfdb/higher_genus_w_automorphisms/__init__.py
@@ -17,5 +17,5 @@ import main
 assert main # silence pyflakes
 
 app.register_blueprint(higher_genus_w_automorphisms_page, url_prefix="/HigherGenus/C/Aut")
-app.register_blueprint(higher_genus_w_automorphisms_page, url_prefix="/HigherGenus/C/aut")
+
 

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -144,9 +144,10 @@
            status: future
          - title: "Higher genus:"
            part3:
-             - title: w/ automorphisms
+             - title: Families
                url_for:  "higher_genus_w_automorphisms.index"
-           colspan: onecolumn
+               status: beta
+               colspan: onecolumn
      - title: 2-d
        style: rotate
        status: future_rotated

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -144,7 +144,7 @@
            status: future
          - title: "Higher genus:"
            part3:
-             - title: Group Actions
+             - title: Families
                url_for:  "higher_genus_w_automorphisms.index"
                status: beta
                colspan: onecolumn

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -144,7 +144,7 @@
            status: future
          - title: "Higher genus:"
            part3:
-             - title: Families
+             - title: Group Actions
                url_for:  "higher_genus_w_automorphisms.index"
                status: beta
                colspan: onecolumn

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -1,4 +1,3 @@
----
 1intro:
    type: simple
    heading:
@@ -143,8 +142,10 @@
            status: future
          - title: Belyi
            status: future
-         - title: Higher genus
-           status: future
+         - title: "Higher genus:"
+           part3:
+             - title: w/ automorphisms
+               url_for:  "higher_genus_w_automorphisms.index"
            colspan: onecolumn
      - title: 2-d
        style: rotate


### PR DESCRIPTION
This pull is to request that the Higher Genus data go from alpha to beta testing.  It adds a link on the sidebar under "Higher Genus" 
http://127.0.0.1:37777/HigherGenus/C/Aut

Also, in higher_genus_w_automorphisms/_init_.py  I removed the second link to the old URL for this page (lower case "a" in Aut).

Most of my code is here: https://github.com/jenpaulhus/group-actions-RS
A preprint of what I've done so far is here: http://www.math.grinnell.edu/~paulhusj/Paulhus-lmfdb.pdf

