### PR TITLE
fix issue 1967, plus some formatting

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -287,12 +287,16 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
                     cc = str(abs(c))
                 s += "{0} \cdot ".format(cc)
                 a = monom[i][0]; b = monom[i][1]
+                if a == 1:
+                    a = ""
+                if b == 1:
+                    b = ""
                 if a == 0 and b != 0:
-                    s+="E_6^{{ {0} }}".format(b)
+                    s+="E_6^{{ {0} }}(z)".format(b)
                 elif b ==0 and a != 0:
-                    s+="E_4^{{ {0} }}".format(a)
+                    s+="E_4^{{ {0} }}(z)".format(a)
                 else:
-                    s+="E_4^{{ {0} }}E_6^{{ {1} }}".format(a,b)
+                    s+="E_4^{{ {0} }}(z) \cdot E_6^{{ {1} }}(z)".format(a,b)
                 info['explicit_formulas'] += s
             info['explicit_formulas'] += " \)"            
     # cur_url = '?&level=' + str(level) + '&weight=' + str(weight) + '&character=' + str(character) + '&label=' + str(label) # never used

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -176,7 +176,7 @@ are shown in the table below. Note that these include embeddings that do not pre
 
 
 {% if explicit_formulas is defined %}
-<h2> {{KNOWL('mf.elliptic.explicit_formula',title='')}}Explicit Formulas</h2>
+<h2> {{KNOWL('mf.elliptic.particular',title='Explicit Formulas')}}</h2>
   {{ explicit_formulas }}
 {% endif %}
 <h2>{{ KNOWL_INC(KNOWL_ID+'.formulas', title='') }}</h2>

--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_sample.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_sample.html
@@ -67,7 +67,7 @@
 </table>
 
 {% if info.explicit_formula_bytes %}
-<h2>{{KNOWL('mf.siegel.explicit_formula',title='Explicit formula')}}</h2>
+<h2>{{KNOWL('mf.siegel.particular',title='Explicit formula')}}</h2>
 {% if not info.explicit_formula %}
 <button id ="toggle1">Show</button>&nbsp;<span id="explicit_formula" style="display: none;"><span style="color:red"><i>&nbsp;&nbsp;Too large to display, please use download button to view</i></span><br></span>({{info.explicit_formula_bytes}} bytes)
 {% else %}


### PR DESCRIPTION
Fixes Issue #1967:
Fix format of explicit formula in modular forms and change knowls from
mf.elliptic.explicit_formulas to mf.elliptic.particular .
See:
/ModularForm/GL2/Q/holomorphic/1/12/1/a/
or
/ModularForm/GL2/Q/holomorphic/1/18/1/a/

David Farmer added/fixed the necessary knowls.

Also, fixed some formatting of E_k so that exponent of 1 is omitted.