### PR TITLE
Plot rational points on genus 2 curves

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -9,7 +9,7 @@ from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
-from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, real, sqrt, var, expand, nth_prime
+from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime
 from sage.plot.text import text
 from flask import url_for
 
@@ -211,7 +211,7 @@ def inflate_interval(a,b,x=1.5):
     d *= x
     return (c-d,c+d)
 
-def eqn_list_to_curve_plot(L):
+def eqn_list_to_curve_plot(L,rat_pts):
     xpoly_rng = PolynomialRing(QQ,'x')
     poly_tup = [xpoly_rng(tup) for tup in L]
     f = poly_tup[0]
@@ -250,9 +250,23 @@ def eqn_list_to_curve_plot(L):
         plotzones.append((c,d,m,M))
     x = var('x')
     y = var('y')
-    return sum(implicit_plot(y**2 + y*h(x) - f(x), (x,R[0],R[1]),
-        (y,R[2],R[3]), aspect_ratio='automatic', plot_points=500) for R in
-        plotzones)
+    plot=sum(implicit_plot(y**2 + y*h(x) - f(x), (x,R[0],R[1]),(y,R[2],R[3]), aspect_ratio='automatic', plot_points=500, zorder=1) for R in plotzones)
+    xmin=min([R[0] for R in plotzones])
+    xmax=max([R[1] for R in plotzones])
+    ymin=min([R[2] for R in plotzones])
+    ymax=max([R[3] for R in plotzones])
+    for P in rat_pts:
+    	(x,y,z)=eval(P.replace(':',','))
+        dbg.append([x,y,z]);
+     	z=ZZ(z)
+     	if z: # Do not attempt to plot points at infinity
+      		x=ZZ(x)/z
+      		y=ZZ(y)/z**3
+      		if x >= xmin and x <= xmax and y >= ymin and y <= ymax:
+       			plot += point((x,y),color='red',size=40,zorder=2)
+                        #dbg.append([x/z,y/z])
+    #return text(str(dbg[8])+str(dbg[9]),(0,1),fontsize=15)
+    return plot
 
 ###############################################################################
 # Name conversions for the Sato-Tate and real endomorphism algebras
@@ -688,7 +702,7 @@ class WebG2C(object):
         # Properties
         self.properties = properties = [('Label', data['label'])]
         if is_curve:
-            self.plot = encode_plot(eqn_list_to_curve_plot(data['min_eqn']))
+            self.plot = encode_plot(eqn_list_to_curve_plot(data['min_eqn'], data['rat_pts'].split(',') if 'rat_pts' in data else []))
             plot_link = '<img src="%s" width="200" height="150"/>' % self.plot
             properties += [
                 (None, plot_link),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -257,15 +257,12 @@ def eqn_list_to_curve_plot(L,rat_pts):
     ymax=max([R[3] for R in plotzones])
     for P in rat_pts:
     	(x,y,z)=eval(P.replace(':',','))
-        dbg.append([x,y,z]);
      	z=ZZ(z)
      	if z: # Do not attempt to plot points at infinity
       		x=ZZ(x)/z
       		y=ZZ(y)/z**3
       		if x >= xmin and x <= xmax and y >= ymin and y <= ymax:
        			plot += point((x,y),color='red',size=40,zorder=2)
-                        #dbg.append([x/z,y/z])
-    #return text(str(dbg[8])+str(dbg[9]),(0,1),fontsize=15)
     return plot
 
 ###############################################################################


### PR DESCRIPTION
Now that we display a list of rational points on genus 2 curves, I thought that I'd add code to display these points on the plot (execpt the points at infinity, of course).

Here is a nice example (in my opinion): Genus2Curve/Q/432248/a/864496/1

I had to make two non-trivial implementation choices:

- I chose to display the red points above the blue curve, because the other way round was ugly. However, in some cases the points hide the tiny component of the locus of the real points they lie on, so that the picture seems to show a point which is not at all on the curve (whereas it really is). Examples: Genus2Curve/Q/673305/a/673305/1 give you an idea of what's going on (you have to magnify the plot a bit to see it); and with Genus2Curve/Q/581923/a/581923/1, the component of the curve is completely masked (it was barely visible in the first place).

- I also decided that the rational points that do not fit in the plotting window chosen to represent the curve do not get diplayed. Examples: Genus2Curve/Q/830804/a/830804/1, Genus2Curve/Q/70304/a/140608/1 .
This is because the plotting window is determined by the code so as to show the interesting bits of the curve (such as Weierstrass points) without showing too much of the infinite branches (else the interesting bits get squashed). The code that does this is empirical but seems to work well in practice. I did some tests to see what happens if we enlarge the plotting window so that all rational points fit in, and in many cases it did not look good at all (the nice part of the curve was completely squashed).

But of course, these are just personal preferences; your opininon is welcome !