### PR TITLE
fix Q-curve text for unknown case

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -410,7 +410,13 @@ This curve {% if ec.base_change %} is the
 defined over \(\Q\), so it is also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 {% else %}
 is not the {{KNOWL('ec.base_change','base-change')}} of an elliptic curve defined over \(\Q\).
-It {% if ec.qc=="yes" %} is {% else %} is not {% endif %} a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{% if ec.qc=="yes" %}
+It is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{% elif ec.qc=="no" %}
+It is not a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{% else %}
+It has not yet been determined whether or not it is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{% endif %}
 {% endif %}
 </div>
 


### PR DESCRIPTION
This fixes the small thing mentioned on #2219 .  Check out EllipticCurve/2.2.5.1/4225.1/b/1 for one of the curves which @edgarcosta first pointed out was a non-base-change Q-curve but was tagged as not a Q-curve, and EllipticCurve/3.3.321.1/27.1/a/1 for an undetermined one (new text near foot of page).
After this we can push to beta.