### PR TITLE
tiny change to keep Sage-7.4 happy

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -154,7 +154,7 @@ def list_to_factored_poly_otherorder(s, galois=False):
             this_poly = expand(x**this_degree*this_poly.substitute(T=1/x))
             this_number_field = NumberField(this_poly, "a")
             this_gal = this_number_field.galois_group(type='pari')
-            this_t_number = this_gal.group()._pari_()[2]._sage_()
+            this_t_number = this_gal.group()._pari_()[2].sage()
             gal_list.append([this_degree, this_t_number])
         vcf = v[0].list()
         started = False


### PR DESCRIPTION
This fixes Issue #1937 -- some tiny change between Sage 7.3 and 7.4 means that two underscores had to be deleted (in converting from a pari integer to a Sage integer).  I tested on both 7.3 and 7.4, the important thing to do before merging this is to check that all really is well with 7.3 since that's what all our sites currently run.