### PR TITLE
ec/Q torsion structure search box now a drop-down list

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -594,7 +594,7 @@ This curve has non-trivial cyclic isogenies of degree \(d\) for \(d=\)
 Its isogeny class <a href={{ data.class_url }}>{{data.lmfdb_iso}}</a>
 consists of {{data.class_size}} curves linked by isogenies of
 {% if data.one_deg %}degree{% else %}degrees dividing{% endif %}
-{{data.class_deg}}.
+ {{data.class_deg}}.
 {% else %}
 This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_url }}>{{data.lmfdb_iso}}</a>
     consists of this curve only.

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -130,7 +130,28 @@ Please enter a value or leave blank:
           {{ KNOWL('ec.q.torsion_subgroup',title="torsion structure") }}
           </td>
           <td>
-          <input type='text' name='torsion_structure' example="[2,4]" size=10 value="{{torsion_structure}}" />
+         <select name='torsion_structure'>
+           <option value="" selected="yes">any</option>
+           <option value="[]">trivial</option>
+           <option value="[2]">$C_2$</option>
+           <option value="[3]">$C_3$</option>
+           <option value="[4]">$C_4$</option>
+           <option value="[5]">$C_5$</option>
+           <option value="[6]">$C_6$</option>
+           <option value="[7]">$C_7$</option>
+           <option value="[8]">$C_8$</option>
+           <option value="[9]">$C_9$</option>
+           <option value="[10]">$C_{10}$</option>
+           <option value="[12]">$C_{12}$</option>
+           <option value="[2,2]">$C_2\times C_2$</option>
+           <option value="[2,4]">$C_2\times C_4$</option>
+           <option value="[2,6]">$C_2\times C_6$</option>
+           <option value="[2,8]">$C_2\times C_8$</option>
+         </select>
+         {#
+         <input type='text' name='torsion_structure' example="[2,4]"
+                size=10 value="{{torsion_structure}}" />
+         #}
           </td>
           <td>
           <span class="formexample"> e.g. [2,4] </span>

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -154,7 +154,7 @@ Please enter a value or leave blank:
          #}
           </td>
           <td>
-          <span class="formexample"> e.g. [2,4] </span>
+          {#<span class="formexample"> e.g. [2,4] </span>#}
           </td>
       </tr>
 

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -9,7 +9,7 @@
 
 <form id='re-search'>
 <input type="hidden" name="start" value="{{info.start}}"/>
-<table border="0">
+<table border="0" cellpadding="5">
 
 <tr>
 <td align=left>{{ KNOWL('ec.q.conductor', title='Conductor') }}</td>
@@ -19,7 +19,6 @@
 <td align=left>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</td>
 <td align=left>{{ KNOWL('ec.q.torsion_subgroup', title='Torsion structure') }}</td>
 <td align=left>{{ KNOWL('ec.q.analytic_sha_order', title='Analytic order of &#1064;') }}</td>
-<td align=left>{{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
 </tr>
 
 <tr>
@@ -45,12 +44,93 @@
 </td>
 <td align=left><input type='text' name='rank'size=2 value={{info.rank}}></td>
 <td align=left><input type='text' name='torsion' size=6 value={{info.torsion}}> </td>
-<td align=left><input type='text' name='torsion_structure' size=7 value={{info.torsion_structure}}> </td>
+<td align=left>
+         <select name='torsion_structure'>
+           {% if info.torsion_structure=="[]" %}
+           <option value="[]" selected="yes">trivial</option>
+           {% else %}
+           <option value="[]">trivial</option>
+           {% endif %}
+           {% if info.torsion_structure=="[2]" %}
+           <option value="[2]" selected="yes">$C_2$</option>
+           {% else %}
+           <option value="[2]">$C_2$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[3]" %}
+           <option value="[3]" selected="yes">$C_3$</option>
+           {% else %}
+           <option value="[3]">$C_3$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[4]" %}
+           <option value="[4]" selected="yes">$C_4$</option>
+           {% else %}
+           <option value="[4]">$C_4$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[5]" %}
+           <option value="[5]" selected="yes">$C_5$</option>
+           {% else %}
+           <option value="[5]">$C_5$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[6]" %}
+           <option value="[6]" selected="yes">$C_6$</option>
+           {% else %}
+           <option value="[6]">$C_6$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[7]" %}
+           <option value="[7]" selected="yes">$C_7$</option>
+           {% else %}
+           <option value="[7]">$C_7$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[8]" %}
+           <option value="[8]" selected="yes">$C_8$</option>
+           {% else %}
+           <option value="[8]">$C_8$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[9]" %}
+           <option value="[9]" selected="yes">$C_9$</option>
+           {% else %}
+           <option value="[9]">$C_9$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[10]" %}
+           <option value="[10]" selected="yes">$C_{10}$</option>
+           {% else %}
+           <option value="[10]">$C_{10}$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[12]" %}
+           <option value="[12]" selected="yes">$C_{12}$</option>
+           {% else %}
+           <option value="[12]">$C_{12}$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[2,2]" %}
+           <option value="[2,2]" selected="yes">$C_2\times C_2$</option>
+           {% else %}
+           <option value="[2,2]">$C_2\times C_2$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[2,4]" %}
+           <option value="[2,4]" selected="yes">$C_2\times C_4$</option>
+           {% else %}
+           <option value="[2,4]">$C_2\times C_4$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[2,6]" %}
+           <option value="[2,6]" selected="yes">$C_2\times C_6$</option>
+           {% else %}
+           <option value="[2,6]">$C_2\times C_6$</option>
+           {% endif %}
+           {% if info.torsion_structure=="[2,8]" %}
+           <option value="[2,8]" selected="yes">$C_2\times C_8$</option>
+           {% else %}
+           <option value="[2,8]">$C_2\times C_8$</option>
+           {% endif %}
+         </select>
+{#  <input type='text' name='torsion_structure' size=7
+           value={{info.torsion_structure}}>
+         #}
+</td>
 <td align=left><input type='text' name='sha' size=5 value={{info.sha}}> </td>
-<td align=left><input type='text' name='isodeg' size=5 value={{info.isodeg}}> </td>
 </tr>
 
 <tr>
+<td align=left>{{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
 {% if info.galois_data_type=='new' %}
 <td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}} 
 {% else %}
@@ -66,6 +146,7 @@
 <td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
 </tr>
 <tr>
+<td align=left><input type='text' name='isodeg' size=5 value={{info.isodeg}}> </td>
 <td align=left>
    <input type='text' name='surj_primes' size=10 value={{info.surj_primes}}>
 </td>
@@ -99,8 +180,10 @@
 </td>
 <td align=left><input type='text' name='count' value={{info.count}} size=10>
 </td>
+<td>&nbsp;
+</td>
 <td colspan=3>
-<button type='submit' value='refine'>Refine or change search</button>
+<button type='submit' value='refine'>Update search</button>
 </td> </tr>
 </table>
 </form>


### PR DESCRIPTION
See Issue #962 .
This changes the torsion structure search box for elliptic curves over Q to a drop-down list instead of free-format.
Doing the same for ecnf would be possible though it would mean being careful to update whenever a new torsion structure is present.  Right now there are 

sage: Set([tuple(e['torsion_structure']) for e in nfcurves.find()])
{(21,), (2, 18), (2, 8), (9,), (11,), (2, 12), (13,), (15,), (3, 3), (4, 4), (3,), (5,), (16,), (3, 6), (2, 2), (7,), (18,), (20,), (2, 16), (2, 6), (22,), (8,), (2, 10), (10,), (37,), (12,), (2, 14), (14,), (25,), (27,), (2,), (4,), (), (6,), (17,), (19,), (2, 4)}
