### PR TITLE
bmfs efficiency changes

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -6,7 +6,7 @@ from pymongo import ASCENDING
 from flask import render_template, url_for, request, redirect, flash
 from markupsafe import Markup
 
-from sage.all import latex, Set
+from sage.all import latex
 
 from lmfdb.base import getDBConnection
 from lmfdb.utils import to_dict, random_object_from_collection
@@ -225,21 +225,6 @@ def bmf_field_dim_table(**args):
     query = {}
     query['field_label'] = field_label
     query[gl_or_sl] = {'$exists': True}
-    if level_flag != 'all':
-        # find which weights are present (TODO: get this from a stats collection)
-        wts = list(sum((Set(d.keys()) for d in db_dims().distinct(gl_or_sl)),Set()))
-    if level_flag == 'cusp':
-        # restrict the query to only return levels where at least one
-        # cuspidal dimension is positive:
-        query.update(
-            {'$or':[{gl_or_sl+'.{}.cuspidal_dim'.format(w):{'$gt':0}} for w in wts]}
-        )
-    if level_flag == 'new':
-        # restrict the query to only return levels where at least one
-        # new dimension is positive:
-        query.update(
-            {'$or':[{gl_or_sl+'.{}.new_dim'.format(w):{'$gt':0}} for w in wts]}
-        )
     data = db_dims().find(query)
     data = data.sort([('level_norm', ASCENDING)])
     info['number'] = nres = data.count()
@@ -248,7 +233,17 @@ def bmf_field_dim_table(**args):
     else:
         info['report'] = 'Displaying all %s levels,' % nres
 
-    data = list(data.skip(start).limit(count))
+    # convert data to a list and eliminate levels where all
+    # new/cuspidal dimensions are 0.  (This could be done at the
+    # search stage, but that requires adding new fields to each
+    # record.)
+    def filter(dat, flag):
+        dat1 = dat[gl_or_sl]
+        return any([int(dat1[w][flag])>0 for w in dat1])
+    flag = 'cuspidal_dim' if level_flag=='cusp' else 'new_dim'
+    data = [dat for dat in data if level_flag == 'all' or filter(dat, flag)]
+
+    data = data[start:start+count]
     info['field'] = field_label
     info['field_pretty'] = pretty_field_label
     nf = WebNumberField(field_label)
@@ -282,7 +277,6 @@ def bmf_field_dim_table(**args):
                  'level_norm': dat['level_norm'],
                  'level_space': url_for(".render_bmf_space_webpage", field_label=field_label, level_label=dat['level_label']) if gl_or_sl=='gl2_dims' else "",
                   'dims': dims[dat['level_label']]} for dat in data]
-    print("Length of dimtable = {}".format(len(dimtable)))
     info['dimtable'] = dimtable
     return render_template("bmf-field_dim_table.html", info=info, title=t, properties=properties, bread=bread)
 

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -14,6 +14,9 @@ logger = make_logger("bmf")
 def db_dims():
     return getDBConnection().bmfs.dimensions
 
+def db_dimstats():
+    return getDBConnection().bmfs.dimensions.stats
+
 def db_forms():
     return getDBConnection().bmfs.forms
 

--- a/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
+++ b/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
@@ -296,3 +296,9 @@ def make_indices():
                         ('gl2_dims',ASCENDING)])
     dims.create_index([('field_label',ASCENDING),
                         ('sl2_dims',ASCENDING)])
+
+def update_stats():
+    # We don't yet have proper stats info for bmfs.  When we do it will  be created / updated here
+    fields = dims.distinct('field_label')
+    print("fields: {}".format(fields))
+

--- a/scripts/bianchi_modular_forms/import_bianchi_forms.py
+++ b/scripts/bianchi_modular_forms/import_bianchi_forms.py
@@ -264,6 +264,8 @@ def make_indices():
                         ('dimension',ASCENDING),
                         ('level_norm',ASCENDING)])
     forms.create_index([('field_label',ASCENDING),
+                        ('level_norm',ASCENDING)])
+    forms.create_index([('field_label',ASCENDING),
                         ('level_label',ASCENDING)])
     forms.create_index([('field_label',ASCENDING),
                         ('level_label',ASCENDING),
@@ -274,6 +276,8 @@ def make_indices():
     forms.create_index([('field_label',ASCENDING),
                         ('level_label',ASCENDING),
                         ('CM',ASCENDING),
+                        ('bc',ASCENDING)])
+    forms.create_index([('CM',ASCENDING),
                         ('bc',ASCENDING)])
 
 # function to compare newforms and curves:


### PR DESCRIPTION
This avoids some slower searches.  Two new indexes are added (as shown by the additional entries in the import scripts).  Some complicated searches are replaced by post-processing of the search results.  Anything better seems to require more than some entries in a stats collection (which I did start to create but which is *not used* currently).   I need something like "for one field_label, give me all the database entries for which gl2_dims exists and for at least one weight has a postive new (or cuspidal) dimension".

I think this is fast enough (and faster than before) though the time has moved from a complicated search to the post-processing.  It only happens when dimension tables are created, not for anything to do with the forms themselves.  If people want it faster than this I could do a collection rewrite (for the dimension collection) which adds 4 new flags to each entry saying whether that entry was positive dimension for GL2/SL2 and cuspidal/new in any weight present.