### PR TITLE
Fix sign to colour

### DIFF
--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -7,7 +7,9 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebN
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
 from lmfdb.characters.ListCharacters import get_character_modulus
 from lmfdb.lfunctions import logger
-from sage.all import prod, CC
+from sage.all import prod
+from lmfdb.utils import signtocolour
+
 
 ###############################################################################
 # Maass form for GL(n) n>2
@@ -716,21 +718,6 @@ def paintCSHoloTMP(width, height, xMax, yMax, xfactor, yfactor, ticlength):
     return(xmlText)
 
 ##================================================
-#+++++++++++++++++++++++++++++++++++++++++++++++++
-##
-##================================================
-
-
-def signtocolour(sign):
-    import cmath
-    argument = cmath.phase(CC(str(sign)))
-    r = int(255.0 * (math.cos((1.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
-    g = int(255.0 * (math.cos((2.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
-    b = int(255.0 * (math.cos(argument / 2.0)) ** 2)
-    return("rgb(" + str(r) + "," + str(g) + "," + str(b) + ")")
-
-#=====================
-
 
 ###############################################################################
 # Dirichlet characters

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -23,6 +23,7 @@ import LfunctionDatabase
 from lmfdb import base
 from pymongo import ASCENDING
 from lmfdb.modular_forms.maass_forms.maass_waveforms.views.mwf_plot import paintSvgMaass
+from lmfdb.utils import signtocolour, rgbtohex
 
 def get_degree(degree_string):
     if not re.match('degree[0-9]+',degree_string):
@@ -104,6 +105,8 @@ def l_function_maass_browse_page():
     info = {"bread": get_bread(2, [("MaassForm", url_for('.l_function_maass_browse_page'))])}
     info["contents"] = [processMaassNavigation()]
     info["gl2spectrum0"] = [paintSvgMaass(1, 10, 0, 10, L="/L")]
+    info["colorminus1"] = rgbtohex(signtocolour(-1))
+    info["colorplus1"] = rgbtohex(signtocolour(1))
     return render_template("MaassformGL2.html", title='L-functions of GL(2) Maass Forms of weight 0', **info)
 
 

--- a/lmfdb/lfunctions/templates/MaassformGL2.html
+++ b/lmfdb/lfunctions/templates/MaassformGL2.html
@@ -27,9 +27,9 @@ when $f$ is odd (or even).
 <div>
 The dots in the plot correspond to L-functions with trivial character and
 $(R, N)$ as in the functional equation.
-Each eigenvalue is colored <font color="red"><b>red</b></font> 
-or <font color="blue"><b>blue</b></font> depending on whether
-the corresponding Maass cusp form is <font color="red"><b>even</b></font> or <font color="blue"><b>odd</b></font>.
+The color shows whether the functional equation has <b><font color="{{colorplus1}}">sign&nbsp;+1</font></b>
+or
+<b><font color="{{colorminus1}}">sign&nbsp;-1</font></b>.
 These have been found by a computer search.
 Click on any of the dots for details about the L-function.
 </div>

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -32,6 +32,7 @@ from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.mwf_classes import 
 from mwf_plot import paintSvgMaass
 logger = mwf_logger
 import json
+from lmfdb.utils import rgbtohex, signtocolour
 
 
 # this is a blueprint specific default for the tempate system.
@@ -121,6 +122,8 @@ def render_maass_browse_graph(min_level, max_level, min_R, max_R):
     info['max_level'] = max_level
     info['min_R'] = min_R
     info['max_R'] = max_R
+    info['coloreven'] = rgbtohex(signtocolour(1))
+    info['colorodd'] = rgbtohex(signtocolour(-1))
     bread = [('Modular forms', url_for('mf.modular_form_main_page')),
              ('Maass waveforms', url_for('.render_maass_waveforms'))]
     info['bread'] = bread

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_plot.py
@@ -2,6 +2,7 @@ import pymongo
 from lmfdb import base
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db \
      import MaassDB
+from lmfdb.utils import signtocolour
 
 def paintSvgMaass(min_level, max_level, min_R, max_R, weight=0, char=1,
                   width=1000, heightfactor=20, L=""):
@@ -26,9 +27,6 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, weight=0, char=1,
     ticlength = 4
     radius = 3
     xshift = extraSpace
-    color_even = 'rgb(255,0,0)'
-    color_odd = 'rgb(0,0,255)'
-    color_neither = 'rgb(0,255,0)'
 
     # Start of file and add coordinate system
     ans = "<svg  xmlns='http://www.w3.org/2000/svg'"
@@ -60,14 +58,14 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, weight=0, char=1,
         try:  # Shifting even slightly up and odd slightly down
             if f['Symmetry'] == 0 or f['Symmetry'] == 'even':
                 y -=  1
-                color = color_even
+                color = signtocolour(1)
             elif f['Symmetry'] == 1 or f['Symmetry'] == 'odd':
                 y += 1
-                color = color_odd
+                color = signtocolour(-1)
             else:
-                color = color_neither
+                color = signtocolour(0)
         except Exception:
-            color = color_neither
+            color = signtocolour(0)
             
         ans += "<a xlink:href='{0}' target='_top'>".format(linkurl)
         ans += "<circle cx='{0}' cy='{1}' ".format(str(x)[0:6],str(y))

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_graph.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_graph.html
@@ -3,7 +3,13 @@
 {% block content %}
 <h1>Graph of eigenvalues of Maass forms of levels {{min_level}} to {{max_level}} with ${{min_R}} \leq R\leq {{max_R}}$</h1>
 <p>
-    {{KNOWL_INC('mf.maass.mwf.browsegraph')}}
+   The horizontal axis is the {{KNOWL('mf.maass.mwf.spectralparameter', title='spectral parameter')}} $R$ with the {{KNOWL('mf.maass.mwf.eigenvalue', title='Laplace eigenvalue')}}
+satisying $\lambda=1/4+R²$. The vertical axis is the {{KNOWL('mf.maass.mwf.level', title='level')}} $N$. Each point
+corresponds to a Maass form of {{KNOWL('mf.maass.mwf.weight', title='weight')}} 0 and trivial character on $\Gamma_0(N)$
+with the color showing whether the {{KNOWL('mf.maass.mwf.symmetry', title='symmetry')}} is <b><font color="{{coloreven}}">even</font></b>
+or <b><font color="{{colorodd}}">odd</font></b>. Clicking on a dot takes you
+to the homepage of the Maass form. For $N>100$ there are only results for prime level.
+
 </p>
 <p>
 Examples of some ranges with complete data:

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -23,7 +23,9 @@ from markupsafe import Markup
 
 from lmfdb.base import app
 
-from sage.all import latex
+import math
+import cmath
+from sage.all import latex, CC
 
 
 def flash_error(errmsg, *args):
@@ -617,3 +619,25 @@ def encode_plot(P):
     fig.savefig(virtual_file, format='png')
     virtual_file.seek(0)
     return "data:image/png;base64," + quote(b64encode(virtual_file.buf))
+
+
+def signtocolour(sign):
+    argument = cmath.phase(CC(str(sign)))
+    r = int(255.0 * (math.cos((1.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
+    g = int(255.0 * (math.cos((2.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)
+    b = int(255.0 * (math.cos(argument / 2.0)) ** 2)
+    return("rgb(" + str(r) + "," + str(g) + "," + str(b) + ")")
+
+def rgbtohex(rgb):
+    """
+    convert rgb(63,255,100) to #3fff64
+    """
+
+    r,g,b = rgb[4:-1].split(',')
+    r = int(r)
+    g = int(g)
+    b = int(b)
+
+    return "#{:02x}{:02x}{:02x}".format(r,g,b)
+
+


### PR DESCRIPTION
The function signtocolour was intended as a uniform way to color-code
the numbers of modulus 1, but it was not widely used.

Now it is also used on
    /L/degree2/MaassForm/    (note: previous changes to that page are not yet in beta)
and
   /ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/

Once this pull request is accepted, the knowl
   mf.maass.mwf.browsegraph
should be deleted, because it was only used in one template, but now the
contents are in that template.