### PR TITLE
Fix Issue #2103: non-collapsing properties box

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -6,7 +6,6 @@
 </style>
 
 {#
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script><script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script><script src="http://aleph.sagemath.org/embedded_sagecell.js">
 
 </script><style type="text/css">
   .sagecell .CodeMirror-scroll {

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -13,10 +13,6 @@ white-space: pre in order to keep line breaks! #}
 {% endfor %}
 {% endmacro %}
 
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
-<script type="text/javascript"
-src="http://code.jquery.com/jquery-latest.min.js"></script>
 {#
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -24,10 +24,6 @@ function show_invs(invstyle) {
   }
 </script>
 
-<script type="text/javascript"
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
-<script type="text/javascript"
-        src="http://place_code.jquery.com/jquery-latest.min.js"></script>
 {#
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 #}


### PR DESCRIPTION
Removed mathjax and jQuery from elliptic curves template.
mathjax--because it's in the main template;
jQuery--because it caused Issue #2103 (see Issue #2124 for more details).

See:
/EllipticCurve/Q/11/a/1
versus
/ModularForm/GL2/Q/holomorphic/11/2/1/a/

(try to collapse Properties box)