### PR TITLE
Added label to missing modular forms for L-functions of elliptic curves with high conductor

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -499,7 +499,7 @@ def set_bread_and_friends(L, request):
                                                                                 level=L.modform['level'], weight=2,
                                                                                 character=1, label=L.modform['iso'])))
         else:
-            origins.append(('Modular form not available', ""))
+            origins.append(('Modular form ' + label.replace('.', '.2') +'&nbsp;  n/a', ""))
            
         origins.append(('Isogeny class ' + label, friendlink))
 

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -148,7 +148,7 @@
         {% if url %}
            <li><a href="{{ url }}">{{ text }}</a></li>
         {% else %}
-           <li>{{ text }}</li>
+           <li>{{ text|safe }}</li>
         {% endif %}
         {% endfor %}
     </ul>


### PR DESCRIPTION
When the conductor is too high, the corresponding modular form is not in the data base. Under "Origins" in the properties box, this is rendered as 
"Modular form xxxx.2x n/a" 
to indicate that we know which modular form the L-function comes from, but the modular form is not in the database. 
See 
L/EllipticCurve/Q/10002/e/