### PR TITLE
correct sign of level 1 modular form L-functions

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -473,8 +473,8 @@ class Lfunction_EMF(Lfunction):
                 float(n ** self.automorphyexp))
 
         # Determining the sign
-        if self.level == 1:  # For level 1, the sign is always plus
-            self.sign = 1
+        if self.level == 1:  # For level 1, sign = (-1)^(k/2)
+            self.sign = (-1)** (self.weight/2)
         else:  # for level>1, calculate sign from Fricke involution and weight
             if self.character > 0:
                 self.sign = signOfEmfLfunction(self.level, self.weight,


### PR DESCRIPTION
This fixes issues #1950 and #1914 .

Once this fix is live, then I will email the people who noticed the problem and then
close the issues.

Once we read these L-functions from the database, all this code will be deleted.