### PR TITLE
fixing up test_workshoplinks

### DIFF
--- a/lmfdb/test_acknowlegments.py
+++ b/lmfdb/test_acknowlegments.py
@@ -8,9 +8,12 @@ class HomePageTest(LmfdbTest):
         assert text in self.tc.get(path).data
 
     def check_external(self, homepage, path, text):
-        import urllib2
+        import urllib2, ssl
+        headers = {'User-Agent': 'Mozilla/5.0'}
+        context = ssl._create_unverified_context()
+        request = urllib2.Request(path, headers = headers)
         assert path in homepage
-        assert text in urllib2.urlopen(path).read()
+        assert text in urllib2.urlopen(request, context = context).read()
 
     # All tests should pass
     #


### PR DESCRIPTION
At the moment  `test_workshoplinks` errors with:
`
HTTPError: HTTP Error 403: Forbidden
`

I fixed that by adding a user-agent.

That get's me to a different error 
`
URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)>
`
In short, python doesn't verify Let's encrypt SSL certificates by default, given that we are only checking for the content, I have disabled SSL in `check_external`