### PR TITLE
Ecnflayout1

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -4,7 +4,7 @@ from flask import url_for
 from urllib import quote
 from sage.all import ZZ, var, PolynomialRing, QQ, RDF, rainbow, implicit_plot, plot, text, Infinity, sqrt, prod, Factorization
 from lmfdb.base import getDBConnection
-from lmfdb.utils import web_latex, web_latex_ideal_fact, encode_plot
+from lmfdb.utils import web_latex, web_latex_split_on, web_latex_ideal_fact, encode_plot
 from lmfdb.WebNumberField import WebNumberField
 from lmfdb.sato_tate_groups.main import st_link_by_name
 
@@ -66,7 +66,10 @@ def parse_ainvs(K,ainvs):
 
 def web_ainvs(field_label, ainvs):
     K = make_field(field_label).K()
-    return web_latex(parse_ainvs(K,ainvs))
+    ainvsinlatex = web_latex_split_on(parse_ainvs(K,ainvs), on=[","])
+    ainvsinlatex = ainvsinlatex.replace("\\left[", "\\bigl[")
+    ainvsinlatex = ainvsinlatex.replace("\\right]", "\\bigr]")
+    return ainvsinlatex
 
 from sage.misc.all import latex
 def web_point(P):

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -209,6 +209,10 @@ body.knowl #header {
     color: {{color.header_text_title}};
 }
 
+#header #title .MathJax{
+    font-weight: bold !important;
+}
+
 #header #title-content {
   position: absolute;
   bottom: 4px;


### PR DESCRIPTION
TWO un-related formatting changes:

1.  The Weierstrass coefficients for elliptic curves over number fields used to be pushed below the properties box, but now they wrap. You can see this when making the page narrow.
See:
/EllipticCurve/5.5.160801.1/9.1/b/

2.  Fix title bold consistency for arithmetic and analytic normalization.
See:
/L/Character/Dirichlet/15/14/
or
/L/EllipticCurve/Q/97482.d/

_(Toggle between arithmetic and analytic normalizations.)_