### PR TITLE
ecnf: improved base-change and Q-curve handling

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -408,12 +408,15 @@ class ECNF(object):
             self.ST = st_link_by_name(1,2,'SU(2)')
 
         # Q-curve / Base change
-        self.qc = "no"
-        try:
-            if self.q_curve:
-                self.qc = "yes"
-        except AttributeError:  # in case the db entry does not have this field set
-            pass
+        self.qc = self.q_curve
+        if self.qc == "?":
+            self.qc = "not determined"
+        elif self.qc == True:
+            self.qc = "yes"
+        elif self.qc == False:
+            self.qc = "no"
+        else: # just in case
+            self.qc = "not determined"
 
         # Torsion
         self.ntors = web_latex(self.torsion_order)
@@ -544,7 +547,8 @@ class ECNF(object):
             self.properties += [('base-change', 'yes: %s' % ','.join([str(lab) for lab in self.base_change]))]
         else:
             self.base_change = []  # in case it was False instead of []
-            self.properties += [('Q-curve', self.qc)]
+            self.properties += [('base-change', 'no')]
+        self.properties += [('Q-curve', self.qc)]
 
         r = self.rk
         if r == "?":

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -407,7 +407,7 @@ This curve {% if ec.base_change %} is the
 {% for E0 in ec.base_change%}
 <a href={{url_for("ec.by_ec_label",label=E0)}}>{{E0}}</a>,
 {% endfor %}
-defined over \(\Q\), so is also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+defined over \(\Q\), so it is also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 {% else %}
 is not the {{KNOWL('ec.base_change','base-change')}} of an elliptic curve defined over \(\Q\).
 It {% if ec.qc=="yes" %} is {% else %} is not {% endif %} a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -380,14 +380,15 @@ if \(\left(\frac{ {{ec.cm_sqf}} }{p}\right)=-1\).
 </div>
 
 <div>
-  <h2> Isogenies </h2>
+  <h2> {{KNOWL('ec.isogeny_class','Isogenies')}} and {{KNOWL('ec.isogeny_class','isogeny class')}}</h2>
 <p>
 {% if ec.isogeny_degrees %}
-This curve has non-trivial cyclic isogenies {% if ec.rational_cm %}
+This curve has non-trivial cyclic {{KNOWL('ec.isogeny_class','isogenies')}} {% if ec.rational_cm %}
 (excluding endomorphisms){% endif %} of degree \(d\) for \(d=\)
 {{ ec.isogeny_degrees}}.
 <br>
-Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>
+Its {{KNOWL('ec.isogeny_class','isogeny class')}}
+<a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>
 consists of {{ec.ncurves}} curves linked by isogenies of
 {% if ec.one_deg %}degree{% else %}degrees dividing {% endif %}
 {{ec.class_deg}}.
@@ -396,6 +397,20 @@ This curve has no rational isogenies{% if ec.rational_cm %} other than
 endomorphisms{% endif %}.
 Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>   consists of this curve only.
 </p>
+{% endif %}
+</div>
+
+<div>
+<h2> {{KNOWL('ec.base_change','Base change')}} </h2>
+This curve {% if ec.base_change %} is the
+{{KNOWL('ec.base_change','base-change')}} of elliptic curves
+{% for E0 in ec.base_change%}
+<a href={{url_for("ec.by_ec_label",label=E0)}}>{{E0}}</a>,
+{% endfor %}
+defined over \(\Q\), so is also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{% else %}
+is not the {{KNOWL('ec.base_change','base-change')}} of an elliptic curve defined over \(\Q\).
+It {% if ec.qc=="yes" %} is {% else %} is not {% endif %} a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 {% endif %}
 </div>
 


### PR DESCRIPTION
This does 3 related things:

   1. Handles cases where the 'q_curve' field is '?' (see Issue #2218 )
   1. Shows "Base change: no" in properties box instead of omitting it and only showing it when True (suggestion of @jvoight )
   1. Adds a section at the bottom of ecnf home pages about Q-curviness and base-change-ness.

For examples see EllipticCurve/2.0.8.1/34166.3/b/2 (neither bc nor qc), EllipticCurve/2.2.5.1/45.1/a/5 (bc and hence qc) .  I cannot yet give an example of a qc not bc because of the problems raised at #2218 but there will be.  However I hope this PR can be merged first since the data changes under way to fix #2218 will make some q_curve fields '?' and that is not handled i the current code.
