### PR TITLE
Remove unneeded search parameters from some urls

### DIFF
--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -52,7 +52,7 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
 <h2> Search for an Artin representation </h2>
 Enter values into one or more boxes to restrict the search.
 <p></p>
-<form>
+<form id="search" onsubmit="cleanSubmit(this.id)">
   <table>
     <tr>
         <td align="right">{{ KNOWL('artin.dimension',title="Dimension") }}</td>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -2,7 +2,7 @@
 {% block content %}
 {# Refine search page #}
 
-<form id="re-search">
+<form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{start}}"/>
 <input type="hidden" name="paging" value="0"/>
   <table>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -4,7 +4,6 @@
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{start}}"/>
-<input type="hidden" name="paging" value="0"/>
   <table>
     <tr>
       <td>{{ KNOWL('artin.dimension',title="Dimension") }}</td>

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -59,7 +59,7 @@
 <h2> Search </h2>
 Please enter a value or leave blank:
 <p></p>
-<form>
+<form id='search' onsubmit="cleanSubmit(this.id)">
   <table>
     <tr>
      <td align=right>base {{ KNOWL('nf',title = "number field") }}</td>

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -10,7 +10,7 @@
 
 <h2> Refine search </h2>
 
-<form id='re-search'>
+<form id='re-search' onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
 

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -77,7 +77,7 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 <h2> Search </h2>
 Please enter a value or leave blank:
 <p></p>
-<form>
+<form id='search' onsubmit="cleanSubmit(this.id)">
   <table>
     <tr>
       <td>{{ KNOWL('ec.q.conductor',title = "conductor") }}</td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -7,7 +7,7 @@
 
 <h2> Further refine search </h2>
 
-<form id='re-search'>
+<form id='re-search' onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <table border="0" cellpadding="5">
 

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -58,25 +58,25 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
               </tr>
               <tr>
                 <td> <select name='parity'>
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='-1'>Odd</option>
                    <option value='1'>Even</option>
                   </select>
                 </td>
                 <td> <select name='cyc'>
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
                   </select>
                 </td>
                 <td> <select name='solv'>
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
                   </select>
                 </td>
                 <td> <select name='prim'>
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
                   </select>
@@ -110,7 +110,7 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
         </tr>
 
        </table>
-        <button type="submit" name="Submit" value="Search">Search</button>
+        <button type="submit" value="Search">Search</button>
       </form>
 
     

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -35,7 +35,7 @@ A <a href={{url_for('.random_group')}}>random Galois group</a> from the database
 <h2>Find a specific Galois group</h2>
 
 <div>
-<form name="search" method = "get" action="{{search}}">
+<form>
 Search by {{KNOWL('gg.label',title="Galois group label")}}
 <input type="text" name="jump_to" value="" placeholder="8T14"> 
 <button type="submit" value="Find">Find</button>
@@ -45,7 +45,7 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 
 
 <h2>Search</h2>
-<form name="search" method = "get" action="{{search}}">
+<form id="search" onsubmit="cleanSubmit(this.id)">
         <table class="">
           <tr>
             <td colspan="2" align="center">

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -26,15 +26,15 @@ table.ntdata a {
               <tr>
                 <td> <select name='parity'>
  {% if info.parity=='1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='-1'>Odd</option>
                    <option selected='yes' value='1'>Even</option>
  {% elif info.parity=='-1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option selected='yes' value='-1'>Odd</option>
                    <option value='1'>Even</option>
  {% else %}
-                   <option selected='yes' value='0'>All</option>
+                   <option selected='yes' value=''>All</option>
                    <option value='-1'>Odd</option>
                    <option value='1'>Even</option>
  {% endif %}
@@ -42,15 +42,15 @@ table.ntdata a {
                 </td>
                 <td> <select name='cyc'>
  {% if info.cyc=='1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option selected='yes' value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% elif info.cyc=='-1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option selected='yes' value='-1'>No</option>
  {% else %}
-                   <option selected='yes' value='0'>All</option>
+                   <option selected='yes' value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% endif %}
@@ -58,15 +58,15 @@ table.ntdata a {
                 </td>
                 <td> <select name='solv'>
  {% if info.solv=='1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option selected='yes' value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% elif info.solv=='-1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option selected='yes' value='-1'>No</option>
  {% else %}
-                   <option selected='yes' value='0'>All</option>
+                   <option selected='yes' value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% endif %}
@@ -74,15 +74,15 @@ table.ntdata a {
                 </td>
                 <td> <select name='prim'>
  {% if info.prim=='1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option selected='yes' value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% elif info.prim=='-1' %}
-                   <option value='0'>All</option>
+                   <option value=''>All</option>
                    <option value='1'>Yes</option>
                    <option selected='yes' value='-1'>No</option>
  {% else %}
-                   <option selected='yes' value='0'>All</option>
+                   <option selected='yes' value=''>All</option>
                    <option value='1'>Yes</option>
                    <option value='-1'>No</option>
  {% endif %}

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -11,7 +11,6 @@ table.ntdata a {
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
 <table border="0">
 
           <tr>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -9,7 +9,7 @@ table.ntdata a {
 }
 </style>
 
-<form id="re-search">
+<form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="paging" value="0"/>
 <table border="0">

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -151,7 +151,7 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
             </td><td><input type="text" name="count" value="{{info.count}}" size="10"></td>
           </tr>
   </table>
-        <button type="submit" name="Submit" value="Search">Search</button>
+        <button type="submit" value="Search">Search</button>
       </form>
 
 

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -76,7 +76,7 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
 
     <h2>Find a specific local number field</h2>
 
-    <form name="search" method = "get" action="{{search}}">
+    <form>
         <table class="">
 	  <tr>
 	    <td>
@@ -97,7 +97,7 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
 
 
         <h2>Search</h2>
-      <form name="search" method = "get" action="{{search}}">
+      <form id="search"  onsubmit="cleanSubmit(this.id)">
         <table class="">
           <tr align=left>
             <td align=right>

--- a/lmfdb/local_fields/templates/lf-search.html
+++ b/lmfdb/local_fields/templates/lf-search.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<form id="re-search">
+<form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="paging" value="0"/>
 <table border="0">

--- a/lmfdb/local_fields/templates/lf-search.html
+++ b/lmfdb/local_fields/templates/lf-search.html
@@ -4,7 +4,6 @@
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
 <table border="0">
 
 <tr>

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -569,14 +569,6 @@ def number_field_search(info):
     count = parse_count(info)
     start = parse_start(info)
 
-    if info.get('paging'):
-        try:
-            paging = int(info['paging'])
-            if paging == 0:
-                start = 0
-        except:
-            pass
-
     C = base.getDBConnection()
     # nf_logger.debug(query)
     info['query'] = dict(query)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -193,7 +193,7 @@ def class_group_request_error(info, bread):
 
 @nf_page.route("/")
 def number_field_render_webpage():
-    args = request.args
+    args = to_dict(request.args)
     sig_list = sum([[[d - 2 * r2, r2] for r2 in range(
         1 + (d // 2))] for d in range(1, 7)], []) + sum([[[d, 0]] for d in range(7, 11)], [])
     sig_list = sig_list[:10]
@@ -216,7 +216,7 @@ def number_field_render_webpage():
         info['learnmore'] = [(Completename, url_for(".render_discriminants_page")), ('How data was computed', url_for(".how_computed_page")), ('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
         return render_template("number_field_all.html", info=info, credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
     else:
-        return number_field_search(**args)
+        return number_field_search(args)
 
 @nf_page.route("/random")
 def random_nfglobal():
@@ -517,16 +517,11 @@ def make_disc_key(D):
         D1 = int(Dz.log(10))
     return s, '%03d%s' % (D1, str(Dz))
 
-def number_field_search(**args):
-    info = to_dict(args)
+def number_field_search(info):
 
     info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
     t = 'Global Number Field search results'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Search results', ' ')]
-
-    # for k in info.keys():
-    #  nf_logger.debug(str(k) + ' ---> ' + str(info[k]))
-    # nf_logger.debug('******************* '+ str(info['search']))
 
     if 'natural' in info:
         query = {'label_orig': info['natural']}
@@ -585,7 +580,7 @@ def number_field_search(**args):
     C = base.getDBConnection()
     # nf_logger.debug(query)
     info['query'] = dict(query)
-    if 'lucky' in args:
+    if 'lucky' in info:
         one = C.numberfields.fields.find_one(query)
         if one:
             label = one['label']

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -109,7 +109,7 @@ set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
 <tr>
 <td align="left" colspan="4">Maximum number of fields to display <input type='text' name='count' value="{{info.count}}" size="6" />
 <tr><td>
-<button type='submit' name='search' value='Search'>Search</button></td>
+<button type='submit'>Search</button></td>
 
 
 </table>

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -57,7 +57,7 @@ A <a href={{url_for('.random_nfglobal')}}>random global number field</a> from th
 
 
 <h2> Search for fields </h2>
-<form>
+<form id="search" onsubmit="cleanSubmit(this.id)">
 <p>
 Enter values into one or more boxes to restrict the search.
 </p>

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -6,7 +6,6 @@
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
 <table border="0">
 
 <tr>
@@ -28,19 +27,19 @@ set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
 {% if info.ram_quantifier == 'contained' %}
 <select name = "ram_quantifier">
   <option value='contained' selected='yes'>subset of</option>
-  <option value='exactly'>equal to</option>
+  <option value=''>equal to</option>
   <option value='include'>superset of</option>
 </select>
 {% elif info.ram_quantifier == 'include' %}
 <select name = "ram_quantifier">
   <option value='contained'>subset of</option>
-  <option value='exactly' >equal to</option>
+  <option value='' >equal to</option>
   <option value='include' selected='yes'>superset of</option>
 </select>
 {% else %}
 <select name = "ram_quantifier">
   <option value='contained'>subset of</option>
-  <option value='exactly' selected='yes'>equal to</option>
+  <option value='' selected='yes'>equal to</option>
   <option value='include'>superset of</option>
 </select>
 {% endif %}

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -4,7 +4,7 @@
 
 <h2> Further refine search </h2>
 
-<form id="re-search">
+<form id="re-search" onsubmit="cleanSubmit(this.id)">
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="paging" value="0"/>
 <table border="0">

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -31,17 +31,17 @@ set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
   <option value='exactly'>equal to</option>
   <option value='include'>superset of</option>
 </select>
-{% elif info.ram_quantifier == 'exactly' %}
-<select name = "ram_quantifier">
-  <option value='contained'>subset of</option>
-  <option value='exactly' selected='yes'>equal to</option>
-  <option value='include'>superset of</option>
-</select>
-{% else %}
+{% elif info.ram_quantifier == 'include' %}
 <select name = "ram_quantifier">
   <option value='contained'>subset of</option>
   <option value='exactly' >equal to</option>
   <option value='include' selected='yes'>superset of</option>
+</select>
+{% else %}
+<select name = "ram_quantifier">
+  <option value='contained'>subset of</option>
+  <option value='exactly' selected='yes'>equal to</option>
+  <option value='include'>superset of</option>
 </select>
 {% endif %}
  <td align=left> <input type='text' name='ram_primes' size=5 value="{{info.ram_primes}}"></td>

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -263,7 +263,7 @@
 
             for(i = 0; item = allInputs[i]; i++) { if (item.getAttribute('name') ) { if (!item.value) { item.setAttribute('name', ''); } else { n++ }; } }
             for(i = 0; item = allSelects[i]; i++) { if (item.getAttribute('name') ) { if (!item.value) { item.setAttribute('name', ''); } else { n++ }; } }
-            if (!n) { var all = document.createElement('input'); all.type='text'; all.name='all'; all.value='1'; myForm.appendChild(all); }
+            if (!n) { var all = document.createElement('input'); all.type='hidden'; all.name='all'; all.value='1'; myForm.appendChild(all); }
         }
         </script>
     {% endblock content_js %}


### PR DESCRIPTION
Deals with global fields, local fields, Galois groups, and Artin representations.  In each case, look at the url after do a search or refining a search.  With Galois groups, there is almost no change (if you specify only the degree, then the only difference is whether or not t is in the url).  This addresses issue #2277 for these areas.