### PR TITLE
Determinants of artin reps

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -173,14 +173,13 @@ def render_artin_representation_webpage(label):
         friends.append(("Artin Field", nf_url))
     cc = the_rep.central_character()
     if cc is not None:
-        if cc.modulus <= 100000: 
-            if the_rep.dimension()==1:
-                if cc.order == 2:
-                    cc_name = cc.symbol
-                else:
-                    cc_name = cc.texname
-                friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
-        if the_rep.dimension()>1:
+        if the_rep.dimension()==1:
+            if cc.order == 2:
+                cc_name = cc.symbol
+            else:
+                cc_name = cc.texname
+            friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
+        else:
             detrep = the_rep.central_character_as_artin_rep()
             friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
 

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -180,8 +180,9 @@ def render_artin_representation_webpage(label):
                 else:
                     cc_name = cc.texname
                 friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
-            else:
-                friends.append(("Determinant character", url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
+        if the_rep.dimension()>1:
+            detrep = the_rep.central_character_as_artin_rep()
+            friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
 
     # once the L-functions are in the database, the link can always be shown
     #if the_rep.dimension() <= 6:

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -254,13 +254,11 @@ class ArtinRepresentation(object):
         arts = nfgg.ArtinReps()
         # Filter for 1-dim
         arts = [a for a in arts if ArtinRepresentation(str(a['Baselabel'])+"c1").dimension()==1]
-        # Explode these to see actual characters, not just conj classes
         artfull = [ArtinRepresentation(str(a['Baselabel'])+"c"+str(a['GalConj'])) for a in arts]
-        #artfull = [a for b in artfull for a in b]
-        hold = artfull
+        # hold = artfull
         # Loop as we evaluate at primes until there is only one left
         # Fix the return value to be what we want
-        artfull = [[a, a.central_char_function()] for a in artfull]
+        artfull = [[a, a.central_char_function(),2*a.character_field()] for a in artfull]
         n = 2*self.character_field()
         p = 2
         disc = nfgg.discriminant()
@@ -268,7 +266,7 @@ class ArtinRepresentation(object):
             if (disc % p) != 0:
               k=0
               while k<len(artfull):
-                  if artfull[k][1](p,n) == myfunc(p,n):
+                  if n*artfull[k][1](p,artfull[k][2]) == artfull[k][2]*myfunc(p,n):
                       k += 1
                   else:
                       # Quick deletion of k-th term

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -4,7 +4,7 @@ from lmfdb.base import getDBConnection
 from lmfdb.utils import url_for, pol_to_html
 from lmfdb.artin_representations.databases.Dokchitser_databases import Dokchitser_ArtinRepresentation_Collection, Dokchitser_NumberFieldGaloisGroup_Collection
 from lmfdb.artin_representations.databases.standard_types import PolynomialAsSequenceTooLargeInt
-from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField, RealField, log, I, factor, crt, euler_phi, primitive_root, mod
+from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField, RealField, log, I, factor, crt, euler_phi, primitive_root, mod, next_prime
 from lmfdb.transitive_group import group_display_knowl, group_display_short, tryknowl
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.WebCharacter import WebSmallDirichletCharacter
@@ -238,6 +238,46 @@ class ArtinRepresentation(object):
             return (pvals % n)
         return myfunc
 
+    def central_character_as_artin_rep(self):
+        """
+          Returns the central character, i.e., determinant character
+          as a web character, but as an Artin representation
+        """
+        if self.dimension() == 1:
+            return self
+        if 'central_character_as_artin_rep' in self._data:
+            return self._data['central_character_as_artin_rep']
+        myfunc = self.central_char_function()
+        # Get the Artin field
+        nfgg = self.number_field_galois_group()
+        # Get its artin reps
+        arts = nfgg.ArtinReps()
+        # Filter for 1-dim
+        arts = [a for a in arts if ArtinRepresentation(str(a['Baselabel'])+"c1").dimension()==1]
+        # Explode these to see actual characters, not just conj classes
+        artfull = [ArtinRepresentation(str(a['Baselabel'])+"c"+str(a['GalConj'])) for a in arts]
+        #artfull = [a for b in artfull for a in b]
+        hold = artfull
+        # Loop as we evaluate at primes until there is only one left
+        # Fix the return value to be what we want
+        artfull = [[a, a.central_char_function()] for a in artfull]
+        n = 2*self.character_field()
+        p = 2
+        disc = nfgg.discriminant()
+        while len(artfull)>1:
+            if (disc % p) != 0:
+              k=0
+              while k<len(artfull):
+                  if artfull[k][1](p,n) == myfunc(p,n):
+                      k += 1
+                  else:
+                      # Quick deletion of k-th term
+                      artfull[k] = artfull[-1]
+                      del artfull[-1]
+            p = next_prime(p)
+        self._data['central_character_as_artin_rep'] = artfull[0][0]
+        return artfull[0][0]
+
     def central_character(self):
         """
           Returns the central character, i.e., determinant character
@@ -264,6 +304,9 @@ class ArtinRepresentation(object):
         if cc.order == 2:
             return cc.symbol
         return cc.texname
+
+    def det_as_artin_display(self):
+        return self.central_character_as_artin_rep().label()
 
     def det_url(self):
         cc= self.central_character()

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -19,7 +19,7 @@
                 <tr><td> {{ KNOWL('artin.dimensionone', title='Corresponding Dirichlet character') }}: <td> <a href={{object.det_url()}}>{{ object.det_display()|safe}}</a> </tr>
             {%endif%}
         {% else %}
-            <tr><td> {{ KNOWL('artin.determinant', title='Determinant') }}: <td> {{ object.det_display()|safe}} </tr>
+            <tr><td> {{ KNOWL('artin.determinant', title='Determinant') }}: <td> {{ object.det_as_artin_display()|safe}} </tr>
         {% endif %}
     </table>
 


### PR DESCRIPTION
Fix rest of issue 1994, giving the determinant of an Artin rep as an Artin rep.

A decent test is

  http://beta.lmfdb.org/ArtinRepresentation/3.3e6_7e3.9t6.1c1

since it has to pick out the determinant from a Galois conjugate pair (change the c1 at the end to c2 to see the conjugate degree 3 representation, which has a conjugate determinant rep'n (so also the end switches from c1 to c2).
