### PR TITLE
Correct double parentheses in bmf ideal display

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -9,7 +9,7 @@ from markupsafe import Markup
 from sage.all import latex
 
 from lmfdb.base import getDBConnection
-from lmfdb.utils import to_dict, random_object_from_collection
+from lmfdb.utils import to_dict, random_object_from_collection, web_latex_ideal_fact
 from lmfdb.search_parsing import parse_range, nf_string_to_label, parse_nf_string
 from lmfdb.hilbert_modular_forms.hilbert_modular_form import teXify_pol
 from lmfdb.bianchi_modular_forms import bmf_page
@@ -319,7 +319,7 @@ def render_bmf_space_webpage(field_label, level_label):
                 info['field_gen'] = latex(alpha)
                 I = ideal_from_label(L,level_label)
                 info['level_gen'] = latex(I.gens_reduced()[0])
-                info['level_fact'] = latex(I.factor())
+                info['level_fact'] = web_latex_ideal_fact(I.factor(), enclose=False)
                 dim_data = data['gl2_dims']
                 weights = dim_data.keys()
                 weights.sort(key=lambda w: int(w))

--- a/lmfdb/test_utils.py
+++ b/lmfdb/test_utils.py
@@ -160,7 +160,6 @@ class UtilsTest(unittest2.TestCase):
         self.assertEqual(web_latex(x**23 + 2*x + 1, enclose=False),
                          ' x^{23} + 2 \\, x + 1 ')
 
-
     def test_web_latex_ideal_fact(self):
         r"""
         Checking utility: web_latex_ideal_fact

--- a/lmfdb/test_utils.py
+++ b/lmfdb/test_utils.py
@@ -157,6 +157,9 @@ class UtilsTest(unittest2.TestCase):
         self.assertEqual(web_latex("test string"), "test string")
         self.assertEqual(web_latex(x**23 + 2*x + 1),
                          '\\( x^{23} + 2 \\, x + 1 \\)')
+        self.assertEqual(web_latex(x**23 + 2*x + 1, enclose=False),
+                         ' x^{23} + 2 \\, x + 1 ')
+
 
     def test_web_latex_ideal_fact(self):
         r"""
@@ -169,6 +172,8 @@ class UtilsTest(unittest2.TestCase):
         I = K.ideal(2/(5+a)).factor()
         self.assertEqual(web_latex_ideal_fact(I),
                          '\\( \\left(-a\\right)^{-1} \\)')
+        self.assertEqual(web_latex_ideal_fact(I, enclose=False),
+                         ' \\left(-a\\right)^{-1} ')
 
     def test_web_latex_split_on(self):
         r"""

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -286,9 +286,11 @@ def pol_to_html(p):
 #  latex/mathjax utilities
 ################################################################################
 
-def web_latex(x):
+def web_latex(x, enclose=True):
     """
-    Convert input to latex string unless it's a string or unicode.
+    Convert input to latex string unless it's a string or unicode. The key word
+    argument `enclose` indicates whether to surround the string with
+    `\(` and `\)` to make it a mathjax equation.
 
     Note:
     if input is a factored ideal, use web_latex_ideal_fact instead.
@@ -300,13 +302,16 @@ def web_latex(x):
     """
     if isinstance(x, (str, unicode)):
         return x
-    else:
+    if enclose == True:
         return "\( %s \)" % latex(x)
+    return "%s" % latex(x)
 
 
-def web_latex_ideal_fact(x):
+def web_latex_ideal_fact(x, enclose=True):
     """
-    Convert input factored ideal to latex string.
+    Convert input factored ideal to latex string.  The key word argument
+    `enclose` indicates whether to surround the string with `\(` and
+    `\)` to make it a mathjax equation.
 
     sage puts many parentheses around latex representations of factored ideals.
     This function removes excessive parentheses.
@@ -321,7 +326,7 @@ def web_latex_ideal_fact(x):
     >>> web_latex_ideal_fact(I)
     '\\( \\left(-a\\right)^{-1} \\)'
     """
-    y = web_latex(x)
+    y = web_latex(x, enclose=enclose)
     y = y.replace("(\\left(","\\left(")
     y = y.replace("\\right))","\\right)")
     return y

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -304,7 +304,7 @@ def web_latex(x, enclose=True):
         return x
     if enclose == True:
         return "\( %s \)" % latex(x)
-    return "%s" % latex(x)
+    return " %s " % latex(x)
 
 
 def web_latex_ideal_fact(x, enclose=True):


### PR DESCRIPTION
The bmf pages displayed double parentheses around factored ideals. This short request corrects that by having the bmf pages use the `web_latex_ideal_fact` utility function from utils.py (which really just removes the double parentheses).