### PR TITLE
ec stats now handles ints and strings for certain fields (temporary f…

### DIFF
--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -86,8 +86,12 @@ class ECstats(object):
         rdict = dict(ecdbstats.find_one({'_id':'rank'})['counts'])
         crdict = dict(ecdbstats.find_one({'_id':'class/rank'})['counts'])
         for r in range(counts['max_rank']+1):
-            ncu = rdict[str(r)]
-            ncl = crdict[str(r)]
+            try:
+                ncu = rdict[str(r)]
+                ncl = crdict[str(r)]
+            except KeyError:
+                ncu = rdict[r]
+                ncl = crdict[r]
             prop = format_percentage(ncl,counts['nclasses'])
             rank_counts.append({'r': r, 'ncurves': ncu, 'nclasses': ncl, 'prop': prop})
         stats['rank_counts'] = rank_counts
@@ -97,7 +101,10 @@ class ECstats(object):
         tdict = dict(ecdbstats.find_one({'_id':'torsion'})['counts'])
         tsdict = dict(ecdbstats.find_one({'_id':'torsion_structure'})['counts'])
         for t in  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16]:
-            ncu = tdict[str(t)]
+            try:
+                ncu = tdict[t]
+            except KeyError:
+                ncu = tdict[str(t)]
             if t in [4,8,12]: # two possible structures
                 ncyc = tsdict[str(t)]
                 gp = "\(C_{%s}\)"%t


### PR DESCRIPTION
…or type changeover in collection)

Check that the page EllipticCurve/Q/stats works.  This is so that when I recreate the stats collection after #2038 and some things which were strings become ints, the website will not fall over.