### PR TITLE
sorting search results for abelian varieties

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -4,6 +4,7 @@ import time
 import ast
 import StringIO
 import lmfdb.base
+from pymongo import ASCENDING
 from lmfdb.base import app
 from lmfdb.utils import to_dict, make_logger, random_object_from_collection
 from lmfdb.abvar.fq import abvarfq_page
@@ -187,8 +188,10 @@ def abelian_variety_search(**args):
     if start < 0:
         start = 0
 
+
     #res = cursor.sort([]).skip(start).limit(count)
-    res = cursor.skip(start).limit(count)
+    res = cursor.sort([('g', ASCENDING), ('q', ASCENDING), ('label', ASCENDING), ('p_rank', ASCENDING)]).skip(start).limit(count)
+    #res = cursor.skip(start).limit(count)
     res = list(res)
     info['abvars'] = [AbvarFq_isoclass(x) for x in res]
     info['number'] = nres

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -63,10 +63,11 @@ class AVHomeTest(LmfdbTest):
         r"""
         Check that we can search by dimension
         """
-        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=2&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=", '2.11.ae_f')
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=2&simple=any&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=", '2.11.ae_f')
+        # check that 2.2.a_a and  2.3.a_a show up in the first 50 results 
+        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=2&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=", '2.2.a_a')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=2&simple=any&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=", '2.3.a_a')
         #this last one is url only
-        self.check_args("/Variety/Abelian/Fq/2/", '2.11.ae_f')
+        self.check_args("/Variety/Abelian/Fq/2/", '2.3.a_a')
 
     def test_search_basefield(self):
         r"""
@@ -113,17 +114,17 @@ class AVHomeTest(LmfdbTest):
         Check that we can search by newton polygon
         """
         # [0,1] from browse page
-        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=%5B0%2C1%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'1.13.g')
+        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=%5B0%2C1%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'1.2.ab')
         # 1/3 from browse page
-        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=1%2F3&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'3.2.ac_c_ac')
+        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=1%2F3&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'3.2.a_a_ac')
         # 1/5 from refine search
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=&newton_polygon=1%2F5&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'5.2.ae_i_ao_ba_abq')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=&newton_polygon=1%2F5&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'5.2.a_a_a_a_ac')
         # slope not a rational number
         self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=t&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'is not a valid input')
         # slopes are not increasing
         self.check_args("/Variety/Abelian/Fq/?start=&count=&q=&g=&simple=any&p_rank=&newton_polygon=%5B1%2C1%2F2%2C0%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'Slopes must be increasing')
         # [(1,0),(3,1)]
-        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=%5B%281%2C0%29%2C%283%2C1%29%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'2.16.j_ca')
+        self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=%5B%281%2C0%29%2C%283%2C1%29%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'2.3.ab_d')
         # breaks don't give a convex hull
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=&newton_polygon=%5B%281%2C2%29%2C%283%2C1%29%5D&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'Slopes specified by break points must be increasing')
         # break coordinates not integers
@@ -135,6 +136,8 @@ class AVHomeTest(LmfdbTest):
         """
         self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=&curve_point_count=&decomposition=&count=",'4.3.b_ab_d_j')
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=&curve_point_count=&decomposition=",'4.3.b_ab_d_j')
+        # there should be only one match
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&p_rank=&angle_ranks=&newton_polygon=&initial_coefficients=%5B3%2C+9%2C+10%2C+87-100%5D&abvar_point_count=&curve_point_count=&decomposition=&number_field=&simple=any&primitive=any&jacobian=any&polarizable=any", "3.11.d_j_k");
 
     def test_search_pointcountsav(self):
         r"""
@@ -154,8 +157,8 @@ class AVHomeTest(LmfdbTest):
         r"""
         Check that we can search by angle rank
         """
-        self.check_args("/Variety/Abelian/Fq/?q=3&primitive=any&g=4&simple=any&p_rank=&jacobian=any&angle_ranks=2&polarizable=any&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&count=",'4.3.ag_u_abw_dn')
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=3&g=4&p_rank=&angle_ranks=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&simple=any&primitive=any&jacobian=any&polarizable=any",'4.3.ag_u_abw_dn')
+        self.check_args("/Variety/Abelian/Fq/?q=3&primitive=any&g=4&simple=any&p_rank=&jacobian=any&angle_ranks=2&polarizable=any&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&count=",'4.3.a_a_ae_ad')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=3&g=4&p_rank=&angle_ranks=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&simple=any&primitive=any&jacobian=any&polarizable=any",'4.3.a_a_ae_ad')
         self.not_check_args("/Variety/Abelian/Fq/?q=3&primitive=any&g=4&simple=any&p_rank=&jacobian=any&angle_ranks=2&polarizable=any&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&count=",'4.3.a_ad_a_j')
         self.not_check_args("/Variety/Abelian/Fq/?start=0&count=50&q=3&g=4&p_rank=&angle_ranks=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&number_field=&simple=any&primitive=any&jacobian=any&polarizable=any",'4.3.a_ad_a_j')
 
@@ -224,12 +227,12 @@ class AVHomeTest(LmfdbTest):
         Check that various search combinations work.
         """
         # dimension and base field, last one is from the table
-        self.check_args("/Variety/Abelian/Fq/?q=7&simple=any&g=1&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'1.7.af')
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=7&g=1&simple=any&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'1.7.af')
+        self.check_args("/Variety/Abelian/Fq/?q=7&simple=any&g=1&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'1.7.f')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=7&g=1&simple=any&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'1.7.f')
         self.check_args("/Variety/Abelian/Fq/1/7/", '1.7.af')
         # dimension, base field and p-rank
-        self.check_args("/Variety/Abelian/Fq/?q=9&simple=any&g=2&p_rank=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'2.9.ag_w')
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=9&g=2&simple=any&p_rank=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'2.9.ag_w')
+        self.check_args("/Variety/Abelian/Fq/?q=9&simple=any&g=2&p_rank=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=",'2.9.a_n')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=9&g=2&simple=any&p_rank=2&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=",'2.9.a_n')
         # dimension, base field and initial coefficients
         self.check_args("/Variety/Abelian/Fq/?q=25&simple=any&g=2&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-13%5D&abvar_point_count=&curve_point_count=&decomposition=&count=",'2.25.b_an')
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=25&g=2&simple=any&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-13%5D&abvar_point_count=&curve_point_count=&decomposition=",'2.25.b_an')
@@ -239,7 +242,7 @@ class AVHomeTest(LmfdbTest):
         # dimension, base field and point counts of the curve
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=3&g=4&p_rank=&angle_ranks=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=%5B0%2C4%2C15%5D&decomposition=&number_field=&simple=any&primitive=any&jacobian=any&polarizable=any",'4.3.ae_f_ad_e')
         # dimension, base field and maximum number to display
-        self.check_args("/Variety/Abelian/Fq/?q=25&simple=any&g=2&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=100", '2.25.am_cw')
+        self.check_args("/Variety/Abelian/Fq/?q=25&simple=any&g=2&p_rank=&newton_polygon=&initial_coefficients=&abvar_point_count=&curve_point_count=&decomposition=&count=100", '2.25.ab_abm')
         # p-rank and initial coefficients
         self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=2&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=&curve_point_count=&decomposition=&count=", '4.3.b_ab_d_j')
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=2&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=&curve_point_count=&decomposition=", '4.3.b_ab_d_j')
@@ -247,5 +250,5 @@ class AVHomeTest(LmfdbTest):
         self.check_args("/Variety/Abelian/Fq/?q=&simple=any&g=&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=%5B75%2C7125%5D&curve_point_count=&decomposition=&count=", 'no matches')
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=&simple=any&p_rank=&newton_polygon=&initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=%5B75%2C7125%5D&curve_point_count=&decomposition=", 'no matches')
         # Combining unknown fields on Jacobian and Principal polarization.
-        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=3&simple=any&primitive=any&jacobian=no&polarizable=not_no", '3.2.b_ab_af')
+        self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=3&simple=any&primitive=any&jacobian=no&polarizable=not_no", '3.2.a_a_ae')
         self.check_args("/Variety/Abelian/Fq/?start=0&count=50&q=&g=3&simple=any&primitive=any&jacobian=no&polarizable=yes", 'no matches')


### PR DESCRIPTION
The search results for abelian varieties weren't sorted.
This made some tests works/fail depending from what server you were reading the data.


I sort them by: (dimension, finite field cardinality, label, p-rank).
I have also fixed the test to accommodate this and added the corresponding index to the development database.


