### PR TITLE
icms.org.uk/workshops -> aimath.org/pastworkshops

### DIFF
--- a/lmfdb/templates/workshops.html
+++ b/lmfdb/templates/workshops.html
@@ -84,7 +84,9 @@ Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
 
 <br>
 
-<li><a href="http://icms.org.uk/workshops/onlinedatabases">Online databases: from L-functions 
+<li><a href="https://aimath.org/pastworkshops/onlinedata.html">
+<!-- <a href="http://icms.org.uk/workshops/onlinedatabases"> -->
+        Online databases: from L-functions
 to combinatorics</a>,  <br>
 January 21-25, 2013, <a href="http://www.icms.org.uk/">International Centre for Mathematical 
 Sciences</a>, University of Edinburgh, Edinburgh, UK

--- a/lmfdb/test_acknowlegments.py
+++ b/lmfdb/test_acknowlegments.py
@@ -27,18 +27,29 @@ class HomePageTest(LmfdbTest):
     def test_workshops(self):
         homepage = self.tc.get("/acknowledgment/activities").data
         assert 'Computational Aspects of the Langlands Program' in homepage
-       
-        
-    # 
+    #
     # External Links on workshops page
     def test_workshoplinks(self):
         homepage = self.tc.get("/acknowledgment/activities").data
-        self.check_external(homepage, "http://people.oregonstate.edu/~swisherh/CRTNTconference/index.html", 'Galois')                 
-        self.check_external(homepage, "http://www2.warwick.ac.uk/fac/sci/maths/research/events/2013-2014/nonsymp/lmfdb/",'elliptic curves over number fields' )
-        self.check_external(homepage, "http://hobbes.la.asu.edu/lmfdb-14/",'Arizona State University' )
-        self.check_external(homepage, "http://www.maths.bris.ac.uk/~maarb/public/lmfdb2013.html", 'Development of algorithms')
-        self.check_external(homepage, "http://icms.org.uk/workshops/onlinedatabases",'development of new software tools' )
-        self.check_external(homepage, "http://www.msri.org/programs/262", 'algebraic number fields')
-        self.check_external(homepage, "http://aimath.org/pastworkshops/lfunctionsandmf.html", 'L-functions and modular forms')
+        self.check_external(homepage,
+                "http://people.oregonstate.edu/~swisherh/CRTNTconference/index.html",
+                'Galois')
+        self.check_external(homepage,
+                "http://www2.warwick.ac.uk/fac/sci/maths/research/events/2013-2014/nonsymp/lmfdb/",
+                'elliptic curves over number fields' )
+        self.check_external(homepage,
+                "http://hobbes.la.asu.edu/lmfdb-14/",
+                'Arizona State University' )
+        self.check_external(homepage,
+                "http://www.maths.bris.ac.uk/~maarb/public/lmfdb2013.html",
+                'Development of algorithms')
+        self.check_external(homepage,
+                #"http://icms.org.uk/workshops/onlinedatabases"
+                "https://aimath.org/pastworkshops/onlinedata.html"
+                ,'development of new software tools' )
+        self.check_external(homepage, "http://www.msri.org/programs/262",
+                'algebraic number fields')
+        self.check_external(homepage,
+                "http://aimath.org/pastworkshops/lfunctionsandmf.html",
+                'L-functions and modular forms')
 
-      


### PR DESCRIPTION
I have:
1- replaced the link to http://icms.org.uk/workshops/onlinedatabases
by 
https://aimath.org/pastworkshops/onlinedata.html
2- updated the test to reflect this.
3- the formatting of `lmfdb/test_acknowlegments.py`, but didn't change its content.

This fixes: #2356 


