### PR TITLE
L-functions associated to Elliptic curves over real quadratic number fields

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -504,7 +504,7 @@ class ECNF(object):
         if totally_real:
             self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
-            self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
+            self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
 
         if imag_quadratic:
             self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])

--- a/lmfdb/lfunctions/LfunctionComp.py
+++ b/lmfdb/lfunctions/LfunctionComp.py
@@ -2,7 +2,7 @@
 
 from pymongo import ASCENDING
 from lmfdb.elliptic_curves.web_ec import lmfdb_label_regex, db_ec
-
+from lmfdb.ecnf.WebEllipticCurve import db_ecnf
 
 def isogeny_class_table(Nmin, Nmax):
     ''' Returns a table of all isogeny classes of elliptic curves with
@@ -24,11 +24,16 @@ def isogeny_class_cm(label):
     return db_ec().find_one({'lmfdb_iso':label},{'_id':False,'cm':True})['cm']
 
 
-def nr_of_EC_in_isogeny_class(label):
+#FIXME These should perhaps be defined in the elliptic curves codebase
+def nr_of_EC_in_isogeny_class(long_isogeny_class_label, field_label = "1.1.1.1"):
     ''' Returns the number of elliptic curves in the isogeny class
      with given label.
     '''
-    return db_ec().find({'lmfdb_iso':label}).count()
+    if field_label == "1.1.1.1":
+        return db_ec().find({'lmfdb_iso':long_isogeny_class_label}).count()
+    else:
+        return db_ecnf().find({'class_label':field_label + "." + long_isogeny_class_label}).count()
+
 
 
 def modform_from_EC(label):
@@ -37,7 +42,7 @@ def modform_from_EC(label):
     '''
     N, iso, number = lmfdb_label_regex.match(label).groups()
     return {'level': N, 'iso': iso}
-
+        
 
 def EC_from_modform(level, iso):
     ''' The inverse to modform_from_EC

--- a/lmfdb/lfunctions/LfunctionDatabase.py
+++ b/lmfdb/lfunctions/LfunctionDatabase.py
@@ -9,21 +9,28 @@ def getEllipticCurveData(label):
     curves = connection.elliptic_curves.curves
     return curves.find_one({'lmfdb_label': label})
     
-def getInstanceLdata(label,label_type="url"):
-    db = base.getDBConnection().Lfunctions
+def getInstanceLdata(label, label_type="url"):
+    Lfunctions_db = base.getDBConnection()['Lfunctions']
+    Lfunctions =  Lfunctions_db["Lfunctions"];
+    instances = Lfunctions_db["instances"];
+
+    if label[:13] == "EllipticCurve" and label[:16] != "EllipticCurve/Q/":
+        Lfunctions =  Lfunctions_db["ecqd_Lfunctions"];
+        instances = Lfunctions_db["ecqd_instances"];
+
     try:
         if label_type == "url":
-            Lpointer = db.instances.find_one({'url': label})
+            Lpointer = instances.find_one({'url': label})
             if not Lpointer:
                 return None
             Lhash = Lpointer['Lhash']
-            Ldata = db.Lfunctions.find_one({'Lhash': Lhash})
+            Ldata = Lfunctions.find_one({'Lhash': Lhash})
             # do not ignore this error, if the instances record exists the
             # Lhash should be there and we want to know if it is not
             if not Ldata:
                 raise KeyError("Lhash '%s' in instances record for URL '%s' not found in Lfunctions collection" % (label, Lhash))
         elif label_type == "Lhash":
-            Ldata = db.Lfunctions.find_one({'Lhash': label})
+            Ldata = Lfunctions.find_one({'Lhash': label})
         else:
             raise ValueError("Invalid label_type = '%s', should be 'url' or 'Lhash'" % label)
             
@@ -36,8 +43,7 @@ def getInstanceLdata(label,label_type="url"):
             Ldata['values'] = [ central_value ]
         else:
             Ldata['values'] += [ central_value ]
-
-    except ValueError:
+    except ValueError:   
         Ldata = None
     return Ldata
 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -364,7 +364,7 @@ def lfuncEPtex(L, fmt):
     """ Returns the LaTex for displaying the Euler product of the L-function L.
         fmt could be any of the values: "abstract"
     """
-    if L.Ltype() in ["genus2curveQ", "ellipticcurveQ"] and fmt == "arithmetic":
+    if L.Ltype() in ["genus2curveQ", "ellipticcurveQ", "ellipticcurve"] and fmt == "arithmetic":
         return lfuncEPhtml(L, fmt)
 
     ans = ""


### PR DESCRIPTION
Hello,

First of all, do not merge this!

This is just a hack to show you the data the data of the L-functions associated to Elliptic curves over real quadratic number fields.
If you are happy with the data, then I would move it to the right collections.

Here are some examples, and their corresponding objects in the database:
* 2.2.5.1-49.1-a1 (a quadratic twis of http://www.lmfdb.org/EllipticCurve/Q/175/a/1)
http://beta.lmfdb.org/api/Lfunctions/ecqd_Lfunctions/?origin=sEllipticCurve/2.2.5.1/49.1/a
http://127.0.0.1:37777/L/EllipticCurve/2.2.5.1/49.1/a/
However, I have no way to automatically detect the quadratic twist, thus it's hash is: '_3835819448407117806631286663382'.

* The only two curves with rank > 2 in this set:
http://beta.lmfdb.org/api/Lfunctions/ecqd_Lfunctions/?order_of_vanishing=i3
http://127.0.0.1:37777/L/EllipticCurve/2.2.93.1/197.1/b/
http://127.0.0.1:37777/L/EllipticCurve/2.2.93.1/197.2/b/

* A base change:
http://beta.lmfdb.org/api/Lfunctions/ecqd_Lfunctions/?origin=sEllipticCurve/2.2.5.1/80.1/a
http://127.0.0.1:37777/L/EllipticCurve/2.2.5.1/80.1/a/

Let me know what you think.

ps: After I'm done with CM quadratic fields I will push the code that I used to generate all the data

Cheers,
Edgar

