### PR TITLE
Fix #2073

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -296,6 +296,7 @@ def render_hmf_webpage(**args):
         numeigs = int(numeigs)
     except:
         numeigs = 20
+    info['numeigs'] = numeigs
 
     hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
     gen_name = findvar(hmf_field['ideals'])
@@ -357,9 +358,6 @@ def render_hmf_webpage(**args):
     except KeyError:
         display_eigs = False
 
-    if 'numeigs' in request.args:
-        display_eigs = True
-
     info['hecke_polynomial'] = teXify_pol(info['hecke_polynomial'])
 
     if 'AL_eigenvalues_fixed' in data:
@@ -375,6 +373,7 @@ def render_hmf_webpage(**args):
 
     max_eig_len = max([len(eig['eigenvalue']) for eig in info['eigs']])
     display_eigs = display_eigs or (max_eig_len<=300)
+    info['display_eigs'] = display_eigs
     if not display_eigs:
         for eig in info['eigs']:
             if len(eig['eigenvalue']) > 300:

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -38,8 +38,8 @@
 <div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
 <div style='overflow-x:auto; overflow-y:hidden'>${{ info.hecke_polynomial }}$ </div>
 
-<p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Show full eigenvalues</a>
-&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>
+<p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True&numeigs={{ info.numeigs }}'>Show full eigenvalues</a>
+&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False&numeigs={{ info.numeigs }}'>Hide large eigenvalues</a></p>
 
 {% else %}
 <div>The Hecke eigenvalue field is $\Q$</a>.</div>
@@ -75,6 +75,7 @@ div.scrollable {
 <tr>
 <td>Display number of eigenvalues</td>
 <td><input type='text' name='numeigs' placeholder='20' size=10>
+  <input type="hidden" name="display_eigs" value="{{ info.display_eigs }}">
 </tr>
 <tr>
 <td colspan=3><button type='submit' value='display'>Display</button>


### PR DESCRIPTION
This PR fixes #2073. It removes the implication numeigs set to a value => display_eigs. Now HMF pages keep the numeigs argument when switching display_eigs using the buttons, and keep the display_eigs argument when setting numeigs using the form.

Example of page to play with: /ModularForm/GL2/TotallyReal/3.3.321.1/holomorphic/3.3.321.1-293.1-b
