### PR TITLE
Handle erros in random_xxx_from_collection

### DIFF
--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -38,7 +38,10 @@ def random_object_from_collection(collection):
         m = collection.count()
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} != {2}), proceeding anyway.".format(collection,n,m))
-        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
+        try:
+            return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
+        except:
+            pass
     if pymongo.version_tuple[0] < 3:
         return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()
     else:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -55,7 +55,9 @@ def random_value_from_collection(collection,attribute):
         m = collection.count()
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} < {2})".format(collection,n,m))
-        return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True}).get(attribute)
+        obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True}).get(attribute)
+        if obj:
+            return obj
     if pymongo.version_tuple[0] < 3:
         return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next().get(attribute) # don't both optimizing this
     else:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -55,11 +55,11 @@ def random_value_from_collection(collection,attribute):
         m = collection.count()
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} < {2})".format(collection,n,m))
-        obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True}).get(attribute)
+        obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True})
         if obj:
-            return obj
+            return obj.get(attribute)
     if pymongo.version_tuple[0] < 3:
-        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next().get(attribute) # don't both optimizing this
+        return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next().get(attribute) # don't bother optimizing this
     else:
         # Changed in version 3.0: The aggregate() method always returns a CommandCursor. The pipeline argument must be a list.
         return collection.aggregate([{ '$sample': { 'size': int(1) } }, { '$project' : {'_id':False,attribute:True}} ]).next().get(attribute)

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -38,10 +38,9 @@ def random_object_from_collection(collection):
         m = collection.count()
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} != {2}), proceeding anyway.".format(collection,n,m))
-        try:
-            return collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
-        except:
-            pass
+        obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
+        if obj:
+            return obj
     if pymongo.version_tuple[0] < 3:
         return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()
     else:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -39,7 +39,7 @@ def random_object_from_collection(collection):
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} != {2}), proceeding anyway.".format(collection,n,m))
         obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']})
-        if obj:
+        if obj: # we could get null here if objects have been deleted without recreating the collection.rand index, if this happens, just rever to old method
             return obj
     if pymongo.version_tuple[0] < 3:
         return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next()
@@ -56,7 +56,7 @@ def random_value_from_collection(collection,attribute):
         if m != n:
             current_app.logger.warning("Random object index {0}.rand is out of date ({1} < {2})".format(collection,n,m))
         obj = collection.find_one({'_id':collection.rand.find_one({'num':randint(1,n)})['_id']},{'_id':False,attribute:True})
-        if obj:
+        if obj: # we could get null here if objects have been deleted without recreating the collection.rand index, if this happens, just rever to old method
             return obj.get(attribute)
     if pymongo.version_tuple[0] < 3:
         return collection.aggregate({ '$sample': { 'size': int(1) } }, cursor = {} ).next().get(attribute) # don't bother optimizing this


### PR DESCRIPTION
If objects have been deleted from collection xxx and the random object index xxx.rand has not been updated using create_random_object_index (see rewrite.py) then it is possible for the random_xxx_from_collection functions to attempt to access an object that no longer exists, causing an error.  This is a simple fix to check for a null object and revert to the old/slow method for retrieving random objects using pymongo aggregate with $sample.

I have tested this on a test collection (we don't want to test it on any of our "real" collections), and the change is small and safe, so I am just going to merge it.