### PR TITLE
wrap defining equation on hmf homepage

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -18,6 +18,8 @@ from markupsafe import Markup
 from lmfdb.utils import to_dict, random_object_from_collection
 from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, parse_count, parse_start
 
+from lmfdb.utils import web_latex_split_on_pm
+
 hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
 
 
@@ -360,7 +362,7 @@ def render_hmf_webpage(**args):
     if 'numeigs' in request.args:
         display_eigs = True
 
-    info['hecke_polynomial'] = teXify_pol(info['hecke_polynomial'])
+    info['hecke_polynomial'] = web_latex_split_on_pm(teXify_pol(info['hecke_polynomial']))
 
     if 'AL_eigenvalues_fixed' in data:
         if data['AL_eigenvalues_fixed'] == 'done':

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -36,7 +36,7 @@
 
 {% if info.dimension > 1 %}
 <div>The Hecke eigenvalue field is $\Q(e)$ where $e$ is a root of the defining polynomial:</div> 
-<div style='overflow-x:auto; overflow-y:hidden'>${{ info.hecke_polynomial }}$ </div>
+<div >{{ info.hecke_polynomial }} </div>
 
 <p>&nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=True'>Show full eigenvalues</a>
 &nbsp;&nbsp;<a href='{{ info.label }}?display_eigs=False'>Hide large eigenvalues</a></p>


### PR DESCRIPTION
Response to Issue #2097     
Modifying the display of the defining polynomial for Hilbert cusp
forms so as to fit on the homepage with wrapping.  This becomes a
problem for large coefficient fields.

Example:
http://localhost:37777/ModularForm/GL2/TotallyReal/3.3.321.1/holomorphic/3.3.321.1-293.1-b
