### PR TITLE
Wrap Hilbert Modular Form defining polynomials

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -360,7 +360,10 @@ def render_hmf_webpage(**args):
     if 'numeigs' in request.args:
         display_eigs = True
 
-    info['hecke_polynomial'] = teXify_pol(info['hecke_polynomial'])
+    # Break hecke polynomial on each term to allow newlines in rendering webpage
+    info['hecke_polynomial'] = "\(" + teXify_pol(info['hecke_polynomial']) + "\)"
+    info['hecke_polynomial'] = info['hecke_polynomial'].replace("+", "+ \) \(")
+    info['hecke_polynomial'] = info['hecke_polynomial'].replace("-", "- \) \(")
 
     if 'AL_eigenvalues_fixed' in data:
         if data['AL_eigenvalues_fixed'] == 'done':

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -15,7 +15,7 @@ from lmfdb.ecnf.WebEllipticCurve import db_ecnf
 from lmfdb.WebNumberField import WebNumberField
 
 from markupsafe import Markup
-from lmfdb.utils import to_dict, random_object_from_collection
+from lmfdb.utils import to_dict, random_object_from_collection, web_latex_split_on_pm
 from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, parse_count, parse_start
 
 hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
@@ -360,10 +360,7 @@ def render_hmf_webpage(**args):
     if 'numeigs' in request.args:
         display_eigs = True
 
-    # Break hecke polynomial on each term to allow newlines in rendering webpage
-    info['hecke_polynomial'] = "\(" + teXify_pol(info['hecke_polynomial']) + "\)"
-    info['hecke_polynomial'] = info['hecke_polynomial'].replace("+", "+ \) \(")
-    info['hecke_polynomial'] = info['hecke_polynomial'].replace("-", "- \) \(")
+    info['hecke_polynomial'] = web_latex_split_on_pm(teXify_pol(info['hecke_polynomial']))
 
     if 'AL_eigenvalues_fixed' in data:
         if data['AL_eigenvalues_fixed'] == 'done':

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -36,7 +36,7 @@
 
 {% if info.dimension > 1 %}
 <div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
-<div style='overflow-x:auto; overflow-y:hidden'>${{ info.hecke_polynomial }}$ </div>
+<div style='overflow-x:auto; overflow-y:hidden'>{{ info.hecke_polynomial }}</div>
 
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Show full eigenvalues</a>
 &nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -36,7 +36,7 @@
 
 {% if info.dimension > 1 %}
 <div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
-<div style='overflow-x:auto; overflow-y:hidden'>{{ info.hecke_polynomial }}</div>
+<div>{{ info.hecke_polynomial }}</div>
 
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Show full eigenvalues</a>
 &nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>


### PR DESCRIPTION
In #2097, it was noted that hmf defining polynomials currently extend
off the page with an invisible slider. I adopt the same convention as
used for the q-expansions of GL2 classical holomorphic cusp forms, as in
/ModularForm/GL2/Q/holomorphic/11/6/1/b/, and separate the hmf defining
polynomial termwise.

With this change, long defining polynomials (such as on
/ModularForm/GL2/TotallyReal/3.3.321.1/holomorphic/3.3.321.1-293.1-b )
line-wrap.

Resolves
--------
  #2097