### PR TITLE
fix bug in ecnf CM display when no Galois data (again)

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -400,14 +400,8 @@ class ECNF(object):
         # CM and End(E)
         self.cm_bool = "no"
         self.End = "\(\Z\)"
-        if self.cm and self.galois_images != '?':
+        if self.cm:
             self.rational_cm = K(self.cm).is_square()
-            self.cm_ramp = [p for p in ZZ(self.cm).support() if not p in self.non_surjective_primes]
-            self.cm_nramp = len(self.cm_ramp)
-            if self.cm_nramp==1:
-                self.cm_ramp = self.cm_ramp[0]
-            else:
-                self.cm_ramp = ", ".join([str(p) for p in self.cm_ramp])
             self.cm_sqf = ZZ(self.cm).squarefree_part()
             self.cm_bool = "yes (\(%s\))" % self.cm
             if self.cm % 4 == 0:
@@ -415,8 +409,20 @@ class ECNF(object):
                 self.End = "\(\Z[\sqrt{%s}]\)" % (d4)
             else:
                 self.End = "\(\Z[(1+\sqrt{%s})/2]\)" % self.cm
-            # The line below will need to change once we have curves over non-quadratic fields
-            # that contain the Hilbert class field of an imaginary quadratic field
+
+        # Galois images in CM case:
+        if self.cm and self.galois_images != '?':
+            self.cm_ramp = [p for p in ZZ(self.cm).support() if not p in self.non_surjective_primes]
+            self.cm_nramp = len(self.cm_ramp)
+            if self.cm_nramp==1:
+                self.cm_ramp = self.cm_ramp[0]
+            else:
+                self.cm_ramp = ", ".join([str(p) for p in self.cm_ramp])
+
+        # Sato-Tate:
+        # The lines below will need to change once we have curves over non-quadratic fields
+        # that contain the Hilbert class field of an imaginary quadratic field
+        if self.cm:
             if self.signature == [0,1] and ZZ(-self.abs_disc*self.cm).is_square():
                 self.ST = st_link_by_name(1,2,'U(1)')
             else:


### PR DESCRIPTION
This fixes properly the bug which was wrongly fixed at #2104 .
To test compare http://beta.lmfdb.org/EllipticCurve/2.0.4.1/10000.3/CMa/1 which wrongly report no CM, with the new version which correctly reports CM by -11.