### PR TITLE
read from m0 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ before_script:
     # it gets quite tricky.
     - export TESTMATCH='"(?:^|\/)[Tt]est_"'
     - export COVERAGE='--with-coverage  --cover-package=lmfdb'
-    # create the mongoclient.config to connect to m0
-    - sed s/localhost/m0.lmfdb.xyz/ default_mongoclient.config  |  sed s/37010/27017/ >> mongoclient.config
-    # This is our external ip address
-    - dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | awk -F'"' '{ print $2}'
     # assert that m0.lmfdb.xyz accepts our connections
     - printf "db\nexit" | mongo m0.lmfdb.xyz 
     # create a list of files and folder where we will run the nosetests

--- a/default_mongoclient.config
+++ b/default_mongoclient.config
@@ -7,8 +7,8 @@
 # the read_preference setting is processed in a special way
 # all the other values are passed to MongoClient as int or strings
 [db]
-port = 37010
-host = localhost
+port = 27017 
+host = m0.lmfdb.xyz
 replicaset =
 # the options for read_preference are PRIMARY, PRIMARY_PREFERRED, SECONDARY, SECONDARY_PREFERRED, and NEAREST
 # see https://docs.mongodb.org/manual/reference/read-preference/ for more details

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -96,7 +96,7 @@ from base import app, set_logfocus, get_logfocus, _init
 from flask import g, render_template, request, make_response, redirect, url_for, current_app, abort
 import sage
 
-DEFAULT_DB_PORT = 37010
+DEFAULT_DB_PORT = 27017
 LMFDB_SAGE_VERSION = '7.1'
 
 def timestamp():
@@ -200,10 +200,10 @@ Usage: %s [OPTION]...
   -m, --mongo-client=FILE   config file for connecting to MongoDB (default is "mongoclient.config")
       --logfocus=NAME       name of a logger to focus on
       --debug               enable debug mode
-      --dbport=NUM          bind the MongoDB to the given port (default base.DEFAULT_DB_PORT)
+      --dbport=NUM          bind the MongoDB to the given port (default %d)
       --dbmon=NAME          monitor MongoDB commands to the specified database (use NAME=* to monitor everything, NAME=~DB to monitor all but DB)
       --help                show this help
-""" % sys.argv[0]
+""" % (sys.argv[0], DEFAULT_DB_PORT)
 
 def get_configuration():
 
@@ -212,7 +212,7 @@ def get_configuration():
     logging_options = {"logfile": "flasklog"}
 
     # default options to pass to the MongoClient
-    mongo_client_options = {"port": DEFAULT_DB_PORT, "host": "localhost", "replicaset": None, "read_preference": ReadPreference.NEAREST};
+    mongo_client_options = {"port": DEFAULT_DB_PORT, "host": "m0.lmfdb.xyz", "replicaset": None, "read_preference": ReadPreference.NEAREST};
     read_preference_classes = {"PRIMARY": ReadPreference.PRIMARY, "PRIMARY_PREFERRED": ReadPreference.PRIMARY_PREFERRED , "SECONDARY": ReadPreference.SECONDARY, "SECONDARY_PREFERRED": ReadPreference.SECONDARY_PREFERRED, "NEAREST": ReadPreference.NEAREST };
     
     #setups the default mongo_client_config_filename


### PR DESCRIPTION
We are allowing anyone to read directly from `m0.lmfdb.xyz`.
To reflect this, I'm changing the default values for port and host.

I'm also changing the Travis config file. Please wait for the tests to pass before merge.