### PR TITLE
round up elliptic curve conductor bound to next multiple of 1000

### DIFF
--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -61,6 +61,14 @@ class ECstats(object):
         counts['nclasses'] = nclasses
         counts['nclasses_c'] = comma(nclasses)
         max_N = ecdb.find().sort('conductor', DESCENDING).limit(1)[0]['conductor']
+        # round up to nearest multiple of 1000
+        max_N = 1000*((max_N/1000)+1)
+        # NB while we only have the Cremona database, the upper bound
+        # will always be a multiple of 1000, but it looks funny to
+        # show the maximum condictor as something like 399998; there
+        # are no elliptic curves whose conductor is a multiple of
+        # 1000.
+
         counts['max_N'] = max_N
         counts['max_N_c'] = comma(max_N)
         counts['max_rank'] = ecdb.find().sort('rank', DESCENDING).limit(1)[0]['rank']


### PR DESCRIPTION
Instead of saying that we have all elliptic curves of conductor up to (say) 399998 it will say  400000, after rounding up.  This makes sense since the Cremona database will always have an upper bound which is a multiple of 1000 (actually 10000), and just looks a bit better.  (I have had comments about this in demos.)