### PR TITLE
Addition to GettingStarted.md on SSL dependency

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -25,9 +25,18 @@ Installation
       sage -i database_gap
       sage -i pip
       sage -b
-      # in the `lmfdb/` directory:
+      # in the 'lmfdb/' directory:
       sage -pip install -r requirements.txt
    ```
+  * [SSL dependency] On some systems the final line above may fail with an
+    error message stating that the SSL module in Python was not found. If this
+    happens, then follow one of the three possible solutions in [Sage's
+    installation
+    guide](http://doc.sagemath.org/html/en/installation/source.html#building-the-notebook-with-ssl-support).
+    Depending on your chosen solution, Sage may thereafter claim upon shutdown
+    that the service_identity package is still missing; this can be installed
+    with
+    * `sage -pip install --upgrade service_identity`
   * [optional] Memcache.  *This step is not at all necessary and can
     safely be ignored!* Memcache speeds up recompilation of python
     modules during development.  Using it requires both installing the

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -11,9 +11,17 @@ Installation
 
   and follow these instructions.
 
-* Make sure you have sage (>=7.0) installed and that
-  `sage` is available from the commandline.  In particular see
+* Make sure you have Sage (>=7.0) installed and that `sage` is available from
+  the commandline.  In particular see
   [Sage installation](http://doc.sagemath.org/html/en/installation/source.html).
+  Also check that your version of Sage has ssl available by checking that
+  `import ssl` works on its command line. If not, then the `pip install`
+  commands below will fail. To remedy this, either install SSL globally on
+  your system or have Sage build its own local version, as mentioned
+  [here](http://doc.sagemath.org/html/en/installation/source.html#notebook-additional-features)
+  and
+  [here](http://doc.sagemath.org/html/en/installation/source.html#building-the-notebook-with-ssl-support),
+  respectively.
 
 * Install dependencies.  This requires you to have write access to the
   Sage installation directory, so should be no problem on a personal
@@ -28,15 +36,6 @@ Installation
       # in the 'lmfdb/' directory:
       sage -pip install -r requirements.txt
    ```
-  * [SSL dependency] On some systems the final line above may fail with an
-    error message stating that the SSL module in Python was not found. If this
-    happens, then follow one of the three possible solutions in [Sage's
-    installation
-    guide](http://doc.sagemath.org/html/en/installation/source.html#building-the-notebook-with-ssl-support).
-    Depending on your chosen solution, Sage may thereafter claim upon shutdown
-    that the service_identity package is still missing; this can be installed
-    with
-    * `sage -pip install --upgrade service_identity`
   * [optional] Memcache.  *This step is not at all necessary and can
     safely be ignored!* Memcache speeds up recompilation of python
     modules during development.  Using it requires both installing the


### PR DESCRIPTION
On some systems the installation process in GettingStarted.md is not sufficient due to issues with the SSL module in Python. This addition describes what to do then.

This fixes Issue #1941 (already closed). See also https://groups.google.com/forum/#!topic/sage-support/c2fm64j55Jk, but the solution there is a suboptimal hybrid of the ones in the Sage installation guide to which this addition points.