### PR TITLE
stats functions now attempt to preserve integers

### DIFF
--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import time
 
 def rewrite_collection(db, incoll, outcoll, func, batchsize=1000, reindex=True, filter=None, projection=None):

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -168,15 +168,22 @@ def update_attribute_stats(db, coll, attributes, prefix=None, filter=None):
     total = db[coll].find(filter).count()
     reducer = Code("""function(key,values){return Array.sum(values);}""")
     for attr in attributes:
-        mapper = Code("""function(){emit(this."""+attr+""",1);}""")
-        counts = sorted([ [r['_id'],int(r['value'])] for r in db[coll].inline_map_reduce(mapper,reducer,query=filter)])
-        # convert integer floats to ints (the javascript mapper converts all numbers to floats)
+        mapper = Code("""function(){emit(""+this."""+attr+""",1);}""")
+        counts = [ [r['_id'],int(r['value'])] for r in db[coll].inline_map_reduce(mapper,reducer,query=filter)]
+        # convert numeric value back to numeric values if possible so they sort correctly
         try:
-            if all([c[0] == int(c[0]) for c in counts]):
+            if all([c[0] == unicode(int(c[0])) for c in counts]):
                 counts = [[int(c[0]),c[1]] for c in counts]
         except:
             pass
+        if type(counts[0][0]) == unicode:
+            try:
+                if all([c[0] == unicode(float(c[0])) for c in counts]):
+                    counts = [[float(c[0]),c[1]] for c in counts]
+            except:
+                pass
         id = prefix + "/" + attr if prefix else attr
+        counts.sort()
         min, max = (counts[0][0], counts[-1][0]) if counts else (None, None)
         db[statscoll].delete_one({'_id':id})
         db[statscoll].insert_one({'_id':id, 'total':total, 'counts':counts, 'min':min, 'max':max})
@@ -228,11 +235,18 @@ def update_joint_attribute_stats(db, coll, attributes, prefix=None, filter=None,
         for pair in counts:
             values = pair[0].split(":")
             if lastval and (values[0] != lastval or pair[1] < 0):
+                # convert numeric value back to numeric values if possible so they sort correctly
                 try:
                     if all([c[0] == unicode(int(c[0])) for c in vcounts]):
                         vcounts = sorted([[int(c[0]),c[1]] for c in vcounts])
                 except:
                     pass
+                if type(counts[0][0]) == unicode:
+                    try:
+                        if all([c[0] == unicode(float(c[0])) for c in counts]):
+                            counts = [[float(c[0]),c[1]] for c in counts]
+                    except:
+                        pass
                 min, max = vcounts[0][0], vcounts[-1][0]
                 vkey = prefix + "/" if prefix else ""
                 vkey += lastval + "/" + ":".join(attributes[1:])

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -172,7 +172,7 @@ def update_attribute_stats(db, coll, attributes, prefix=None, filter=None):
         counts = sorted([ [r['_id'],int(r['value'])] for r in db[coll].inline_map_reduce(mapper,reducer,query=filter)])
         # convert integer floats to ints (the javascript mapper converts all numbers to floats)
         try:
-            if prod([c[0] == int(c[0]) for c in counts]):
+            if all([c[0] == int(c[0]) for c in counts]):
                 counts = [[int(c[0]),c[1]] for c in counts]
         except:
             pass
@@ -229,7 +229,7 @@ def update_joint_attribute_stats(db, coll, attributes, prefix=None, filter=None,
             values = pair[0].split(":")
             if lastval and (values[0] != lastval or pair[1] < 0):
                 try:
-                    if prod([c[0] == unicode(int(c[0])) for c in vcounts]):
+                    if all([c[0] == unicode(int(c[0])) for c in vcounts]):
                         vcounts = sorted([[int(c[0]),c[1]] for c in vcounts])
                 except:
                     pass

--- a/data_mgt/utilities/rewrite.py
+++ b/data_mgt/utilities/rewrite.py
@@ -241,10 +241,10 @@ def update_joint_attribute_stats(db, coll, attributes, prefix=None, filter=None,
                         vcounts = sorted([[int(c[0]),c[1]] for c in vcounts])
                 except:
                     pass
-                if type(counts[0][0]) == unicode:
+                if type(vcounts[0][0]) == unicode:
                     try:
-                        if all([c[0] == unicode(float(c[0])) for c in counts]):
-                            counts = [[float(c[0]),c[1]] for c in counts]
+                        if all([c[0] == unicode(float(c[0])) for c in vcounts]):
+                            vcounts = sorted([[float(c[0]),c[1]] for c in vcounts])
                     except:
                         pass
                 min, max = vcounts[0][0], vcounts[-1][0]


### PR DESCRIPTION
This PR addresses https://github.com/LMFDB/lmfdb/pull/2033#issuecomment-298866215.  If all the values of an attribute that is being analyzed are integers, counts will be stored and sorted as integers.  This also applies to "unflattened" joint stats.  See http://beta.lmfdb.org/api/genus2_curves/curves.stats/ for some examples.
