### PR TITLE
display name of template to every web page when in debug mode

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -95,7 +95,7 @@ def rational_elliptic_curves(err_args=None):
     credit = 'John Cremona and Andrew Sutherland'
     t = 'Elliptic curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
-    return render_template("ec-index.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'), **err_args)
+    return render_template("ec-index.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'), calling_function = "ec.rational_elliptic_curves", **err_args)
 
 @ec_page.route("/random")
 def random_curve():

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -266,6 +266,19 @@
   </div>
 </div>
 
+{% if DEBUG %}
+<div>
+<p>
+The template for this page is: {{ self._TemplateReference__context.name }}
+</p>
+{% if calling_function %}
+<p>
+The function which was called for this page is: {{calling_function}}
+</p>
+{% endif %}
+</div>
+{% endif %}
+
 <div id="footer">
     {% if credit -%}
       Data computed by {{ credit|safe }}.<br />


### PR DESCRIPTION
With this change to homepage.html, every page displays the name of the template it was created from when in debug mode.  No other action required by you!
Optional extra: if when calling render_template() you set the parameter calling_function to a string then it sill display that too: for one example try http://localhost:37777/EllipticCurve/Q/
This is to help debugging.