### PR TITLE
minor fix to avoid deprecation warning with Sage-8.1

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -161,7 +161,7 @@ def list_to_factored_poly_otherorder(s, galois=False, vari = 'T'):
             this_poly = expand(x**this_degree*this_poly.substitute(T=1/x))
             this_number_field = NumberField(this_poly, "a")
             this_gal = this_number_field.galois_group(type='pari')
-            this_t_number = this_gal.group()._pari_()[2].sage()
+            this_t_number = this_gal.group().__pari__()[2].sage()
             gal_list.append([this_degree, this_t_number])
         vcf = v[0].list()
         started = False


### PR DESCRIPTION
Small change to avoid getting a deprecation warning with Sage-8.1.  I tested this works also on 8.0 (as now run on prod and beta servers).  Let's see if Travis is happy too.