### PR TITLE
Add doctesting, unittesting to tests

### DIFF
--- a/lmfdb/test_unittest_template.py
+++ b/lmfdb/test_unittest_template.py
@@ -1,0 +1,27 @@
+# -*- coding: utf8 -*-
+# LMFDB - L-function and Modular Forms Database web-site - www.lmfdb.org
+# Copyright (C) 2017 by the LMFDB authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+import unittest2
+
+from lmfdb.base import DoctestExampleTest
+
+
+class ExampleUnitTest(unittest2.TestCase):
+    """
+    This is an example unittest. For this example, we will test
+    DoctestExampleTest, from lmfdb/base.py
+    """
+
+    # Note that the docstring to this function is printed during testing
+    def test_DoctestExampleTest(self):
+        r"""
+        Testing DoctestExampleTest.
+        """
+        ex = DoctestExampleTest(2)
+        self.assertEqual(ex.__str__(), "I am 2")

--- a/lmfdb/test_utils.py
+++ b/lmfdb/test_utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf8 -*-
+# LMFDB - L-function and Modular Forms Database web-site - www.lmfdb.org
+# Copyright (C) 2017 by the LMFDB authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+import unittest2
+
+from lmfdb.utils import truncatenumber
+
+class UtilsTest(unittest2.TestCase):
+    """
+    An example of unit tests that are not based on the website itself.
+    """
+
+    def test_truncatenumber(self):
+        r"""
+        Testing utility: truncatenumber
+        """
+        self.assertEqual(truncatenumber(1.000001, 5), "1")
+        self.assertEqual(truncatenumber(1.123456, 5), "1.123")
+        self.assertEqual(truncatenumber(-1.123456, 5), "-1.123")
+        self.assertEqual(truncatenumber(0.000002, 5), "0")

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ else
   echo "pyflakes is happy"
 fi
 
-ARGS='-v -s --testmatch="(?:^|\/)[Tt]est_"'
+ARGS='-v -s --with-doctest --testmatch="(?:^|\/)[Tt]est_"'
 
 SAGE_COMMAND=$SAGE
 if [[ "$SAGE_COMMAND" == "" ]]; then


### PR DESCRIPTION
**Note: This is not ready to be pulled yet.**

In #2177, John Cremona asked about adding in doctesting into our testing suite. This is possible, and the change to the testing suite is minimal (it now includes `--with-doctest`).

We also don't have any unittests in the code, but this is possible from our framework as well. So I've added an example unittest for utils.py, as well as a template unittest in case others felt inclined to see what this looks like. This is only good, I think.

However, there is a downside to incorporating doctests. Before, the only python files called during testing were files of the form test_<something>.py. An advantage and disadvantage of doctests is that now generic python files are called during testing, and docstrings are parsed to give doctests. The disadvantage here is that this also means that the various scripts and files that some have made for importing data to the database or testing for database coverage are called.

This has two negative side effects. 

1. Firstly, this causes files which are actually scripts (in the sense that their functionality isn't hiding behind functions) to be called. This is clearly a bad thing. As an example, this causes lmfdb/modular_forms/elliptic_modular_forms/emf_db_stats.py (which computes some statistics related to the database, and which takes some time) to run.

2. This also causes several scripts (such as lmfdb/local_fields/import_fields.py) to run. These should fail, and cause spurious errors. But it is dangerous to run random import scripts throughout the code.

Both of these are resolved by separating out scripts into the scripts/ directory, instead of lying somewhere within lmfdb/. I believe this is the intention of the scripts/ directory, but I wasn't certain enough to move those scripts first. It is also possible to avoid testing files which satisfy a REGEX, such as being named `import_<restOfFilename>.py`. But this wouldn't catch emf_db_stats.py, for example.

It is also possible to have a separate doctest call, which only calls certain files. We would probably want to doctest utility functions, but much of the frontend display code is not appropriate for doctesting.

Alternately, we may simply choose to not have doctests. It is still possible (and I think desirable) to include unittests, with or without doctests. But doctests have some nice properties.

So I ask others, what do you think is the best path to follow? I am happy to pursue any of these (or another) courses of action regarding tests (though I think that incorporating some unittests is a good idea).