### PR TITLE
Remove CSS width of Maass coeff table

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
@@ -15,10 +15,10 @@ var evTable = $("table#eigenvalues").dataTable(
             "sAjaxSource": "{{url_for('mwf.get_table')}}",
              "fnServerData": function ( sSource, aoData, fnCallback ) {
                     jQuery.ajax( {
-                        "dataType": 'json', 
-                        "type": "POST", 
-                        "url": sSource, 
-                        "data": aoData, 
+                        "dataType": 'json',
+                        "type": "POST",
+                        "url": sSource,
+                        "data": aoData,
                         "success": fnCallback
                     } );
                 },
@@ -46,7 +46,7 @@ var evTable = $("table#eigenvalues").dataTable(
                  "sWidth": "15%", "bSortable":false, "bSearchable": false,"sClass":"alignLeft atkinl","fnRender":"text-align:left"}],
 
     "bSort":true,
-    "iDisplayLength": 15,    
+    "iDisplayLength": 15,
     "iDisplayStart": 0,
     "fnSort":[[1,"asc"],[2,"asc"],[3,"asc"]],
     "oLanguage": {
@@ -57,11 +57,11 @@ var evTable = $("table#eigenvalues").dataTable(
             "sInfoFiltered": "(filtered from _MAX_ total records)",
             "sSearch":"Filter records:",
 
-     }, 
+     },
      "bjQueryUI":true,
      "sPaginationType": "full_numbers",
      "sDom": 'ti<"paging"p><"bottom"lfr><"filterbox"><"clear">',
-     "sScorollX": "500px", 
+     "sScorollX": "500px",
      "bStateSave": false,
      "aLengthMenu": [[15, 25, 50, 100 ,200, -1], [15, 25, 50, 100, 200, "All"]],
      "bAutoWidth": false,
@@ -91,7 +91,7 @@ $('.bottom').css("width","100%")
 $('.bottom').css("text-align","left")
 $('.atkinl').css("width","400px")
 
-evTable.fnDraw(); 
+evTable.fnDraw();
 $('#eigenvalues_length').css("width","50%")
 $('#eigenvalues').css("width","875px")
 $('#eigenvalues_wrapper').css("width","875px")
@@ -133,11 +133,11 @@ table.eigenvalues {clear:both}
 }
 a.paginate_button {
     padding:10px;
- } 
+ }
 a.paginate_active {
     font-weight:bold;
     padding:10px;
- } 
+ }
 </style>
 
 
@@ -146,7 +146,7 @@ a.paginate_active {
 
 <h1>There was an error in meeting your previous request. Please change parameters.</h1>
 
-<div> 
+<div>
 <h2> Error message: </h2>
 
 {{ info.error | safe }}

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_display_search_result.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_display_search_result.html
@@ -29,9 +29,9 @@ var evTable = $("table#eigenvalues").dataTable(
                  {"sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass": "alignLeft","fnRender":"text-align:left"},
                  {"sWidth": "10%", "bSortable": false, "bSearchable": false,"sClass": "alignLeft","fnRender":"text-align:right","sType":"numeric"},
                  {"sWidth": "20%", "bSortable": false, "bSearchable":
- false,"sClass": "alignLeft", "fnRender":"text-align:left","minWidth":"200px"}],  
+ false,"sClass": "alignLeft", "fnRender":"text-align:left","minWidth":"200px"}],
     "bSort":false,
-    "iDisplayLength": 15,    
+    "iDisplayLength": 15,
     "iDisplayStart": 0,
     "fnSort":[[1,"asc"],[2,"asc"],[3,"asc"]],
     "oLanguage": {
@@ -45,11 +45,11 @@ var evTable = $("table#eigenvalues").dataTable(
                         "sPrevious": "Previous",
                         "sNext": "Next"
                 }
-     }, 
+     },
      "bjQueryUI":true,
      "sPaginationType": "full_numbers",
      "sDom": 'ti<"paging"p><"bottom"lfr><"filterbox"><>',
-     "sScorollX": "500px", 
+     "sScorollX": "500px",
      "bStateSave": false,
      "aLengthMenu": [[15, 25, 50, 100 ,200, 500, -1], [15, 25, 50, 100, 200, 500, "All"]],
      "bAutoWidth": false,
@@ -58,7 +58,7 @@ var evTable = $("table#eigenvalues").dataTable(
 
 $('.dataTables_filter input').attr("placeholder", "Strings to filter by");
 $('.dataTables_filter input').attr("title", "E.g. 'even 2.' will give all even forms between 2 and 3.");
- 
+
 /* Add filtering box if we don't have a fixed weight*/
 
 {% if wtis1 !='' %}
@@ -73,7 +73,7 @@ $('#eigenvalues_filter').append(s);
 /* Add event listener to the weight filtering */
 $('#weight').change( function() { evTable.fnDraw(); } );
 {% endif %}
-evTable.fnDraw(); 
+evTable.fnDraw();
 $('#eigenvalues_wrapper').css("width","875px")
 
 s='<h1>New Search</h1>';
@@ -103,7 +103,7 @@ $('#newsearchtable').append(s);
 
 <h1>There was an error in meeting your previous request. Please change parameters.</h1>
 
-<div> 
+<div>
 <h2> Error message: </h2>% extends "homepage.html" %}
 
 {{ info.error | safe }}
@@ -122,7 +122,7 @@ $('#newsearchtable').append(s);
 <!--div id="searchresults" -->
 <table class="ntdata pretty" id="eigenvalues">
   <colgroup>
-    <col/> <col/><col/> 
+    <col/> <col/><col/>
     <col align="char" char="."/>
     <col/> <col/><col/> <col/> <col/> <col/>
   </colgroup>
@@ -148,41 +148,41 @@ $('#newsearchtable').append(s);
     {% for r in range(0,nnrows) %}
     {% if data[r] is defined %}
     <tr>
-        <td>            
+        <td>
              {% if data[r].N is defined %} {{ data[r].N}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].k is defined %} {{ data[r].k}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].ch is defined %} {{ data[r].ch | safe }}  {% endif %}
            </td>
-           <td>            
-             {% if data[r].R is defined %} 
-               {% if data[r].url is defined %} 
+           <td>
+             {% if data[r].R is defined %}
+               {% if data[r].url is defined %}
                <a href="{{ data[r].url}}">{{data[r].R}}</a>
                {% else %}
                {{data[r].R}}
                {% endif %}
             {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].symmetry is defined %} {{ data[r].symmetry}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].err is defined %} {{ data[r].err}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].dim is defined %} {{ data[r].dim}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].numc is defined %} {{ data[r].numc}}  {% endif %}
            </td>
-           <td>            
+           <td>
              {% if data[r].fricke is defined %} {{ data[r].fricke}}  {% endif %}
            </td>
 
-           <td>            
+           <td>
              {% if data[r].cuspevs is defined %} {{ data[r].cuspevs}}  {% endif %}
            </td>
     </tr>

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_one_form.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_one_form.html
@@ -38,13 +38,11 @@ var oTable = $("table#coeffs").dataTable(
 $('.dataTables_filter input').attr("placeholder", "Strings to filter by");
 $('.dataTables_filter input').attr("title", "E.g. '2.' will give all ooefficients larger than 2 or less than -2.");
 
-$('#coeffs').css('width','400px')
 });
 </script>
 
 <style type="text/css">
 .dataTables_wrapper {
-     width: 750px;
      class:"ntdata"}
  .dataTables_wrapper:after {
     content: ".";

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_table.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_table.html
@@ -11,7 +11,7 @@ Weight: {{wt}}
     {% if k==wt %}
     {%  if table.data[(k,N,x)] is defined %}
         {% set n,nc=table.data[(k,N,x)] %}
-        <td> 
+        <td>
            <a href="{{url_for('mwf.render_maass_waveforms',level=N,weight=k,character=x)}}">
              {{ N }}/{{x}}:{{n}}  {# |{{nc}} #}
           </a> </td>

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_upload_confirm.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_upload_confirm.html
@@ -6,7 +6,7 @@
 
 <h1>There was an error in meeting your previous request. Please change parameters.</h1>
 
-<div> 
+<div>
 <h2> Error message: </h2>% extends "homepage.html" %}
 
 {{ info.error | safe }}


### PR DESCRIPTION
As David Farmer noted in #2260, the coefficient table was hard coded for
Maass form pages. The width of the box for more coefficient information
at the bottom of the page was also hard coded. This removes both,
so that both CSS defaults to auto.

For a moment I considered setting the bottom table to have `width: 100%;`
so that it scales with the page, but this looks bad on small screens.