### PR TITLE
capped display of generating vectors default to 20

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -38,6 +38,8 @@ def split_passport_label(lab):
     return passport_label_regex.match(lab).groups()
 
 
+credit ='Jen Paulhus, using group and signature data originally computed by Thomas Breuer'
+
 
 def get_bread(breads=[]):
     bc = [("Higher Genus", url_for(".index")),("C", url_for(".index")),("Aut", url_for(".index"))]
@@ -130,7 +132,7 @@ def index():
     learnmore = [('Source of the data', url_for(".how_computed_page")),
                 ('Labeling convention', url_for(".labels_page"))]
     
-    return render_template("hgcwa-index.html", title="Families of Higher Genus Curves with Automorphisms", bread=bread, info=info, learnmore=learnmore)
+    return render_template("hgcwa-index.html", title="Families of Higher Genus Curves with Automorphisms", bread=bread, credit=credit, info=info, learnmore=learnmore)
 
 
 @higher_genus_w_automorphisms_page.route("/random")
@@ -239,7 +241,7 @@ def higher_genus_w_automorphisms_search(**args):
         else:
             info['report'] = 'displaying all %s matches' % nres
 
-    return render_template("hgcwa-search.html", info=info, title="Families of Higher Genus Curves with Automorphisms Search Result", bread=bread)
+    return render_template("hgcwa-search.html", info=info, title="Families of Higher Genus Curves with Automorphisms Search Result", credit=credit, bread=bread)
 
 
 
@@ -323,7 +325,7 @@ def render_family(args):
         return render_template("hgcwa-show-family.html", 
                                title=title, bread=bread, info=info,
                                properties2=prop2, friends=friends,
-                               learnmore=learnmore, downloads=downloads)
+                               learnmore=learnmore, downloads=downloads, credit=credit)
 
 
 def render_passport(args):
@@ -486,12 +488,12 @@ def render_passport(args):
         return render_template("hgcwa-show-passport.html", 
                                title=title, bread=bread, info=info,
                                properties2=prop2, friends=friends,
-                               learnmore=learnmore, downloads=downloads)
+                               learnmore=learnmore, downloads=downloads, credit=credit)
 
 
     
 def search_input_error(info, bread):
-    return render_template("hgcwa-search.html", info=info, title='Families of Higher Genus Curve Search Input Error', bread=bread)
+    return render_template("hgcwa-search.html", info=info, title='Families of Higher Genus Curve Search Input Error', bread=bread, credit=credit)
 
 
  
@@ -502,7 +504,7 @@ def completeness_page():
     learnmore = [('Source of the data', url_for(".how_computed_page")),
                 ('Labeling convention', url_for(".labels_page"))]
     return render_template("single.html", kid='dq.curve.highergenus.aut.extent',
-                            title=t, bread=bread,learnmore=learnmore)
+                            title=t, bread=bread,learnmore=learnmore, credit=credit)
 
 
 @higher_genus_w_automorphisms_page.route("/Labels")
@@ -512,7 +514,7 @@ def labels_page():
     learnmore = [('Completeness of the data', url_for(".completeness_page")),
                 ('Source of the data', url_for(".how_computed_page"))]
     return render_template("single.html", kid='dq.curve.highergenus.aut.label',
-                           learnmore=learnmore, title=t, bread=bread)
+                           learnmore=learnmore, title=t, bread=bread,credit=credit)
 
 @higher_genus_w_automorphisms_page.route("/Source")
 def how_computed_page():
@@ -521,7 +523,7 @@ def how_computed_page():
     learnmore = [('Completeness of the data', url_for(".completeness_page")),
                 ('Labeling convention', url_for(".labels_page"))]
     return render_template("single.html", kid='dq.curve.highergenus.aut.source',
-                           title=t, bread=bread, learnmore=learnmore)
+                           title=t, bread=bread, learnmore=learnmore, credit=credit)
 
 
 

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -354,6 +354,13 @@ def render_passport(args):
 
         numb = dataz.count()
 
+        try:
+            numgenvecs = request.args['numgenvecs']
+            numgenvecs = int(numgenvecs)
+        except:
+            numgenvecs = 20
+        info['numgenvecs']=numgenvecs
+
         title = 'One refined passport of genus ' + str(g) + ' with automorphism group $' + pretty_group +'$'
         smallgroup="[" + str(gn) + "," +str(gt) +"]"   
 
@@ -376,7 +383,8 @@ def render_passport(args):
         Ldata=[]
         HypColumn = False
         Lfriends=[]
-        for dat in dataz:
+        for i in range (0, min(numgenvecs,numb)):
+            dat= dataz[i]
             x1=dat['total_label']
             if 'full_auto' in dat:
                 x2='No'

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -374,7 +374,9 @@ def render_passport(args):
                     'cc': cc_display(data['con']), 
                     'sign': sign_display(ast.literal_eval(data['signature'])),   
                      'group': pretty_group,
-                     'gpid': smallgroup
+                     'gpid': smallgroup,
+                     'numb':numb,
+                     'disp_numb':min(numb,numgenvecs)
                    })
 
         if spname:

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -24,7 +24,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 <a href="?genus={{gen}}">{{gen}}</a>
 {% endfor %}</p>
 
-<p>Hyperelliptic curves by genus:
+<p>{{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curves')}}: by genus:
 {% for gen in info.genus_list %}
 <a href="?genus={{gen}}&inc_hyper=only">{{gen}}</a>
 {% endfor %} 
@@ -91,7 +91,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	<span class="formexample">e.g. 1, or a range like 0..2</span>
 	 </td> </tr>
               <tr>  <td align=right>
-	       Hyperelliptic curve(s):
+	       {{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curve(s)')}}:
             </td>  <td> <select name='inc_hyper'>
                     <option value='include'>include </option>
 		    <option value='exclude'>exclude</option>
@@ -103,7 +103,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	 </td></tr>
 
 	  <tr>  <td align=right>
-	       Cyclic trigonal curve(s):
+	       {{KNOWL('ag.cyclic_trigonal',title='Cyclic trigonal curve(s)')}}:
             </td>  <td> <select name='inc_cyc_trig'>
                     <option value='include'>include </option>
 		    <option value='exclude'>exclude</option>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -21,7 +21,7 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 </tr>
 
 <tr><td>
-	       Hyperelliptic curve(s):
+	      {{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curve(s)')}}:
 </td>
 
   <td> <select name='inc_hyper'>
@@ -43,7 +43,7 @@ Group: <td align=left> <input type="text" name="group" size="8" value="{{info.gr
 </td> 
 
 <td >
-	      Cyclic trigonal curve(s):
+	 {{KNOWL('ag.cyclic_trigonal',title='Cyclic trigonal curve(s)')}}:
 </td>
 
   <td> <select name='inc_cyc_trig'>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -45,20 +45,22 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     <table>
         <tr><td>Dimension of the corresponding {{KNOWL('ag.shimura_variety',title='Shimura variety')}}:</td><td>{{ info.Ndim}}</td></tr>
       {% if info.ishyp %}     
-      <tr><td>Hyperelliptic curve(s):</td><td>{{info.ishyp}}</td></tr>
+      <tr><td>{{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curve(s)')}}:</td><td>{{info.ishyp}}</td></tr>
       {% if info.hypinv  %}
        <tr><td>Hyperelliptic involution:</td> <td>{{info.hypinv}}</td></tr>
        {% endif %}  {% endif %}
       {% if info.iscyctrig %}     
-      <tr><td>Cyclic trigonal curve(s):</td><td>{{info.iscyctrig}}</td></tr>
+      <tr><td> {{KNOWL('ag.cyclic_trigonal',title='Cyclic trigonal curve(s)')}}:</td><td>{{info.iscyctrig}}</td></tr>
       {% if info.cinv  %}
        <tr><td>Trigonal automorphism:</td> <td>{{info.cinv}}</td></tr>
        {% endif %}  {% endif %}
     </table>
 
+  </p>
+
+  <p>
     {% if info.eqns %}
-    <br>
-    Equations(s) of curve(s) in this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}:
+    <table><tr><td>Equations(s) of curve(s) in this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}:</td></tr></table>
        <table>{% for eqn in info.eqns %}
 	  <tr><td> &nbsp; </td><td>${{eqn}}$</td></tr>
 	  {% endfor %} </table> <br>
@@ -68,8 +70,9 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
 
 
-<p><h2>{{KNOWL('curve.highergenus.aut.generatingvector',title='Generating Vector(s)')}}</h2>
+<h2>{{KNOWL('curve.highergenus.aut.generatingvector',title='Generating Vector(s)')}}</h2>
 
+<p>
   {% if info.numb == 1 %}
   Displaying the unique {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vector')}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}.
 
@@ -77,8 +80,6 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
   Displaying {{info.disp_numb}} of {{info.numb}} {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vectors')}} for this  {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}.
   
   {% endif %}
-
-
 </p>
 
 
@@ -88,7 +89,9 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 	  <tr><td> &nbsp; </td><td>{{perm}}</td></tr>
 	  {% endfor %} </table> <br>   
   {% endfor %}
+ </p>
 
+ <p>
   {% if info.numb >= 2 %}
  <form>
   <table>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -12,7 +12,6 @@ table,td {
 
 
 
-
 <p><h2> Family Information</h2>
 
   <table>
@@ -71,19 +70,30 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
 <p><h2>{{KNOWL('curve.highergenus.aut.generatingvector',title='Generating Vector(s)')}}</h2>
 
- 
-    {% for cdata in info.genvects %}
+  {% if info.numb == 1 %}
+  Displaying the unique {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vector')}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}.
+
+  {% else %}
+  Displaying {{info.disp_numb}} of {{info.numb}} {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vectors')}} for this  {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}.
+  
+  {% endif %}
+
+
+</p>
+
+
+ <p>{% for cdata in info.genvects %}
    {{cdata[0]}}
      <table>{% for perm in cdata[3] %}
 	  <tr><td> &nbsp; </td><td>{{perm}}</td></tr>
-	  {% endfor %} </table> <br>
-    {% endfor %}
-</table>    
+	  {% endfor %} </table> <br>   
+  {% endfor %}
 
-<form>
+  {% if info.numb >= 2 %}
+ <form>
   <table>
     <tr>
-      <td>Display number of generating vectors </td>
+      <td>Display number of {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vectors')}}:</td>
       <td><input type='text' name='numgenvecs' placeholder='20' size=10></td>
     </tr>
     <tr>
@@ -91,9 +101,9 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     </tr>
   </table>
 </form>
+{% endif %} </p>
 
 
-</p>
 
   
 {% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -80,6 +80,19 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
     {% endfor %}
 </table>    
 
+<form>
+  <table>
+    <tr>
+      <td>Display number of generating vectors </td>
+      <td><input type='text' name='numgenvecs' placeholder='20' size=10></td>
+    </tr>
+    <tr>
+      <td colspan=3><button type='submit' value='display'>Display</button></td>
+    </tr>
+  </table>
+</form>
+
+
 </p>
 
   


### PR DESCRIPTION
These changes address an issue in #2150 and should be merged before that PR.

I've set a default of 20 generating vectors, and added a button to change that number as needed.  You can see an example of it here:
http://127.0.0.1:37777/HigherGenus/C/Aut/8.28-3.0.2-2-2-2-2.1

There are 24 total generating vectors in this example.