### PR TITLE
Fix tests

### DIFF
--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -17,7 +17,8 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/12350/s/')
         assert '[1, -1, 1, -3655, -83403]' in L.data
         L = self.tc.get('/EllipticCurve/Q/12350/s')
-        assert 'You should be redirected automatically to target URL: <a href="http://localhost/EllipticCurve/Q/12350/s/">http://localhost/EllipticCurve/Q/12350/s/</a>' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.data
+        assert '/EllipticCurve/Q/12350/s/' in L.data
 
     def test_Cremona_label_mal(self):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class')
@@ -29,11 +30,13 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/210/')
         assert '[1, 0, 0, 729, -176985]' in L.data
         L = self.tc.get('/EllipticCurve/Q/210')
-        assert 'You should be redirected automatically to target URL: <a href="http://localhost/EllipticCurve/Q/210/">http://localhost/EllipticCurve/Q/210/</a>' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.data
+        assert '/EllipticCurve/Q/210/' in L.data
 
     def test_Weierstrass_search(self):
         L = self.tc.get('/EllipticCurve/Q/[1,2,3,4,5]')
-        assert 'You should be redirected automatically to target URL: <a href="http://localhost/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/">http://localhost/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/</a>' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.data
+        assert '/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/' in L.data
 
     def test_j_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2000&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.base import LmfdbTest
 
 class EllCurveTest(LmfdbTest):
@@ -33,7 +33,7 @@ class EllCurveTest(LmfdbTest):
 
     def test_Weierstrass_search(self):
         L = self.tc.get('/EllipticCurve/Q/[1,2,3,4,5]')
-        assert 'You should be redirected automatically to target URL: <a href="/EllipticCurve/Q/10351.b1">/EllipticCurve/Q/10351.b1</a>' in L.data
+        assert 'You should be redirected automatically to target URL: <a href="http://localhost/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/">http://localhost/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/</a>' in L.data
 
     def test_j_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2000&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -26,7 +26,7 @@ class HMFTest(LmfdbTest):
 
     def test_typo(self): #771
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=2.2.5.1') 
-        assert 'or change' in L.data
+        assert 'Search again' in L.data
 
     def test_large(self): #616
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=4.4.2000.1&count=1200')


### PR DESCRIPTION
Two minor test fixes after some changes at the June workshop.  I also changed 3 tests for redirections so that they no longer test for the precise URL including the 'localhost' part since that seemed fragile.
The fixed tests are in lmfdb/elliptic_curves and lmfdb/hilbert_modular_forms.