### PR TITLE
Adds more features to update_joint_attribute_stats

### DIFF
--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -227,7 +227,7 @@ def update_joint_attribute_stats(db, coll, attributes, prefix=None, filter=None,
                 db[statscoll].delete_one({'_id':vkey})
                 db[statscoll].insert_one({'_id':vkey, 'total':vtotal, 'counts':vcounts, 'min':min, 'max':max})
                 vcounts = []; vtotal = 0
-            vototal += pair[1]
+            vtotal += pair[1]
             vcounts.append([":".join(values[1:]),pair[1]])
             lastval = values[0]
     else:

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -170,7 +170,7 @@ def update_attribute_stats(db, coll, attributes, prefix=None, filter=None):
         mapper = Code("""function(){emit(""+this."""+attr+""",1);}""")
         counts = sorted([ [r['_id'],int(r['value'])] for r in db[coll].inline_map_reduce(mapper,reducer,query=filter)])
         id = prefix + "/" + attr if prefix else attr
-        min, max = counts[0][0], counts[-1][0] if counts else None, None
+        min, max = (counts[0][0], counts[-1][0]) if counts else (None, None)
         db[statscoll].delete_one({'_id':id})
         db[statscoll].insert_one({'_id':id, 'total':total, 'counts':counts, 'min':min, 'max':max})
 
@@ -229,7 +229,7 @@ def update_joint_attribute_stats(db, coll, attributes, prefix=None, filter=None,
             vcounts.append([":".join(vals[1:]),pair[1]])
     else:
         jointkey = prefix + "/" + ":".join(attributes) if prefix else ":".join(attributes)
-        min, max = counts[0][0], counts[-1][0] if counts else None, None
+        min, max = (counts[0][0], counts[-1][0]) if counts else (None, None)
         db[statscoll].delete_one({'_id':jointkey})
         db[statscoll].insert_one({'_id':jointkey, 'total':total, 'counts':counts, 'min':min, 'max':max})
 


### PR DESCRIPTION
This PR adds attributes prefix=None, filter=None, unflatten=False to the update_joint_attribute_stats function.  The functionality of prefix and filter is the same as for update_attribute_stats.  If the unflatten parameter is set to true, rather than create a single record with counts for all combinations of the specified attributes, it will split this information across several records, one for each distinct value of the first attribute.  

The key names for these records will be of the form "val1/attr2:...:attrn" (you can also include a prefix if you wish).  For example, I used

update_joint_attribute_stats(db, "curves", ["analytic_rank","torsion_order"],prefix="byrank",unflatten=True)

to create records 12-16 in http://beta.lmfdb.org/api/genus2_curves/curves.stats/

One further change: the behavior of both update_attribute_stats and update_joint_attribute_stats on empty collections (or using a filter that matches no records) has been changed -- a stats record with an empty counts list and a total of 0 will be created.
