### PR TITLE
remove beta status from Bianchi forms

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -162,6 +162,8 @@ def bianchi_modular_form_search(**args):
         v_clean['field_label'] = v['field_label']
         v_clean['short_label'] = v['short_label']
         v_clean['level_label'] = v['level_label']
+        v_clean['level_norm']  = v['level_norm']
+        v_clean['level_number'] = v['level_label'].split(".")[1]
         v_clean['label_suffix'] = v['label_suffix']
         v_clean['label'] = v['label']
         v_clean['level_ideal'] = teXify_pol(v['level_ideal'])
@@ -172,6 +174,7 @@ def bianchi_modular_form_search(**args):
         v_clean['cm'] = cm_info(v['CM'])
         res_clean.append(v_clean)
 
+    res_clean.sort(key=lambda x: [int(x['level_norm']), int(x['level_number']), x['label_suffix']])
     info['forms'] = res_clean
     info['count'] = count
     info['start'] = start
@@ -270,6 +273,7 @@ def bmf_field_dim_table(**args):
     info['start'] = start
     info['more'] = int(start + count < nres)
 
+    data.sort(key = lambda x: [int(y) for y in x['level_label'].split(".")])
     dims = {}
     for dat in data:
         dims[dat['level_label']] = d = {}

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -92,7 +92,12 @@ def bianchi_modular_form_search(**args):
     info = to_dict(args)  # what has been entered in the search boxes
     if 'label' in info:
         # The Label button has been pressed.
-        return bianchi_modular_form_by_label(info['label'])
+        label = info['label']
+        dat = label.split("-")
+        if len(dat)==2: # assume field & level, display space
+            return render_bmf_space_webpage(dat[0], dat[1])
+        else: # assume single newform label; will display an error if invalid
+            return bianchi_modular_form_by_label(label)
 
     query = {}
     for field in ['field_label', 'weight', 'level_norm', 'dimension']:

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -35,12 +35,13 @@ Browse {{ KNOWL('mf.bianchi.spaces', title='newform spaces')}} by  {{ KNOWL('nf'
 
 
 
-<h2> Find a specific form by  {{ KNOWL('mf.bianchi.labels', title='label')}} </h2>
+<h2> Find a specific form or space by  {{ KNOWL('mf.bianchi.labels', title='label')}} </h2>
 
 <form>
 <input type='text' name='label' placeholder='2.0.4.1-65.2-a'>
 <button type='submit'>Label</button>
-<br><span class="formexample">e.g. 2.0.4.1-65.2-a </span>
+<br><span class="formexample">e.g. 2.0.4.1-65.2-a (single form) or
+  2.0.4.1-65.2 (space of forms at a level)</span>
 </form>
 
 <h4>Examples of  {{ KNOWL('mf.bianchi.base_change', title='base change')}} forms</h4>

--- a/lmfdb/modular_forms/views/templates/mf_navigation.html
+++ b/lmfdb/modular_forms/views/templates/mf_navigation.html
@@ -30,11 +30,11 @@ Below you can browse classes of modular forms currently in the LMFDB.
 <a href="{{ url_for('hmf.hilbert_modular_form_render_webpage')
          }}">Hilbert Modular Forms</a> (on \(\GL(2)\) over totally real fields)
 </p>
-{% if BETA %}
+
 <p><a href="{{ url_for('bmf.index') }}">Bianchi Modular Forms</a> (on
    \(\GL(2)\)  over Euclidean imaginary quadratic fields)
 </p>
-{% endif %}
+
 <p>
 <a href="{{ url_for('mwf.render_maass_waveforms') }}">Maass Forms on \(\GL(2,\Q) \)</a>
 </p>

--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -75,7 +75,6 @@
          - title: Hilbert
            url_for: "hmf.hilbert_modular_form_render_webpage"
          - title: Bianchi
-           status: beta
            url_for: "bmf.index"
          - title: Half-integral
            status: future


### PR DESCRIPTION
Just two things here: remove beta status in sidebar so you see Bianchi under Modular Forms even when running without beta (and the colour is standard under beta); and the page ModularForm/ includes Bianchi forms in the list always, instead of only in beta.

There was a discussions a few weeks ago which agreed that this was ready.