### PR TITLE
Galois representations for elliptic curves over Q

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -114,7 +114,7 @@ def get_nf_info(lab):
     return label, pretty
 
 
-ecnf_credit = "John Cremona, Alyson Deines, Steve Donelly, Paul Gunnells, Warren Moore, Haluk Sengun, John Voight, Dan Yasaki"
+ecnf_credit = "John Cremona, Alyson Deines, Steve Donelly, Paul Gunnells, Warren Moore, Haluk Sengun, Andrew V Sutherland, John Voight, Dan Yasaki"
 
 
 def get_bread(*breads):

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -95,6 +95,9 @@ def rational_elliptic_curves(err_args=None):
     credit = 'John Cremona and Andrew Sutherland'
     t = 'Elliptic curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
+    info['galois_data_type'] = 'old'
+    if 'non-maximal_primes' in db_ec().find_one():
+        info['galois_data_type'] = 'new'
     return render_template("ec-index.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'), **err_args)
 
 @ec_page.route("/random")
@@ -278,6 +281,10 @@ def elliptic_curve_search(info):
     credit = 'John Cremona'
     if 'non-surjective_primes' in query:
         credit += 'and Andrew Sutherland'
+    info['galois_data_type'] = 'old'
+    if 'non-maximal_primes' in db_ec().find_one():
+        info['galois_data_type'] = 'new'
+
     t = info.get('title','Elliptic Curves search results')
     return render_template("ec-search-results.html", info=info, credit=credit, bread=bread, title=t)
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -292,7 +292,7 @@ def elliptic_curve_search(info):
             info['report'] = 'displaying all %s matches' % nres
     credit = 'John Cremona'
     if 'non-surjective_primes' in query or 'non-maximal_primes' in query:
-        credit += 'and Andrew Sutherland'
+        credit += ' and Andrew Sutherland'
 
     t = info.get('title','Elliptic Curves search results')
     return render_template("ec-search-results.html", info=info, credit=credit, bread=bread, title=t)

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -385,14 +385,22 @@ data.twoadic_index }}.
 
     {{ place_code('galrep') }}
 
+{% if data.data.new_galois_data %}
+
+{# ######## code for new Galois data (non-maximal primes) ###### #}
+
 <p>
 The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
 representation')}}
 has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
+{% if not data.data.CMD %}
+\(\GL(2,\F_p)\)
+{% endif %}
 for all primes \( p \)
 {% if data.data.galois_data %} {# there are non-maximal primes #}
 except those listed.
 </p>
+
 <p>
 <table>
 <tr>
@@ -431,6 +439,53 @@ the {{KNOWL('gl2.normalizer_nonsplit_cartan', title='normalizer of a nonsplit Ca
 if \(\left(\frac{ {{data.data.cm_sqf}} }{p}\right)=-1\).
 </p>
 {% endif %} {# CM case #}
+
+{% else %}
+
+{# ######## code for old Galois data (non-surjective primes) ###### #}
+
+
+
+{% if data.data.galois_data %}
+<p>
+{% if data.data.CMD %}
+The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
+representations')}} of an elliptic curve with {{
+KNOWL('ec.complex_multiplication', title='Complex Multiplication') }}
+are non-surjective for all odd primes \( p \).  We only show the image
+for
+primes \( p\le 37 \).
+{% else %}
+The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
+representation')}} is surjective for all primes \( p \) except those
+    listed.
+{% endif %}
+</p>
+<table>
+<tr>
+<th>prime</th>
+<th>{{KNOWL('ec.q.galois_rep_image', title='Image of Galois
+  representation')}}</th>
+</tr>
+{% for pr in data.data.galois_data %}
+<tr>
+<td align=center> \({{pr.p}}\)</td>
+<td align=center>{{pr.image}}</td>
+</tr>
+{% endfor %}
+</table>
+{% else %}
+<p>
+The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
+representation')}} is surjective for all primes \( p \).
+</p>
+{% endif %}
+
+
+{# ######## end of new/old Galois data split ###### #}
+
+{% endif %}
+
 
 
     <h2> p-adic data </h2>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -385,20 +385,15 @@ data.twoadic_index }}.
 
     {{ place_code('galrep') }}
 
-{% if data.data.galois_data %}
 <p>
-{% if data.data.CMD %}
 The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representations')}} of an elliptic curve with {{
-KNOWL('ec.complex_multiplication', title='Complex Multiplication') }}
-are non-surjective for all odd primes \( p \).  We only show the image for
-primes \( p\le 37 \).
-{% else %}
-The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representation')}} is surjective for all primes \( p \) except those
-    listed.
-{% endif %}
+representation')}}
+has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
+for all primes \( p \)
+{% if data.data.galois_data %} {# there are non-maximal primes #}
+except those listed.
 </p>
+<p>
 <table>
 <tr>
 <th>prime</th>
@@ -412,12 +407,30 @@ representation')}} is surjective for all primes \( p \) except those
 {% endfor %}
 </table>
 {% else %}
-<p>
-The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representation')}} is surjective for all primes \( p \).
-</p>
+.
 {% endif %}
+</p>
 
+{% if data.data.CMD %}
+<p>
+{% if data.data.galois_data %} For all other primes \(p\), the
+{% else %} The
+{% endif %}
+image is
+{% if data.data.cm_nramp!=0 %}
+a {{KNOWL('gl2.borel', title='Borel subgroup')}}
+{% if data.data.cm_nramp==1 %}
+if \(p={{data.data.cm_ramp}}\),
+{% else %}
+if \(p\in \{ {{ data.data.cm_ramp }}\}\),
+{% endif %}
+{% endif %}
+the {{KNOWL('gl2.normalizer_split_cartan', title='normalizer of a split Cartan subgroup')}}
+if \(\left(\frac{ {{data.data.cm_sqf}} }{p}\right)=+1\) or
+the {{KNOWL('gl2.normalizer_nonsplit_cartan', title='normalizer of a nonsplit Cartan subgroup')}}
+if \(\left(\frac{ {{data.data.cm_sqf}} }{p}\right)=-1\).
+</p>
+{% endif %} {# CM case #}
 
 
     <h2> p-adic data </h2>

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -161,11 +161,19 @@ Please enter a value or leave blank:
       </tr>
 
 <tr>
-<td align=left>{{KNOWL('ec.q.surjective_prime', title='surjective primes')}} 
+{% if info.galois_data_type=='new' %}
+<td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}} 
+{% else %}
+<td align=left>{{KNOWL('ec.q.non-surjective_prime', title='surjective primes')}} 
+{% endif %}
    <td><input type='text' name='surj_primes' size=10 example='2,3'></td>
 <td><span class="formexample"> e.g. 2,3</span></td>
 <td align=left>
+{% if info.galois_data_type=='new' %}
+{{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}} 
+{% else %}
 {{KNOWL('ec.q.non-surjective_prime', title='non-surjective primes')}} 
+{% endif %}
   <select name='surj_quantifier'>
   <option value='include'>include</option>
   <option value='exactly'>exactly</option>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -49,9 +49,17 @@
 </tr>
 
 <tr>
+{% if info.galois_data_type=='new' %}
+<td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}} 
+{% else %}
 <td align=left>{{KNOWL('ec.q.surjective_prime', title='surjective primes')}} 
+{% endif %}
 </td>
-<td align=left colspan=2>{{KNOWL('ec.q.non-surjective_prime', title='non-surjective primes')}} 
+{% if info.galois_data_type=='new' %}
+<td align=left colspan=2>{{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}} 
+{% else %}
+<td align=left colspan=2>{{KNOWL('ec.q.surjective_prime', title='non-surjective primes')}} 
+{% endif %}
 </td>
 <td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
 </tr>
@@ -138,7 +146,11 @@ table td.params {
   <th class="center">{{ KNOWL('ec.q.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
 {% if info.surj_primes or info.nonsurj_primes  %}
+{% if info.galois_data_type=='new' %}
+  <th class="center">{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}</th>
+{% else %}
   <th class="center">{{KNOWL('ec.q.non-surjective_prime', title='Non-surjective primes')}}</th>
+{% endif %}
 {% endif %}
 </tr>
 {% for curve in info.curves: %}
@@ -150,7 +162,11 @@ table td.params {
 <td class="center">{{curve.rank}}</td>
 <td class="center">{{curve.torsion}}</td>
 {% if info.surj_primes or info.nonsurj_primes %}
+{% if info.galois_data_type=='new' %}
+<td class="center">{{curve['non-maximal_primes']}}</td>
+{% else %}
 <td class="center">{{curve['non-surjective_primes']}}</td>
+{% endif %}
 {% endif %}
 </tr>
 {% endfor %}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -58,7 +58,7 @@ def db_ec():
     global ecdb
     if ecdb is None:
         ec = lmfdb.base.getDBConnection().elliptic_curves
-        ecdb = ec.curves.new
+        ecdb = ec.curves
     return ecdb
 
 def padic_db():

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -335,7 +335,7 @@ def alllabels(line):
         'lmfdb_number': int(data[5])
     }
 
-def galrep(line):
+def galrep(line, new_format=True):
     r""" Parses one line from a galrep file.  Returns the label and a
     dict containing two fields: 'non-surjective_primes', a list of
     primes p for which the Galois representation modulo p is not
@@ -346,7 +346,7 @@ def galrep(line):
     start with a 1 or 2 digit prime followed a letter in
     ['B','C','N','S'].
 
-    Input line fields:
+    Input line fields (new_format=False):
 
     conductor iso number ainvs rank torsion codes
 
@@ -354,10 +354,22 @@ def galrep(line):
 
     66 c 3 [1,0,0,-10065,-389499] 0 2 2B 5B.1.2
 
+    Input line fields (new_format=True):
+
+    label codes
+
+    Sample input line:
+
+    66c3 2B 5B.1.2
+
     """
     data = split(line)
-    label = data[0] + data[1] + data[2]
-    image_codes = data[6:]
+    if new_format:
+        label = data[0]
+        image_codes = data[1:]
+    else:
+        label = data[0] + data[1] + data[2]
+        image_codes = data[6:]
     pr = [ int(s[:2]) if s[1].isdigit() else int(s[:1]) for s in image_codes]
     return label, {
         'non-surjective_primes': pr,
@@ -643,6 +655,37 @@ isogdata = {} # to keep pyflakes happy
 def add_isogs_to_one(c):
     c.update(isogdata[c['label']])
     c['lmfdb_number'] = int(c['lmfdb_number'])
+    return c
+
+def readallgalreps(base_path, f):
+    r""" Returns a dictionary whose keys are Cremona labels of individual
+    curves, and whose values are a dictionary with the keys
+    'non-surjective_primes' and 'galois_images'
+
+    This function reads one new-format galrep file.
+    """
+    h = open(os.path.join(base_path, f))
+    print("Opened {}".format(os.path.join(base_path, f)))
+    data = {}
+    for line in h.readlines():
+        label, data1 = galrep(line, new_format=True)
+        data[label] = data1
+    return data
+
+# To add all the galrep data to the database, first use the
+# preceding function readllgalreps() to create a large dict called
+# galrepdata keyed on curve labels, then pass the following function to
+# the rewrite_collection() function:
+
+galrepdata = {} # to keep pyflakes happy
+
+def add_galreps_to_one(c):
+    if c['cm']:
+        c.update(galrepdata[c['label']])
+    else:
+        # test no change
+        for k in ['non-surjective_primes', 'galois_images']:
+            assert c[k]==galrepdata[c['label']][k]
     return c
 
 


### PR DESCRIPTION
@AndrewVSutherland has recomputed the mod-p Galois image data for elliptic curves over Q, changing the data for CM curves where the important distinction to make is between "maximal" and "non-maximal" image.  We have uploaded this, into a collection called (right now) curves.new.
The revised code is currently set to read from curves.new, but also works fine if the collection name is changed to curves in line 61 of web_ec.py.  To test this, please test as it is (which will show the new style) and also with that line changes back (to show that all is still well with the old collection).

Assuming that all looks good, I will revise the PR to read from curves, the this can be merged and pushed to beta and prod, where it will show the old style;  then we can rename curves.new --> curves and copy to the cloud, after which the beta and production websites will show the new data.  A final step will be to clean out the conditional code.

If this looks complicated it is because so in order to never break anything while making (fairly minor) change.