### PR TITLE
Fixed bug in displaying p-adic regulators in rank 0 case.

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -425,7 +425,7 @@ representation')}} is surjective for all primes \( p \).
     {{ place_code('padicreg') }}
 
     <p>
-{% if data.bsd.rank==0 %}
+{% if data.rank==0 %}
 All \(p\)-adic regulators are identically \(1\) since the rank is \(0\).
 {% else %}
 {% if data.data.p_adic_data_exists %}


### PR DESCRIPTION
For rank 0 curves, instead of displaying that the p-adic regulators were 1 it said something else.

