### PR TITLE
fix ecnf tests after relabelling IQF curves

### DIFF
--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -37,7 +37,7 @@ class EllCurveTest(LmfdbTest):
         r"""
         Check that the elliptic curve/#field tells about its Weirstrass eqn
         """
-        L = self.tc.get('/EllipticCurve/2.0.4.1/225.0.15/a/2')
+        L = self.tc.get('/EllipticCurve/2.0.4.1/225.2/a/2')
         assert '396' in L.data
         assert '2982' in L.data
 
@@ -45,7 +45,7 @@ class EllCurveTest(LmfdbTest):
         r"""
         Check that the elliptic curve/#field tells about its conductor and disciminant
         """
-        L = self.tc.get('/EllipticCurve/2.0.7.1/10000.125.25/a/1')
+        L = self.tc.get('/EllipticCurve/2.0.7.1/10000.5/a/1')
         assert '10000' in L.data
         assert '15625000000000000' in L.data
         assert '87890625' in L.data
@@ -56,7 +56,7 @@ class EllCurveTest(LmfdbTest):
         r"""
         Check that the elliptic curve/#field tells about its j invariant
         """
-        L = self.tc.get('/EllipticCurve/2.0.4.1/5525.870.5/b/9')
+        L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
         assert '226834389543384' in L.data
         assert '1490902050625' in L.data
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1') # Test factorisation
@@ -68,10 +68,10 @@ class EllCurveTest(LmfdbTest):
         """
         # Conductor 1
         L = self.tc.get('/EllipticCurve/?start=0&count=50&conductor_norm=1&include_isogenous=on&include_base_change=on')
-        assert 'a, 0, a + 1, -41 a + 158813, 2115 a - 13286543' in L.data
+        assert '2115 a - 13286543' in L.data
         # 4*4 torsion
         L = self.tc.get('/EllipticCurve/?start=0&count=50&include_isogenous=on&include_base_change=on&torsion=&torsion_structure=[4%2C4]')
-        assert '/EllipticCurve/2.0.4.1/5525.870.5/b/9' in L.data
+        assert '/EllipticCurve/2.0.4.1/5525.5/b/9' in L.data
         # 13 torsion
         L = self.tc.get('/EllipticCurve/?torsion=13')
         assert '2745' in L.data

--- a/lmfdb/ecnf/test_isog_class.py
+++ b/lmfdb/ecnf/test_isog_class.py
@@ -9,15 +9,15 @@ class EcnfIsogClassTest(LmfdbTest):
         r"""
         Check rendering of title name of ECNF isogeny class.
         """
-        L = self.tc.get('/EllipticCurve/2.0.7.1/16.10.1/CMa/').data
-        assert 'Elliptic curves in class 16.10.1-CMa' in L
+        L = self.tc.get('/EllipticCurve/2.0.7.1/16.1/CMa/').data
+        assert 'Elliptic curves in class 16.1-CMa' in L
 
     def test_ecnf_label_in_isgclass(self):
         r"""
         Check curve in ECNF isogeny class by label.
         """
-        L = self.tc.get('/EllipticCurve/2.0.3.1/2268.36.18/a/').data
-        assert '2268.36.18-a5' in L
+        L = self.tc.get('/EllipticCurve/2.0.3.1/2268.1/a/').data
+        assert '2268.1-a5' in L
 
     def test_ecnf_weiercoeffs_in_isgclass(self):
         r"""


### PR DESCRIPTION
All changes are consequent on the relabelling of curves over imaginary quadratic fields, except one which comes from the reformatting of long Weierstrass equations.