### PR TITLE
HMF: remove references to 'AL_eigenvalues_fixed' in website code

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -387,9 +387,6 @@ def render_hmf_webpage(**args):
         for eig in info['eigs']:
             if len(eig['eigenvalue']) > 300:
                 eig['eigenvalue'] = '...'
-        for eig in info['AL_eigs']:
-            if len(eig['eigenvalue']) > 300:
-                eig['eigenvalue'] = '...'
 
     info['level_ideal'] = teXify_pol(info['level_ideal'])
 

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -369,16 +369,16 @@ def render_hmf_webpage(**args):
 
     info['hecke_polynomial'] = web_latex_split_on_pm(teXify_pol(info['hecke_polynomial']))
 
-    if 'AL_eigenvalues_fixed' in data:
-        if data['AL_eigenvalues_fixed'] == 'done':
-            info['AL_eigs'] = [{'eigenvalue': teXify_pol(al[1]),
-                                'prime_ideal': teXify_pol(al[0]),
-                                'prime_norm': al[0][1:al[0].index(',')]} for al in data['AL_eigenvalues']]
-        else:
-            info['AL_eigs'] = [{'eigenvalue': '?', 'prime_ideal': '?'}]
+    AL_eigs = data['AL_eigenvalues']
+    if not AL_eigs: # empty list
+        if data['level_norm']==1: # OK, no bad primes
+            info['AL_eigs'] = 'none'
+        else:                     # not OK, AL eigs are missing
+            info['AL_eigs'] = 'missing'
     else:
-        info['AL_eigs'] = [{'eigenvalue': '?', 'prime_ideal': '?'}]
-    info['AL_eigs_count'] = len(info['AL_eigs']) != 0
+        info['AL_eigs'] = [{'eigenvalue': teXify_pol(al[1]),
+                            'prime_ideal': teXify_pol(al[0]),
+                            'prime_norm': al[0][1:al[0].index(',')]} for al in data['AL_eigenvalues']]
 
     max_eig_len = max([len(eig['eigenvalue']) for eig in info['eigs']])
     display_eigs = display_eigs or (max_eig_len<=300)

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form.html
@@ -86,7 +86,15 @@ div.scrollable {
 
 <h2>  Atkin-Lehner eigenvalues  </h2>
 
-{% if info.AL_eigs_count %} 
+{% if info.AL_eigs=='missing' %}
+<p>
+  The Atkin-Lehner eigenvalues for this form are not in the database.
+</p>
+{% elif info.AL_eigs=='none' %}
+<p>
+  This form has no Atkin-Lehner eigenvalues since the level is \((1)\).
+</p>
+{% else %}
 <p>
 <table class="ntdata" cellpadding=5>
 <tr>
@@ -103,8 +111,6 @@ div.scrollable {
 {% endfor %}
 </table>
 </p>
-{% else %}
-<p>None</P> 
 {% endif %}
 
 

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -97,3 +97,11 @@ class HMFTest(LmfdbTest):
     def test_browse_by_degree(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/2/')
         assert 'Number of newforms' in L.data
+
+    def test_missing_AL(self):
+        L = self.tc.get('/ModularForm/GL2/TotallyReal/3.3.49.1/holomorphic/3.3.49.1-512.1-a')
+        assert 'The Atkin-Lehner eigenvalues for this form are not in the database' in L.data
+
+    def test_level_one_AL(self):
+        L = self.tc.get('ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a')
+        assert 'This form has no Atkin-Lehner eigenvalues' in L.data

--- a/lmfdb/hilbert_modular_forms/web_HMF.py
+++ b/lmfdb/hilbert_modular_forms/web_HMF.py
@@ -162,7 +162,6 @@ class WebHMF(object):
 
         data['is_CM'] = '?'
         data['is_base_change'] = '?'
-        data['AL_eigenvalues_fixed'] = None
 
 
     def save_to_db(self):
@@ -178,7 +177,7 @@ class WebHMF(object):
             field = HilbertNumberField(self.dbdata['field_label'])
         agree = True
         for key in self.dbdata.keys():
-            if key in ['is_base_change', 'is_CM', 'AL_eigenvalues_fixed']:
+            if key in ['is_base_change', 'is_CM']:
                 continue
             if key=='hecke_eigenvalues':
                 if self.dbdata[key]!=f.dbdata[key]:


### PR DESCRIPTION
This will enable us to delete the field 'AL_eigenvalues_fixed' from the forms collection.  It was only ever intended to be temporary.

I also slightly improved (I think) the Atkin-Lehner Eigenvalue section of the web page for an individual HMF in two cases: /ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a where the level is 1 so there are none (it used to just say "None." as in http://www.lmfdb.org/ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a) and where there are no AL eigenvalues in the database despite the level not being one (currently true for 4990 forms), for example ModularForm/GL2/TotallyReal/3.3.49.1/holomorphic/3.3.49.1-512.1-a (compare with http://www.lmfdb.org/ModularForm/GL2/TotallyReal/3.3.49.1/holomorphic/3.3.49.1-512.1-a which displays a table with one row of '?', regardless of the number of bad primes).

I added these examples to the tests.

One small point of discussion (see the first example above) is the text which says "This form has no Atkin-Lehner eigenvalues since the level is (1)."  and if someone has a suggestion for a better way to say that the level is the unit ideal, please say so!