### PR TITLE
HMF url errors handling

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -284,7 +284,8 @@ def render_hmf_webpage(**args):
         label = str(args['label'])
         data = C.hmfs.forms.find_one({'label': label})
     if data is None:
-        return "No such form"
+        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a" % args['label']), "error")
+        return search_input_error()
     info = {}
     try:
         info['count'] = args['count']

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -18,8 +18,8 @@ class HMFTest(LmfdbTest):
 
     def test_EC(self): #778
         L = self.tc.get('ModularForm/GL2/TotallyReal/5.5.126032.1/holomorphic/5.5.126032.1-82.1-b')
-        assert 'Elliptic curve not available' in L.data     #TODO remove or change url when
-                                                            #the elliptic curve is in the database
+        assert 'EllipticCurve/5.5.126032.1/82.1/b/' in L.data   
+        
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.89.1/holomorphic/2.2.89.1-2.1-a')
         assert 'Isogeny class' in L.data
         assert 'EllipticCurve/2.2.89.1/2.1/a' in L.data


### PR DESCRIPTION
This solves issue #1959, i.e. errors for url typing.

http://beta.lmfdb.org/ModularForm/GL2/TotallyReal/2.2.145.1/holomorphic/2.2.145.1-1.1
check now
/ModularForm/GL2/TotallyReal/2.2.145.1/holomorphic/2.2.145.1-1.1
/ModularForm/GL2/TotallyReal/4.4.9225.1/holomorphic/4.4.9225.jd1-176.6-e

Fixed also a test for hmf, now all hmf tests pass.