### PR TITLE
fix bug in title of ecnf isogeny class page

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -318,7 +318,7 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     if not isinstance(cl, ECNF_isoclass):
         info = {'query':{}, 'err':'No elliptic curve isogeny class in the database has label %s.' % label}
         return search_input_error(info, bread)
-    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field)
+    title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field_name)
     bread.append((cl.field, url_for(".show_ecnf1", nf=nf_label)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))


### PR DESCRIPTION
A page such as http://beta.lmfdb.org/EllipticCurve/2.0.4.1/65.2/a/ should say what the field is in the title but does not.  AFter this trivial fix, it does.
