### PR TITLE
refactor ec stats to use curves.stats collection

### DIFF
--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from pymongo import DESCENDING
 from lmfdb.base import app
 from lmfdb.utils import comma, make_logger
-from lmfdb.elliptic_curves.web_ec import db_ec
+from lmfdb.elliptic_curves.web_ec import db_ecstats
 from flask import url_for
 
 def format_percentage(num, denom):
@@ -35,7 +34,7 @@ class ECstats(object):
 
     def __init__(self):
         logger.debug("Constructing an instance of ECstats")
-        self.ecdb = db_ec()
+        self.ecdbstats = db_ecstats()
         self._counts = {}
         self._stats = {}
 
@@ -52,15 +51,16 @@ class ECstats(object):
         if self._counts:
             return
         logger.debug("Computing elliptic curve counts...")
-        ecdb = self.ecdb
+        ecdbstats = self.ecdbstats
         counts = {}
-        ncurves = ecdb.count()
+        rankstats = ecdbstats.find_one({'_id':'rank'})
+        ncurves = rankstats['total']
         counts['ncurves']  = ncurves
         counts['ncurves_c'] = comma(ncurves)
-        nclasses = ecdb.find({'number': 1}).count()
+        nclasses = ecdbstats.find_one({'_id':'class/rank'})['total']
         counts['nclasses'] = nclasses
         counts['nclasses_c'] = comma(nclasses)
-        max_N = ecdb.find().sort('conductor', DESCENDING).limit(1)[0]['conductor']
+        max_N = ecdbstats.find_one({'_id':'conductor'})['max']
         # round up to nearest multiple of 1000
         max_N = 1000*((max_N/1000)+1)
         # NB while we only have the Cremona database, the upper bound
@@ -71,32 +71,35 @@ class ECstats(object):
 
         counts['max_N'] = max_N
         counts['max_N_c'] = comma(max_N)
-        counts['max_rank'] = ecdb.find().sort('rank', DESCENDING).limit(1)[0]['rank']
+        counts['max_rank'] = int(rankstats['max'])
         self._counts  = counts
         logger.debug("... finished computing elliptic curve counts.")
-        #logger.debug("%s" % self._counts)
 
     def init_ecdb_stats(self):
         if self._stats:
             return
         logger.debug("Computing elliptic curve stats...")
-        ecdb = self.ecdb
+        ecdbstats = self.ecdbstats
         counts = self._counts
         stats = {}
         rank_counts = []
+        rdict = dict(ecdbstats.find_one({'_id':'rank'})['counts'])
+        crdict = dict(ecdbstats.find_one({'_id':'class/rank'})['counts'])
         for r in range(counts['max_rank']+1):
-            ncu = ecdb.find({'rank': r}).count()
-            ncl = ecdb.find({'rank': r, 'number': 1}).count()
+            ncu = rdict[str(r)]
+            ncl = crdict[str(r)]
             prop = format_percentage(ncl,counts['nclasses'])
             rank_counts.append({'r': r, 'ncurves': ncu, 'nclasses': ncl, 'prop': prop})
         stats['rank_counts'] = rank_counts
         tor_counts = []
         tor_counts2 = []
         ncurves = counts['ncurves']
+        tdict = dict(ecdbstats.find_one({'_id':'torsion'})['counts'])
+        tsdict = dict(ecdbstats.find_one({'_id':'torsion_structure'})['counts'])
         for t in  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16]:
-            ncu = ecdb.find({'torsion': t}).count()
+            ncu = tdict[str(t)]
             if t in [4,8,12]: # two possible structures
-                ncyc = ecdb.find({'torsion_structure': [str(t)]}).count()
+                ncyc = tsdict[str(t)]
                 gp = "\(C_{%s}\)"%t
                 prop = format_percentage(ncyc,ncurves)
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncyc, 'prop': prop})
@@ -113,16 +116,17 @@ class ECstats(object):
                 prop = format_percentage(ncu,ncurves)
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
         stats['tor_counts'] = tor_counts+tor_counts2
-        stats['max_sha'] = ecdb.find().sort('sha', DESCENDING).limit(1)[0]['sha']
+
+        shadict = dict(ecdbstats.find_one({'_id':'sha'})['counts'])
+        stats['max_sha'] = max([int(s) for s in shadict])
         sha_counts = []
         from sage.misc.functional import isqrt
         for s in range(1,1+isqrt(stats['max_sha'])):
             s2 = s*s
-            nc = ecdb.find({'sha': s2}).count()
+            nc = shadict.get(str(s2),0)
             if nc:
                 sha_counts.append({'s': s, 'ncurves': nc})
         stats['sha_counts'] = sha_counts
         self._stats = stats
         logger.debug("... finished computing elliptic curve stats.")
-        #logger.debug("%s" % self._stats)
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -53,6 +53,7 @@ logger = make_logger("ec")
 
 ecdb = None
 padicdb = None
+ecdbstats = None
 
 def db_ec():
     global ecdb
@@ -60,6 +61,13 @@ def db_ec():
         ec = lmfdb.base.getDBConnection().elliptic_curves
         ecdb = ec.curves
     return ecdb
+
+def db_ecstats():
+    global ecdbstats
+    if ecdbstats is None:
+        ec = lmfdb.base.getDBConnection().elliptic_curves
+        ecdbstats = ec.curves.stats
+    return ecdbstats
 
 def padic_db():
     global padicdb

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -17,7 +17,7 @@ class HMFTest(LmfdbTest):
         assert 'edirect' in L.data
 
     def test_EC(self): #778
-        L = self.tc.get('ModularForm/GL2/TotallyReal/6.6.1312625.1/holomorphic/6.6.1312625.1-1.1-a')
+        L = self.tc.get('ModularForm/GL2/TotallyReal/5.5.126032.1/holomorphic/5.5.126032.1-82.1-b')
         assert 'Elliptic curve not available' in L.data     #TODO remove or change url when
                                                             #the elliptic curve is in the database
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.89.1/holomorphic/2.2.89.1-2.1-a')

--- a/scripts/ecnf/hmf_check_find.py
+++ b/scripts/ecnf/hmf_check_find.py
@@ -644,7 +644,7 @@ def find_curves(field_label='2.2.5.1', min_norm=0, max_norm=None, label=None, ou
             Plist0 = [Plist[i] for i in inds]
             aplist0 = [aplist[i] for i in inds]
             curves = EllipticCurveSearch(K.K(), Plist0, N, aplist0, effort)
-            rep = 0
+            # rep = 0
             allrep=0
             while not curves and allrep<10:
                 allrep += 1

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -89,7 +89,6 @@ password = pw_dict['data']['password']
 C['elliptic_curves'].authenticate(username, password)
 print "setting curves"
 curves = C.elliptic_curves.curves
-curves2 = C.elliptic_curves.curves2
 
 def parse_tgens(s):
     r"""
@@ -803,6 +802,7 @@ def add_extra_data(N1,N2,store=False):
    - 'anlist': (list of ints) a_p for p<20
 
     """
+    curves2 = C.elliptic_curves.curves2
     query = {}
     query['conductor'] = { '$gte': int(N1), '$lte': int(N2) }
     res = curves.find(query)
@@ -810,10 +810,10 @@ def add_extra_data(N1,N2,store=False):
     n = 0
     res = list(res) # since the cursor times out after a few thousand curves
     newcurves = []
-    for C in res:
+    for c in res:
         n += 1
         if n%100==0:
-            print C['lmfdb_label']
+            print c['lmfdb_label']
         if n%1000==0:
             if store and len(newcurves):
                 curves2.insert_many(newcurves)
@@ -821,13 +821,13 @@ def add_extra_data(N1,N2,store=False):
         else:
             sys.stdout.write(".")
             sys.stdout.flush()
-        data = make_extra_data(C['label'],C['number'],C['ainvs'],C['gens'])
-        C.update(data)
+        data = make_extra_data(c['label'],c['number'],c['ainvs'],c['gens'])
+        c.update(data)
         if store:
-            newcurves.append(C)
+            newcurves.append(c)
         else:
             pass
-            #print("Not writing updated %s to database.\n" % C['label'])
+            #print("Not writing updated %s to database.\n" % c['label'])
     # insert the final left-overs since the last full batch
     if store and len(newcurves):
         curves2.insert_many(newcurves)
@@ -958,3 +958,36 @@ def check_database_consistency(collection, N1=None, N2=None, iwasawa_bound=10000
             diff2 = [k for k in db_keys if not k in expected_keys]
             if diff1: print("expected but absent:      {}".format(diff1))
             if diff2: print("not expected but present: {}".format(diff2))
+
+def update_stats(verbose=True):
+    if verbose:
+        print("Finding max and min conductor and total number of curves")
+    Nlist = curves.distinct('conductor')
+    Nmax = int(max(Nlist))
+    Nmin = int(min(Nlist))
+    Ncurves = int(curves.count())
+    if verbose:
+        print("{} curves of conductor from {} to {}".format(Ncurves,Nmin,Nmax))
+    curves.stats.insert_one({'_id':'conductor', 'min':Nmin, 'max': Nmax, 'total': Ncurves})
+    from data_mgt.utilities.rewrite import (update_attribute_stats, update_joint_attribute_stats)
+    # Basic counts for these attributes:
+    ec = C.elliptic_curves
+    if verbose:
+        print("Adding simple counts for rank, torsion, torsion structure and Sha")
+    update_attribute_stats(ec, 'curves', ['rank', 'torsion', 'torsion_structure', 'sha'])
+    # rank counts for isogeny classes:
+    if verbose:
+        print("Adding isogeny class rank counts")
+    update_attribute_stats(ec, 'curves', 'rank', prefix='class', filter={'number':1})
+    # torsion order by rank:
+    if verbose:
+        print("Adding torsion counts by rank")
+    update_joint_attribute_stats(ec, 'curves', ['rank','torsion'], prefix='byrank', unflatten=True)
+    # torsion structure by rank:
+    if verbose:
+        print("Adding torsion structure counts by rank")
+    update_joint_attribute_stats(ec, 'curves', ['rank','torsion_structure'], prefix='byrank', unflatten=True)
+    # sha by rank:
+    if verbose:
+        print("Adding sha counts by rank")
+    update_joint_attribute_stats(ec, 'curves', ['rank','sha'], prefix='byrank', unflatten=True)


### PR DESCRIPTION
Using the new utilities in the rewrite module I have created new entries in the curves.stats collection which mean that the numbers appearing in EllipticCurve/Q/stats are now all precomputed with no quesries to the main curves collection being required.  This should make this page load faster, with no change in what is on it (these two are the things to test).

I also added a new function update_stats() to the ec import script file so that the required stats can be recreated and updated easily.

Later it will be possible to add additional information on the stats web page using this functionality, but for now I have made no changes to what is on the page, only changed how the numbers are obtained.