### PR TITLE
add search by isogeny degree

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -235,6 +235,8 @@ def elliptic_curve_search(info):
             elif info['include_cm'] == 'only':
                 query['cm'] = {'$ne' : 0}
 
+        parse_ints(info,query,field='isodeg',qfield='isogeny_degrees')
+
         if info['galois_data_type'] == 'new':
             parse_primes(info, query, 'surj_primes', name='surjective primes',
                          qfield='non-maximal_primes', mode='complement')

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -147,9 +147,8 @@ Please enter a value or leave blank:
           <td>
           <span class="formexample"> e.g. 4 </span>
           </td>
-          {# search by isogeny degree not yet implemented
           <td>
-          {{ KNOWL('ec.isogeny_degree',title="isogeny degree") }}
+          {{ KNOWL('ec.isogeny',title="isogeny degree") }}
           </td>
           <td>
           <input type='text' name='isodeg' example="16" size=10 />
@@ -157,7 +156,6 @@ Please enter a value or leave blank:
           <td>
           <span class="formexample"> e.g. 16 </span>
           </td>
-          #}
       </tr>
 
 <tr>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -19,6 +19,7 @@
 <td align=left>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</td>
 <td align=left>{{ KNOWL('ec.q.torsion_subgroup', title='Torsion structure') }}</td>
 <td align=left>{{ KNOWL('ec.q.analytic_sha_order', title='Analytic order of &#1064;') }}</td>
+<td align=left>{{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
 </tr>
 
 <tr>
@@ -46,6 +47,7 @@
 <td align=left><input type='text' name='torsion' size=6 value={{info.torsion}}> </td>
 <td align=left><input type='text' name='torsion_structure' size=7 value={{info.torsion_structure}}> </td>
 <td align=left><input type='text' name='sha' size=5 value={{info.sha}}> </td>
+<td align=left><input type='text' name='isodeg' size=5 value={{info.isodeg}}> </td>
 </tr>
 
 <tr>

--- a/scripts/ecnf/import_ecnf_data.py
+++ b/scripts/ecnf/import_ecnf_data.py
@@ -83,7 +83,7 @@ import os
 import pymongo
 from lmfdb.base import getDBConnection
 from lmfdb.utils import web_latex
-from sage.all import NumberField, PolynomialRing, cm_j_invariants_and_orders, EllipticCurve, ZZ, QQ
+from sage.all import NumberField, PolynomialRing, cm_j_invariants_and_orders, EllipticCurve, ZZ, QQ, Set
 from sage.databases.cremona import cremona_to_lmfdb
 from lmfdb.ecnf.ecnf_stats import field_data
 from lmfdb.ecnf.WebEllipticCurve import ideal_from_string, ideal_to_string, ideal_HNF, parse_ainvs, parse_point
@@ -819,7 +819,7 @@ def check_database_consistency(collection, field=None, degree=None, ignore_ranks
     int_type = type(int(1))
     float_type = type(float(1))
     list_type = type([1,2,3])
-    dict_type = type({'a':1})
+    #dict_type = type({'a':1})
     bool_type = type(True)
 
     keys_and_types = {'field_label':  str_type,

--- a/scripts/elliptic_curves/import_iwasawa_data.py
+++ b/scripts/elliptic_curves/import_iwasawa_data.py
@@ -18,7 +18,7 @@ Additional data fields for each elliptic curve over Q
 
 """
 import os
-from sage.all import ZZ, primes, sqrt, EllipticCurve
+from sage.all import ZZ, primes
 
 from lmfdb.base import getDBConnection
 print "getting connection"
@@ -54,7 +54,6 @@ def read_line(line, debug=0):
     N = ZZ(fields[0])
     badp = N.support()
     nbadp = len(badp)
-    ainvs = fields[3]
     p0 = int(fields[4])
     data['iwp0'] = p0
     if debug: print("p0={}".format(p0))


### PR DESCRIPTION
As requested by Elkies, this adds searching for elliptic curves over Q by isogeny degree.
I had added the additional data already (each curve now stores a list of the degrees of cyclic isogenies it admits, including 1) and also the template code but it was commented out.  This removes the commenting and adds the necessary item to the search query.
Check the main search page EllipticCurve/Q  -- you can put a single integer in the box, or a list or a range, as the standard parsing function is used.  The search results page has the same value preloaded as it should.  Searching for (for example) 3.5 will give all curves with either a 3-isogeny or a 5-isogeny; if you want those with both, use your own brain and search for 15!
Behind the scenes: I added a new index on the isogeny_degrees field, and I edited the knowl so that degrees are defined.