### PR TITLE
added list of citations

### DIFF
--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -238,9 +238,26 @@ def management_board():
 
 @app.route("/citation")
 def citation():
-    t = "How to cite LMFDB"
+    t = "Citing the LMFDB"
     b = [(t, url_for("citation"))]
+    return render_template('citation.html', title=t, body_class='', bread=b)
+
+@app.route("/citation/citing")
+def citing():
+    t = "How to cite LMFDB"
+    b = [("Citing the LMFDB", url_for("citation")), (t, url_for("citing"))]
     return render_template(_single_knowl, title=t, kid='content.how-to-cite', body_class='', bread=b)
+
+@app.route("/citation/citations")
+def citations():
+    t = "LMFDB citations"
+    b = [("Citing the LMFDB", url_for("citation")), (t, url_for("citations"))]
+    return render_template('citations.html', title=t, body_class='', bread=b)
+
+@app.route("/citation/citations_bib")
+def citations_bib():
+    t = "LMFDB citations (BiBTeX entries)"
+    return render_template('citations_content_bib.html', title=t, body_class='')
 
 @app.route("/contact")
 def contact():

--- a/lmfdb/templates/citation.html
+++ b/lmfdb/templates/citation.html
@@ -1,0 +1,19 @@
+{% extends 'homepage.html' %}
+{% import 'color.css' as color %}
+{% block content %}
+
+<div>
+<p>
+We encourage authors of books, papers and other articles which mention
+the LMFDB to cite it, following <a href="{{url_for('citing')}}">these
+instructions</a>.
+</p>
+<p>
+A list of articles which cite the LMFDB (last updated October
+2016) is available <a href="{{url_for('citations')}}">here</a>.
+Please let us know if there any omissions using the Contact link below.
+</p>
+</div>
+
+
+{% endblock %}

--- a/lmfdb/templates/citations.html
+++ b/lmfdb/templates/citations.html
@@ -1,0 +1,20 @@
+{% extends 'homepage.html' %}
+{% import 'color.css' as color %}
+{% block content %}
+
+<p>
+The following items cite the LMFDB.  This list was last updated in
+October 2016.  Please report any omissions
+via <a href="mailto:lmfdb-support@googlegroups.com"
+target="_blank">email</a> to
+the <a href="http://groups.google.co.uk/d/forum/lmfdb-support"
+target="_blank">LMFDB mailing list</a>.
+
+</p>
+
+<div>
+{% include "citations_content.html" %}
+</div>
+
+
+{% endblock %}

--- a/lmfdb/templates/citations_content.html
+++ b/lmfdb/templates/citations_content.html
@@ -1,0 +1,1553 @@
+
+<!-- This document was automatically generated with bibtex2html 1.97
+     (see http://www.lri.fr/~filliatr/bibtex2html/),
+     with the following command:
+     /usr/bin/bibtex2html -a -nodoc -header  -footer  -nofooter -f url -html-entities -o citations_content citations.bib  -->
+
+
+<table>
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="anni2014local">1</a>]
+</td>
+<td class="bibtexitem">
+Samuele Anni.
+ A local&ndash;global principle for isogenies of prime degree over number
+  fields.
+ <em>Journal of the London Mathematical Society</em>, 89(3):745&ndash;761,
+  2014.
+[&nbsp;<a href="/citation/citations_bib#anni2014local">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="antieau2016brauer">2</a>]
+</td>
+<td class="bibtexitem">
+Benjamin Antieau and Lennart Meier.
+ The Brauer group of the moduli stack of elliptic curves.
+ <em>arXiv preprint arXiv:1608.00851</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#antieau2016brauer">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="bachilov2014statistics">3</a>]
+</td>
+<td class="bibtexitem">
+Yuri Bachilov.
+ On statistics of the Riemann zeros differences.
+ <em>arXiv preprint arXiv:1402.0865</em>, 2014.
+[&nbsp;<a href="/citation/citations_bib#bachilov2014statistics">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="baker2015elliptic">4</a>]
+</td>
+<td class="bibtexitem">
+Michael Baker.
+ Elliptic curves over finite fields and their l-torsion Galois
+  representations.
+ M.s., 2015.
+[&nbsp;<a href="/citation/citations_bib#baker2015elliptic">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="balakrishnan2015shadow">5</a>]
+</td>
+<td class="bibtexitem">
+J.&nbsp;S. Balakrishnan, M.&nbsp;&Ccedil;iperiani, J.&nbsp;Lang, B.&nbsp;Mirza, and R.&nbsp;Newton.
+ Shadow lines in the arithmetic of elliptic curves.
+ 2015.
+ preprint.
+[&nbsp;<a href="/citation/citations_bib#balakrishnan2015shadow">bib</a>&nbsp;| 
+<a href="http://guests.mpim-bonn.mpg.de/rachel/ShadowLines.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="balakrishnan2015explicit">6</a>]
+</td>
+<td class="bibtexitem">
+Jennifer&nbsp;S Balakrishnan.
+ Explicit p-adic methods for elliptic and hyperelliptic curves.
+ <em>Advances on Superelliptic Curves and Their Applications</em>,
+  41:260, 2015.
+[&nbsp;<a href="/citation/citations_bib#balakrishnan2015explicit">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="balakrishnan2016databases">7</a>]
+</td>
+<td class="bibtexitem">
+Jennifer&nbsp;S Balakrishnan, Wei Ho, Nathan Kaplan, Simon Spicer, William Stein,
+  and James Weigandt.
+ Databases of elliptic curves ordered by height and distributions of
+  selmer groups and ranks.
+ <em>arXiv preprint arXiv:1602.01894</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#balakrishnan2016databases">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="banwait2013some">8</a>]
+</td>
+<td class="bibtexitem">
+Barinder&nbsp;S Banwait.
+ <em>On some local to global phenomena for abelian varieties</em>.
+ PhD thesis, University of Warwick, 2013.
+[&nbsp;<a href="/citation/citations_bib#banwait2013some">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="bartel2016torsion">9</a>]
+</td>
+<td class="bibtexitem">
+Alex Bartel and Aurel Page.
+ Torsion homology and regulators of isospectral manifolds.
+ <em>arXiv preprint arXiv:1601.06821</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#bartel2016torsion">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="bertin2016mahler">10</a>]
+</td>
+<td class="bibtexitem">
+Marie&nbsp;Jos&eacute; Bertin and Wadim Zudilin.
+ On the mahler measure of hyperelliptic families.
+ <em>arXiv preprint arXiv:1601.07583</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#bertin2016mahler">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="billerey2015some">11</a>]
+</td>
+<td class="bibtexitem">
+Nicolas Billerey.
+ On some remarkable congruences between two elliptic curves, 2015.
+ preprint.
+[&nbsp;<a href="/citation/citations_bib#billerey2015some">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="booker2016database">12</a>]
+</td>
+<td class="bibtexitem">
+Andrew&nbsp;R Booker, Jeroen Sijsling, Andrew&nbsp;V Sutherland, John Voight, and Dan
+  Yasaki.
+ A database of genus 2 curves over the rational numbers.
+ <em>arXiv preprint arXiv:1602.03715</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#booker2016database">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="browndegree">13</a>]
+</td>
+<td class="bibtexitem">
+Jim Brown, Robert Cass, Rodney Keaton, Salvatore Parenti, and Daniel Shankman.
+ Degree 14 extensions of <em>Q</em><sub>7</sub>.
+ <em>International Journal of Pure and Applied Mathematics</em>,
+  100(2):337&ndash;345, 2015.
+[&nbsp;<a href="/citation/citations_bib#browndegree">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="brown2015classifying">14</a>]
+</td>
+<td class="bibtexitem">
+Jim Brown, Alfeen Hasmani, Lindsey Hiltner, Angela Kraft, Daniel Scofield,
+  Kirsti Wash, et&nbsp;al.
+ Classifying extensions of the field of formal laurent series over
+  <em>F</em><sub>p</sub>.
+ <em>Rocky Mountain Journal of Mathematics</em>, 45(1):115&ndash;130, 2015.
+[&nbsp;<a href="/citation/citations_bib#brown2015classifying">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="hasmani2012classifying">15</a>]
+</td>
+<td class="bibtexitem">
+Jim Brown, Alfeen Hasmani, Lindsey Hiltner, Angela Kraft, Daniel Scofield, and
+  Kristi Wash.
+ Classifying extensions of the field of formal laurent series over
+  <em>F</em><sub>p</sub>.
+ <em>Rocky Mountain Journal of Mathematics</em>, 45(1):115&ndash;130, 2015.
+[&nbsp;<a href="/citation/citations_bib#hasmani2012classifying">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="brunault2015regulators">16</a>]
+</td>
+<td class="bibtexitem">
+Fran&ccedil;ois Brunault and Masataka Chida.
+ Regulators for Rankin-Selberg products of modular forms.
+ <em>Annales math&eacute;matiques du Qu&eacute;bec</em>, pages 1&ndash;29, 2016.
+[&nbsp;<a href="/citation/citations_bib#brunault2015regulators">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cahn2015powers">17</a>]
+</td>
+<td class="bibtexitem">
+Jordan Cahn, Rafe Jones, and Jacob Spear.
+ Powers in orbits of rational functions: cases of an arithmetic
+  dynamical mordell-lang conjecture.
+ <em>arXiv preprint arXiv:1512.03085</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#cahn2015powers">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cass2013tetrakaidecic">18</a>]
+</td>
+<td class="bibtexitem">
+Robert Cass, Salvatore Parenti, and Daniel Shankman.
+ Tetrakaidecic extensions of <em>q</em><sub>p</sub>, 2013.
+[&nbsp;<a href="/citation/citations_bib#cass2013tetrakaidecic">bib</a>&nbsp;| 
+<a href="http://www.math.clemson.edu/~kevja/REU/2013/TetrakaidecicExtensionsOfQp.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cesnavicius2016manin">19</a>]
+</td>
+<td class="bibtexitem">
+Kestutis Cesnavicius.
+ The manin-stevens constant in the semistable case.
+ <em>arXiv preprint arXiv:1604.02165</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#cesnavicius2016manin">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="checcoli2016explicit">20</a>]
+</td>
+<td class="bibtexitem">
+Sara Checcoli, Francesco Veneziano, and Evelina Viada.
+ On the explicit torsion anomalous conjecture.
+ <em>arXiv preprint arXiv:1605.04801</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#checcoli2016explicit">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="choudhry2015sextuples">21</a>]
+</td>
+<td class="bibtexitem">
+Ajai Choudhry.
+ Sextuples of integers whose sums in pairs are squares.
+ <em>International Journal of Number Theory</em>, 11(02):543&ndash;555, 2015.
+[&nbsp;<a href="/citation/citations_bib#choudhry2015sextuples">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="chung2016arithmetic">22</a>]
+</td>
+<td class="bibtexitem">
+Hee-Joong Chung, Dohyeong Kim, Minhyong Kim, Jeehoon Park, and Hwajong Yoo.
+ Arithmetic Chern-Simons theory II.
+ <em>arXiv preprint arXiv:1609.03012</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#chung2016arithmetic">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cohencomputational">23</a>]
+</td>
+<td class="bibtexitem">
+Henri Cohen.
+ Computational number theory in relation with L-functions.
+[&nbsp;<a href="/citation/citations_bib#cohencomputational">bib</a>&nbsp;| 
+<a href="http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cohen2013dirichlet">24</a>]
+</td>
+<td class="bibtexitem">
+Henri Cohen and Frank Thorne.
+ Dirichlet series associated to quartic fields with given resolvent.
+ <em>Michigan Math. J.</em>, 63(2):253&ndash;273, 2014.
+[&nbsp;<a href="/citation/citations_bib#cohen2013dirichlet">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="lmfdb2016functions">25</a>]
+</td>
+<td class="bibtexitem">
+LMFDB Collaboration et&nbsp;al.
+ The L-functions and modular forms database (2016), 2016.
+[&nbsp;<a href="/citation/citations_bib#lmfdb2016functions">bib</a>&nbsp;| 
+<a href="http://lmfdb.org">http</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="conrey2015riemann">26</a>]
+</td>
+<td class="bibtexitem">
+Brian Conrey.
+ Riemann’s hypothesis.
+ In <em>Colloquium De Giorgi 2013 and 2014</em>, pages 109&ndash;117.
+  Springer, 2015.
+[&nbsp;<a href="/citation/citations_bib#conrey2015riemann">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="cooper2016beyond">27</a>]
+</td>
+<td class="bibtexitem">
+Ian&nbsp;A Cooper, Patrick&nbsp;W Morris, and Nina&nbsp;C Snaith.
+ Beyond the excised ensemble: modelling elliptic curve L-functions
+  with random matrices.
+ <em>Journal of Physics A: Mathematical and Theoretical</em>,
+  49(7):075202, 2016.
+[&nbsp;<a href="/citation/citations_bib#cooper2016beyond">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="corbett2016order">28</a>]
+</td>
+<td class="bibtexitem">
+Andrew Corbett and Abhishek Saha.
+ On the order of vanishing of newforms at cusps.
+ <em>arXiv preprint arXiv:1609.08939</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#corbett2016order">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="crump2016properties">29</a>]
+</td>
+<td class="bibtexitem">
+Iain Crump.
+ Properties of the extended graph permanent.
+ <em>arXiv preprint arXiv:1608.01414</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#crump2016properties">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="dalawat2016solvable">30</a>]
+</td>
+<td class="bibtexitem">
+Chandan&nbsp;Singh Dalawat.
+ Solvable primitive  <em>p</em> -extensions.
+ <em>arXiv preprint arXiv:1608.04673</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#dalawat2016solvable">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="danielsranks">31</a>]
+</td>
+<td class="bibtexitem">
+Harris&nbsp;B Daniels and ASA Goodwillie.
+ On the ranks of elliptic curves with isogenies.
+[&nbsp;<a href="/citation/citations_bib#danielsranks">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="daniels2015torsion">32</a>]
+</td>
+<td class="bibtexitem">
+Harris&nbsp;B Daniels, Alvaro Lozano-Robledo, Filip Najman, and Andrew&nbsp;V Sutherland.
+ Torsion subgroups of rational elliptic curves over the compositum of
+  all cubic fields.
+ <em>arXiv preprint arXiv:1509.00528</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#daniels2015torsion">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="dehaye2016interoperability">33</a>]
+</td>
+<td class="bibtexitem">
+Paul-Olivier Dehaye, Michael Kohlhase, Alexander Konovalov, Samuel
+  Leli&egrave;vre, Markus Pfeiffer, and Nicolas&nbsp;M Thi&eacute;ry.
+ Interoperability in the opendreamkit project: The math-in-the-middle
+  approach.
+ <em>arXiv preprint arXiv:1603.06424</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#dehaye2016interoperability">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="deines2016generalized">34</a>]
+</td>
+<td class="bibtexitem">
+Alyson Deines, Jenny&nbsp;G Fuselier, Ling Long, Holly Swisher, and Fang-Ting Tu.
+ Generalized Legendre curves and quaternionic multiplication.
+ <em>Journal of Number Theory</em>, 161:175&ndash;203, 2016.
+[&nbsp;<a href="/citation/citations_bib#deines2016generalized">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="deines2014shimura">35</a>]
+</td>
+<td class="bibtexitem">
+Alyson&nbsp;Laurene Deines.
+ <em>Shimura Degrees for Elliptic Curves over Number Fields</em>.
+ PhD thesis, 2014.
+[&nbsp;<a href="/citation/citations_bib#deines2014shimura">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="donnelly2015table">36</a>]
+</td>
+<td class="bibtexitem">
+Steve Donnelly, Paul&nbsp;E Gunnells, Ariah Klages-Mundt, and Dan Yasaki.
+ A table of elliptic curves over the cubic field of discriminant&ndash;23.
+ <em>Experimental Mathematics</em>, 24(4):375&ndash;390, 2015.
+[&nbsp;<a href="/citation/citations_bib#donnelly2015table">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="dujella2016diophantine">37</a>]
+</td>
+<td class="bibtexitem">
+Andrej Dujella and Matija Kazalicki.
+ Diophantine <em>m</em>-tuples in finite fields and fields and modular forms.
+ <em>arXiv preprint arXiv:1609.09356</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#dujella2016diophantine">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="dummigan2013simple">38</a>]
+</td>
+<td class="bibtexitem">
+Neil Dummigan.
+ A simple trace formula for algebraic modular forms.
+ <em>Experimental Mathematics</em>, 22(2):123&ndash;131, 2013.
+[&nbsp;<a href="/citation/citations_bib#dummigan2013simple">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="farmer2015second">39</a>]
+</td>
+<td class="bibtexitem">
+David&nbsp;W Farmer and Sally Koutsoliotas.
+ The second dirichlet coefficient starts out negative.
+ <em>The Ramanujan Journal</em>, pages 1&ndash;9, 2015.
+[&nbsp;<a href="/citation/citations_bib#farmer2015second">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="farmer2014maass">40</a>]
+</td>
+<td class="bibtexitem">
+David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
+ Maass forms on GL(3) and GL(4).
+ <em>International mathematics research notices</em>,
+  2014(22):6276&ndash;6301, 2014.
+[&nbsp;<a href="/citation/citations_bib#farmer2014maass">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="farmer2015varieties">41</a>]
+</td>
+<td class="bibtexitem">
+David&nbsp;W Farmer, Sally Koutsoliotas, and Stefan Lemurell.
+ Varieties via their L-functions.
+ <em>arXiv preprint arXiv:1502.00850</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#farmer2015varieties">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="fite2015fields">42</a>]
+</td>
+<td class="bibtexitem">
+Francesc Fit&eacute; and Xavier Guitart.
+ Fields of definition of elliptic <em>k</em>-curves and the realizability of
+  all genus 2 Sato-Tate groups over a number field.
+ <em>arXiv preprint arXiv:1511.02322</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#fite2015fields">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="fite2012sato">43</a>]
+</td>
+<td class="bibtexitem">
+Francesc Fit&eacute;, Kiran&nbsp;S Kedlaya, and Andrew&nbsp;V Sutherland.
+ Sato-Tate groups of some weight 3 motives.
+ <em>Contemporary Mathematics</em>, 663:57&ndash;102, 2016.
+[&nbsp;<a href="/citation/citations_bib#fite2012sato">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="garcia2016computational">44</a>]
+</td>
+<td class="bibtexitem">
+Alejandro&nbsp;Arg&aacute;ez Garc&iacute;a.
+ <em>Computational aspects of Galois representations</em>.
+ PhD thesis, University of Warwick, 2016.
+[&nbsp;<a href="/citation/citations_bib#garcia2016computational">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ghitza2013computations">45</a>]
+</td>
+<td class="bibtexitem">
+Alexandru Ghitza, Nathan&nbsp;C Ryan, and David Sulon.
+ Computations of vector-valued Siegel modular forms.
+ <em>Journal of Number Theory</em>, 133(11):3921&ndash;3940, 2013.
+[&nbsp;<a href="/citation/citations_bib#ghitza2013computations">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="grenie2015zeros">46</a>]
+</td>
+<td class="bibtexitem">
+Lo&iuml;c Greni&eacute; and Giuseppe Molteni.
+ Zeros of Dedekind zeta functions under GRH.
+ <em>Mathematics of Computation</em>, 85:1503&ndash;1522, 2015.
+[&nbsp;<a href="/citation/citations_bib#grenie2015zeros">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="guitart2016uniformization">47</a>]
+</td>
+<td class="bibtexitem">
+Xavier Guitart, Marc Masdeu, and Mehmet&nbsp;Haluk Seng&uuml;n.
+ Uniformization of modular elliptic curves via p-adic periods.
+ <em>Journal of Algebra</em>, 445:458&ndash;502, 2016.
+[&nbsp;<a href="/citation/citations_bib#guitart2016uniformization">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="gurel2016occurrence">48</a>]
+</td>
+<td class="bibtexitem">
+Erhan G&uuml;rel.
+ On the occurrence of perfect squares among values of certain
+  polynomial products.
+ <em>The American Mathematical Monthly</em>, 123(6):597&ndash;599, 2016.
+[&nbsp;<a href="/citation/citations_bib#gurel2016occurrence">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="harris2015random">49</a>]
+</td>
+<td class="bibtexitem">
+Katherine&nbsp;Elizabeth Harris.
+ Random matrix theory and the attraction of zeros of L-functions
+  from the central point.
+ Honors, 2015.
+[&nbsp;<a href="/citation/citations_bib#harris2015random">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="harvey2016computing">50</a>]
+</td>
+<td class="bibtexitem">
+David Harvey, Maike Massierer, and Andrew&nbsp;V Sutherland.
+ Computing L-series of geometrically hyperelliptic curves of genus
+  three.
+ <em>arXiv preprint arXiv:1605.04708</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#harvey2016computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="he2014conjecture">51</a>]
+</td>
+<td class="bibtexitem">
+Junhua He.
+ On a conjecture concerning integral real roots of certain cubic
+  polynomials.
+ <em>Linear Algebra and its Applications</em>, 446:265&ndash;268, 2014.
+[&nbsp;<a href="/citation/citations_bib#he2014conjecture">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="hulse2016counting">52</a>]
+</td>
+<td class="bibtexitem">
+Thomas&nbsp;A Hulse, Chan&nbsp;Ieong Kuan, Eren&nbsp;Mehmet Kiral, and Li-Mei Lim.
+ Counting square discriminants.
+ <em>Journal of Number Theory</em>, 162:255&ndash;274, 2016.
+[&nbsp;<a href="/citation/citations_bib#hulse2016counting">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="jenkins2016dynamic">53</a>]
+</td>
+<td class="bibtexitem">
+Robert Jenkins and Ken DT-R McLaughlin.
+ Dynamic behavior of the roots of the taylor polynomials of the
+  Riemann xi function with growing degree.
+ <em>arXiv preprint arXiv:1609.05965</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#jenkins2016dynamic">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="johnson2015fourier">54</a>]
+</td>
+<td class="bibtexitem">
+Jennifer Johnson-Leung and Brooks Roberts.
+ Fourier coefficients for twists of Siegel paramodular forms
+  (expanded version).
+ <em>arXiv preprint arXiv:1505.05463</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#johnson2015fourier">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="jones2014tame">55</a>]
+</td>
+<td class="bibtexitem">
+John Jones and David Roberts.
+ The tame-wild principle for discriminant relations for number fields.
+ <em>Algebra &amp; Number Theory</em>, 8(3):609&ndash;645, 2014.
+[&nbsp;<a href="/citation/citations_bib#jones2014tame">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="jones2013minimal">56</a>]
+</td>
+<td class="bibtexitem">
+John&nbsp;W Jones.
+ Minimal solvable nonic fields.
+ <em>LMS Journal of Computation and Mathematics</em>, 16:130&ndash;138, 2013.
+[&nbsp;<a href="/citation/citations_bib#jones2013minimal">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="jones2016mixed">57</a>]
+</td>
+<td class="bibtexitem">
+John&nbsp;W Jones and David&nbsp;P Roberts.
+ Mixed degree number field computations.
+ <em>arXiv preprint arXiv:1602.09119</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#jones2016mixed">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="katok2014fried">58</a>]
+</td>
+<td class="bibtexitem">
+Anatole Katok, Svetlana Katok, and Federico&nbsp;Rodriguez Hertz.
+ The Fried average entropy and slow entropy for actions of higher
+  rank abelian groups.
+ <em>Geometric and Functional Analysis</em>, 24(4):1204&ndash;1228, 2014.
+[&nbsp;<a href="/citation/citations_bib#katok2014fried">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="klemm2015direct">59</a>]
+</td>
+<td class="bibtexitem">
+Albrecht Klemm, Maximilian Poretschkin, Thorsten Schimannek, and Martin
+  Westerholt-Raum.
+ Direct integration for mirror curves of genus two and an almost
+  meromorphic Siegel modular form.
+ <em>arXiv preprint arXiv:1502.00557</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#klemm2015direct">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="koutsianas2015computing">60</a>]
+</td>
+<td class="bibtexitem">
+Angelos Koutsianas.
+ Computing all elliptic curves over an arbitrary number field with
+  prescribed primes of bad reduction.
+ <em>arXiv preprint arXiv:1511.05108</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#koutsianas2015computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="kraus2015theoreme">61</a>]
+</td>
+<td class="bibtexitem">
+Alain Kraus.
+ Sur le th&eacute;or&egrave;me de fermat sur <em>Q</em>(&radic;(5).
+ <em>Annales math&eacute;matiques du Qu&eacute;bec</em>, 39(1):49&ndash;59, 2015.)
+[&nbsp;<a href="/citation/citations_bib#kraus2015theoreme">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="kumar2014algebraic">62</a>]
+</td>
+<td class="bibtexitem">
+Abhinav Kumar and Ronen&nbsp;E Mukamel.
+ Algebraic models and arithmetic geometry of Teichm&uuml;ller curves in
+  genus two.
+ <em>arXiv preprint arXiv:1406.7057</em>, 2014.
+[&nbsp;<a href="/citation/citations_bib#kumar2014algebraic">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="li2016potentially">63</a>]
+</td>
+<td class="bibtexitem">
+Wen-Ching&nbsp;Winnie Li, Tong Liu, and Ling Long.
+ Potentially GL<sub>2</sub>-type Galois representations associated to
+  noncongruence modular forms.
+ <em>arXiv preprint arXiv:1609.06414</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#li2016potentially">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="linowitzbounds">64</a>]
+</td>
+<td class="bibtexitem">
+Benjamin Linowitz.
+ Bounds for arithmetic hyperbolic reflection groups in dimension 2.
+[&nbsp;<a href="/citation/citations_bib#linowitzbounds">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="linowitz2016spectral">65</a>]
+</td>
+<td class="bibtexitem">
+Benjamin Linowitz.
+ The spectral geometry of arithmetic hyperbolic 3-manifolds.
+ 2016.
+[&nbsp;<a href="/citation/citations_bib#linowitz2016spectral">bib</a>&nbsp;| 
+<a href="http://www-personal.umich.edu/~linowitz/papers/spectralnotes.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="linowitz2015noncommutative">66</a>]
+</td>
+<td class="bibtexitem">
+Benjamin Linowitz, Matthew Satriano, and Roope Vehkalahti.
+ A noncommutative analogue of the Odlyzko bounds and bounds on
+  performance for space-time lattice codes.
+ <em>Information Theory, IEEE Transactions on</em>, 61(4):1971&ndash;1984,
+  2015.
+[&nbsp;<a href="/citation/citations_bib#linowitz2015noncommutative">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="linowitz2015small">67</a>]
+</td>
+<td class="bibtexitem">
+Benjamin Linowitz and John Voight.
+ Small isospectral and nonisometric orbifolds of dimension 2 and 3.
+ <em>Mathematische Zeitschrift</em>, 281(1-2):523&ndash;569, 2015.
+[&nbsp;<a href="/citation/citations_bib#linowitz2015small">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="long2016characterization">68</a>]
+</td>
+<td class="bibtexitem">
+Ling Long, Rafael Plaza, Peter Sin, and Qing Xiang.
+ Characterization of intersecting families of maximum size in
+  PSL(2,<em>q</em>).
+ <em>arXiv preprint arXiv:1608.07304</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#long2016characterization">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="martin2016refined">69</a>]
+</td>
+<td class="bibtexitem">
+Kimball Martin.
+ Refined dimensions of cusp forms, and equidistribution and bias of
+  signs.
+ <em>arXiv preprint arXiv:1609.05386</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#martin2016refined">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="mercuri2016equations">70</a>]
+</td>
+<td class="bibtexitem">
+Pietro Mercuri.
+ Equations and rational points of the modular curves X<sup>+</sup><sub>0</sub>(<em>p</em>).
+ <em>arXiv preprint arXiv:1607.04558</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#mercuri2016equations">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="mertens2014eichler">71</a>]
+</td>
+<td class="bibtexitem">
+Michael&nbsp;H Mertens.
+ Eichler-Selberg type identities for mixed mock modular forms.
+ <em>arXiv preprint arXiv:1404.5491</em>, 2014.
+[&nbsp;<a href="/citation/citations_bib#mertens2014eichler">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="mertens2014mock">72</a>]
+</td>
+<td class="bibtexitem">
+Michael&nbsp;Helmut Mertens.
+ <em>Mock modular forms and class numbers of quadratic forms</em>.
+ PhD thesis, Universit&auml;t zu K&ouml;ln, 2014.
+[&nbsp;<a href="/citation/citations_bib#mertens2014mock">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="minemodular">73</a>]
+</td>
+<td class="bibtexitem">
+Alex Mine.
+ Modular forms and applications in number theory.
+[&nbsp;<a href="/citation/citations_bib#minemodular">bib</a>&nbsp;| 
+<a href="http://math.uchicago.edu/~may/REUDOCS/Mine.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="mosunov2015unconditional">74</a>]
+</td>
+<td class="bibtexitem">
+A&nbsp;Mosunov and M&nbsp;Jacobson&nbsp;Jr.
+ Unconditional class group tabulation of imaginary quadratic fields to
+  |&Delta;|&lt;2<sup>40</sup>.
+ <em>Mathematics of Computation</em>, 85:1983&ndash;2009, 2016.
+[&nbsp;<a href="/citation/citations_bib#mosunov2015unconditional">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="nelson2016quantum">75</a>]
+</td>
+<td class="bibtexitem">
+Paul&nbsp;D Nelson.
+ Quantum variance on quaternion algebras, I.
+ <em>arXiv preprint arXiv:1601.02526</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#nelson2016quantum">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="pastor2016regularity">76</a>]
+</td>
+<td class="bibtexitem">
+Carlos Pastor.
+ On the regularity of fractional integrals of modular forms.
+ <em>arXiv preprint arXiv:1603.06491</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#pastor2016regularity">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="patrikis2015deformations">77</a>]
+</td>
+<td class="bibtexitem">
+Stefan Patrikis.
+ Deformations of Galois representations and exceptional monodromy.
+ <em>Inventiones mathematicae</em>, pages 1&ndash;68, 2015.
+[&nbsp;<a href="/citation/citations_bib#patrikis2015deformations">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="platt2015computing">78</a>]
+</td>
+<td class="bibtexitem">
+David Platt.
+ Computing &pi;(<em>x</em>) analytically.
+ <em>Mathematics of Computation</em>, 84(293):1521&ndash;1535, 2015.
+[&nbsp;<a href="/citation/citations_bib#platt2015computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="plouffe2013values">79</a>]
+</td>
+<td class="bibtexitem">
+Simon Plouffe.
+ On the values of the functions zeta and gamma.
+ <em>arXiv preprint arXiv:1310.7195</em>, 2013.
+[&nbsp;<a href="/citation/citations_bib#plouffe2013values">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="rahm2013level">80</a>]
+</td>
+<td class="bibtexitem">
+Alexander&nbsp;D Rahm and Mehmet&nbsp;Haluk Seng&uuml;n.
+ On level one cuspidal Bianchi modular forms.
+ <em>LMS Journal of Computation and Mathematics</em>, 16:187&ndash;199, 2013.
+[&nbsp;<a href="/citation/citations_bib#rahm2013level">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ramakrishnan2015number">81</a>]
+</td>
+<td class="bibtexitem">
+B&nbsp;Ramakrishnan and Brundaban Sahu.
+ On the number of representations of certain quadratic forms in 20
+  and 24 variables.
+ <em>Functiones et Approximatio Commentarii Mathematici</em>.
+ to appear.
+[&nbsp;<a href="/citation/citations_bib#ramakrishnan2015number">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ramakrishnan2013evaluation">82</a>]
+</td>
+<td class="bibtexitem">
+B&nbsp;Ramakrishnan and Brundaban Sahu.
+ Evaluation of the convolution sums &sum;<sub>l+15m=
+  n</sub>&sigma;(<em>l</em>)&sigma;(<em>m</em>) and &sum;_3<em>l</em>+ 5<em>m</em>= <em>n</em>&sigma;(<em>l</em>)&sigma;(<em>m</em>) and some
+  applications.
+ <em>International Journal of Number Theory</em>, 9(03):799&ndash;809, 2013.
+[&nbsp;<a href="/citation/citations_bib#ramakrishnan2013evaluation">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ramakrishnan2014number">83</a>]
+</td>
+<td class="bibtexitem">
+B&nbsp;Ramakrishnan and Brundaban Sahu.
+ On the number of representations of an integer by certain quadratic
+  forms in sixteen variables.
+ <em>International Journal of Number Theory</em>, 10(08):1929&ndash;1937,
+  2014.
+[&nbsp;<a href="/citation/citations_bib#ramakrishnan2014number">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ramakrishnan2016representations">84</a>]
+</td>
+<td class="bibtexitem">
+B&nbsp;Ramakrishnan, Brundaban Sahu, and Anup&nbsp;Kumar Singh.
+ On the representations of a positive integer by certain classes of
+  quadratic forms in eight variables.
+ <em>arXiv preprint arXiv:1607.04764</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#ramakrishnan2016representations">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="roe2016algebraic">85</a>]
+</td>
+<td class="bibtexitem">
+David Roe.
+ Algebraic tori and a computational inverse Galois problem, 2016.
+[&nbsp;<a href="/citation/citations_bib#roe2016algebraic">bib</a>&nbsp;| 
+<a href="http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf">.pdf</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="rouse2013explicit">86</a>]
+</td>
+<td class="bibtexitem">
+Jeremy Rouse and Jesse Thorner.
+ The explicit Sato-Tate conjecture and densities pertaining to
+  Lehmer-type questions.
+ <em>Transactions of the AMS</em>, 2016.
+ to appear.
+[&nbsp;<a href="/citation/citations_bib#rouse2013explicit">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="rubinstein2013elliptic">87</a>]
+</td>
+<td class="bibtexitem">
+Michael&nbsp;O Rubinstein.
+ Elliptic curves of high rank and the Riemann zeta function on the
+  one line.
+ <em>Experimental Mathematics</em>, 22(4):465&ndash;480, 2013.
+[&nbsp;<a href="/citation/citations_bib#rubinstein2013elliptic">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="rubinstein2015moments">88</a>]
+</td>
+<td class="bibtexitem">
+Michael&nbsp;O Rubinstein and Kaiyu Wu.
+ Moments of zeta functions associated to hyperelliptic curves over
+  finite fields.
+ <em>Philosophical Transactions of the Royal Society of London A:
+  Mathematical, Physical and Engineering Sciences</em>, 373(2040):20140307, 2015.
+[&nbsp;<a href="/citation/citations_bib#rubinstein2015moments">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ryan2016computing">89</a>]
+</td>
+<td class="bibtexitem">
+Nathan&nbsp;C Ryan, Nicol&aacute;s Sirolli, Nils-Peter Skoruppa, and Gonzalo
+  Tornar&iacute;a.
+ Computing Jacobi forms.
+ <em>arXiv preprint arXiv:1602.07021</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#ryan2016computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ryan2014nonvanishing">90</a>]
+</td>
+<td class="bibtexitem">
+Nathan&nbsp;C Ryan, Gonzalo Tornaria, and John Voight.
+ Nonvanishing of twists of-functions attached to Hilbert modular
+  forms.
+ <em>LMS Journal of Computation and Mathematics</em>, 17(A):330&ndash;348,
+  2014.
+[&nbsp;<a href="/citation/citations_bib#ryan2014nonvanishing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="sairaiji2016class">91</a>]
+</td>
+<td class="bibtexitem">
+Fumio Sairaiji and Takuya Yamauchi.
+ On the class numbers of the fields of the <em>p</em><sup>n</sup>-torsion points of
+  elliptic curves over <em>Q</em>.
+ <em>arXiv preprint arXiv:1603.01296</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#sairaiji2016class">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="saouter2015still">92</a>]
+</td>
+<td class="bibtexitem">
+Yannick Saouter, Timothy Trudgian, and Patrick Demichel.
+ A still sharper region where 𝜋 (𝑥)-𝑙𝑖 (𝑥) is positive.
+ <em>Mathematics of Computation</em>, 84(295):2433&ndash;2446, 2015.
+[&nbsp;<a href="/citation/citations_bib#saouter2015still">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="savala2016computing">93</a>]
+</td>
+<td class="bibtexitem">
+Paul Savala.
+ Computing spectral data for Maass cusp forms using resonance.
+ 2016.
+[&nbsp;<a href="/citation/citations_bib#savala2016computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="schaeffer2015hecke">94</a>]
+</td>
+<td class="bibtexitem">
+George&nbsp;J Schaeffer.
+ Hecke stability and weight 1 modular forms.
+ <em>Mathematische Zeitschrift</em>, 281(1-2):159&ndash;191, 2015.
+[&nbsp;<a href="/citation/citations_bib#schaeffer2015hecke">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="sha2014pseudolinearly">95</a>]
+</td>
+<td class="bibtexitem">
+Min Sha and Igor&nbsp;E Shparlinski.
+ Pseudolinearly dependent points on elliptic curves.
+ <em>arXiv preprint arXiv:1410.1596</em>, 2014.
+[&nbsp;<a href="/citation/citations_bib#sha2014pseudolinearly">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="sohexplicit">96</a>]
+</td>
+<td class="bibtexitem">
+Charlene Soh.
+ Explicit methods for the Birch and Swinnerton-Dyer conjecture.
+ Msc.
+[&nbsp;<a href="/citation/citations_bib#sohexplicit">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="sutherland2012computing">97</a>]
+</td>
+<td class="bibtexitem">
+Andrew&nbsp;V Sutherland.
+ Computing the image of Galois.
+ <em>CNTA XII</em>, page&nbsp;22, 2012.
+[&nbsp;<a href="/citation/citations_bib#sutherland2012computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="sutherland2015computing">98</a>]
+</td>
+<td class="bibtexitem">
+Andrew&nbsp;V Sutherland.
+ Computing images of Galois representations attached to elliptic
+  curves.
+ <em>Forum of Mathematics, Sigma</em>, 4:79 pages, 2016.
+[&nbsp;<a href="/citation/citations_bib#sutherland2015computing">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="swinarski2016equations">99</a>]
+</td>
+<td class="bibtexitem">
+David Swinarski.
+ Equations of Riemann surfaces with automorphisms.
+ <em>arXiv preprint arXiv:1607.04778</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#swinarski2016equations">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="MR3100414">100</a>]
+</td>
+<td class="bibtexitem">
+Audrey Terras.
+ <em>Harmonic analysis on symmetric spaces&mdash;Euclidean space, the
+  sphere, and the Poincar&eacute; upper half-plane</em>.
+ Springer, New York, second edition, 2013.
+[&nbsp;<a href="/citation/citations_bib#MR3100414">bib</a>&nbsp;| 
+<a href="http://dx.doi.org/10.1007/978-1-4614-7972-7">DOI</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="ugolini2015functional">101</a>]
+</td>
+<td class="bibtexitem">
+Simone Ugolini.
+ Functional graphs of rational maps induced by endomorphisms of
+  ordinary elliptic curves over finite fields of odd characteristic.
+ <em>arXiv preprint arXiv:1509.05365</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#ugolini2015functional">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="viada2016explicit">102</a>]
+</td>
+<td class="bibtexitem">
+Evelina Viada.
+ Explicit height bounds and the explicit Mordell-Lang
+  Conjecture.
+ <em>arXiv preprint arXiv:1609.04607</em>, 2016.
+[&nbsp;<a href="/citation/citations_bib#viada2016explicit">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="waltoncongruent">103</a>]
+</td>
+<td class="bibtexitem">
+Florence Walton.
+ The congruent number problem and the Birch and Swinnerton-Dyer
+  conjecture.
+ Mmathphil.
+[&nbsp;<a href="/citation/citations_bib#waltoncongruent">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="wan2014slopes">104</a>]
+</td>
+<td class="bibtexitem">
+Daqing Wan, Liang Xiao, and Jun Zhang.
+ Slopes of eigencurves over boundary disks.
+ <em>arXiv preprint arXiv:1407.0279</em>, 2014.
+[&nbsp;<a href="/citation/citations_bib#wan2014slopes">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="zhu2015more">105</a>]
+</td>
+<td class="bibtexitem">
+Yan Zhu, Eiichi Bannai, Etsuko Bannai, Kyoung-Tark Kim, and Wei-Hsuan Yu.
+ More on spherical designs of harmonic index <em>t</em>.
+ <em>arXiv preprint arXiv:1507.05373</em>, 2015.
+[&nbsp;<a href="/citation/citations_bib#zhu2015more">bib</a>&nbsp;]
+
+</td>
+</tr>
+
+
+<tr valign="top">
+<td align="right" class="bibtexnumber">
+[<a name="横山俊一2013統合システム">106</a>]
+</td>
+<td class="bibtexitem">
+横山俊一.
+ 統合システム sage とクラウド型 cas の最新事情.
+ <em>数理解析研究所講究録</em>, 1843:131&ndash;139, 2013.
+[&nbsp;<a href="/citation/citations_bib#横山俊一2013統合システム">bib</a>&nbsp;]
+
+</td>
+</tr>
+</table>

--- a/lmfdb/templates/citations_content_bib.html
+++ b/lmfdb/templates/citations_content_bib.html
@@ -1,0 +1,1095 @@
+<h1>citations.bib</h1><a name="corbett2016order"></a><pre>
+@article{<a href="/citation/citations#corbett2016order">corbett2016order</a>,
+  title = {On the order of vanishing of newforms at cusps},
+  author = {Corbett, Andrew and Saha, Abhishek},
+  journal = {arXiv preprint arXiv:1609.08939},
+  year = {2016}
+}
+</pre>
+
+<a name="dujella2016diophantine"></a><pre>
+@article{<a href="/citation/citations#dujella2016diophantine">dujella2016diophantine</a>,
+  title = {Diophantine $m$-tuples in finite fields and fields and modular forms},
+  author = {Dujella, Andrej and Kazalicki, Matija},
+  journal = {arXiv preprint arXiv:1609.09356},
+  year = {2016}
+}
+</pre>
+
+<a name="li2016potentially"></a><pre>
+@article{<a href="/citation/citations#li2016potentially">li2016potentially</a>,
+  title = {Potentially {GL}$_2$-type {Galois} representations associated to noncongruence modular forms},
+  author = {Li, Wen-Ching Winnie and Liu, Tong and Long, Ling},
+  journal = {arXiv preprint arXiv:1609.06414},
+  year = {2016}
+}
+</pre>
+
+<a name="martin2016refined"></a><pre>
+@article{<a href="/citation/citations#martin2016refined">martin2016refined</a>,
+  title = {Refined dimensions of cusp forms, and equidistribution and bias of signs},
+  author = {Martin, Kimball},
+  journal = {arXiv preprint arXiv:1609.05386},
+  year = {2016}
+}
+</pre>
+
+<a name="jenkins2016dynamic"></a><pre>
+@article{<a href="/citation/citations#jenkins2016dynamic">jenkins2016dynamic</a>,
+  title = {Dynamic behavior of the roots of the Taylor polynomials of the {Riemann} xi function with growing degree},
+  author = {Jenkins, Robert and McLaughlin, Ken DT-R},
+  journal = {arXiv preprint arXiv:1609.05965},
+  year = {2016}
+}
+</pre>
+
+<a name="savala2016computing"></a><pre>
+@article{<a href="/citation/citations#savala2016computing">savala2016computing</a>,
+  title = {Computing spectral data for {M}aass cusp forms using resonance},
+  author = {Savala, Paul},
+  year = {2016},
+  publisher = {University of Iowa}
+}
+</pre>
+
+<a name="long2016characterization"></a><pre>
+@article{<a href="/citation/citations#long2016characterization">long2016characterization</a>,
+  title = {Characterization of intersecting families of maximum size in {PSL}$(2,q)$},
+  author = {Long, Ling and Plaza, Rafael and Sin, Peter and Xiang, Qing},
+  journal = {arXiv preprint arXiv:1608.07304},
+  year = {2016}
+}
+</pre>
+
+<a name="chung2016arithmetic"></a><pre>
+@article{<a href="/citation/citations#chung2016arithmetic">chung2016arithmetic</a>,
+  title = {Arithmetic {C}hern-{S}imons Theory {I}{I}},
+  author = {Chung, Hee-Joong and Kim, Dohyeong and Kim, Minhyong and Park, Jeehoon and Yoo, Hwajong},
+  journal = {arXiv preprint arXiv:1609.03012},
+  year = {2016}
+}
+</pre>
+
+<a name="viada2016explicit"></a><pre>
+@article{<a href="/citation/citations#viada2016explicit">viada2016explicit</a>,
+  title = {Explicit height bounds and the explicit {M}ordell-{L}ang {C}onjecture},
+  author = {Viada, Evelina},
+  journal = {arXiv preprint arXiv:1609.04607},
+  year = {2016}
+}
+</pre>
+
+<a name="danielsranks"></a><pre>
+@article{<a href="/citation/citations#danielsranks">danielsranks</a>,
+  title = {On the ranks of elliptic curves with isogenies},
+  author = {Daniels, Harris B and Goodwillie, ASA}
+}
+</pre>
+
+<a name="dalawat2016solvable"></a><pre>
+@article{<a href="/citation/citations#dalawat2016solvable">dalawat2016solvable</a>,
+  title = {Solvable primitive $ p $-extensions},
+  author = {Dalawat, Chandan Singh},
+  journal = {arXiv preprint arXiv:1608.04673},
+  year = {2016}
+}
+</pre>
+
+<a name="garcia2016computational"></a><pre>
+@phdthesis{<a href="/citation/citations#garcia2016computational">garcia2016computational</a>,
+  title = {Computational aspects of {G}alois representations},
+  author = {Garc{\'\i}a, Alejandro Arg{\'a}ez},
+  year = {2016},
+  school = {University of Warwick}
+}
+</pre>
+
+<a name="antieau2016brauer"></a><pre>
+@article{<a href="/citation/citations#antieau2016brauer">antieau2016brauer</a>,
+  title = {The {B}rauer group of the moduli stack of elliptic curves},
+  author = {Antieau, Benjamin and Meier, Lennart},
+  journal = {arXiv preprint arXiv:1608.00851},
+  year = {2016}
+}
+</pre>
+
+<a name="crump2016properties"></a><pre>
+@article{<a href="/citation/citations#crump2016properties">crump2016properties</a>,
+  title = {Properties of the extended graph permanent},
+  author = {Crump, Iain},
+  journal = {arXiv preprint arXiv:1608.01414},
+  year = {2016}
+}
+</pre>
+
+<a name="harvey2016computing"></a><pre>
+@article{<a href="/citation/citations#harvey2016computing">harvey2016computing</a>,
+  title = {Computing {L}-series of geometrically hyperelliptic curves of genus three},
+  author = {Harvey, David and Massierer, Maike and Sutherland, Andrew V},
+  journal = {arXiv preprint arXiv:1605.04708},
+  year = {2016}
+}
+</pre>
+
+<a name="checcoli2016explicit"></a><pre>
+@article{<a href="/citation/citations#checcoli2016explicit">checcoli2016explicit</a>,
+  title = {On the Explicit Torsion Anomalous Conjecture},
+  author = {Checcoli, Sara and Veneziano, Francesco and Viada, Evelina},
+  journal = {arXiv preprint arXiv:1605.04801},
+  year = {2016}
+}
+</pre>
+
+<a name="gurel2016occurrence"></a><pre>
+@article{<a href="/citation/citations#gurel2016occurrence">gurel2016occurrence</a>,
+  title = {On the Occurrence of Perfect Squares Among Values of Certain Polynomial Products},
+  author = {G{\"u}rel, Erhan},
+  journal = {The American Mathematical Monthly},
+  volume = {123},
+  number = {6},
+  pages = {597--599},
+  year = {2016},
+  publisher = {JSTOR}
+}
+</pre>
+
+<a name="mercuri2016equations"></a><pre>
+@article{<a href="/citation/citations#mercuri2016equations">mercuri2016equations</a>,
+  title = {Equations and Rational Points of the Modular Curves {X}$^+_0(p)$},
+  author = {Mercuri, Pietro},
+  journal = {arXiv preprint arXiv:1607.04558},
+  year = {2016}
+}
+</pre>
+
+<a name="swinarski2016equations"></a><pre>
+@article{<a href="/citation/citations#swinarski2016equations">swinarski2016equations</a>,
+  title = {Equations of {Riemann} surfaces with automorphisms},
+  author = {Swinarski, David},
+  journal = {arXiv preprint arXiv:1607.04778},
+  year = {2016}
+}
+</pre>
+
+<a name="MR3100414"></a><pre>
+@book{<a href="/citation/citations#MR3100414">MR3100414</a>,
+  author = {Terras, Audrey},
+  title = {Harmonic analysis on symmetric spaces---{E}uclidean space, the
+              sphere, and the {P}oincar\'e upper half-plane},
+  edition = {Second},
+  publisher = {Springer, New York},
+  year = {2013},
+  pages = {xviii+413},
+  isbn = {978-1-4614-7971-0; 978-1-4614-7972-7},
+  mrclass = {22E30 (11F72 43-02 43A85)},
+  mrnumber = {3100414},
+  mrreviewer = {Rudra P. Sarkar},
+  doi = {10.1007/978-1-4614-7972-7}
+}
+</pre>
+
+<a name="cesnavicius2016manin"></a><pre>
+@article{<a href="/citation/citations#cesnavicius2016manin">cesnavicius2016manin</a>,
+  title = {The Manin-Stevens constant in the semistable case},
+  author = {Cesnavicius, Kestutis},
+  journal = {arXiv preprint arXiv:1604.02165},
+  year = {2016}
+}
+</pre>
+
+<a name="sutherland2012computing"></a><pre>
+@article{<a href="/citation/citations#sutherland2012computing">sutherland2012computing</a>,
+  title = {Computing the image of {Galois}},
+  author = {Sutherland, Andrew V},
+  journal = {CNTA XII},
+  pages = {22},
+  year = {2012}
+}
+</pre>
+
+<a name="roe2016algebraic"></a><pre>
+@misc{<a href="/citation/citations#roe2016algebraic">roe2016algebraic</a>,
+  title = {Algebraic tori and a computational inverse {Galois} problem},
+  author = {Roe, David},
+  url = {<a href="http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf">http://www.pitt.edu/~roed/writings/talks/2016_01_26.pdf</a>},
+  year = {2016}
+}
+</pre>
+
+<a name="横山俊一2013統合システム"></a><pre>
+@article{<a href="/citation/citations#横山俊一2013統合システム">横山俊一2013統合システム</a>,
+  title = {統合システム Sage とクラウド型 CAS の最新事情},
+  author = {横山俊一},
+  journal = {数理解析研究所講究録},
+  volume = {1843},
+  pages = {131--139},
+  year = {2013}
+}
+</pre>
+
+<a name="lmfdb2016functions"></a><pre>
+@misc{<a href="/citation/citations#lmfdb2016functions">lmfdb2016functions</a>,
+  title = {The {L}-functions and Modular Forms Database (2016)},
+  author = {LMFDB Collaboration and others},
+  url = {<a href="http://lmfdb.org">http://lmfdb.org</a>},
+  year = {2016}
+}
+</pre>
+
+<a name="dehaye2016interoperability"></a><pre>
+@article{<a href="/citation/citations#dehaye2016interoperability">dehaye2016interoperability</a>,
+  title = {Interoperability in the OpenDreamKit Project: The Math-in-the-Middle Approach},
+  author = {Dehaye, Paul-Olivier and Kohlhase, Michael and Konovalov, Alexander and Leli{\`e}vre, Samuel and Pfeiffer, Markus and Thi{\'e}ry, Nicolas M},
+  journal = {arXiv preprint arXiv:1603.06424},
+  year = {2016}
+}
+</pre>
+
+<a name="minemodular"></a><pre>
+@misc{<a href="/citation/citations#minemodular">minemodular</a>,
+  title = {Modular forms and applications in number theory},
+  author = {Mine, Alex},
+  url = {<a href="http://math.uchicago.edu/~may/REUDOCS/Mine.pdf">http://math.uchicago.edu/~may/REUDOCS/Mine.pdf</a>}
+}
+</pre>
+
+<a name="linowitzbounds"></a><pre>
+@article{<a href="/citation/citations#linowitzbounds">linowitzbounds</a>,
+  title = {Bounds for arithmetic hyperbolic reflection groups in dimension 2},
+  author = {Linowitz, Benjamin}
+}
+</pre>
+
+<a name="linowitz2016spectral"></a><pre>
+@article{<a href="/citation/citations#linowitz2016spectral">linowitz2016spectral</a>,
+  title = {The spectral geometry of arithmetic hyperbolic 3-manifolds},
+  author = {Linowitz, Benjamin},
+  url = {<a href="http://www-personal.umich.edu/~linowitz/papers/spectralnotes.pdf">http://www-personal.umich.edu/~linowitz/papers/spectralnotes.pdf</a>},
+  year = {2016}
+}
+</pre>
+
+<a name="pastor2016regularity"></a><pre>
+@article{<a href="/citation/citations#pastor2016regularity">pastor2016regularity</a>,
+  title = {On the regularity of fractional integrals of modular forms},
+  author = {Pastor, Carlos},
+  journal = {arXiv preprint arXiv:1603.06491},
+  year = {2016}
+}
+</pre>
+
+<a name="patrikis2015deformations"></a><pre>
+@article{<a href="/citation/citations#patrikis2015deformations">patrikis2015deformations</a>,
+  title = {Deformations of {Galois} representations and exceptional monodromy},
+  author = {Patrikis, Stefan},
+  journal = {Inventiones mathematicae},
+  pages = {1--68},
+  year = {2015},
+  publisher = {Springer}
+}
+</pre>
+
+<a name="johnson2015fourier"></a><pre>
+@article{<a href="/citation/citations#johnson2015fourier">johnson2015fourier</a>,
+  title = {Fourier coefficients for twists of {Siegel} paramodular forms (expanded version)},
+  author = {Johnson-Leung, Jennifer and Roberts, Brooks},
+  journal = {arXiv preprint arXiv:1505.05463},
+  year = {2015}
+}
+</pre>
+
+<a name="cahn2015powers"></a><pre>
+@article{<a href="/citation/citations#cahn2015powers">cahn2015powers</a>,
+  title = {Powers in orbits of rational functions: cases of an arithmetic dynamical Mordell-Lang conjecture},
+  author = {Cahn, Jordan and Jones, Rafe and Spear, Jacob},
+  journal = {arXiv preprint arXiv:1512.03085},
+  year = {2015}
+}
+</pre>
+
+<a name="klemm2015direct"></a><pre>
+@article{<a href="/citation/citations#klemm2015direct">klemm2015direct</a>,
+  title = {Direct Integration for Mirror Curves of Genus Two and an Almost Meromorphic {Siegel} Modular Form},
+  author = {Klemm, Albrecht and Poretschkin, Maximilian and Schimannek, Thorsten and Westerholt-Raum, Martin},
+  journal = {arXiv preprint arXiv:1502.00557},
+  year = {2015}
+}
+</pre>
+
+<a name="mertens2014mock"></a><pre>
+@phdthesis{<a href="/citation/citations#mertens2014mock">mertens2014mock</a>,
+  title = {Mock modular forms and class numbers of quadratic forms},
+  author = {Mertens, Michael Helmut},
+  year = {2014},
+  school = {Universit{\"a}t zu K{\"o}ln}
+}
+</pre>
+
+<a name="nelson2016quantum"></a><pre>
+@article{<a href="/citation/citations#nelson2016quantum">nelson2016quantum</a>,
+  title = {Quantum variance on quaternion algebras, {I}},
+  author = {Nelson, Paul D},
+  journal = {arXiv preprint arXiv:1601.02526},
+  year = {2016}
+}
+</pre>
+
+<a name="grenie2015zeros"></a><pre>
+@article{<a href="/citation/citations#grenie2015zeros">grenie2015zeros</a>,
+  title = {Zeros of {Dedekind} zeta functions under {GRH}},
+  author = {Greni{\'e}, Lo{\"\i}c and Molteni, Giuseppe},
+  journal = {Mathematics of Computation},
+  volume = {85},
+  pages = {1503--1522},
+  year = {2015}
+}
+</pre>
+
+<a name="ryan2016computing"></a><pre>
+@article{<a href="/citation/citations#ryan2016computing">ryan2016computing</a>,
+  title = {Computing {Jacobi} Forms},
+  author = {Ryan, Nathan C and Sirolli, Nicol{\'a}s and Skoruppa, Nils-Peter and Tornar{\'\i}a, Gonzalo},
+  journal = {arXiv preprint arXiv:1602.07021},
+  year = {2016}
+}
+</pre>
+
+<a name="fite2015fields"></a><pre>
+@article{<a href="/citation/citations#fite2015fields">fite2015fields</a>,
+  title = {Fields of definition of elliptic $k$-curves and the realizability of all genus 2 {Sato}-{Tate} groups over a number field},
+  author = {Fit{\'e}, Francesc and Guitart, Xavier},
+  journal = {arXiv preprint arXiv:1511.02322},
+  year = {2015}
+}
+</pre>
+
+<a name="sairaiji2016class"></a><pre>
+@article{<a href="/citation/citations#sairaiji2016class">sairaiji2016class</a>,
+  title = {On the class numbers of the fields of the $p^n$-torsion points of elliptic curves over $\mathbb{Q}$},
+  author = {Sairaiji, Fumio and Yamauchi, Takuya},
+  journal = {arXiv preprint arXiv:1603.01296},
+  year = {2016}
+}
+</pre>
+
+<a name="bartel2016torsion"></a><pre>
+@article{<a href="/citation/citations#bartel2016torsion">bartel2016torsion</a>,
+  title = {Torsion homology and regulators of isospectral manifolds},
+  author = {Bartel, Alex and Page, Aurel},
+  journal = {arXiv preprint arXiv:1601.06821},
+  year = {2016}
+}
+</pre>
+
+<a name="cooper2016beyond"></a><pre>
+@article{<a href="/citation/citations#cooper2016beyond">cooper2016beyond</a>,
+  title = {Beyond the excised ensemble: modelling elliptic curve {L}-functions with random matrices},
+  author = {Cooper, Ian A and Morris, Patrick W and Snaith, Nina C},
+  journal = {Journal of Physics A: Mathematical and Theoretical},
+  volume = {49},
+  number = {7},
+  pages = {075202},
+  year = {2016},
+  publisher = {IOP Publishing}
+}
+</pre>
+
+<a name="bertin2016mahler"></a><pre>
+@article{<a href="/citation/citations#bertin2016mahler">bertin2016mahler</a>,
+  title = {On the Mahler measure of hyperelliptic families},
+  author = {Bertin, Marie Jos{\'e} and Zudilin, Wadim},
+  journal = {arXiv preprint arXiv:1601.07583},
+  year = {2016}
+}
+</pre>
+
+<a name="ramakrishnan2016representations"></a><pre>
+@article{<a href="/citation/citations#ramakrishnan2016representations">ramakrishnan2016representations</a>,
+  title = {On the representations of a positive integer by certain classes of quadratic forms in eight variables},
+  author = {Ramakrishnan, B and Sahu, Brundaban and Singh, Anup Kumar},
+  journal = {arXiv preprint arXiv:1607.04764},
+  year = {2016}
+}
+</pre>
+
+<a name="ramakrishnan2015number"></a><pre>
+@article{<a href="/citation/citations#ramakrishnan2015number">ramakrishnan2015number</a>,
+  title = {On the number of representations of certain quadratic forms in $20$ and $24$ variables},
+  author = {Ramakrishnan, B and Sahu, Brundaban},
+  journal = {Functiones et Approximatio Commentarii Mathematici},
+  note = {to appear}
+}
+</pre>
+
+<a name="balakrishnan2016databases"></a><pre>
+@article{<a href="/citation/citations#balakrishnan2016databases">balakrishnan2016databases</a>,
+  title = {Databases of elliptic curves ordered by height and distributions of Selmer groups and ranks},
+  author = {Balakrishnan, Jennifer S and Ho, Wei and Kaplan, Nathan and Spicer, Simon and Stein, William and Weigandt, James},
+  journal = {arXiv preprint arXiv:1602.01894},
+  year = {2016}
+}
+</pre>
+
+<a name="booker2016database"></a><pre>
+@article{<a href="/citation/citations#booker2016database">booker2016database</a>,
+  title = {A database of genus 2 curves over the rational numbers},
+  author = {Booker, Andrew R and Sijsling, Jeroen and Sutherland, Andrew V and Voight, John and Yasaki, Dan},
+  journal = {arXiv preprint arXiv:1602.03715},
+  year = {2016}
+}
+</pre>
+
+<a name="jones2016mixed"></a><pre>
+@article{<a href="/citation/citations#jones2016mixed">jones2016mixed</a>,
+  title = {Mixed degree number field computations},
+  author = {Jones, John W and Roberts, David P},
+  journal = {arXiv preprint arXiv:1602.09119},
+  year = {2016}
+}
+</pre>
+
+<a name="koutsianas2015computing"></a><pre>
+@article{<a href="/citation/citations#koutsianas2015computing">koutsianas2015computing</a>,
+  title = {Computing all elliptic curves over an arbitrary number field with prescribed primes of bad reduction},
+  author = {Koutsianas, Angelos},
+  journal = {arXiv preprint arXiv:1511.05108},
+  year = {2015}
+}
+</pre>
+
+<a name="mosunov2015unconditional"></a><pre>
+@article{<a href="/citation/citations#mosunov2015unconditional">mosunov2015unconditional</a>,
+  title = {Unconditional class group tabulation of imaginary quadratic fields to $|{\Delta}|<2^{40}$},
+  author = {Mosunov, A and Jacobson Jr,  M},
+  journal = {Mathematics of Computation},
+  volume = {85},
+  pages = {1983--2009},
+  year = {2016}
+}
+</pre>
+
+<a name="cohen2013dirichlet"></a><pre>
+@article{<a href="/citation/citations#cohen2013dirichlet">cohen2013dirichlet</a>,
+  title = {Dirichlet series associated to quartic fields with given resolvent},
+  author = {Cohen, Henri and Thorne, Frank},
+  journal = {Michigan Math. J.},
+  volume = {63},
+  number = {2},
+  pages = {253--273},
+  year = {2014}
+}
+</pre>
+
+<a name="rouse2013explicit"></a><pre>
+@article{<a href="/citation/citations#rouse2013explicit">rouse2013explicit</a>,
+  title = {The explicit {Sato}-{Tate} conjecture and densities pertaining to {Lehmer}-type questions},
+  author = {Rouse, Jeremy and Thorner, Jesse},
+  journal = {Transactions of the AMS},
+  note = {to appear},
+  year = {2016}
+}
+</pre>
+
+<a name="balakrishnan2015shadow"></a><pre>
+@article{<a href="/citation/citations#balakrishnan2015shadow">balakrishnan2015shadow</a>,
+  title = {Shadow lines in the arithmetic of elliptic curves},
+  author = {Balakrishnan, J. S. and {\c{C}}iperiani, M. and Lang, J. and Mirza, B. and Newton, R.},
+  note = {preprint},
+  url = {<a href="http://guests.mpim-bonn.mpg.de/rachel/ShadowLines.pdf">http://guests.mpim-bonn.mpg.de/rachel/ShadowLines.pdf</a>},
+  year = {2015}
+}
+</pre>
+
+<a name="kraus2015theoreme"></a><pre>
+@article{<a href="/citation/citations#kraus2015theoreme">kraus2015theoreme</a>,
+  title = {Sur le th{\'e}or{\`e}me de Fermat sur $\mathbb{Q}(\sqrt5)$},
+  author = {Kraus, Alain},
+  journal = {Annales math{\'e}matiques du Qu{\'e}bec},
+  volume = {39},
+  number = {1},
+  pages = {49--59},
+  year = {2015},
+  publisher = {Springer}
+}
+</pre>
+
+<a name="hulse2016counting"></a><pre>
+@article{<a href="/citation/citations#hulse2016counting">hulse2016counting</a>,
+  title = {Counting square discriminants},
+  author = {Hulse, Thomas A and Kuan, Chan Ieong and K{\i}ral, Eren Mehmet and Lim, Li-Mei},
+  journal = {Journal of Number Theory},
+  volume = {162},
+  pages = {255--274},
+  year = {2016},
+  publisher = {Academic Press}
+}
+</pre>
+
+<a name="schaeffer2015hecke"></a><pre>
+@article{<a href="/citation/citations#schaeffer2015hecke">schaeffer2015hecke</a>,
+  title = {Hecke stability and weight 1 modular forms},
+  author = {Schaeffer, George J},
+  journal = {Mathematische Zeitschrift},
+  volume = {281},
+  number = {1-2},
+  pages = {159--191},
+  year = {2015},
+  publisher = {Springer Berlin Heidelberg}
+}
+</pre>
+
+<a name="saouter2015still"></a><pre>
+@article{<a href="/citation/citations#saouter2015still">saouter2015still</a>,
+  title = {A still sharper region where 𝜋 (𝑥)-𝑙𝑖 (𝑥) is positive},
+  author = {Saouter, Yannick and Trudgian, Timothy and Demichel, Patrick},
+  journal = {Mathematics of Computation},
+  volume = {84},
+  number = {295},
+  pages = {2433--2446},
+  year = {2015}
+}
+</pre>
+
+<a name="jones2013minimal"></a><pre>
+@article{<a href="/citation/citations#jones2013minimal">jones2013minimal</a>,
+  title = {Minimal solvable nonic fields},
+  author = {Jones, John W},
+  journal = {LMS Journal of Computation and Mathematics},
+  volume = {16},
+  pages = {130--138},
+  year = {2013},
+  publisher = {Cambridge University Press}
+}
+</pre>
+
+<a name="sohexplicit"></a><pre>
+@mastersthesis{<a href="/citation/citations#sohexplicit">sohexplicit</a>,
+  title = {Explicit Methods for the {Birch} and {Swinnerton}-{Dyer} Conjecture},
+  type = {MSc},
+  institution = {University of Oxford},
+  author = {Soh, Charlene}
+}
+</pre>
+
+<a name="linowitz2015small"></a><pre>
+@article{<a href="/citation/citations#linowitz2015small">linowitz2015small</a>,
+  title = {Small isospectral and nonisometric orbifolds of dimension 2 and 3},
+  author = {Linowitz, Benjamin and Voight, John},
+  journal = {Mathematische Zeitschrift},
+  volume = {281},
+  number = {1-2},
+  pages = {523--569},
+  year = {2015},
+  publisher = {Springer Berlin Heidelberg}
+}
+</pre>
+
+<a name="platt2015computing"></a><pre>
+@article{<a href="/citation/citations#platt2015computing">platt2015computing</a>,
+  title = {Computing $\pi(x)$ analytically},
+  author = {Platt, David},
+  journal = {Mathematics of Computation},
+  volume = {84},
+  number = {293},
+  pages = {1521--1535},
+  year = {2015}
+}
+</pre>
+
+<a name="guitart2016uniformization"></a><pre>
+@article{<a href="/citation/citations#guitart2016uniformization">guitart2016uniformization</a>,
+  title = {Uniformization of modular elliptic curves via p-adic periods},
+  author = {Guitart, Xavier and Masdeu, Marc and {\c{S}}eng{\"u}n, Mehmet Haluk},
+  journal = {Journal of Algebra},
+  volume = {445},
+  pages = {458--502},
+  year = {2016},
+  publisher = {Academic Press}
+}
+</pre>
+
+<a name="brunault2015regulators"></a><pre>
+@article{<a href="/citation/citations#brunault2015regulators">brunault2015regulators</a>,
+  title = {Regulators for {Rankin}-{Selberg} products of modular forms},
+  author = {Brunault, Fran{\c{c}}ois and Chida, Masataka},
+  journal = {Annales math\'ematiques du Qu\'ebec},
+  pages = {1--29},
+  year = {2016}
+}
+</pre>
+
+<a name="linowitz2015noncommutative"></a><pre>
+@article{<a href="/citation/citations#linowitz2015noncommutative">linowitz2015noncommutative</a>,
+  title = {A Noncommutative Analogue of the {Odlyzko} Bounds and Bounds on Performance for Space-Time Lattice Codes},
+  author = {Linowitz, Benjamin and Satriano, Matthew and Vehkalahti, Roope},
+  journal = {Information Theory, IEEE Transactions on},
+  volume = {61},
+  number = {4},
+  pages = {1971--1984},
+  year = {2015},
+  publisher = {IEEE}
+}
+</pre>
+
+<a name="kumar2014algebraic"></a><pre>
+@article{<a href="/citation/citations#kumar2014algebraic">kumar2014algebraic</a>,
+  title = {Algebraic models and arithmetic geometry of {Teichm\"uller} curves in genus two},
+  author = {Kumar, Abhinav and Mukamel, Ronen E},
+  journal = {arXiv preprint arXiv:1406.7057},
+  year = {2014}
+}
+</pre>
+
+<a name="cohencomputational"></a><pre>
+@misc{<a href="/citation/citations#cohencomputational">cohencomputational</a>,
+  title = {Computational number theory in relation with {L}-functions},
+  author = {Cohen, Henri},
+  url = {<a href="http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf">http://journees-louis-antoine.univ-rennes1.fr/Documents/NotesCohen.pdf</a>}
+}
+</pre>
+
+<a name="sutherland2015computing"></a><pre>
+@article{<a href="/citation/citations#sutherland2015computing">sutherland2015computing</a>,
+  title = {Computing images of {Galois} representations attached to elliptic curves},
+  author = {Sutherland, Andrew V},
+  journal = {Forum of Mathematics, Sigma},
+  volume = {4},
+  pages = {79 pages},
+  year = {2016}
+}
+</pre>
+
+<a name="balakrishnan2015explicit"></a><pre>
+@article{<a href="/citation/citations#balakrishnan2015explicit">balakrishnan2015explicit</a>,
+  title = {Explicit p-adic methods for elliptic and hyperelliptic curves},
+  author = {Balakrishnan, Jennifer S},
+  journal = {Advances on Superelliptic Curves and Their Applications},
+  volume = {41},
+  pages = {260},
+  year = {2015},
+  publisher = {IOS Press}
+}
+</pre>
+
+<a name="daniels2015torsion"></a><pre>
+@article{<a href="/citation/citations#daniels2015torsion">daniels2015torsion</a>,
+  title = {Torsion subgroups of rational elliptic curves over the compositum of all cubic fields},
+  author = {Daniels, Harris B and Lozano-Robledo, Alvaro and Najman, Filip and Sutherland, Andrew V},
+  journal = {arXiv preprint arXiv:1509.00528},
+  year = {2015}
+}
+</pre>
+
+<a name="ryan2014nonvanishing"></a><pre>
+@article{<a href="/citation/citations#ryan2014nonvanishing">ryan2014nonvanishing</a>,
+  title = {Nonvanishing of twists of-functions attached to {Hilbert} modular forms},
+  author = {Ryan, Nathan C and Tornaria, Gonzalo and Voight, John},
+  journal = {LMS Journal of Computation and Mathematics},
+  volume = {17},
+  number = {A},
+  pages = {330--348},
+  year = {2014},
+  publisher = {Cambridge University Press}
+}
+</pre>
+
+<a name="rahm2013level"></a><pre>
+@article{<a href="/citation/citations#rahm2013level">rahm2013level</a>,
+  title = {On level one cuspidal {Bianchi} modular forms},
+  author = {Rahm, Alexander D and {\c{S}}eng{\"u}n, Mehmet Haluk},
+  journal = {LMS Journal of Computation and Mathematics},
+  volume = {16},
+  pages = {187--199},
+  year = {2013},
+  publisher = {Cambridge University Press}
+}
+</pre>
+
+<a name="choudhry2015sextuples"></a><pre>
+@article{<a href="/citation/citations#choudhry2015sextuples">choudhry2015sextuples</a>,
+  title = {Sextuples of integers whose sums in pairs are squares},
+  author = {Choudhry, Ajai},
+  journal = {International Journal of Number Theory},
+  volume = {11},
+  number = {02},
+  pages = {543--555},
+  year = {2015},
+  publisher = {World Scientific}
+}
+</pre>
+
+<a name="waltoncongruent"></a><pre>
+@mastersthesis{<a href="/citation/citations#waltoncongruent">waltoncongruent</a>,
+  title = {The Congruent Number Problem and the {Birch} and {Swinnerton}-{Dyer} Conjecture},
+  type = {MMathPhil},
+  institution = {University of Oxford},
+  author = {Walton, Florence}
+}
+</pre>
+
+<a name="ghitza2013computations"></a><pre>
+@article{<a href="/citation/citations#ghitza2013computations">ghitza2013computations</a>,
+  title = {Computations of vector-valued {Siegel} modular forms},
+  author = {Ghitza, Alexandru and Ryan, Nathan C and Sulon, David},
+  journal = {Journal of Number Theory},
+  volume = {133},
+  number = {11},
+  pages = {3921--3940},
+  year = {2013},
+  publisher = {Elsevier}
+}
+</pre>
+
+<a name="baker2015elliptic"></a><pre>
+@mastersthesis{<a href="/citation/citations#baker2015elliptic">baker2015elliptic</a>,
+  title = {Elliptic Curves over Finite Fields and their l-Torsion {Galois} Representations},
+  type = {M.S.},
+  author = {Baker, Michael},
+  year = {2015},
+  institution = {University of Waterloo}
+}
+</pre>
+
+<a name="jones2014tame"></a><pre>
+@article{<a href="/citation/citations#jones2014tame">jones2014tame</a>,
+  title = {The tame-wild principle for discriminant relations for number fields},
+  author = {Jones, John and Roberts, David},
+  journal = {Algebra \& Number Theory},
+  volume = {8},
+  number = {3},
+  pages = {609--645},
+  year = {2014},
+  publisher = {Mathematical Sciences Publishers}
+}
+</pre>
+
+<a name="farmer2015varieties"></a><pre>
+@article{<a href="/citation/citations#farmer2015varieties">farmer2015varieties</a>,
+  title = {Varieties via their {L}-functions},
+  author = {Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
+  journal = {arXiv preprint arXiv:1502.00850},
+  year = {2015}
+}
+</pre>
+
+<a name="harris2015random"></a><pre>
+@mastersthesis{<a href="/citation/citations#harris2015random">harris2015random</a>,
+  title = {Random Matrix Theory and the Attraction of Zeros of {L}-functions from the Central Point},
+  author = {Harris, Katherine Elizabeth},
+  type = {Honors},
+  institution = {Bucknell University},
+  year = {2015}
+}
+</pre>
+
+<a name="cass2013tetrakaidecic"></a><pre>
+@misc{<a href="/citation/citations#cass2013tetrakaidecic">cass2013tetrakaidecic</a>,
+  title = {Tetrakaidecic Extensions of $Q_p$},
+  author = {Cass, Robert and Parenti, Salvatore and Shankman, Daniel},
+  url = {<a href="http://www.math.clemson.edu/~kevja/REU/2013/TetrakaidecicExtensionsOfQp.pdf">http://www.math.clemson.edu/~kevja/REU/2013/TetrakaidecicExtensionsOfQp.pdf</a>},
+  year = {2013}
+}
+</pre>
+
+<a name="mertens2014eichler"></a><pre>
+@article{<a href="/citation/citations#mertens2014eichler">mertens2014eichler</a>,
+  title = {Eichler-{Selberg} type identities for mixed mock modular forms},
+  author = {Mertens, Michael H},
+  journal = {arXiv preprint arXiv:1404.5491},
+  year = {2014}
+}
+</pre>
+
+<a name="wan2014slopes"></a><pre>
+@article{<a href="/citation/citations#wan2014slopes">wan2014slopes</a>,
+  title = {Slopes of eigencurves over boundary disks},
+  author = {Wan, Daqing and Xiao, Liang and Zhang, Jun},
+  journal = {arXiv preprint arXiv:1407.0279},
+  year = {2014}
+}
+</pre>
+
+<a name="deines2016generalized"></a><pre>
+@article{<a href="/citation/citations#deines2016generalized">deines2016generalized</a>,
+  title = {Generalized {Legendre} curves and quaternionic multiplication},
+  author = {Deines, Alyson and Fuselier, Jenny G and Long, Ling and Swisher, Holly and Tu, Fang-Ting},
+  journal = {Journal of Number Theory},
+  volume = {161},
+  pages = {175--203},
+  year = {2016},
+  publisher = {Academic Press}
+}
+</pre>
+
+<a name="banwait2013some"></a><pre>
+@phdthesis{<a href="/citation/citations#banwait2013some">banwait2013some</a>,
+  title = {On some local to global phenomena for abelian varieties},
+  author = {Banwait, Barinder S},
+  year = {2013},
+  school = {University of Warwick}
+}
+</pre>
+
+<a name="rubinstein2013elliptic"></a><pre>
+@article{<a href="/citation/citations#rubinstein2013elliptic">rubinstein2013elliptic</a>,
+  title = {Elliptic curves of high rank and the {Riemann} zeta function on the one line},
+  author = {Rubinstein, Michael O},
+  journal = {Experimental Mathematics},
+  volume = {22},
+  number = {4},
+  pages = {465--480},
+  year = {2013},
+  publisher = {Taylor \& Francis}
+}
+</pre>
+
+<a name="rubinstein2015moments"></a><pre>
+@article{<a href="/citation/citations#rubinstein2015moments">rubinstein2015moments</a>,
+  title = {Moments of zeta functions associated to hyperelliptic curves over finite fields},
+  author = {Rubinstein, Michael O and Wu, Kaiyu},
+  journal = {Philosophical Transactions of the Royal Society of London A: Mathematical, Physical and Engineering Sciences},
+  volume = {373},
+  number = {2040},
+  pages = {20140307},
+  year = {2015},
+  publisher = {The Royal Society}
+}
+</pre>
+
+<a name="deines2014shimura"></a><pre>
+@phdthesis{<a href="/citation/citations#deines2014shimura">deines2014shimura</a>,
+  title = {Shimura Degrees for Elliptic Curves over Number Fields},
+  author = {Deines, Alyson Laurene},
+  institution = {University of Washington},
+  year = {2014}
+}
+</pre>
+
+<a name="dummigan2013simple"></a><pre>
+@article{<a href="/citation/citations#dummigan2013simple">dummigan2013simple</a>,
+  title = {A simple trace formula for algebraic modular forms},
+  author = {Dummigan, Neil},
+  journal = {Experimental Mathematics},
+  volume = {22},
+  number = {2},
+  pages = {123--131},
+  year = {2013},
+  publisher = {Taylor \& Francis}
+}
+</pre>
+
+<a name="zhu2015more"></a><pre>
+@article{<a href="/citation/citations#zhu2015more">zhu2015more</a>,
+  title = {More on spherical designs of harmonic index $t$},
+  author = {Zhu, Yan and Bannai, Eiichi and Bannai, Etsuko and Kim, Kyoung-Tark and Yu, Wei-Hsuan},
+  journal = {arXiv preprint arXiv:1507.05373},
+  year = {2015}
+}
+</pre>
+
+<a name="sha2014pseudolinearly"></a><pre>
+@article{<a href="/citation/citations#sha2014pseudolinearly">sha2014pseudolinearly</a>,
+  title = {Pseudolinearly Dependent Points on Elliptic Curves},
+  author = {Sha, Min and Shparlinski, Igor E},
+  journal = {arXiv preprint arXiv:1410.1596},
+  year = {2014}
+}
+</pre>
+
+<a name="ugolini2015functional"></a><pre>
+@article{<a href="/citation/citations#ugolini2015functional">ugolini2015functional</a>,
+  title = {Functional graphs of rational maps induced by endomorphisms of ordinary elliptic curves over finite fields of odd characteristic},
+  author = {Ugolini, Simone},
+  journal = {arXiv preprint arXiv:1509.05365},
+  year = {2015}
+}
+</pre>
+
+<a name="katok2014fried"></a><pre>
+@article{<a href="/citation/citations#katok2014fried">katok2014fried</a>,
+  title = {The {Fried} average entropy and slow entropy for actions of higher rank abelian groups},
+  author = {Katok, Anatole and Katok, Svetlana and Hertz, Federico Rodriguez},
+  journal = {Geometric and Functional Analysis},
+  volume = {24},
+  number = {4},
+  pages = {1204--1228},
+  year = {2014},
+  publisher = {Springer}
+}
+</pre>
+
+<a name="donnelly2015table"></a><pre>
+@article{<a href="/citation/citations#donnelly2015table">donnelly2015table</a>,
+  title = {A Table of Elliptic Curves over the Cubic Field of Discriminant--23},
+  author = {Donnelly, Steve and Gunnells, Paul E and Klages-Mundt, Ariah and Yasaki, Dan},
+  journal = {Experimental Mathematics},
+  volume = {24},
+  number = {4},
+  pages = {375--390},
+  year = {2015},
+  publisher = {Taylor \& Francis}
+}
+</pre>
+
+<a name="hasmani2012classifying"></a><pre>
+@article{<a href="/citation/citations#hasmani2012classifying">hasmani2012classifying</a>,
+  title = {Classifying extensions of the field of formal Laurent series over $\mathbb{F}_p$},
+  author = {Brown, Jim and Hasmani, Alfeen and Hiltner, Lindsey and Kraft, Angela and Scofield, Daniel and Wash, Kristi},
+  journal = {Rocky Mountain Journal of Mathematics},
+  volume = {45},
+  number = {1},
+  pages = {115--130},
+  year = {2015}
+}
+</pre>
+
+<a name="plouffe2013values"></a><pre>
+@article{<a href="/citation/citations#plouffe2013values">plouffe2013values</a>,
+  title = {On the values of the functions zeta and gamma},
+  author = {Plouffe, Simon},
+  journal = {arXiv preprint arXiv:1310.7195},
+  year = {2013}
+}
+</pre>
+
+<a name="ramakrishnan2013evaluation"></a><pre>
+@article{<a href="/citation/citations#ramakrishnan2013evaluation">ramakrishnan2013evaluation</a>,
+  title = {Evaluation of the convolution sums $\sum_{l+15m= n}\sigma(l)\sigma(m)$ and $\sum\_{3l+ 5m= n}\sigma(l)\sigma(m)$ and some applications},
+  author = {Ramakrishnan, B and Sahu, Brundaban},
+  journal = {International Journal of Number Theory},
+  volume = {9},
+  number = {03},
+  pages = {799--809},
+  year = {2013},
+  publisher = {World Scientific}
+}
+</pre>
+
+<a name="farmer2014maass"></a><pre>
+@article{<a href="/citation/citations#farmer2014maass">farmer2014maass</a>,
+  title = {Maass Forms on {GL}(3) and {GL}(4)},
+  author = {Farmer, David W and Koutsoliotas, Sally and Lemurell, Stefan},
+  journal = {International mathematics research notices},
+  volume = {2014},
+  number = {22},
+  pages = {6276--6301},
+  year = {2014},
+  publisher = {Oxford University Press}
+}
+</pre>
+
+<a name="bachilov2014statistics"></a><pre>
+@article{<a href="/citation/citations#bachilov2014statistics">bachilov2014statistics</a>,
+  title = {On Statistics of the {Riemann} Zeros Differences},
+  author = {Bachilov, Yuri},
+  journal = {arXiv preprint arXiv:1402.0865},
+  year = {2014}
+}
+</pre>
+
+<a name="conrey2015riemann"></a><pre>
+@incollection{<a href="/citation/citations#conrey2015riemann">conrey2015riemann</a>,
+  title = {Riemann’s hypothesis},
+  author = {Conrey, Brian},
+  booktitle = {Colloquium De Giorgi 2013 and 2014},
+  pages = {109--117},
+  year = {2015},
+  publisher = {Springer}
+}
+</pre>
+
+<a name="fite2012sato"></a><pre>
+@article{<a href="/citation/citations#fite2012sato">fite2012sato</a>,
+  title = {Sato-{Tate} groups of some weight 3 motives},
+  author = {Fit{\'e}, Francesc and Kedlaya, Kiran S and Sutherland, Andrew V},
+  journal = {Contemporary Mathematics},
+  volume = {663},
+  pages = {57--102},
+  year = {2016},
+  publisher = {American Mathematical Society}
+}
+</pre>
+
+<a name="ramakrishnan2014number"></a><pre>
+@article{<a href="/citation/citations#ramakrishnan2014number">ramakrishnan2014number</a>,
+  title = {On the number of representations of an integer by certain quadratic forms in sixteen variables},
+  author = {Ramakrishnan, B and Sahu, Brundaban},
+  journal = {International Journal of Number Theory},
+  volume = {10},
+  number = {08},
+  pages = {1929--1937},
+  year = {2014},
+  publisher = {World Scientific}
+}
+</pre>
+
+<a name="billerey2015some"></a><pre>
+@misc{<a href="/citation/citations#billerey2015some">billerey2015some</a>,
+  title = {On some remarkable congruences between two elliptic curves},
+  author = {Billerey, Nicolas},
+  note = {preprint},
+  year = {2015}
+}
+</pre>
+
+<a name="browndegree"></a><pre>
+@article{<a href="/citation/citations#browndegree">browndegree</a>,
+  title = {Degree 14 extensions of $\mathbb{Q}_7$},
+  author = {Brown, Jim and Cass, Robert and Keaton, Rodney and Parenti, Salvatore and Shankman, Daniel},
+  journal = {International Journal of Pure and Applied Mathematics},
+  volume = {100},
+  number = {2},
+  pages = {337--345},
+  year = {2015}
+}
+</pre>
+
+<a name="farmer2015second"></a><pre>
+@article{<a href="/citation/citations#farmer2015second">farmer2015second</a>,
+  title = {The second Dirichlet coefficient starts out negative},
+  author = {Farmer, David W and Koutsoliotas, Sally},
+  journal = {The Ramanujan Journal},
+  pages = {1--9},
+  year = {2015},
+  publisher = {Springer}
+}
+</pre>
+
+<a name="he2014conjecture"></a><pre>
+@article{<a href="/citation/citations#he2014conjecture">he2014conjecture</a>,
+  title = {On a conjecture concerning integral real roots of certain cubic polynomials},
+  author = {He, Junhua},
+  journal = {Linear Algebra and its Applications},
+  volume = {446},
+  pages = {265--268},
+  year = {2014},
+  publisher = {Elsevier}
+}
+</pre>
+
+<a name="anni2014local"></a><pre>
+@article{<a href="/citation/citations#anni2014local">anni2014local</a>,
+  title = {A local--global principle for isogenies of prime degree over number fields},
+  author = {Anni, Samuele},
+  journal = {Journal of the London Mathematical Society},
+  volume = {89},
+  number = {3},
+  pages = {745--761},
+  year = {2014},
+  publisher = {Oxford University Press}
+}
+</pre>
+
+<a name="brown2015classifying"></a><pre>
+@article{<a href="/citation/citations#brown2015classifying">brown2015classifying</a>,
+  title = {Classifying extensions of the field of formal Laurent series over $\mathbb{F}_p$},
+  author = {Brown, Jim and Hasmani, Alfeen and Hiltner, Lindsey and Kraft, Angela and Scofield, Daniel and Wash, Kirsti and others},
+  journal = {Rocky Mountain Journal of Mathematics},
+  volume = {45},
+  number = {1},
+  pages = {115--130},
+  year = {2015},
+  publisher = {Rocky Mountain Mathematics Consortium}
+}
+</pre>
+


### PR DESCRIPTION
Using 2 html files created from the repository LMFDB/citations the URL /citation now gives a new short page linking to both the old version which now has URL /citation/citing and also to the new page at /citation/citations which is a (recently updated) list of over 100 citations.  The latter page also has links to (and back from) a separate bibtex file.

This is intended as a proof of concept.  No doubt people will have improvements to suggest.
