### PR TITLE
fix 2 deprecation warnings from flask_markdown and flask_login

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -63,7 +63,7 @@ class KnowlTagPatternWithTitle(markdown.inlinepatterns.Pattern):
         return "{{ KNOWL('%s') }}" % kid
 
 # Initialise the markdown converter, sending a wikilink [[topic]] to the L-functions wiki
-md = markdown.Markdown(extensions=['wikilinks'],
+md = markdown.Markdown(extensions=['markdown.extensions.wikilinks'],
                        extension_configs={'wikilinks': [('base_url', 'http://wiki.l-functions.org/')]})
 # Prevent $..$, $$..$$, \(..\), \[..\] blocks from being processed by Markdown
 md.inlinePatterns.add('mathjax$', IgnorePattern(r'(?<![\\\$])(\$[^\$].*?\$)'), '<escape')

--- a/lmfdb/users/__init__.py
+++ b/lmfdb/users/__init__.py
@@ -10,6 +10,6 @@ from lmfdb.base import app
 # in turn necessary for users to login
 app.secret_key = '9af"]ßÄ!_°$2ha€42~µ…010'
 
-login_manager.setup_app(app)
+login_manager.init_app(app)
 
 app.register_blueprint(login_page, url_prefix="/users")


### PR DESCRIPTION
This fixes 2 issues identified in #1332 .

One is changing a function (called in lmfdb/users initialization) from flask-login since its name has changed from setup_app to init_app.

The other is to make a flask-markdown extension load cleanly.  For this one, I guess that the relevant lines 65-67 in lmfdb/knowledge/main.py can be deleted, since they seem to be about something which no longer exists (the URL http://wiki.l-functions.org seems to go back years to when this whole site was at l-functions.org).  But I left them in.