### PR TITLE
Fixed search again issue mentioned #1951

### DIFF
--- a/lmfdb/abvar/fq/templates/abvarfq-search-results.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-search-results.html
@@ -79,7 +79,7 @@
         </tr>
         
         <tr>
-            <td>
+            <td class="button">
                 <button type='submit' value='refine'>Search again</button>
             </td> </tr>
     </table>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -45,7 +45,7 @@
       <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value="{{req.count}}" size=10></td>
     </tr>
   <tr>
-    <td><button type='submit' value='Search'>Search again</button></td>
+    <td class="button"><button type='submit' value='Search'>Search again</button></td>
   </tr>
   </table>
 </form>

--- a/lmfdb/characters/templates/character_search.html
+++ b/lmfdb/characters/templates/character_search.html
@@ -83,7 +83,7 @@ table td.params {
 {#<td align=left colspan=4>Maximum number of characters to display <input type='text' name='count' value={{count}} size=10>#}
     </table>
     <p></p>
-    <td>
+    <td class="button">
         <button type='submit' value='refine'>Search again</button>
     </td>
 </form>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -37,8 +37,9 @@
 </tr>
 <tr>
 <td colspan=2 align=left>maximum results to display</td>
-<td align=left> <input type='text' name='limit'size=6 value="{{args.limit}}"> </td>
-<td colspan=2><button type='submit' width="170" style="width: 170px" name='refine' value='1'>Refine or change search</button>
+<td align=left> <input type='text' name='limit'size=6 value="{{args.limit}}"> </td></tr>
+<tr>
+<td class="button"><button type='submit' width="170" style="width: 170px" name='refine' value='1'>Search again</button>
 </td> </tr>
 </table>
 

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -109,7 +109,7 @@
 </tr>
 
 <tr>
-<td>
+<td class="button">
 <button type='submit' value='refine'>Search again</button>
 </td> </tr>
 </table>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -95,9 +95,8 @@
 </td>
 <td>&nbsp;
 </td>
-<td colspan=3>
-<button type='submit' value='refine'>Update search</button>
-</td> </tr>
+</tr>
+<tr><td class="button"><button type='submit' value='refine'>Search again</button></td></tr>
 </table>
 </form>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -147,7 +147,7 @@
 
 </tr>
 
-<tr><td><br><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
+<tr><td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
 
 </table>
 </form>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -126,12 +126,11 @@
 </tr>
 
 <tr>
-<td></td>
 <td>{{ KNOWL('ag.geom_simple', title='$\\overline{\\mathbb Q}$-simple') }}</td>
 </tr>
 
+
 <tr>
-<td><button type='submit' value='refine' style="width: 110px">Search again</button></td>
 <td><select name='is_simple_geom' width="110" style="width: 110px">
   <option ></option>
 {% if info.is_simple_geom == 'True' %}
@@ -145,7 +144,10 @@
   <option value="False">False</option>
 {% endif %}
 </select></td>
+
 </tr>
+
+<tr><td><br><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
 
 </table>
 </form>

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
@@ -35,7 +35,9 @@
 <tr>
 <td>Maximum number</td>
 <td><input type='text' name='count' size=10 value={{info.count}}></td>
-<td colspan=3><button type='submit' value='Search'>Refine or change search</button>
+</tr>
+<tr>
+<td class="button"><button type='submit' value='Search'>Search again</button>
 </td>
 </tr>
 </table>

--- a/lmfdb/lattice/templates/lattice-search.html
+++ b/lmfdb/lattice/templates/lattice-search.html
@@ -36,7 +36,9 @@
 <tr>
 <td align=left colspan=2>Maximum number of integral lattices to display</td>
 <td align=left><input type='text' name='count' value={{info.count}} size=10></td>
-<td><button type='submit' size=10  value='refine'>Search again</button></td>
+</tr>
+<tr>
+<td class="button"><button type='submit' size=10  value='refine'>Search again</button></td>
 </tr>
 </table>
 </form>

--- a/lmfdb/modlmf/templates/modlmf-search.html
+++ b/lmfdb/modlmf/templates/modlmf-search.html
@@ -38,10 +38,14 @@
 <tr align=left><td>{{KNOWL('modlmf.q_expansion', title='Coefficient')}} of <i>q<sup>n</sup></i> for <i>n=</i><input type='text' name='index_coeff' size=5 value="{{info.index_coeff}}"> is <input type='text' name='req_coeff' size=5 value="{{info.req_coeff}}">
 </td><td><button type='button' id='more_modp_button'>more</button>
 </td></tr>
+<tr>
+<td class="button"><button type='submit' size=10  value='refine'>Search again</button>
+ </td>
+</tr>
+
 </table>
 
 
-<button type='submit' size=10  value='refine'>Search again</button></td>
 </form>
 
 {% if info.err is defined %}

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -55,7 +55,7 @@ set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
 
 
 <tr> 
-<td align=left><button type='submit' value='refine'>Search again</button></td> 
+<td class="button" align=left><button type='submit' value='refine'>Search again</button></td> 
 </tr>
 </table>
 </form>

--- a/lmfdb/sato_tate_groups/templates/st_results.html
+++ b/lmfdb/sato_tate_groups/templates/st_results.html
@@ -41,11 +41,9 @@
 <td><input type='text' name='components' placeholder='1' style="width: 100px" value="{{info.components}}"></td>
 <td><input type='text' name='trace_zero_density' placeholder='1/2' style="width: 100px" value="{{info.trace_zero_density}}"></td>
 </tr>
+
 <tr>
-<td>&nbsp;</td>
-</tr>
-<tr>
-<td><button type='submit' name='refine' value='1' style="width: 110px">Search again</button></td>
+<td class="button"><button type='submit' name='refine' value='1' style="width: 110px">Search again</button></td>
 </tr>
 
 </table>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -619,6 +619,10 @@ body.knowl form select:hover {
     border: 2px solid {{color.knowl_thin_border}};
 }
 
+form table td.button {
+	padding-top: 7px
+}
+
 table {
     border: 0;
     border-collapse:collapse;


### PR DESCRIPTION
Sally and Alina added a class to the css file for "search" and "search again" button in a table. We made all the refine search pages display "Search again" in the button (consistency) and moved the button below the table on the left. 
Search again pages affected: number fields, elliptic curves, elliptic curves over number fields, lattices, artin rep, genus 2 curves, sato-tate groups

Examples:

/SatoTateGroup/?degree=2&rational_only=yes&count=25

/Genus2Curve/Q/?abs_disc=169&count=50


