### PR TITLE
Bianchi dimensions for more SL2 levels

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -52,10 +52,13 @@ def index():
     args = request.args
     if len(args) == 0:
         info = {}
-        fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11]]
-        names = ["\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11]]
-        info['field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(fields,names)]
-        info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(fields,names)]
+        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11]]
+        sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [19,43,67,163,20]]
+        gl2_names = ["\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11]]
+        sl2_names = gl2_names + ["\(\Q(\sqrt{-%s})\)" % d for d in [19,43,67,163,5]]
+        info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
+        info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
+        info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         bc_examples = []
         bc_examples.append(('base-change of a newform with rational coefficients',
                          '2.0.4.1-100.2-a',

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -18,10 +18,18 @@ Browse {{ KNOWL('mf.bianchi.newform', title='newforms')}} by {{ KNOWL('nf', titl
 
 <p>
 Browse {{ KNOWL('mf.bianchi.spaces', title='newform spaces')}} by  {{ KNOWL('nf', title='base field')}}:
-{% for f in info.field_list %}
+<ul>
+<li> {{ KNOWL('mf.bianchi.level', title='\(\GL_2\) levels')}} over
+{% for f in info.gl2_field_list %}
 {%-if loop.index > 1 %}, {% endif%}
 <a href={{f.url}}>{{f.name}}</a>
 {%-endfor %}
+<li> {{ KNOWL('mf.bianchi.level', title='\(\SL_2\) levels')}} over
+{% for f in info.sl2_field_list %}
+{%-if loop.index > 1 %}, {% endif%}
+<a href={{f.url}}>{{f.name}}</a>
+{%-endfor %}
+</ul>
 </p>
 
 

--- a/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
+++ b/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
@@ -260,10 +260,13 @@ def upload_to_db(base_path, filename, insert=True):
             for key in data:
                 if key in space:
                     if key in ['gl2_dims', 'sl2_dims']:
+                        print("------------------------------------------------------")
                         print("Before update, space[{}] = {}".format(key,space[key]))
                         print("data[{}] = {}".format(key,data[key]))
                         space[key].update(data[key])
+                        print("------------------------------------------------------")
                         print("After update, space[{}] = {}".format(key,space[key]))
+                        print("------------------------------------------------------")
                     else:
                         if space[key] != data[key]:
                             print("space[{}] = {}".format(key,space[key]))
@@ -275,7 +278,7 @@ def upload_to_db(base_path, filename, insert=True):
 
     vals = data_to_insert.values()
     if insert:
-        print("inserting all data")
+        print("inserting all data ({} items)".format(len(vals)))
         dims.insert_many(vals)
     else:
         count = 0


### PR DESCRIPTION
Alexander Rahm has now provided dimensions of Bianchi spaces for all 9 imaginary quadratic fields of class number 1 as well as the first one of class number 2.  Previously we had only some of these and there was no link to their dimension tables, though the code to show them was in place.  Now I have made the SL2 level dimension tables visible at the home page ModularForm/GL2/ImaginaryQuadratic/.

Note that there is quite a difference between the data we have for GL2 and SL2 levels: GL2 is only for the first 5 fields, only weight 2, but has all the (dimension 1) newforms;  while the SL2 data has more fields and weights but no newforms, only dimensions. (NB there is no formula for these dimensions!).

You can see the "new" tables by clicking on the link in the Browse section under Browse newforms spaces, SL2 levels.  For some of these fields the level range is small but the weight range larger: compare 
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/sl2dims/2.0.20.1
which is very wide (many weights) but not deep (only 3 levels), to any of the GL2 tables such as http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/gl2dims/2.0.4.1
which are narrow (weight 2 only) but deep (78549 levels in that case!).  I hope the extra-wide ones are not too ugly.

Last point: I had to remove an index on the bmfs.dimensions collection (by field_label and sl2_dims) since mongo refused as the value of the sl2_dims field was too large!  It's a dictionary containing cuspidal and new dimensions for each weight.  No problem for 8 out of 10 fields, but no good for 2.0.3.1 (weights go up to 27) and 2.0.20.1 (up to 28).  This is not serious, as that index was only used in constructing these tables and they are not too slow.  But it might be an indication that the structure of the dimensions collection should be redesigned.