### PR TITLE
allow trailing slash on URLs for ec isogeny classes

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -306,7 +306,7 @@ def by_triple_label(conductor,iso_label,number):
 # LMFDB or Cremona format, and also whether it is a curve label or an
 # isogeny class label, and calls the appropriate function
 
-@ec_page.route("/<label>")
+@ec_page.route("/<label>/")
 def by_ec_label(label):
     ec_logger.debug(label)
 


### PR DESCRIPTION
Before, the URL EllipticCurve/Q/11.a worked (and was converted to .../Q/11/a/) while EllipticCurve/Q/11.a/ did not.  Now it does -- and gets converted to the same thing.
As a side-effect one can also have EllipticCurve/Q/11.a1/ instead of EllipticCurve/Q/11.a1, both getting redirected to EllipticCurve/Q/11/a/1 (as both are handled by the same route function which determines whether the label is that of a curve or a class).
This is a one byte change!
