### PR TITLE
Show arithmetically equivalent field data in Galois group pages

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -235,11 +235,11 @@ def render_group_webpage(args):
         ae = wgg.arith_equivalent()
         if ae>0:
             if ae>1:
-                data['arith_equiv'] = r'A number field with this Galois group has %d arithmetically equivalent fields'% ae
+                data['arith_equiv'] = r'A number field with this Galois group has %d arithmetically equivalent fields.'% ae
             else:
-                data['arith_equiv'] = r'A number field with this Galois group has exactly one arithmetically equivalent field'
+                data['arith_equiv'] = r'A number field with this Galois group has exactly one arithmetically equivalent field.'
         else:
-            data['arith_equiv'] = r'A number field with this Galois group has no arithmetically equivalent fields'
+            data['arith_equiv'] = r'A number field with this Galois group has no arithmetically equivalent fields.'
         if len(data['otherreps']) == 0:
             data['otherreps']="There is no other low degree representation."
         query={'galois': bson.SON([('n', n), ('t', t)])}

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -235,11 +235,11 @@ def render_group_webpage(args):
         ae = wgg.arith_equivalent()
         if ae>0:
             if ae>1:
-                data['arith_equiv'] = r'A number field with this Galois group has %d arithmetically equivalent fields.'% ae
+                data['arith_equiv'] = r'A number field with this Galois group has %d <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'% ae
             else:
-                data['arith_equiv'] = r'A number field with this Galois group has exactly one arithmetically equivalent field.'
+                data['arith_equiv'] = r'A number field with this Galois group has exactly one <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> field.'
         else:
-            data['arith_equiv'] = r'A number field with this Galois group has no arithmetically equivalent fields.'
+            data['arith_equiv'] = r'A number field with this Galois group has no <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'
         if len(data['otherreps']) == 0:
             data['otherreps']="There is no other low degree representation."
         query={'galois': bson.SON([('n', n), ('t', t)])}

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -232,6 +232,14 @@ def render_group_webpage(args):
         data['subinfo'] = subfield_display(C, n, data['subs'])
         data['resolve'] = resolve_display(C, data['resolve'])
         data['otherreps'] = wgg.otherrep_list()
+        ae = wgg.arith_equivalent()
+        if ae>0:
+            if ae>1:
+                data['arith_equiv'] = r'A number field with this Galois group has %d arithmetically equivalent fields'% ae
+            else:
+                data['arith_equiv'] = r'A number field with this Galois group has exactly one arithmetically equivalent field'
+        else:
+            data['arith_equiv'] = r'A number field with this Galois group has no arithmetically equivalent fields'
         if len(data['otherreps']) == 0:
             data['otherreps']="There is no other low degree representation."
         query={'galois': bson.SON([('n', n), ('t', t)])}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -41,6 +41,11 @@ table.reptable td, table.reptable th {
    <blockquote>
     {{info.otherreps|safe}}
    </blockquote>
+   {% if info.arith_equiv %}
+     <blockquote>
+        {{info.arith_equiv|safe}}
+     </blockquote>
+   {% endif %}
    </p>
 
   <p><h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy Classes') }}</h2>

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -47,6 +47,11 @@ class WebGaloisGroup:
             return True
         return False
 
+    def arith_equivalent(self):
+        if 'arith_equiv' in self._data:
+          return self._data['arith_equiv']
+        return 0
+
     def order(self):
         return int(self._data['order'])
 


### PR DESCRIPTION
This is a small feature addition, which is the first step towards showing arithmetically equivalent fields and other siblings on number field pages (which was demo-ed at AIM in May).  For that, we want to know when the siblings exist even where we haven't computed them (yet) so we can display a "data not computed message" in those cases.  Most of the information was there already in the transitive groups database.

This goes with new data in the transitivegroups.groups database to say how many arithmetically equivalent fields a number field will have for each Galois group.  (Note for degrees above 15, this does not seem to be easily available on the web, but was easy to compute with magma).

The only thing visible to the user now is on individual Galois group pages, depending on whether there would be 0, 1, or more arithmetically equivalent fields:

http://127.0.0.1:37777/GaloisGroup/16t98
http://127.0.0.1:37777/GaloisGroup/4t5
http://127.0.0.1:37777/GaloisGroup/7t5

The message is in the "Other representations" section since this is a special type of other representation.
