### PR TITLE
HMFs: localised collection names so each is in only one place to aid …

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_field.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_field.py
@@ -9,17 +9,11 @@ from sage.all import ZZ
 from lmfdb.base import getDBConnection
 from lmfdb.WebNumberField import WebNumberField
 
-hmf_nfdb = None
-
-
 def db_hmfnf():
     """
     Return the fields collection from the HMF database
     """
-    global hmf_nfdb
-    if hmf_nfdb is None:
-        hmf_nfdb = getDBConnection().hmfs.fields
-    return hmf_nfdb
+    return getDBConnection().hmfs.fields
 
 def findvar(L):
     """

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -2,12 +2,11 @@
 
 import pymongo
 
-from lmfdb.base import getDBConnection
 from flask import render_template, url_for, request, redirect, make_response, flash
 
 from lmfdb.hilbert_modular_forms import hmf_page
 from lmfdb.hilbert_modular_forms.hilbert_field import findvar
-from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, get_counts, hmf_degree_summary
+from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, get_counts, hmf_degree_summary, db_forms, db_search, db_fields
 
 from lmfdb.ecnf.main import split_class_label
 from lmfdb.ecnf.WebEllipticCurve import db_ecnf
@@ -20,10 +19,9 @@ from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, 
 
 hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
 
-
 @hmf_page.route("/random")
 def random_hmf():    # Random Hilbert modular form
-    return hilbert_modular_form_by_label( random_object_from_collection( getDBConnection().hmfs.forms ) )
+    return hilbert_modular_form_by_label( random_object_from_collection( db_forms() ) )
 
 def teXify_pol(pol_str):  # TeXify a polynomial (or other string containing polynomials)
     o_str = pol_str.replace('*', '')
@@ -81,8 +79,7 @@ def split_full_label(lab):
 
 def hilbert_modular_form_by_label(lab):
     if isinstance(lab, basestring):
-        C = getDBConnection()
-        res = C.hmfs.forms.search.find_one({'label': lab},{'label':True})
+        res = db_search().find_one({'label': lab},{'label':True})
     else:
         res = lab
         lab = res['label']
@@ -131,8 +128,7 @@ def hilbert_modular_form_search(**args):
     start = parse_start(info)
 
     info['query'] = dict(query)
-    C = getDBConnection()
-    res = C.hmfs.forms.search.find(
+    res = db_search().find(
         query).sort([('deg', pymongo.ASCENDING), ('disc', pymongo.ASCENDING), ('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)]).skip(start).limit(count)
     nres = res.count()
     if(start >= nres):
@@ -191,14 +187,13 @@ def render_hmf_webpage_download(**args):
 
 
 def download_hmf_magma(**args):
-    C = getDBConnection()
     label = str(args['label'])
-    f = C.hmfs.forms.find_one({'label': label})
+    f = db_forms().find_one({'label': label})
     if f is None:
         return "No such form"
 
     F = WebNumberField(f['field_label'])
-    F_hmf = C.hmfs.fields.find_one({'label': f['field_label']})
+    F_hmf = db_fields().find_one({'label': f['field_label']})
 
     outstr = 'P<x> := PolynomialRing(Rationals());\n'
     outstr += 'g := P!' + str(F.coeffs()) + ';\n'
@@ -247,14 +242,13 @@ def download_hmf_magma(**args):
 
 
 def download_hmf_sage(**args):
-    C = getDBConnection()
     label = str(args['label'])
-    f = C.hmfs.forms.find_one({'label': label})
+    f = db_forms().find_one({'label': label})
     if f is None:
         return "No such form"
 
     F = WebNumberField(f['field_label'])
-    F_hmf = C.hmfs.fields.find_one({'label': f['field_label']})
+    F_hmf = db_fields().find_one({'label': f['field_label']})
 
     outstr = 'P.<x> = PolynomialRing(QQ)\n'
     outstr += 'g = P(' + str(F.coeffs()) + ')\n'
@@ -288,13 +282,12 @@ def download_hmf_sage(**args):
 
 @hmf_page.route('/<field_label>/holomorphic/<label>')
 def render_hmf_webpage(**args):
-    C = getDBConnection()
     if 'data' in args:
         data = args['data']
         label = data['label']
     else:
         label = str(args['label'])
-        data = C.hmfs.forms.find_one({'label': label})
+        data = db_forms().find_one({'label': label})
     if data is None:
         flash(Markup("Error: <span style='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a" % args['label']), "error")
         return search_input_error()
@@ -311,7 +304,7 @@ def render_hmf_webpage(**args):
         numeigs = 20
     info['numeigs'] = numeigs
 
-    hmf_field = C.hmfs.fields.find_one({'label': data['field_label']})
+    hmf_field = db_fields().find_one({'label': data['field_label']})
     gen_name = findvar(hmf_field['ideals'])
     nf = WebNumberField(data['field_label'], gen_name=gen_name)
     info['hmf_field'] = hmf_field
@@ -345,7 +338,7 @@ def render_hmf_webpage(**args):
 
     t = "Hilbert Cusp Form %s" % info['label']
 
-    forms_space = C.hmfs.forms.search.find(
+    forms_space = db_search().find(
         {'field_label': data['field_label'], 'level_ideal': data['level_ideal']},{'dimension':True})
     dim_space = 0
     for v in forms_space:

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import url_for
-import lmfdb.base
-from lmfdb.base import app
+from lmfdb.base import app, getDBConnection
 from lmfdb.utils import comma, make_logger
 from lmfdb.WebNumberField import nf_display_knowl
 
@@ -9,6 +8,29 @@ def format_percentage(num, denom):
     return "%10.2f"%((100.0*num)/denom)
 
 logger = make_logger("hmf")
+
+hmf_forms = None
+hmf_fields = None
+hmf_search = None
+
+def db_forms():
+    global hmf_forms
+    if hmf_forms is None:
+        hmf_forms = getDBConnection().hmfs.forms
+    return hmf_forms
+
+def db_fields():
+    global hmf_fields
+    if hmf_fields is None:
+        hmf_fields = getDBConnection().hmfs.fields
+    return hmf_fields
+
+def db_search():
+    global hmf_search
+    if hmf_search is None:
+        hmf_search = getDBConnection().hmfs.forms.search
+    return hmf_search
+
 
 the_HMFstats = None
 
@@ -73,8 +95,8 @@ class HMFstats(object):
 
     def __init__(self):
         logger.debug("Constructing an instance of HMFstats")
-        self.fields = lmfdb.base.getDBConnection().hmfs.fields
-        self.forms = lmfdb.base.getDBConnection().hmfs.forms
+        self.fields = db_fields()
+        self.forms = db_forms()
         self._counts = {}
         self._stats = {}
 
@@ -131,7 +153,7 @@ class HMFstats(object):
             for d in self._counts['degrees']:
                 statsd = stats[int(d)]
                 for F in statsd['fields']:
-                    statsd['counts'][F]['field_knowl'] = nf_display_knowl(F, lmfdb.base.getDBConnection(), F)
+                    statsd['counts'][F]['field_knowl'] = nf_display_knowl(F, getDBConnection(), F)
                     statsd['counts'][F]['forms'] = url_for('hmf.hilbert_modular_form_render_webpage', field_label=F)
                 self._stats[d] = statsd
         else:
@@ -169,6 +191,6 @@ class HMFstats(object):
         stats = {}
         stats['nforms'] = len(res) # res['nforms']
         stats['maxnorm'] = max(res+[0]) # res['maxnorm']
-        stats['field_knowl'] = nf_display_knowl(F, lmfdb.base.getDBConnection(), F)
+        stats['field_knowl'] = nf_display_knowl(F, getDBConnection(), F)
         stats['forms'] = url_for('hmf.hilbert_modular_form_render_webpage', field_label=F)
         return stats

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -9,28 +9,14 @@ def format_percentage(num, denom):
 
 logger = make_logger("hmf")
 
-hmf_forms = None
-hmf_fields = None
-hmf_search = None
-
 def db_forms():
-    global hmf_forms
-    if hmf_forms is None:
-        hmf_forms = getDBConnection().hmfs.forms
-    return hmf_forms
+    return getDBConnection().hmfs.forms
 
 def db_fields():
-    global hmf_fields
-    if hmf_fields is None:
-        hmf_fields = getDBConnection().hmfs.fields
-    return hmf_fields
+    return getDBConnection().hmfs.fields
 
 def db_search():
-    global hmf_search
-    if hmf_search is None:
-        hmf_search = getDBConnection().hmfs.forms.search
-    return hmf_search
-
+    return getDBConnection().hmfs.forms.search
 
 the_HMFstats = None
 

--- a/lmfdb/hilbert_modular_forms/q_expansion.py
+++ b/lmfdb/hilbert_modular_forms/q_expansion.py
@@ -3,11 +3,9 @@ from sage.misc.preparser import preparse
 from sage.interfaces.magma import magma
 from sage.all import PolynomialRing, Rationals
 from lmfdb.base import getDBConnection
-C = getDBConnection()
+from lmfdb.hilbert_modular_forms.hmf_stats import db_forms, db_fields
 
-hmf_forms = C.hmfs.forms
-hmf_fields = C.hmfs.fields
-fields = C.numberfields.fields
+fields = getDBConnection().numberfields.fields
 
 P = PolynomialRing(Rationals(), 3, ['w', 'e', 'x'])
 w, e, x = P.gens()
@@ -15,9 +13,9 @@ w, e, x = P.gens()
 
 def qexpansion(field_label=None):
     if field_label is None:
-        S = hmf_forms.find({})
+        S = db_forms().find({})
     else:
-        S = hmf_forms.find({"field_label": field_label})
+        S = db_forms().find({"field_label": field_label})
     S = S.sort("label")
 
     field_label = None
@@ -38,7 +36,7 @@ def qexpansion(field_label=None):
             print "...new field " + field_label
 
             F = fields.find_one({"label": field_label})
-            F_hmf = hmf_fields.find_one({"label": field_label})
+            F_hmf = db_fields().find_one({"label": field_label})
 
             magma.eval('P<x> := PolynomialRing(Rationals());')
             magma.eval('F<w> := NumberField(Polynomial(' + str(F["coefficients"]) + '));')
@@ -112,6 +110,6 @@ def qexpansion(field_label=None):
         q_expansions = [[[str(c) for c in q[0]], [str(c) for c in q[1]]] for q in q_expansions]
 
         v["q_expansions"] = q_expansions
-        hmf_forms.save(v)
+        db_forms().save(v)
 
         v = S.next()

--- a/lmfdb/hilbert_modular_forms/web_HMF.py
+++ b/lmfdb/hilbert_modular_forms/web_HMF.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import lmfdb.base
+from lmfdb.base import getDBConnection
 from lmfdb.utils import make_logger
 
 from sage.all import QQ, polygen
@@ -8,27 +8,14 @@ from lmfdb.hilbert_modular_forms.hilbert_field import HilbertNumberField
 
 logger = make_logger("hmf")
 
-hmf_forms = None
-hmf_fields = None
-nf_fields = None
-
 def db_hmf_forms():
-    global hmf_forms
-    if hmf_forms is None:
-        hmf_forms = lmfdb.base.getDBConnection().hmfs.forms
-    return hmf_forms
+    return getDBConnection().hmfs.forms
 
 def db_hmf_fields():
-    global hmf_fields
-    if hmf_fields is None:
-        hmf_fields = lmfdb.base.getDBConnection().hmfs.fields
-    return hmf_fields
+    return getDBConnection().hmfs.fields
 
 def db_nf_fields():
-    global nf_fields
-    if nf_fields is None:
-        nf_fields = lmfdb.base.getDBConnection().numberfields.fields
-    return nf_fields
+    return getDBConnection().numberfields.fields
 
 def construct_full_label(field_label, weight, level_label, label_suffix):
     if all([w==2 for w in weight]):           # Parellel weight 2

--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -42,13 +42,10 @@ def getInstanceLdata(label,label_type="url"):
     return Ldata
 
 def getHmfData(label):
-    connection = base.getDBConnection()
-    try:
-        f = connection.hmfs.forms.find_one({'label': label})
-        F_hmf = connection.hmfs.fields.find_one({'label': f['field_label']})
-    except:
-        f = None
-        F_hmf = None
+    from lmfdb.hilbert_modular_forms.hmf_stats import db_forms, db_fields
+    # these will return None if nothing is found:
+    f = db_forms().find_one({'label': label})
+    F_hmf = db_fields().find_one({'label': f['field_label']})
     return (f, F_hmf)
 
 def getMaassDb():


### PR DESCRIPTION
…testing (and clarity)

There are 3 collections inside hilbert_modular_forms: forms, fields, forms.search.  Each was referred to multiple times in the code which makes it rather hard to test things like switching from forms to forms.new (as I am now doing).  This PR just uses the model used elsewhere, in which for each collection there is one function which delivers the collection, so such changes only need to be done one.  (They are set in hmf_stats to avoid circular imports.)

As I wrote the above I noticed a few other places where these should be used so I will add those, after which a quick review would be welcome.