### PR TITLE
add jacobian variety decomp + dim of corresponding shimura variety

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -63,6 +63,8 @@ def sign_display(L):
 
 def cc_display(L):
     sizeL = len(L)
+    if sizeL == 1:
+        return str(L[0])
     stg = str(L[0])+ ", "
     for i in range(1,sizeL-1):
         stg =stg + str(L[i])+", "
@@ -110,7 +112,8 @@ def decjac_format(decjac_list):
             entry = entry + "^" + str(ints[1])
         entries.append(entry)
     latex = "\\times ".join(entries)
-    ccClasses = [ints[2] for ints in decjac_list]
+    ccClasses = cc_display ([ints[2] for ints in decjac_list])
+    #ccClasses = [ints[2] for ints in decjac_list]
     return latex, ccClasses
 
 @higher_genus_w_automorphisms_page.route("/")
@@ -406,8 +409,8 @@ def render_passport(args):
         if 'eqn' in data:
             info.update({'eqns': data['eqn']})
         
-        if 'Ndim' in data:
-            info.update({'Ndim': data['Ndim']})
+        if 'ndim' in data:
+            info.update({'Ndim': data['ndim']})
 
         other_data = False
 
@@ -427,7 +430,7 @@ def render_passport(args):
         if 'jacobian_decomp' in data:
             jcLatex, conjClasses = decjac_format(data['jacobian_decomp'])
             info.update({'conjClasses': conjClasses, 'jacobian_decomp': jcLatex})
-            other_data = True
+            
             
         if 'cinv' in data:
             cinv=Permutation(data['cinv']).cycle_string()
@@ -600,5 +603,3 @@ def hgcwa_code(**args):
     code += '\n'.join(lines)
     print "%s seconds for %d bytes" %(time.time() - start,len(code))
     return code
-
-

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -428,8 +428,8 @@ def render_passport(args):
             other_data = True
 
         if 'jacobian_decomp' in data:
-            jcLatex, conjClasses = decjac_format(data['jacobian_decomp'])
-            info.update({'conjClasses': conjClasses, 'jacobian_decomp': jcLatex})
+            jcLatex, corrChar = decjac_format(data['jacobian_decomp'])
+            info.update({'corrChar': corrChar, 'jacobian_decomp': jcLatex})
             
             
         if 'cinv' in data:

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -107,13 +107,12 @@ def decjac_format(decjac_list):
         if ints[0] == 1:
             entry = entry + "E"
         else:
-            entry = entry + "A_" + str(ints[0])
+            entry = entry + "A_{" + str(ints[0]) + "}"
         if ints[1] != 1:
-            entry = entry + "^" + str(ints[1])
+            entry = entry + "^{" + str(ints[1]) + "}"
         entries.append(entry)
     latex = "\\times ".join(entries)
     ccClasses = cc_display ([ints[2] for ints in decjac_list])
-    #ccClasses = [ints[2] for ints in decjac_list]
     return latex, ccClasses
 
 @higher_genus_w_automorphisms_page.route("/")

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -98,6 +98,21 @@ def label_to_breadcrumbs(L):
     newsig += ']'    
     return newsig
 
+def decjac_format(decjac_list):
+    entries = []
+    for ints in decjac_list:
+        entry = ""
+        if ints[0] == 1:
+            entry = entry + "E"
+        else:
+            entry = entry + "A_" + str(ints[0])
+        if ints[1] != 1:
+            entry = entry + "^" + str(ints[1])
+        entries.append(entry)
+    latex = "\\times ".join(entries)
+    ccClasses = [ints[2] for ints in decjac_list]
+    return latex, ccClasses
+
 @higher_genus_w_automorphisms_page.route("/")
 def index():
     bread = get_bread()
@@ -389,8 +404,11 @@ def render_passport(args):
         info.update({'passport_cc': cc_display(ast.literal_eval(data['con']))})
 
         if 'eqn' in data:
-           info.update({'eqns': data['eqn']})
+            info.update({'eqns': data['eqn']})
         
+        if 'Ndim' in data:
+            info.update({'Ndim': data['Ndim']})
+
         other_data = False
 
         if 'hyperelliptic' in data:
@@ -406,6 +424,10 @@ def render_passport(args):
             info.update({'iscyctrig':  tfTOyn(data['cyclic_trigonal'])})
             other_data = True
 
+        if 'jacobian_decomp' in data:
+            jcLatex, conjClasses = decjac_format(data['jacobian_decomp'])
+            info.update({'conjClasses': conjClasses, 'jacobian_decomp': jcLatex})
+            other_data = True
             
         if 'cinv' in data:
             cinv=Permutation(data['cinv']).cycle_string()
@@ -425,7 +447,6 @@ def render_passport(args):
                          'signH':sign_display(ast.literal_eval(data['signH'])),
                          'higgenlabel' : data['full_label'] })
 
-            
 
         urlstrng,br_g, br_gp, br_sign, refined_p = split_passport_label(label)
        

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -25,6 +25,9 @@ table,td {
   <td>{{info.gpid}}</td></tr>
   <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
   <tr><td> Conjugacy classes for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
+  {% if 'Ndim' in info %}
+  <tr><td>Ndim</td><td>{{ info.Ndim}}</td></tr>
+  {% endif %}
   </table></p>
 
 
@@ -47,6 +50,11 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
       {% if info.cinv  %}
        <tr><td>Trigonal automorphism:</td> <td>{{info.cinv}}</td></tr>
        {% endif %}  {% endif %}
+      {% if info.jacobian_decomp %}
+      <tr><td>Jacobian Decomposition:</td> <td>${{info.jacobian_decomp}}$</td></tr>
+      {% if info.conjClasses %}
+      <tr><td style="padding-left:1.8em;">Corresponding Conjugacy Classes:</td> <td>{{info.conjClasses}}</td></tr>
+      {% endif %} {% endif %}
     </table>
 
     {% if info.eqns %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -36,7 +36,7 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
 {% if info.jacobian_decomp %}
   <table><tr><td>{{KNOWL('ag.jacobian',title='Jacobian variety')}} decomposition:</td><td>${{info.jacobian_decomp}}$</td></tr>
-      <tr><td style="padding-left:1.8em;"> corresponding conjugacy class(es):</td><td> {{info.conjClasses}}</td>
+    <tr><td >Corresponding character(s):</td><td> {{info.corrChar}}</td></tr>
   </table>
  {% endif %}
 
@@ -59,7 +59,7 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
     {% if info.eqns %}
     <br>
-    Equations(s) of curve(s) in this refined passport:
+    Equations(s) of curve(s) in this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}:
        <table>{% for eqn in info.eqns %}
 	  <tr><td> &nbsp; </td><td>${{eqn}}$</td></tr>
 	  {% endfor %} </table> <br>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -44,7 +44,7 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
   <p><h2>Other Data</h2>
     <table>
-        <tr><td>Dimension of the corresponding Shimura variety:</td><td>{{ info.Ndim}}</td></tr>
+        <tr><td>Dimension of the corresponding {{KNOWL('ag.shimura_variety',title='Shimura variety')}}:</td><td>{{ info.Ndim}}</td></tr>
       {% if info.ishyp %}     
       <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
       {% if info.hypinv  %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -25,9 +25,6 @@ table,td {
   <td>{{info.gpid}}</td></tr>
   <tr><td> {{ KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
   <tr><td> Conjugacy classes for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
-  {% if 'Ndim' in info %}
-  <tr><td>Ndim</td><td>{{ info.Ndim}}</td></tr>
-  {% endif %}
   </table></p>
 
 
@@ -36,10 +33,18 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     {% endif %} 
 </p>
 
-{% if info.other_data %}     
+
+{% if info.jacobian_decomp %}
+  <table><tr><td>{{KNOWL('ag.jacobian',title='Jacobian variety')}} decomposition:</td><td>${{info.jacobian_decomp}}$</td></tr>
+      <tr><td style="padding-left:1.8em;"> corresponding conjugacy class(es):</td><td> {{info.conjClasses}}</td>
+  </table>
+ {% endif %}
+
+
 
   <p><h2>Other Data</h2>
     <table>
+        <tr><td>Dimension of the corresponding Shimura variety:</td><td>{{ info.Ndim}}</td></tr>
       {% if info.ishyp %}     
       <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
       {% if info.hypinv  %}
@@ -50,11 +55,6 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
       {% if info.cinv  %}
        <tr><td>Trigonal automorphism:</td> <td>{{info.cinv}}</td></tr>
        {% endif %}  {% endif %}
-      {% if info.jacobian_decomp %}
-      <tr><td>Jacobian Decomposition:</td> <td>${{info.jacobian_decomp}}$</td></tr>
-      {% if info.conjClasses %}
-      <tr><td style="padding-left:1.8em;">Corresponding Conjugacy Classes:</td> <td>{{info.conjClasses}}</td></tr>
-      {% endif %} {% endif %}
     </table>
 
     {% if info.eqns %}
@@ -67,7 +67,6 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
   </p>
   
 
- {% endif %}
 
 
 <p><h2>{{KNOWL('curve.highergenus.aut.generatingvector',title='Generating Vector(s)')}}</h2>


### PR DESCRIPTION
This commit adds a line for Jacobian variety decompositions, as well as the dimension of the corresponding Shimura variety to the higher genus data.  You can see the new information here, for example:
http://127.0.0.1:37777/HigherGenus/C/Aut/7.16-4.0.2-4-4-4.4

There should be a knowl for "Shimura variety", but I wasn't sure which prefix to put it under (i.e. ag.shimuravariety  or something else?) so I haven't added that yet.  I will write details on where this data comes from under the "Source of the data" entry, but if you need more info now, just let me know and I can elaborate.

Also, test.sh produced some pyflakes errors but they were all from the file ./data_mgt/utilities/browse.py so I chose to ignore them since I have never touched that file.  If this is something I did wrong, just let me know and I'll fix it.


