### PR TITLE
Add top slope as a search parameter for local fields.

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -8,7 +8,7 @@ from lmfdb.base import app, getDBConnection
 from flask import render_template, request, url_for, redirect
 from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, random_object_from_collection, display_multiset
 from lmfdb.search_parsing import parse_galgrp, parse_ints, parse_count, parse_start, clean_input, parse_rats
-from sage.all import PolynomialRing, QQ, RR, gp
+from sage.all import PolynomialRing, QQ, RR
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.WebNumberField import string2list
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -7,8 +7,8 @@ import pymongo
 from lmfdb.base import app, getDBConnection
 from flask import render_template, request, url_for, redirect
 from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, random_object_from_collection, display_multiset
-from lmfdb.search_parsing import parse_galgrp, parse_ints, parse_count, parse_start, clean_input
-from sage.all import PolynomialRing, QQ
+from lmfdb.search_parsing import parse_galgrp, parse_ints, parse_count, parse_start, clean_input, parse_rats
+from sage.all import PolynomialRing, QQ, RR, gp
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.WebNumberField import string2list
 
@@ -116,6 +116,19 @@ def format_subfields(subdata, p):
         return ''
     return display_multiset(subdata, format_lfield, p)
 
+# Encode string for rational into our special format
+def ratproc(inp):
+    if '.' in inp:
+        inp = RR(inp)
+    qs = QQ(inp)
+    sstring = str(qs*1.)
+    sstring += '0'*14
+    if qs < 10:
+        sstring = '0'+sstring
+    sstring = sstring[0:12]
+    sstring += str(qs)
+    return sstring
+
 @local_fields_page.route("/")
 def index():
     bread = get_bread()
@@ -148,6 +161,7 @@ def local_field_search(**args):
         parse_ints(info,query,'n',name='Degree')
         parse_ints(info,query,'c',name='Discriminant exponent c')
         parse_ints(info,query,'e',name='Ramification index e')
+        parse_rats(info,query,'topslope',qfield='top_slope',name='Top slope', process=ratproc)
     except ValueError:
         return search_input_error(info, bread)
     count = parse_count(info)

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -103,53 +103,48 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
             <td align=right>
           {{KNOWL('lf.degree',title='Degree')}}:
             </td><td><input type="text" name="n" value=""
-      placeholder="6"></td>
+      placeholder="6">
       <td>
 	<span class="formexample">e.g. 6, or a range like 3..5</span>
-      </td>
-          </tr>
           <tr>
             <td align=right>
               Prime $p$ for base field  {{KNOWL('lf.qp',title='$\Q_p$')}}:
-            </td><td><input type="text" name="p" value="" placeholder="3"></td>
+            <td><input type="text" name="p" value="" placeholder="3">
       <td>
 	<span class="formexample">e.g. 3, or a range like 3..7</span>
-      </td>
-          </tr>
           <tr>
             <td align=right>
               {{KNOWL('lf.discriminant_exponent',title='Discriminant
               exponent')}} $c$ :
-            </td><td><input type="text" name="c" value="" placeholder="8"></td>
+            <td><input type="text" name="c" value="" placeholder="8">
       <td>
 	<span class="formexample">e.g. 8, or a range like 2..6</span>
-      </td>
-          </tr>
           <tr>
             <td align=right>
               {{KNOWL('lf.ramification_index',title='Ramification
               index')}} $e$ :
-            </td><td><input type="text" name="e" value="" placeholder="3"></td>
+            <td><input type="text" name="e" value="" placeholder="3">
       <td>
 	<span class="formexample">e.g. 3, or a range like 2..6</span>
-      </td>
-          </tr>
+          <tr>
+            <td align=right>
+              {{KNOWL('lf.top_slope',title='Top slope')}}:
+            <td><input type="text" name="topslope" value="" placeholder="4/3">
+      <td>
+	<span class="formexample">e.g. 0, 1, 2, 4/3, 3.5, or a range like 3..5</span>
           <tr>
             <td align=right>
               {{KNOWL('nf.galois_group',title='Galois
               group')}} $G$ :
-            </td><td><input type="text" name="gal" value="" placeholder="5T3"></td>
+            <td><input type="text" name="gal" value="" placeholder="5T3">
       <td>
 	<span class="formexample">e.g. 5T3, C4, or a list of 
 {{KNOWL('nf.galois_group.name',title='labels')}}
 </span>
-      </td>
-          </tr>
           <tr>
           <td align=right>
               Maximum number of fields to display:
-            </td><td><input type="text" name="count" value="{{info.count}}" size="10"></td>
-          </tr>
+            </td><td><input type="text" name="count" value="{{info.count}}" size="10">
   </table>
         <button type="submit" value="Search">Search</button>
       </form>

--- a/lmfdb/local_fields/templates/lf-search.html
+++ b/lmfdb/local_fields/templates/lf-search.html
@@ -9,7 +9,6 @@
 <tr>
 <td align=left> 
 {{KNOWL('lf.degree',title='Degree')}}:</td><td align=left> <input type='text' name='n' size=3 value="{{info.n}}">
-</td>
 <td align=left> 
 {{KNOWL('lf.discriminant_exponent',title='Discriminant exponent')}} $c$:
 <td align=left> <input type="text" name="c" size="3" value="{{info.c}}" >
@@ -18,7 +17,6 @@
 {{KNOWL('nf.galois_group',title='Galois group')}}:
 <td align=left> <input type="text" name="gal" size="8" value="{{info.gal}}" >
 
-</tr>
 <tr>
 <td align=left> 
 Prime $p$:</td><td align=left> <input type="text" name="p" size="3" value="{{info.p}}" ></td>
@@ -27,12 +25,15 @@ Prime $p$:</td><td align=left> <input type="text" name="p" size="3" value="{{inf
 {{KNOWL('lf.ramification_index',title='Ramification index')}} $e$:
 <td align=left> 
 <input type="text" name="e" size="3" value="{{info.e}}" >
-</tr>
+
+<td align=left>
+  {{KNOWL('lf.top_slope',title='Top slope')}}:
+<td align=left> 
+<input type="text" name="topslope" size="8" value="{{info.topslope}}">
+
 
 <tr>
 <td align='left' colspan='4'>Maximum number of fields to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-</td>
-</tr>
 
 <tr>
 <td align=left colspan="2"> 

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -9,6 +9,14 @@ class LocalFieldTest(LmfdbTest):
 		L = self.tc.get('/LocalNumberField/?start=0&paging=0&n=8&c=24&gal=8T5&p=2&e=8&count=20')
 		assert '4 matches' in L.data
 
+    def test_search_top_slope(self):
+		L = self.tc.get('/LocalNumberField/?p=2&topslope=3.5')
+		assert '81' in L.data # number of matches
+		L = self.tc.get('/LocalNumberField/?p=2&topslope=topslope=3.4..3.55')
+		assert '81' in L.data # number of matches
+		L = self.tc.get('/LocalNumberField/?p=2&topslope=topslope=7/2')
+		assert '81' in L.data # number of matches
+
     def test_field_page(self):
 		L = self.tc.get('/LocalNumberField/11.6.4.2')
 		assert 't^{2} - t + 7' in L.data # bad (not robust) test, but it's the best i was able to find...

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -8,9 +8,9 @@ LIST_RE = re.compile(r'^(\d+|(\d+-(\d+)?))(,(\d+|(\d+-(\d+)?)))*$')
 BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
 QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
 # Single non-negative rational, allowing decimals, used in parse_range2rat
-QQ_DEC_RE = re.compile(r'^\d+((.\d+)|(/\d+))?$')
+QQ_DEC_RE = re.compile(r'^\d+((\.\d+)|(/\d+))?$')
 LIST_POSINT_RE = re.compile(r'^(\d+)(,\d+)*$')
-LIST_RAT_RE = re.compile(r'^((\d+((.\d+)|(/\d+))?)|((\d+((.\d+)|(/\d+))?)-((\d+((.\d+)|(/\d+))?))?))(,((\d+((.\d+)|(/\d+))?)|((\d+((.\d+)|(/\d+))?)-(\d+((.\d+)|(/\d+))?)?)))*$')
+LIST_RAT_RE = re.compile(r'^((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-((\d+((\.\d+)|(/\d+))?))?))(,((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-(\d+((\.\d+)|(/\d+))?)?)))*$')
 SIGNED_LIST_RE = re.compile(r'^(-?\d+|(-?\d+--?\d+))(,(-?\d+|(-?\d+--?\d+)))*$')
 ## RE from number_field.py
 #LIST_SIMPLE_RE = re.compile(r'^(-?\d+)(,-?\d+)*$'

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -7,7 +7,10 @@ SPACES_RE = re.compile(r'\d\s+\d')
 LIST_RE = re.compile(r'^(\d+|(\d+-(\d+)?))(,(\d+|(\d+-(\d+)?)))*$')
 BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
 QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
+# Single non-negative rational, allowing decimals, used in parse_range2rat
+QQ_DEC_RE = re.compile(r'^\d+((.\d+)|(/\d+))?$')
 LIST_POSINT_RE = re.compile(r'^(\d+)(,\d+)*$')
+LIST_RAT_RE = re.compile(r'^((\d+((.\d+)|(/\d+))?)|((\d+((.\d+)|(/\d+))?)-((\d+((.\d+)|(/\d+))?))?))(,((\d+((.\d+)|(/\d+))?)|((\d+((.\d+)|(/\d+))?)-(\d+((.\d+)|(/\d+))?)?)))*$')
 SIGNED_LIST_RE = re.compile(r'^(-?\d+|(-?\d+--?\d+))(,(-?\d+|(-?\d+--?\d+)))*$')
 ## RE from number_field.py
 #LIST_SIMPLE_RE = re.compile(r'^(-?\d+)(,-?\d+)*$'
@@ -178,6 +181,29 @@ def parse_range2(arg, key, parse_singleton=int):
     else:
         return [key, parse_singleton(arg)]
 
+# Like parse_range2, but to deal with strings which could be rational numbers
+# process is a function to apply to arguments after they have been parsed
+def parse_range2rat(arg, key, process):
+    if type(arg) == str:
+        arg = arg.replace(' ', '')
+    if QQ_DEC_RE.match(arg):
+        return [key, process(arg)]
+    if ',' in arg:
+        tmp = [parse_range2rat(a, key, process) for a in arg.split(',')]
+        tmp = [{a[0]: a[1]} for a in tmp]
+        return ['$or', tmp]
+    elif '-' in arg[1:]:
+        ix = arg.index('-', 1)
+        start, end = arg[:ix], arg[ix + 1:]
+        q = {}
+        if start:
+            q['$gte'] = process(start)
+        if end:
+            q['$lte'] = process(end)
+        return [key, q]
+    else:
+        return [key, process(arg)]
+
 # We parse into a list of singletons and pairs, like [[-5,-2], 10, 11, [16,100]]
 # If split0, we split ranges [-a,b] that cross 0 into [-a, -1], [1, b]
 def parse_range3(arg, name, split0 = False):
@@ -278,6 +304,14 @@ def parse_signed_ints(inp, query, qfield, parse_one=None):
             collapse_ors(['$or', iquery], query)
     else:
         raise ValueError("It needs to be an integer (such as 25), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
+
+@search_parser(clean_info=True, prep_ranges=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_rats(inp, query, qfield, process=None):
+    if process is None: process = lambda x: x
+    if LIST_RAT_RE.match(inp):
+        collapse_ors(parse_range2rat(inp, qfield, process), query)
+    else:
+        raise ValueError("It needs to be a non-negative rational number (such as 4/3), a range of non-negative rational numbers (such as 2-5/2 or 2.5..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
 
 @search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
 def parse_primes(inp, query, qfield, mode=None, to_string=False):


### PR DESCRIPTION
This resolves issue #2191 .  Since slopes can be rational numbers, these are stored in the database as strings.  To make searches work with ranges, we encode the rational number in a form explained on the inventory page (basically, a fixed width for the decimal expansion followed by the rational number in its natural form).  This allows searches to mix decimals and things like 7/3.

If there is tame ramification and no wild ramification, we call the top slope 1; unramified means it is 0 (this is explained in the top slope knowl).

The bulk of the changes are to add the parsing routines to the search-parsing file.

Some searches to try, put in 0 or 1 for a given prime in for top slope, or 2.333..2.334 (with p=2 since 7/3 is a top slope which occurs), or just 7/3, or mix/match making a list of items and ranges.