### PR TITLE
added utility to aid browsing of collections (read-only)

### DIFF
--- a/data_mgt/utilities/browse.py
+++ b/data_mgt/utilities/browse.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+r""" 
+
+Utility script to connect to the database (read-only) for browsing.
+
+To run this, cd to the top-level lmfdb directory, start sage and use
+the command
+
+   sage: %runfile scripts/usilities/browse.py
+"""
+
+import os.path
+import re
+import os
+import pymongo
+from lmfdb.base import getDBConnection
+from lmfdb.utils import web_latex
+from sage.all import NumberField, PolynomialRing, cm_j_invariants_and_orders, EllipticCurve, ZZ, QQ, Set
+from sage.databases.cremona import cremona_to_lmfdb
+from lmfdb.ecnf.ecnf_stats import field_data
+from lmfdb.ecnf.WebEllipticCurve import ideal_from_string, ideal_to_string, ideal_HNF, parse_ainvs, parse_point
+
+print "getting connection"
+C= getDBConnection()
+
+print "setting databases..."
+
+for db in C.database_names():
+    if db in ['admin', 'userdb', 'local', 'contrib']:
+        continue
+    print("============================")
+    print("assigning identifier {} to the database {}".format(db,db))
+    exec("{} = C['{}']".format(db,db))
+    for coll in C[db].collection_names():
+        if not 'system' in coll and not "." in coll:
+            lcoll = coll.replace("-","_")
+            print("assigning identifier {} to the collection {} in database {}".format(lcoll,coll,db))
+            exec("{} = {}['{}']".format(lcoll,db,coll))
+


### PR DESCRIPTION
To use, start sage in the lmfdb root directory and do:

sage: %runfile data_mgt/utilities/browse.py

This will assign a python variable for each collection with the same name as that collection, in every database except 'admin', 'userdb', 'local', 'contrib' and omitting any collections with 'system' or a dot '.' in their names.  You can then do, for example:
sage: nfcurves.count()
507465
sage: instances.distinct('type')
[u'DIR', u'ECQ', u'G2Q', u'MaassGL3', u'MaassGL4', u'MaassGSp4']

It is not perfect, for example two different databases might have collections with the same name and the second one will overwrite the first, but it's a start and improvements are welcome.