### PR TITLE
Track number of coeffs of Maass form even when only a few coefficients are present

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
@@ -145,6 +145,9 @@ class WebMaassForm(object):
         if self._get_coeffs:
             self.coeffs = f.get('Coefficient', [0, 1, 0, 0, 0])
 
+            if self.coeffs != [0,1,0,0,0]:
+                self.num_coeff = len(self.coeffs)
+
             if self._get_dirichlet_c_only:
                 # if self.coeffs!=[0,1,0,0,0]:
                 if len(self.coeffs) == 1:


### PR DESCRIPTION
In #2075, it was noted that some Maass forms are missing coefficients,
even though the associated L-function *does* have coefficients. This is
due to the fact that more data on some Maass forms is available than
some others. The number of coefficients is called when creating the
table displaying the coefficients, but this is only tracked correctly
when the database has lots of coefficients of the Maass form included.

This (small) change causes the number of coefficients to be tracked
always, allowing the table to be displayed.

As an example, this fixes the display of

    /ModularForm/GL2/Q/Maass/5411a477acf7560ce8a6f594

(though note that only 59 coefficients are currently available).

NOTE
----
  A long-term solution should include updating the database with further
  coefficients, including the coefficients at the different cusps. For the 
  problematic Maass forms, the coefficients are only computed at one cusp.

RESOLVES
--------
  #2075