### PR TITLE
For transitive group knowls, check first if we have data

### DIFF
--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -19,3 +19,8 @@ class ArtinRepTest(LmfdbTest):
         L = self.tc.get('/ArtinRepresentation/4.5_17_43.8t44.1c1')
         assert ('Odd' in L.data)
 
+    # big degree fields ok
+    def test_big_degree(self):
+        L = self.tc.get('/ArtinRepresentation/2.1951e2.120.1c1')
+        assert '24T201' in L.data # Galois group
+

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -175,7 +175,7 @@ def tryknowl(n, t):
 def group_display_short(n, t, C):
     label = base_label(n, t)
     group = C.transitivegroups.groups.find_one({'label': label})
-    if group['pretty']:
+    if group is not None and group['pretty']:
         return group['pretty']
     return "%dT%d"%(n,t)
     #name = group['name']
@@ -193,6 +193,9 @@ def group_display_pretty(n, t, C):
 def group_display_knowl(n, t, C, name=None):
     if not name:
         name = group_display_short(n, t, C)
+    group = C.transitivegroups.groups.find_one({'label': base_label(n, t)})
+    if group is None:
+        return name
     return '<a title = "' + name + ' [nf.galois_group.data]" knowl="nf.galois_group.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
 
 


### PR DESCRIPTION
When asked to produce a knowl for a transitive group, we used to assume the data was in the database.  This checks first, and produces plain text if it is not there.

The motivation comes from artin representations.  To support a project of Booker et. al., I added representations of (the Galois closure of) a degree 24 field, and we don't go that high in the transitive group database.

Two pages which fail without this change:

http://127.0.0.1:37777/ArtinRepresentation/?dimension=2&ramified=1951&count=50

http://127.0.0.1:37777/ArtinRepresentation/2.1951e2.120.1c1