### PR TITLE
Improve small group knowls

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -5,7 +5,7 @@ from sage.all import gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, 
 import yaml, os
 import hashlib
 from sage.misc.cachefunc import cached_function
-from lmfdb.utils import make_logger, web_latex, coeff_to_poly, pol_to_html
+from lmfdb.utils import make_logger, web_latex, coeff_to_poly, pol_to_html, display_multiset
 from flask import url_for
 from collections import Counter
 from lmfdb.transitive_group import group_display_short, WebGaloisGroup, group_display_knowl, galois_module_knowl
@@ -103,10 +103,17 @@ def psum(val, li):
 def decodedisc(ads, s):
     return ZZ(ads[3:]) * s
 
-def do_mult(ent):
-    if ent[1]==1:
-        return ent[0]
-    return "%s x%d" % (ent[0], ent[1])
+def formatfield(coef):
+    coef = string2list(coef)
+    thefield = WebNumberField.from_coeffs(coef)
+    C = base.getDBConnection()
+    if thefield._data is None:
+        deg = len(coef) - 1
+        mypol = sage.all.latex(coeff_to_poly(coef))
+        mypol = mypol.replace(' ','').replace('+','%2B').replace('{', '%7B').replace('}','%7d')
+        mypol = '<a title = "Field missing" knowl="nf.field.missing" kwargs="poly=%s">Deg %d</a>' % (mypol,deg)
+        return mypol
+    return nf_display_knowl(thefield.get_label(),C,thefield.field_pretty())
 
 # input is a list of pairs, module and multiplicity
 def modules2string(n, t, modlist):
@@ -356,7 +363,7 @@ class WebNumberField:
         resall = self.resolvents()
         if 'sib' in resall:
             # list of [degree, knowl
-            helpout = [[len(string2list(a))-1,self.myhelper([a,1])] for a in resall['sib']]
+            helpout = [[len(string2list(a))-1,formatfield(a)] for a in resall['sib']]
         else:
             helpout = []
         degsiblist = [[d, cnts[d], [dd[1] for dd in helpout if dd[0]==d] ] for d in sorted(cnts.keys())]
@@ -372,8 +379,7 @@ class WebNumberField:
             # Don't include Q in labels
             sex = [z for z in sex if z != '1.1.1.1']
             labels = sorted(Set(sex))
-            helpout = [self.myhelper([a,1]) for a in resall['sex']]
-            knowls = [a[0] for a in helpout]
+            knowls = [formatfield(a) for a in resall['sex']]
             return [1, knowls, labels]
         return [1,[],[]]
 
@@ -381,8 +387,7 @@ class WebNumberField:
         resall = self.resolvents()
         cnt = self.galois_sib_data()[2]
         if 'gal' in resall:
-            helpout = [self.myhelper([a,1]) for a in resall['gal']]
-            knowls= [a[0] for a in helpout]
+            knowls= [formatfield(a) for a in resall['gal']]
             gal = [self.from_coeffs(str(a)) for a in resall['gal']]
             labs = [a.label for a in gal if a._data is not None]
             return [cnt, knowls, labs]
@@ -392,8 +397,7 @@ class WebNumberField:
         resall = self.resolvents()
         cnt = self.galois_sib_data()[1]
         if 'ae' in resall:
-            helpout = [self.myhelper([a,1]) for a in resall['ae']]
-            knowls = [a[0] for a in helpout]
+            knowls = [formatfield(a) for a in resall['ae']]
             ae = [self.from_coeffs(str(a)) for a in resall['ae']]
             labs = [a.label for a in ae if a._data is not None]
             return [cnt, knowls, labs]
@@ -408,9 +412,7 @@ class WebNumberField:
         subs = self.subfields()
         if subs == []:
             return []
-        subs = [self.myhelper(a) for a in subs]
-        subs = [do_mult(a) for a in subs]
-        return ', '.join(subs)
+        return display_multiset(subs, formatfield)
 
     def unit_galois_action(self):
         if not self.haskey('unitsGmodule'):

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -6,11 +6,11 @@ import pymongo
 #from lmfdb import base
 from lmfdb.base import app, getDBConnection
 from flask import render_template, request, url_for, redirect
-from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, random_object_from_collection
+from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, random_object_from_collection, display_multiset
 from lmfdb.search_parsing import parse_galgrp, parse_ints, parse_count, parse_start, clean_input
 from sage.all import PolynomialRing, QQ
 from lmfdb.local_fields import local_fields_page, logger
-from lmfdb.WebNumberField import string2list, do_mult
+from lmfdb.WebNumberField import string2list
 
 from lmfdb.transitive_group import group_display_short, group_knowl_guts, group_display_knowl, group_display_inertia, small_group_knowl_guts, WebGaloisGroup
 
@@ -82,22 +82,20 @@ def ctx_local_fields():
             'small_group_data': small_group_data}
 
 # Utilities for subfield display
-def subhelper(coefmult,p):
-    data = lfdb().find_one({'coeffs': coefmult[0], 'p': p})
+def format_lfield(coefmult,p):
+    data = lfdb().find_one({'coeffs': coefmult, 'p': p})
     if data is None:
         # This should not happen, what do we do?
         # This is wrong
         return ''
     # This is the nf version
-    return [lf_display_knowl(data['label'],db()), coefmult[1]]
+    return lf_display_knowl(data['label'],db())
 
 # Input is a list of pairs, coeffs of field as string and multiplicity
 def format_subfields(subdata, p):
     if subdata == []:
         return ''
-    subs = [subhelper(a, p) for a in subdata]
-    subs = [do_mult(a) for a in subs]
-    return ', '.join(subs)
+    return display_multiset(subdata, format_lfield, p)
 
 @local_fields_page.route("/")
 def index():

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -380,7 +380,6 @@ def render_field_webpage(args):
             if len(sibdeg[2]) ==0:
                 sibdeg[2] = dnc
             else:
-                sibdeg[2] = [z[0] for z in sibdeg[2]]
                 sibdeg[2] = ', '.join(sibdeg[2])
                 if len(sibdeg[2])<sibdeg[1]:
                     sibdeg[2] += ', some '+dnc

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -580,6 +580,16 @@ def coeff_to_poly(c):
     from sage.all import PolynomialRing, QQ
     return PolynomialRing(QQ, 'x')(c)
 
+def display_multiset(mset, formatter=str, *args):
+    """
+    Input mset is a list of pairs [item, multiplicity]
+    Return a string for display of the multi-set.  The
+    function formatter is a function whose first argument
+    is the item, and *args are the other arguments
+    and is applied to each item.
+    """
+    return ', '.join([formatter(pair[0], *args)+(' x%d'% pair[1] if pair[1]>1 else '') for pair in mset])
+
 def debug():
     """
     this triggers the debug environment on purpose. you have to start


### PR DESCRIPTION
The main goal is to include the new data in the small groups database in the small group knowls.  This includes displaying lists of special subgroups with multiplicity, so it also includes a short function in utils.py for this.  This function is then used when displaying subfields of local and global fields, which is why it touches those files.

To see the new data, the simplest approach is from

  http://127.0.0.1:37777/knowledge/show/group.small.data?gapid=16.8

where you can adjust the gapid to see other groups.

To see it used in a regular page, try http://127.0.0.1:37777/LocalNumberField/3.12.12.1 (in the inertia subgroup entry).