### PR TITLE
Display data on ramified primes on number field pages.

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -733,7 +733,6 @@ class WebNumberField:
     def ramified_algebras_data(self):
         if self.get_local_algebra_dict() is None:
             return dnc
-        ramps = self.ramified_primes()
         return [self.get_local_algebra(p) for p in self.ramified_primes()]
 
     def make_code_snippets(self):

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -706,14 +706,9 @@ class WebNumberField:
         f = self.conductor()
         return DirichletGroup_conrey(f)
 
-    # Helpers for ramified algebras table
-    def get_local_algebra_dict(self):
-        if 'loc_algebras' in self._data.keys():
-            return self._data['loc_algebras']
-        return None
-
+    # Helper for ramified algebras table
     def get_local_algebra(self, p):
-        local_algebra_dict = self.get_local_algebra_dict()
+        local_algebra_dict = self._data.get('loc_algebras', None)
         if local_algebra_dict is None:
             return None
         if str(p) in local_algebra_dict:
@@ -731,7 +726,7 @@ class WebNumberField:
         return None
 
     def ramified_algebras_data(self):
-        if self.get_local_algebra_dict() is None:
+        if 'loc_algebras' not in self._data:
             return dnc
         return [self.get_local_algebra(p) for p in self.ramified_primes()]
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -96,7 +96,7 @@ def local_field_data(label):
 def lf_display_knowl(label, C):
     return '<a title = "%s [lf.field.data]" knowl="lf.field.data" kwargs="label=%s">%s</a>' % (label, label, label)
 
-def local_algebra_display_knowl(label, C):
+def local_algebra_display_knowl(labels, C):
     return '<a title = "%s [lf.algebra.data]" knowl="lf.algebra.data" kwargs="labels=%s">%s</a>' % (labels, labels, labels)
 
 def small_group_data(label):

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -50,6 +50,27 @@ def group_display_shortC(C):
         return group_display_short(nt[0], nt[1], C)
     return gds
 
+def lf_algebra_knowl_guts(labels, C):
+    labs = labels.split(',')
+    f1 = labs[0].split('.')
+    labs = sorted(labs, key=lambda u: (int(j) for j in u.split('.')), reverse=True)
+    ans = '<div align="center">'
+    ans += '$%s$-adic algebra'%str(f1[0])
+    ans += '</div>'
+    ans += '<p>'
+    ans += "<table class='ntdata'><th>Label<th>Polynomial<th>$e$<th>$f$<th>$c$<th>$G$<th>Slopes"
+    fall = [C.localfields.fields.find_one({'label':label}) for label in labs]
+    for f in fall:
+        l = str(f['label'])
+        ans += '<tr><td><a href="/LocalNumberField/%s">%s</a><td>'%(l,l)
+        ans += format_coeffs(f['coeffs'])
+        ans += '<td>%d<td>%d<td>%d<td>'%(f['e'],f['f'],f['c'])
+        ans += group_display_knowl(f['gal'][0],f['gal'][1],db())
+        ans += '<td>$'+ show_slope_content(f['slopes'],f['t'],f['u'])+'$'
+    ans += '</table>'
+    if len(labs) != len(set(labs)):
+        ans +='<p>Fields which appear more than once occur according to their given multiplicities in the algebra'
+    return ans
 
 def lf_knowl_guts(label, C):
     f = C.localfields.fields.find_one({'label':label})
@@ -66,11 +87,17 @@ def lf_knowl_guts(label, C):
     ans += '</div>'
     return ans
 
+def local_algebra_data(labels):
+    return lf_algebra_knowl_guts(labels, db())
+
 def local_field_data(label):
     return lf_knowl_guts(label, db())
 
 def lf_display_knowl(label, C):
     return '<a title = "%s [lf.field.data]" knowl="lf.field.data" kwargs="label=%s">%s</a>' % (label, label, label)
+
+def local_algebra_display_knowl(label, C):
+    return '<a title = "%s [lf.algebra.data]" knowl="lf.algebra.data" kwargs="labels=%s">%s</a>' % (labels, labels, labels)
 
 def small_group_data(label):
     return small_group_knowl_guts(label, db())
@@ -78,7 +105,8 @@ def small_group_data(label):
 @app.context_processor
 def ctx_local_fields():
     return {'local_field_data': local_field_data,
-            'small_group_data': small_group_data}
+            'small_group_data': small_group_data,
+            'local_algebra_data': local_algebra_data}
 
 # Utilities for subfield display
 def format_lfield(coefmult,p):

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -318,15 +318,16 @@ def render_field_webpage(args):
                 p = ram_primes[j]
                 loc_alg += '<tr><td rowspan="%d">$%s$</td>'%(len(mydat),str(p))
                 mm = mydat[0]
+                myurl = url_for('local_fields.by_label', label=mm[0])
                 lab = mm[0]
                 if mm[3]*mm[2]==1:
                     lab = r'$\Q_{%s}$'%str(p)
-                loc_alg += '<td><a href="/LocalNumberField/%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(mm[0],lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                loc_alg += '<td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
                 for mm in mydat[1:]:
                     lab = mm[0]
                     if mm[3]*mm[2]==1:
                         lab = r'$\Q_{%s}$'%str(p)
-                    loc_alg += '<tr><td><a href="/LocalNumberField/%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(mm[0],lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                    loc_alg += '<tr><td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
         loc_alg += '</tbody></table>'
 
     ram_primes = str(ram_primes)[1:-1]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -9,7 +9,8 @@ from lmfdb.base import app, getDBConnection
 from flask import render_template, request, url_for, redirect, send_file, flash
 import StringIO
 from lmfdb.number_fields import nf_page, nf_logger
-from lmfdb.WebNumberField import field_pretty, WebNumberField, nf_knowl_guts, decodedisc
+from lmfdb.WebNumberField import field_pretty, WebNumberField, nf_knowl_guts, decodedisc, factor_base_factor, factor_base_factorization_latex
+from lmfdb.local_fields.main import show_slope_content
 
 from markupsafe import Markup
 
@@ -268,6 +269,7 @@ def render_field_webpage(args):
     info['wnf'] = nf
     data['degree'] = nf.degree()
     data['class_number'] = nf.class_number()
+    ram_primes = nf.ramified_primes()
     t = nf.galois_t()
     n = nf.degree()
     data['is_galois'] = nf.is_galois()
@@ -282,7 +284,9 @@ def render_field_webpage(args):
         if data['conductor'].is_prime() or data['conductor'] == 1:
             data['conductor'] = "\(%s\)" % str(data['conductor'])
         else:
-            data['conductor'] = "\(%s=%s\)" % (str(data['conductor']), latex(data['conductor'].factor()))
+            factored_conductor = factor_base_factor(data['conductor'], ram_primes)
+            factored_conductor = factor_base_factorization_latex(factored_conductor)
+            data['conductor'] = "\(%s=%s\)" % (str(data['conductor']), factored_conductor)
     data['galois_group'] = group_display_knowl(n, t, C)
     data['cclasses'] = cclasses_display_knowl(n, t, C)
     data['character_table'] = character_table_display_knowl(n, t, C)
@@ -292,17 +296,42 @@ def render_field_webpage(args):
     data['coefficients'] = nf.coeffs()
     nf.make_code_snippets()
     D = nf.disc()
-    ram_primes = D.prime_factors()
     data['disc_factor'] = nf.disc_factored_latex()
     if D.abs().is_prime() or D == 1:
         data['discriminant'] = "\(%s\)" % str(D)
     else:
         data['discriminant'] = "\(%s=%s\)" % (str(D), data['disc_factor'])
+    data['frob_data'], data['seeram'] = frobs(nf)
+    # Bad prime information
     npr = len(ram_primes)
+    ramified_algebras_data = nf.ramified_algebras_data()
+    if isinstance(ramified_algebras_data,str):
+        loc_alg = ''
+    else:
+        # [label, latex, e, f, c, gal]
+        loc_alg = ''
+        for j in range(npr):
+            if ramified_algebras_data[j] is None:
+                loc_alg += '<tr><td>%s<td colspan="7">Data not computed'%str(ram_primes[j])
+            else:
+                mydat = ramified_algebras_data[j]
+                p = ram_primes[j]
+                loc_alg += '<tr><td rowspan="%d">$%s$</td>'%(len(mydat),str(p))
+                mm = mydat[0]
+                lab = mm[0]
+                if mm[3]*mm[2]==1:
+                    lab = r'$\Q_{%s}$'%str(p)
+                loc_alg += '<td><a href="/LocalNumberField/%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(mm[0],lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                for mm in mydat[1:]:
+                    lab = mm[0]
+                    if mm[3]*mm[2]==1:
+                        lab = r'$\Q_{%s}$'%str(p)
+                    loc_alg += '<tr><td><a href="/LocalNumberField/%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(mm[0],lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+        loc_alg += '</tbody></table>'
+
     ram_primes = str(ram_primes)[1:-1]
     if ram_primes == '':
         ram_primes = r'\textrm{None}'
-    data['frob_data'], data['seeram'] = frobs(nf)
     data['phrase'] = group_phrase(n, t, C)
     zk = nf.zk()
     Ra = PolynomialRing(QQ, 'a')
@@ -337,7 +366,8 @@ def render_field_webpage(args):
         'unit_rank': nf.unit_rank(),
         'root_of_unity': web_latex(rootofunity),
         'fund_units': nf.units(),
-        'grh_label': grh_label
+        'grh_label': grh_label,
+        'loc_alg': loc_alg
     })
 
     bread.append(('%s' % info['label_raw'], ' '))

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -215,6 +215,32 @@
           {{ place_code('prime_cycle_types') }}
         </p>
 
+{% if info.degree == 1 %}
+  <p><h2> {{KNOWL('nf.local_algebra', 'Local algebras')}} for
+  {{ KNOWL('nf.ramified_primes', title="ramified primes") }}
+  </h2>
+  <p>There are no ramified primes.
+{% elif info.degree > 1 and info.loc_alg is not equalto '' %}
+  <p><h2> {{KNOWL('nf.local_algebra', 'Local algebras')}} for
+  {{ KNOWL('nf.ramified_primes', title="ramified primes") }}
+  </h2>
+  <p>
+  <center>
+  <table border="2">
+    <thead>
+      <th>$p$<th>Label<th>Polynomial
+      <th>{{KNOWL("lf.ramification_index",title="$e$")}}
+      <th>{{KNOWL("lf.residue_field_degree",title="$f$")}}
+      <th>{{KNOWL("lf.discriminant_exponent",title="$c$")}}
+      <th>{{KNOWL("nf.galois_group",title="Galois group")}}
+      <th>{{KNOWL("lf.slope_content",title="Slope content")}}
+    </thead>
+  <tbody>
+  {{ info.loc_alg | safe }}
+</center>
+{% endif %}
+<p>
+
 {% if info.get("tim_number_field", False) %}
     <p><h2> {{ KNOWL('artin', title='Artin representations') }}</h2>
         <div>


### PR DESCRIPTION
This shows, when available, data on local decompositions of number fields at ramified primes.  Data is being computed, and will be progressively added.  This gives a connection between the local field pages and another part of the lmfdb.  The addition is near the bottom of number field pages.

For testing:
http://127.0.0.1:37777/NumberField/1.1.1.1 (Q is special by having no ramified primes, so it gets its own message)
http://127.0.0.1:37777/NumberField/11.1.54517760000000000.1 (has wild primes)
http://127.0.0.1:37777/NumberField/11.1.5999947987.1 (some primes have data, some do not because they are too big)
http://127.0.0.1:37777/NumberField/6.0.10816.1 (no data at all yet, so the section is not shown)

There is also code for making dynamic knowls with similar information.  This is currently not used, but doesn't hurt either.