### PR TITLE
Lbrowse1

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -22,6 +22,7 @@ from LfunctionComp import isogeny_class_table, isogeny_class_cm
 import LfunctionDatabase
 from lmfdb import base
 from pymongo import ASCENDING
+from lmfdb.modular_forms.maass_forms.maass_waveforms.views.mwf_plot import paintSvgMaass
 
 def get_degree(degree_string):
     if not re.match('degree[0-9]+',degree_string):
@@ -102,6 +103,7 @@ def l_function_cuspform_browse_page():
 def l_function_maass_browse_page():
     info = {"bread": get_bread(2, [("MaassForm", url_for('.l_function_maass_browse_page'))])}
     info["contents"] = [processMaassNavigation()]
+    info["gl2spectrum0"] = [paintSvgMaass(1, 10, 0, 10, L="/L")]
     return render_template("MaassformGL2.html", title='L-functions of GL(2) Maass Forms of weight 0', **info)
 
 

--- a/lmfdb/lfunctions/templates/DegreeNavigateL.html
+++ b/lmfdb/lfunctions/templates/DegreeNavigateL.html
@@ -35,7 +35,7 @@ L-functions can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
 
 
 By {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
-<a href="{{url_for('l_functions.l_function_cuspform_browse_page')}}">Holomorphic cusp form with trivial character</a>
+<a href="{{url_for('l_functions.l_function_cuspform_browse_page')}}">HOLOmorphic cusp form with trivial character</a>
 &nbsp; <a href="{{url_for('l_functions.l_function_maass_browse_page')}}">Maass form of weight $0$ for $\GL(2)$</a> &nbsp;
 <a href="{{url_for('l_functions.l_function_ec_browse_page')}}">Elliptic curve</a>
 

--- a/lmfdb/lfunctions/templates/MaassformGL2.html
+++ b/lmfdb/lfunctions/templates/MaassformGL2.html
@@ -20,14 +20,22 @@ and satisfies a
 \end{equation}
 where $N$ is the {{ KNOWL("mf.maass.mwf.level",title="level")}},
 $R$ the {{ KNOWL("mf.maass.mwf.eigenvalue",title="eigenvalue")}} of the
-Maass cusp form, $\varepsilon$ is the {{ KNOWL('lfunction.sign', title='sign')}} and $\delta$ is 1 (or 0) when $f$ is odd (or even).
+Maass cusp form, $\varepsilon$ is the {{ KNOWL('lfunction.sign', title='sign')}}, and $\delta$ is 1 (or 0) 
+when $f$ is odd (or even).
 </div>
-
-{{contents[0]|safe}}
-
 <br>
 <div>
-The eigenvalue is labelled with an 'e' or an 'o' depending on whether the corresponding Maass cusp form is even or odd.
+The dots in the plot correspond to L-functions with trivial character and
+$(R, N)$ as in the functional equation.
+Each eigenvalue is colored <font color="red"><b>red</b></font> 
+or <font color="blue"><b>blue</b></font> depending on whether
+the corresponding Maass cusp form is <font color="red"><b>even</b></font> or <font color="blue"><b>odd</b></font>.
+These have been found by a computer search.
+Click on any of the dots for details about the L-function.
 </div>
+
+<br>
+
+{{gl2spectrum0[0]|safe}}
 
 {% endblock %}

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
@@ -3,12 +3,13 @@ from lmfdb import base
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db \
      import MaassDB
 
-def paintSvgMaass(min_level, max_level, min_R, max_R, weight = 0, char = 1,
-                  width = 1000, heightfactor = 20):
+def paintSvgMaass(min_level, max_level, min_R, max_R, weight=0, char=1,
+                  width=1000, heightfactor=20, L=""):
     ''' Returns the contents (as a string) of the svg-file for
         all Maass forms in the database.
         Takes all levels from min_level to max_level
-        Spectral parameter in [min_R, max_R]
+        Spectral parameter in [min_R, max_R] 
+        Set L="/L" to make link go to the L-function
     '''
     xMax = int(max_R)
     yMax = int(max_level)
@@ -49,11 +50,11 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, weight = 0, char = 1,
               'R1': xMin, 'R2': xMax, 'Newform' : None, 'weight' : weight}
     fields = {'Eigenvalue', 'Level', 'Symmetry'}
     forms = db.get_Maass_forms(search, fields, 
-                               do_sort = False, limit = 10000)
+                               do_sort=False, limit=10000)
 
     # Loop through all forms and add a clickable dot for each
     for f in forms:
-        linkurl = "/ModularForm/GL2/Q/Maass/{0}".format(f['_id'])
+        linkurl = L + "/ModularForm/GL2/Q/Maass/{0}".format(f['_id'])
         x = (f['Eigenvalue'] - xMin) * xfactor + xshift
         y = (f['Level'] - yMin + 1) * yfactor
         try:  # Shifting even slightly up and odd slightly down


### PR DESCRIPTION
Part resolution of Issue #1549:

Modify L-function degree 2 browsing page for consistency with degree-3 and -4 cases.  This was done by modifying the text, removing the table of first-few eigenvalues, and adding a plot
with clickable dots linking to L-function homepages.  This plot was modified from the Maass modular forms page:
/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/
 
(The L-function of the Maass form was obtained by modifying the function: paintSvgMaass--adding another optional parameter.
See:
/L/degree2/MaassForm/
