### PR TITLE
fixed dbport argument in web_object logout function

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_object.py
@@ -577,7 +577,7 @@ class WebObject(object):
         C = cls.connect_to_db()
         C.logout()
         # log back in with usual read-only access
-        lmfdb.base._init(lmfdb.base.dbport)
+        lmfdb.base._init(lmfdb.base._mongo_port)
         
 
     def has_updated_from_db(self):


### PR DESCRIPTION
Someone changed / removed the variable dbport from lmfdb.base and it was still referenced from the 'logout' function in modular forms.elliptic_modular_forms.backend.web_object  
I now changed it to use lmfdb.base._mongo_port instead 