### PR TITLE
move curves with automorphisms data from beta to prod

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -143,11 +143,9 @@
          - title: Belyi
            status: future
          - title: "Higher genus:"
-           status: beta
            part3:
              - title: Families
                url_for:  "higher_genus_w_automorphisms.index"
-               status: beta
                colspan: onecolumn
            colspan: onecolumn
      - title: 2-d


### PR DESCRIPTION
This pull request is to move the "Higher Genus/Familes" from beta to production.  Two comments:

1. The genus 15 data is still loading into the database. Barring more thunderstorm induced power interruptions (a peril of living in the midwest US in June), it should be finished in the next 24 hours.

2. A small performance issue I'm a bit concerned about. A few pages like the following are very long pages (i.e. many, many lines).   They load from the database quickly, but MathJax spends a long time going through each line.  Is there a way to tell it to stop running MathJax once it hits the "Generating Vectors" line, as there is no special math notation beyond that point on any of the pages?
http://127.0.0.1:37777/HigherGenus/C/Aut/15.10-1.0.2-2-2-2-2-2-2-2-5.2