### PR TITLE
clean up transitional ec code for gal reps

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -95,9 +95,6 @@ def rational_elliptic_curves(err_args=None):
     credit = 'John Cremona and Andrew Sutherland'
     t = 'Elliptic curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
-    info['galois_data_type'] = 'old'
-    if 'non-maximal_primes' in db_ec().find_one():
-        info['galois_data_type'] = 'new'
     return render_template("ec-index.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'), **err_args)
 
 @ec_page.route("/random")
@@ -215,10 +212,6 @@ def elliptic_curve_search(info):
         else:
             query['label'] = ''
 
-    info['galois_data_type'] = 'old'
-    if 'non-maximal_primes' in db_ec().find_one():
-        info['galois_data_type'] = 'new'
-
     try:
         parse_rational(info,query,'jinv','j-invariant')
         parse_ints(info,query,'conductor')
@@ -237,22 +230,14 @@ def elliptic_curve_search(info):
 
         parse_ints(info,query,field='isodeg',qfield='isogeny_degrees')
 
-        if info['galois_data_type'] == 'new':
-            parse_primes(info, query, 'surj_primes', name='surjective primes',
-                         qfield='non-maximal_primes', mode='complement')
-        else:
-            parse_primes(info, query, 'surj_primes', name='surjective primes',
-                         qfield='non-surjective_primes', mode='complement')
+        parse_primes(info, query, 'surj_primes', name='surjective primes',
+                     qfield='non-maximal_primes', mode='complement')
         if info.get('surj_quantifier') == 'exactly':
             mode = 'exact'
         else:
             mode = 'append'
-        if info['galois_data_type'] == 'new':
-            parse_primes(info, query, 'nonsurj_primes', name='non-surjective primes',
-                         qfield='non-maximal_primes',mode=mode)
-        else:
-            parse_primes(info, query, 'nonsurj_primes', name='non-surjective primes',
-                         qfield='non-surjective_primes',mode=mode)
+        parse_primes(info, query, 'nonsurj_primes', name='non-surjective primes',
+                     qfield='non-maximal_primes',mode=mode)
     except ValueError as err:
         info['err'] = str(err)
         return search_input_error(info, bread)

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -385,10 +385,6 @@ data.twoadic_index }}.
 
     {{ place_code('galrep') }}
 
-{% if data.data.new_galois_data %}
-
-{# ######## code for new Galois data (non-maximal primes) ###### #}
-
 <p>
 The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
 representation')}}
@@ -440,51 +436,6 @@ if \(\left(\frac{ {{data.data.cm_sqf}} }{p}\right)=-1\).
 </p>
 {% endif %} {# CM case #}
 
-{% else %}
-
-{# ######## code for old Galois data (non-surjective primes) ###### #}
-
-
-
-{% if data.data.galois_data %}
-<p>
-{% if data.data.CMD %}
-The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representations')}} of an elliptic curve with {{
-KNOWL('ec.complex_multiplication', title='Complex Multiplication') }}
-are non-surjective for all odd primes \( p \).  We only show the image
-for
-primes \( p\le 37 \).
-{% else %}
-The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representation')}} is surjective for all primes \( p \) except those
-    listed.
-{% endif %}
-</p>
-<table>
-<tr>
-<th>prime</th>
-<th>{{KNOWL('ec.q.galois_rep_image', title='Image of Galois
-  representation')}}</th>
-</tr>
-{% for pr in data.data.galois_data %}
-<tr>
-<td align=center> \({{pr.p}}\)</td>
-<td align=center>{{pr.image}}</td>
-</tr>
-{% endfor %}
-</table>
-{% else %}
-<p>
-The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois
-representation')}} is surjective for all primes \( p \).
-</p>
-{% endif %}
-
-
-{# ######## end of new/old Galois data split ###### #}
-
-{% endif %}
 
 
 

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -159,19 +159,11 @@ Please enter a value or leave blank:
       </tr>
 
 <tr>
-{% if info.galois_data_type=='new' %}
 <td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}} 
-{% else %}
-<td align=left>{{KNOWL('ec.q.non-surjective_prime', title='surjective primes')}} 
-{% endif %}
    <td><input type='text' name='surj_primes' size=10 example='2,3'></td>
 <td><span class="formexample"> e.g. 2,3</span></td>
 <td align=left>
-{% if info.galois_data_type=='new' %}
 {{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}} 
-{% else %}
-{{KNOWL('ec.q.non-surjective_prime', title='non-surjective primes')}} 
-{% endif %}
   <select name='surj_quantifier'>
   <option value='include'>include</option>
   <option value='exactly'>exactly</option>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -52,17 +52,9 @@
 
 <tr>
 <td align=left>{{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
-{% if info.galois_data_type=='new' %}
-<td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}} 
-{% else %}
-<td align=left>{{KNOWL('ec.q.surjective_prime', title='surjective primes')}} 
-{% endif %}
+<td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}}
 </td>
-{% if info.galois_data_type=='new' %}
-<td align=left colspan=2>{{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}} 
-{% else %}
-<td align=left colspan=2>{{KNOWL('ec.q.surjective_prime', title='non-surjective primes')}} 
-{% endif %}
+<td align=left colspan=2>{{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}}
 </td>
 <td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
 </tr>
@@ -152,11 +144,7 @@ table td.params {
   <th class="center">{{ KNOWL('ec.q.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
 {% if info.surj_primes or info.nonsurj_primes  %}
-{% if info.galois_data_type=='new' %}
   <th class="center">{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}</th>
-{% else %}
-  <th class="center">{{KNOWL('ec.q.non-surjective_prime', title='Non-surjective primes')}}</th>
-{% endif %}
 {% endif %}
 </tr>
 {% for curve in info.curves: %}
@@ -168,11 +156,7 @@ table td.params {
 <td class="center">{{curve.rank}}</td>
 <td class="center">{{curve.torsion}}</td>
 {% if info.surj_primes or info.nonsurj_primes %}
-{% if info.galois_data_type=='new' %}
 <td class="center">{{curve['non-maximal_primes']}}</td>
-{% else %}
-<td class="center">{{curve['non-surjective_primes']}}</td>
-{% endif %}
 {% endif %}
 </tr>
 {% endfor %}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -128,12 +128,8 @@ class WebEC(object):
         # Next lines because the hyphens make trouble
         self.xintcoords = split_list(dbdata['x-coordinates_of_integral_points'])
         self.non_surjective_primes = dbdata['non-surjective_primes']
-        try:
-            self.non_maximal_primes = dbdata['non-maximal_primes']
-            self.mod_p_images = dbdata['mod-p_images']
-            self.new_galois_data = True
-        except KeyError:
-            self.new_galois_data = False
+        self.non_maximal_primes = dbdata['non-maximal_primes']
+        self.mod_p_images = dbdata['mod-p_images']
 
         # Next lines because the python identifiers cannot start with 2
         self.twoadic_index = dbdata['2adic_index']
@@ -317,33 +313,23 @@ class WebEC(object):
         data['disc_latex'] = web_latex(D)
         data['cond_latex'] = web_latex(N)
 
-        if self.new_galois_data:
-            data['new_galois_data'] = True
-            data['galois_images'] = [trim_galois_image_code(s) for s in self.mod_p_images]
-            data['non_maximal_primes'] = self.non_maximal_primes
-            data['galois_data'] = [{'p': p,'image': im }
-                                   for p,im in zip(data['non_maximal_primes'],
-                                                   data['galois_images'])]
-        else:
-            data['new_galois_data'] = False
-            data['galois_images'] = [trim_galois_image_code(s) for s in self.galois_images]
-            data['non_surjective_primes'] = self.non_surjective_primes
-            data['galois_data'] = [{'p': p,'image': im }
-                                   for p,im in zip(data['non_surjective_primes'],
-                                                   data['galois_images'])]
+        data['galois_images'] = [trim_galois_image_code(s) for s in self.mod_p_images]
+        data['non_maximal_primes'] = self.non_maximal_primes
+        data['galois_data'] = [{'p': p,'image': im }
+                               for p,im in zip(data['non_maximal_primes'],
+                                               data['galois_images'])]
 
         data['CMD'] = self.cm
         data['CM'] = "no"
         data['EndE'] = "\(\Z\)"
         if self.cm:
-            if self.new_galois_data:
-                data['cm_ramp'] = [p for p in ZZ(self.cm).support() if not p in self.non_surjective_primes]
-                data['cm_nramp'] = len(data['cm_ramp'])
-                if data['cm_nramp']==1:
-                    data['cm_ramp'] = data['cm_ramp'][0]
-                else:
-                    data['cm_ramp'] = ", ".join([str(p) for p in data['cm_ramp']])
-                data['cm_sqf'] = ZZ(self.cm).squarefree_part()
+            data['cm_ramp'] = [p for p in ZZ(self.cm).support() if not p in self.non_surjective_primes]
+            data['cm_nramp'] = len(data['cm_ramp'])
+            if data['cm_nramp']==1:
+                data['cm_ramp'] = data['cm_ramp'][0]
+            else:
+                data['cm_ramp'] = ", ".join([str(p) for p in data['cm_ramp']])
+            data['cm_sqf'] = ZZ(self.cm).squarefree_part()
 
             data['CM'] = "yes (\(D=%s\))" % data['CMD']
             if data['CMD']%4==0:


### PR DESCRIPTION
When the galois image data for elliptic curves was changed over (from non-surjective to non-maximal) we put in temporary transitional code which worked on either the old data or the new.  For some time now both beta and production databases have had the new data so this code is no longer needed.  This PR simply deletes the redundant code.
To test either run the test suite or various random curves (both CM and not) in EllipticCurve/Q.