### PR TITLE
Lfunfix

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -512,10 +512,11 @@ class ECNF(object):
         if totally_real:
             self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
-            if sig[0] > 2:
-                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
-            else:
+            if sig[0] <= 2:
                 self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
+            elif self.abs_disc ** 2 * self.conductor_norm < 70000:
+                # we shouldn't trust the Lfun computed on the fly for large conductor
+                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
 
         if imag_quadratic:
             self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
@@ -527,7 +528,7 @@ class ECNF(object):
         self.friends += [('Twists', url_for('ecnf.index', field=self.field_label, jinv=rename_j(j)))]
         if totally_real:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
-            self.friends += [('L-function', self.urls['Lfunction'])]
+
         if imag_quadratic:
             if "CM" in self.label:
                 self.friends += [('Bianchi Modular Form is not cuspidal', '')]
@@ -536,7 +537,11 @@ class ECNF(object):
                     self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
                 else:
                     self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]
+
+        if 'Lfunction' in self.urls:
             self.friends += [('L-function', self.urls['Lfunction'])]
+        else:
+            self.friends += [('L-function not available', "")]
 
         self.properties = [
             ('Base field', self.field.field_pretty()),

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -512,7 +512,10 @@ class ECNF(object):
         if totally_real:
             self.hmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field.label, label=self.hmf_label)
-            self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
+            if sig[0] > 2:
+                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
+            else:
+                self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
 
         if imag_quadratic:
             self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -520,6 +520,7 @@ class ECNF(object):
         if imag_quadratic:
             self.bmf_label = "-".join([self.field.label, self.conductor_label, self.iso_label])
             self.bmf_url = url_for('bmf.render_bmf_webpage', field_label=self.field_label, level_label=self.conductor_label, label_suffix=self.iso_label)
+            self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
 
         self.friends = []
         self.friends += [('Isogeny class ' + self.short_class_label, self.urls['class'])]
@@ -535,6 +536,7 @@ class ECNF(object):
                     self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
                 else:
                     self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]
+            self.friends += [('L-function', self.urls['Lfunction'])]
 
         self.properties = [
             ('Base field', self.field.field_pretty()),

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -104,11 +104,15 @@ class ECNF_isoclass(object):
         if totally_real:
             self.hmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field_label, label=self.hmf_label)
-            self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
+            if sig[0] > 2:
+                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
+            else:
+                self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
 
         if imag_quadratic:
             self.bmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
             self.bmf_url = url_for('bmf.render_bmf_webpage', field_label=self.field_label, level_label=self.conductor_label, label_suffix=self.iso_label)
+            self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
 
         self.friends = []
         if totally_real:
@@ -117,6 +121,7 @@ class ECNF_isoclass(object):
         if imag_quadratic:
             #self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]
             self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
+            self.friends += [('L-function', self.urls['Lfunction'])]
 
         self.properties = [('Base field', self.field_name),
                            ('Label', self.class_label),

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -104,10 +104,11 @@ class ECNF_isoclass(object):
         if totally_real:
             self.hmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
             self.urls['hmf'] = url_for('hmf.render_hmf_webpage', field_label=self.field_label, label=self.hmf_label)
-            if sig[0] > 2:
-                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
-            else:
+            if sig[0] <= 2:
                 self.urls['Lfunction'] = url_for("l_functions.l_function_ecnf_page", field_label=self.field_label, conductor_label=self.conductor_label, isogeny_class_label=self.iso_label)
+            elif self.abs_disc ** 2 * self.conductor_norm < 40000:
+                # we shouldn't trust the Lfun computed on the fly for large conductor
+                self.urls['Lfunction'] = url_for("l_functions.l_function_hmf_page", field=self.field_label, label=self.hmf_label, character='0', number='0')
 
         if imag_quadratic:
             self.bmf_label = "-".join([self.field_label, self.conductor_label, self.iso_label])
@@ -117,11 +118,16 @@ class ECNF_isoclass(object):
         self.friends = []
         if totally_real:
             self.friends += [('Hilbert Modular Form ' + self.hmf_label, self.urls['hmf'])]
-            self.friends += [('L-function', self.urls['Lfunction'])]
+
         if imag_quadratic:
             #self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]
             self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
+
+        if 'Lfunction' in self.urls:
             self.friends += [('L-function', self.urls['Lfunction'])]
+        else:
+            self.friends += [('L-function not available', "")]
+
 
         self.properties = [('Base field', self.field_name),
                            ('Label', self.class_label),


### PR DESCRIPTION
This PR:
1- fixes #2346.
2- Adds urls for the L-functions to the pages of elliptic curves over imaginary quadratic fields, and all the pages of the isogeny classes of elliptic curves defined over a field of degree 2.
4- If the the L-function is not on the database or the conductor of L-function is too large, now it displays "L-function not available".  I used the same cut that is used in Hilbert Modular forms. 

ps: A posteriori, I have realized that no elliptic curve over a field of degree >= 3 makes the cut.
pps: This will fail the tests, due to #2356 