### PR TITLE
Check if a polynomial is from the old polredabs

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -204,7 +204,10 @@ class WebNumberField:
             chash = hashlib.md5(coeffs).hexdigest()
             f = nfdb().find_one({'coeffhash': chash, 'coeffs': coeffs})
             if f is None:
-                return cls('a')  # will initialize data to None
+                # Check if we have a result of the old polredabs
+                f = nfdb().find_one({'oldpolredabscoeffhash': chash, 'oldpolredabscoeffs': coeffs})
+                if f is None:
+                    return cls('a')  # will initialize data to None
             return cls(f['label'], f)
         else:
             raise Exception('wrong type')


### PR DESCRIPTION
This handles issue #2135 .  The polynomials (on beta) are from the latest greatest version of polredabs.  Ones which changed have optional data fields with the coefficients from the old polredabs, which this will now check.  

To test, you can put x^5 - x^4 - 10*x^3 + 4*x^2 + 6*x + 1 in the box to search for a global number field.  Currently, in the cloud version it is found (cloud has old version polynomials), on beta it fails, and with this patch it succeeds.

It is probably best if this code (in some form) makes it to the cloud server before the database gets uploaded.