### PR TITLE
added base field info for ecnf iso class and bmfs space pages

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -312,15 +312,11 @@ def render_bmf_space_webpage(field_label, level_label):
             else:
                 data = data.next()
                 info['label'] = data['label']
-                nf = WebNumberField(field_label)
-                info['base_galois_group'] = nf.galois_string()
+                info['nf'] = nf = WebNumberField(field_label)
                 info['field_label'] = field_label
                 info['pretty_field_label'] = pretty_field_label
                 info['level_label'] = level_label
                 info['level_norm'] = data['level_norm']
-                info['field_degree'] = nf.degree()
-                info['field_classno'] = nf.class_number()
-                info['field_disc'] = str(nf.disc())
                 info['field_poly'] = teXify_pol(str(nf.poly()))
                 info['field_knowl'] = nf_display_knowl(field_label, getDBConnection(), pretty_field_label)
                 w = 'i' if nf.disc()==-4 else 'a'

--- a/lmfdb/bianchi_modular_forms/templates/bmf-space.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-space.html
@@ -5,7 +5,18 @@
 {{info.err}}
 {% else %}
 
-<h2>  Base Field  {{info.field_knowl | safe}}</h2>
+<div>
+  <h2>  Base field   {{ info.field_knowl|safe }} </h2>
+<p>
+ {{ KNOWL('nf.generator', 'Generator') }} \({{
+ info.field_gen }}\), with {{
+ KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
+ \({{info.field_poly}}\); {{ KNOWL('nf.class_number', 'class number')
+ }} \({{info.nf.class_number()}}\).
+</p>
+    {{ place_code('field') }}
+</div>
+
 
 
 <h2>  {{ KNOWL('mf.bianchi.level', title='Level')}} {{ info.level_label }}  </h2>

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -2,7 +2,7 @@
 from flask import url_for
 import lmfdb.base
 from lmfdb.utils import make_logger, web_latex, encode_plot
-from lmfdb.ecnf.WebEllipticCurve import web_ainvs, db_ecnf
+from lmfdb.ecnf.WebEllipticCurve import web_ainvs, db_ecnf, FIELD
 from lmfdb.WebNumberField import field_pretty, nf_display_knowl
 import sage.all
 from sage.all import latex, matrix
@@ -82,8 +82,9 @@ class ECNF_isoclass(object):
         self.graph_link = '<img src="%s" width="200" height="150"/>' % self.graph_img
         self.isogeny_matrix_str = latex(matrix(self.isogeny_matrix))
 
-        self.field = field_pretty(self.field_label)
-        self.field_knowl = nf_display_knowl(self.field_label, lmfdb.base.getDBConnection(), self.field)
+        self.field = FIELD(self.field_label)
+        self.field_name = field_pretty(self.field_label)
+        self.field_knowl = nf_display_knowl(self.field_label, lmfdb.base.getDBConnection(), self.field_name)
         def curve_url(c):
             return url_for(".show_ecnf",
                            nf=c['field_label'],
@@ -117,7 +118,7 @@ class ECNF_isoclass(object):
             #self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]
             self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
 
-        self.properties = [('Base field', self.field),
+        self.properties = [('Base field', self.field_name),
                            ('Label', self.class_label),
                            (None, self.graph_link),
                            ('Conductor', '%s' % self.conductor_label)

--- a/lmfdb/ecnf/templates/ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/ecnf-isoclass.html
@@ -29,6 +29,17 @@ function show_code(system) {
         </div>
 -->
 
+<div>
+  <h2>  Base field   {{ cl.field.knowl()|safe }} </h2>
+<p>
+ {{ KNOWL('nf.generator', 'Generator') }} \({{
+ cl.field.generator_name() }}\), with {{
+ KNOWL('nf.minimal_polynomial', 'minimal polynomial') }}
+ {{cl.field.latex_poly}}; {{ KNOWL('nf.class_number', 'class number')
+ }} \({{cl.field.class_number()}}\).
+</p>
+    {{ place_code('field') }}
+</div>
 
 <h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.field_knowl|safe }}</h2>
 <table>

--- a/lmfdb/ecnf/test_isog_class.py
+++ b/lmfdb/ecnf/test_isog_class.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.base import LmfdbTest
 
 class EcnfIsogClassTest(LmfdbTest):
@@ -7,10 +7,11 @@ class EcnfIsogClassTest(LmfdbTest):
     #
     def test_ecnf_isgclass_title(self):
         r"""
-        Check rendering of title name of ECNF isogeny class.
+        Check rendering of title name and base field of ECNF isogeny class.
         """
         L = self.tc.get('/EllipticCurve/2.0.7.1/16.1/CMa/').data
         assert 'Elliptic curves in class 16.1-CMa' in L
+        assert 'minimal polynomial' in L
 
     def test_ecnf_label_in_isgclass(self):
         r"""


### PR DESCRIPTION
This fixes #2261 (see EllipticCurve/2.0.7.1/16.1/CMa/) and similarly for Bianchi modular form space pages (see ModularForm/GL2/ImaginaryQuadratic/2.0.3.1/219.2).