### PR TITLE
Display sibling data on number field pages

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -311,6 +311,20 @@ class WebNumberField:
             self._data['res'] = {}
         return self._data['res']
 
+    def galois_closure_labels(self):
+        resall = self.resolvents()
+        if 'gal' in resall:
+            gal = [self.from_coeffs(str(a)) for a in resall['gal']]
+            return ['' if a._data is None else a.label for a in gal]
+        return []
+
+    def galois_closure_knowls(self):
+        resall = self.resolvents()
+        if 'gal' in resall:
+            helpout = [self.myhelper([a,1]) for a in resall['gal']]
+            return [a[0] for a in helpout]
+        return []
+
     def arith_equiv_labels(self):
         resall = self.resolvents()
         if 'ae' in resall:

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -311,6 +311,24 @@ class WebNumberField:
             self._data['res'] = {}
         return self._data['res']
 
+    def sibling_labels(self):
+        resall = self.resolvents()
+        if 'sib' in resall:
+            sibs = [self.from_coeffs(str(a)) for a in resall['sib']]
+            return ['' if a._data is None else a.label for a in sibs]
+        return []
+
+    def sibling_knowls(self):
+        resall = self.resolvents()
+        if 'sib' in resall:
+            helpout = [self.myhelper([a,1]) for a in resall['sib']]
+            helpout2 = [a[0] for a in helpout]
+            degs = [len(string2list(a))-1 for a in resall['sib']]
+            for j in range(len(helpout2)):
+                helpout2[j] = ['Degree %d'%degs[j], helpout2[j]]
+            return helpout2
+        return []
+
     def galois_closure_labels(self):
         resall = self.resolvents()
         if 'gal' in resall:

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -151,14 +151,14 @@ table.ntdata a {
 <thead>
 <tr>
 <th>Label</th>
-<th>Name</th>
+<th>{{KNOWL('gg.simple_name', title='Name')}}</th>
 <th>Order</th>
-<th>Parity</th>
-<th>Solvable</th>
+<th>{{ KNOWL('gg.parity', 'Parity') }} </th>
+<th>{{ KNOWL('gg.solvable', 'Solvable') }}</th>
 {% if info.show_subs %}
-<th>Subfields</th>
+<th>{{ KNOWL('gg.subfields', title='Subfields') }}</th>
 {% endif %}
-<th>Other Low Degree Representations</th>
+<th>{{ KNOWL('gg.other_representations', 'Low Degree Siblings') }} </th>
 </tr>
 </thead>
 <tbody>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -36,7 +36,7 @@ table.reptable td, table.reptable th {
    </blockquote>
    </p>
 
-  <p><h2>{{ KNOWL('gg.other_representations', title='Other low-degree representations') }}</h2>
+  <p><h2>{{ KNOWL('gg.other_representations', title='Low degree siblings') }}</h2>
    <p>
    <blockquote>
     {{info.otherreps|safe}}

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -362,6 +362,15 @@ def render_field_webpage(args):
         if gc != '':
             info['friends'].append(('Galois closure',url_for(".by_label", label=gc)))
 
+    if len(nf.sextic_twin_knowls())>0:
+        alg = nf.sextic_twin_knowls()
+        resinfo.append(('sex', r' $\times$ '.join(alg)))
+        #siblabels = nf.sibling_labels()
+        #for jj in range(len(siblabels)):
+        #    mysib = siblabels[jj]
+        #    if mysib != '':
+        #        info['friends'].append(("Degree %s sibling"%siblabels[jj][0] ,url_for(".by_label", label=mysib)))
+
     if len(nf.sibling_knowls())>0:
         sibs = nf.sibling_knowls()
         resinfo.append(('sib', sibs))
@@ -483,6 +492,19 @@ def number_field_search(**args):
         except ValueError:
             query['err'] = info['err']
             return search_input_error(query, bread)
+
+    if 'algebra' in info:
+        fields=info['algebra'].split('_')
+        fields2=[WebNumberField.from_coeffs(a) for a in fields]
+        for j in range(len(fields)):
+            if fields2[j] is None:
+                fields2[j] = WebNumberField.fakenf(fields[j])
+        t = 'Number field algebra'
+        info = {}
+        info = {'fields': fields2}
+        return render_template("number_field_algebra.html", info=info, title=t, bread=bread)
+
+
 
     query = {}
     try:

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -362,6 +362,15 @@ def render_field_webpage(args):
         if gc != '':
             info['friends'].append(('Galois closure',url_for(".by_label", label=gc)))
 
+    if len(nf.sibling_knowls())>0:
+        sibs = nf.sibling_knowls()
+        resinfo.append(('sib', sibs))
+        siblabels = nf.sibling_labels()
+        for jj in range(len(siblabels)):
+            mysib = siblabels[jj]
+            if mysib != '':
+                info['friends'].append(("Degree %s sibling"%siblabels[jj][0] ,url_for(".by_label", label=mysib)))
+
     if len(nf.arith_equiv_knowls())>0:
         ae = nf.arith_equiv_knowls()
         resinfo.append(('ae', ae))

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -354,6 +354,15 @@ def render_field_webpage(args):
                                                            char_number_list=','.join(
                                                                [str(a) for a in dirichlet_chars]),
                                                            poly=info['polynomial'])))
+    resinfo=[]
+    if len(nf.arith_equiv_knowls())>0:
+        ae = nf.arith_equiv_knowls()
+        resinfo.append(('ae', ae))
+        ae = nf.arith_equiv_labels()[0] # Maybe change latter if there is >1
+        if ae != '':
+            info['friends'].append(('Arithmetically equivalent sibling',url_for(".by_label", label=ae)))
+
+    info['resinfo'] = resinfo
     info['learnmore'] = [('Global number field labels', url_for(
         ".render_labels_page")), 
         (Completename, url_for(".render_discriminants_page")),

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -355,6 +355,13 @@ def render_field_webpage(args):
                                                                [str(a) for a in dirichlet_chars]),
                                                            poly=info['polynomial'])))
     resinfo=[]
+    if len(nf.galois_closure_knowls())>0:
+        gc = nf.galois_closure_knowls()
+        resinfo.append(('gc', gc))
+        gc = nf.galois_closure_labels()[0] # Maybe change latter if there is >1
+        if gc != '':
+            info['friends'].append(('Galois closure',url_for(".by_label", label=gc)))
+
     if len(nf.arith_equiv_knowls())>0:
         ae = nf.arith_equiv_knowls()
         resinfo.append(('ae', ae))

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -127,6 +127,21 @@
         intermediate fields are shown with their multiplicities.
         {% endif %}
 
+        {% if info.resinfo !=[] %}
+        <h2>{{ KNOWL('nf.sibling', title='Sibling fields') }}</h2>
+        {% for r in info.resinfo %}
+            <div>
+            <table>
+            <tr><td>
+            {% if r[0] == 'ae' %}
+                {{ KNOWL('nf.arithmetically_equivalent', title='Arithmetically equvalently siblings') }}:
+                <td> {{ r[1][0] |safe }}
+            {% endif %}
+            </table>
+            </div>
+        {% endfor %}
+        {% endif %}
+
 {% if nf.unit_galois_action() %}
         <p><h2> {{ KNOWL('nf.multiplicative_gal_module', title='Multiplicative Galois module structure') }}</h2>
             <table>

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -30,8 +30,7 @@
              <tr><td>{{ KNOWL('nf.discriminant', title="Discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.discriminant}}<td>{{ place_code('discriminant') }}
             <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
   {% if info.is_abelian %}
-            <tr><td colspan="3">&nbsp;</tr>
-            <tr><td colspan="3">Extension is Galois and abelian</tr>
+            <tr><td colspan="3">This field is Galois and abelian over $\Q$</tr>
                 <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>
             <tr><td>{{ KNOWL('nf.dirichlet_group', title="Dirichlet group") }}:
                 <td>&nbsp;&nbsp;<td>
@@ -42,9 +41,9 @@
                 {% endif %}
                 </tr> 
   {% elif info.is_galois %}
-            <tr><td colspan="3">Extension is Galois</tr>
+            <tr><td colspan="3">This field is Galois over $\Q$</tr>
   {% else %}
-            <tr><td colspan="3">Extension is not Galois</tr>
+            <tr><td colspan="3">Tihs field is not Galois over $\Q$</tr>
   {% endif %}
 
           </table>

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -139,8 +139,12 @@
         {% for r in info.resinfo %}
             {% if r[0] == 'ae' %}
               <tr><td>
-                {{ KNOWL('nf.arithmetically_equivalent', title='Arithmetically equvalently siblings') }}:
-                <td> {{ r[1][0] |safe }}
+                {% if r[2]==1 %}
+                  {{ KNOWL('nf.arithmetically_equivalent', title='Arithmetically equvalently sibling') }}:
+                {% else %}
+                  {{ KNOWL('nf.arithmetically_equivalent', title='Arithmetically equvalently siblings') }}:
+                {% endif %}
+                <td> {{ r[1] |safe }}
             {% endif %}
             {% if r[0] == 'gc' %}
               <tr><td>
@@ -154,9 +158,13 @@
             {% endif %}
             {% if r[0] == 'sib' %}
                 {% for sib in r[1] %}
-                  <tr><td> {{sib[0]|safe}} 
+                  <tr><td> Degree {{sib[0]}} 
+                  {% if sib[1] == 1 %}
                      {{ KNOWL('nf.sibling', title='sibling') }}:
-                  <td> {{ sib[1] |safe }}
+                  {% else %}
+                     {{ KNOWL('nf.sibling', title='siblings') }}:
+                  {% endif %}
+                  <td> {{ sib[2] |safe }}
                 {% endfor %}
             {% endif %}
         {% endfor %}

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -144,6 +144,13 @@
                 {{ KNOWL('nf.galois_closure', title='Galois closure') }}:
                 <td> {{ r[1][0] |safe }}
             {% endif %}
+            {% if r[0] == 'sib' %}
+                {% for sib in r[1] %}
+                  <tr><td> {{sib[0]|safe}} 
+                     {{ KNOWL('nf.sibling', title='sibling') }}:
+                  <td> {{ sib[1] |safe }}
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         </table>
         </div>

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -43,6 +43,8 @@
                 </tr> 
   {% elif info.is_galois %}
             <tr><td colspan="3">Extension is Galois</tr>
+  {% else %}
+            <tr><td colspan="3">Extension is not Galois</tr>
   {% endif %}
 
           </table>
@@ -129,17 +131,22 @@
 
         {% if info.resinfo !=[] %}
         <h2>{{ KNOWL('nf.sibling', title='Sibling fields') }}</h2>
+        <div>
+        <table>
         {% for r in info.resinfo %}
-            <div>
-            <table>
-            <tr><td>
             {% if r[0] == 'ae' %}
+              <tr><td>
                 {{ KNOWL('nf.arithmetically_equivalent', title='Arithmetically equvalently siblings') }}:
                 <td> {{ r[1][0] |safe }}
             {% endif %}
-            </table>
-            </div>
+            {% if r[0] == 'gc' %}
+              <tr><td>
+                {{ KNOWL('nf.galois_closure', title='Galois closure') }}:
+                <td> {{ r[1][0] |safe }}
+            {% endif %}
         {% endfor %}
+        </table>
+        </div>
         {% endif %}
 
 {% if nf.unit_galois_action() %}

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -130,7 +130,11 @@
         {% endif %}
 
         {% if info.resinfo !=[] %}
-        <h2>{{ KNOWL('nf.sibling', title='Sibling fields') }}</h2>
+           {% if info.degree == 6 %}
+        <h2>{{ KNOWL('nf.sibling', title='Sibling') }} algebras</h2>
+           {% else %}
+        <h2>{{ KNOWL('nf.sibling', title='Sibling') }} fields</h2>
+           {% endif %}
         <div>
         <table>
         {% for r in info.resinfo %}

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -144,6 +144,11 @@
                 {{ KNOWL('nf.galois_closure', title='Galois closure') }}:
                 <td> {{ r[1][0] |safe }}
             {% endif %}
+            {% if r[0] == 'sex' %}
+              <tr><td>
+                {{ KNOWL('nf.sextic_twin', title='Twin sextic algebra') }}:
+                <td> {{ r[1] |safe }}
+            {% endif %}
             {% if r[0] == 'sib' %}
                 {% for sib in r[1] %}
                   <tr><td> {{sib[0]|safe}} 


### PR DESCRIPTION
Display sibling information on number field pages.  There are several types:

  - twin algebra for sextic fields
  - Galois closure
  - arithmetically equivalent fields
  - other siblings

For each field which comes up, there are 3 possibilities: field not computed, field computed but not in the database, and field computed and in database.  We try to handle each possibility gracefully.  As more data is computed, pages will reflect the new information.  Some samples to look at:

Arith. equiv:
http://127.0.0.1:37777/NumberField/7.3.2007889.2

Sextic algebra:
http://127.0.0.1:37777/NumberField/6.6.810448.1

Galois closure:
http://127.0.0.1:37777/NumberField/3.3.148.1

Various siblings:
http://127.0.0.1:37777/NumberField/4.0.229.1

Multiple arith. equiv. fields and siblings:
http://127.0.0.1:37777/NumberField/16.0.2337302235907620864000000.1

Note, this requires the fields and fields.rand collections from numberfields.