### PR TITLE
warning if bcrypt failed to import or generate salt

### DIFF
--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -59,6 +59,7 @@ def bchash(pwd, existing_hash = None):
             existing_hash = unicode(bcrypt.gensalt())
         return bcrypt.hashpw(pwd.encode('utf-8'), existing_hash.encode('utf-8'))
     except:
+        logger.warning("Failed to return bchash, perhaps bcrypt is not installed");
         return None
 
 # Read about flask-login if you are unfamiliar with this UserMixin/Login

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ nose
 cython
 markupsafe
 git+https://github.com/jwbober/conrey-dirichlet-characters.git@master#egg=dirichlet_conrey
+bcrypt


### PR DESCRIPTION
@JohnCremona This might the reason why you aren't able to login while running locally.

Alternatively, I strongly believe that we should add bcrypt to requirements.txt.
I don't see any drawbacks, and not being there causes confusion.