### PR TITLE
small EC/NF tidy-up

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -491,13 +491,7 @@ class ECNF(object):
 
         # Isogeny information
 
-        if self.number==1:
-            isogmat = self.isogeny_matrix
-        else:
-            isogmat = db_ecnf().find_one({'class_label':self.class_label, 'number':1})['isogeny_matrix']
-        self.class_deg = max([max(d) for d in isogmat])
         self.one_deg = ZZ(self.class_deg).is_prime()
-        self.ncurves = db_ecnf().count({'class_label':self.class_label})
         isodegs = [str(d) for d in self.isogeny_degrees if d>1]
         if len(isodegs)<3:
             self.isogeny_degrees = " and ".join(isodegs)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -308,7 +308,7 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     conductor_label = unquote(conductor_label)
     conductor_label = convert_IQF_label(nf,conductor_label)
     try:
-        nf_label = nf_string_to_label(nf)
+        nf_label, nf_pretty = get_nf_info(nf)
     except ValueError:
         return search_input_error()
     label = "-".join([nf_label, conductor_label, class_label])
@@ -319,7 +319,7 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
         info = {'query':{}, 'err':'No elliptic curve isogeny class in the database has label %s.' % label}
         return search_input_error(info, bread)
     title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field_name)
-    bread.append((cl.field_name, url_for(".show_ecnf1", nf=nf_label)))
+    bread.append((nf_pretty, url_for(".show_ecnf1", nf=nf)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
     return render_template("ecnf-isoclass.html",

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -319,7 +319,7 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
         info = {'query':{}, 'err':'No elliptic curve isogeny class in the database has label %s.' % label}
         return search_input_error(info, bread)
     title = "Elliptic Curve isogeny class %s over Number Field %s" % (full_class_label, cl.field_name)
-    bread.append((cl.field, url_for(".show_ecnf1", nf=nf_label)))
+    bread.append((cl.field_name, url_for(".show_ecnf1", nf=nf_label)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
     return render_template("ecnf-isoclass.html",

--- a/lmfdb/ecnf/templates/ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/ecnf-isoclass.html
@@ -42,6 +42,16 @@ function show_code(system) {
 </div>
 
 <h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.field_knowl|safe }}</h2>
+<p>
+Isogeny class {{cl.short_class_label}} contains
+{% if cl.class_size==1 %}
+only one elliptic curve.
+{% else %}
+{{cl.class_size}} curves linked by isogenies of
+{% if cl.one_deg %}degree {% else %}degrees dividing {% endif %}
+{{cl.class_deg}}.
+{% endif %}
+</p>
 <table>
 <tr>
 <th>{{ KNOWL('ec.curve_label',title = "Curve label") }}</th>


### PR DESCRIPTION
Three things here.

   1.  I added fields 'class_size' and 'class_deg' to the records in elliptic_curves.nfcurves where they were missing (about half the records), so I could simplify the code by reducing some trivial on-the-fly work and database lookups.
   2   See http://localhost:37777/EllipticCurve/2.2.12.1/3432.4/o/ or http://localhost:37777/EllipticCurve/2.0.4.1/67600.4/d/ or http://localhost:37777/EllipticCurve/2.0.4.1/233.1/a/ -- before the list of curves in the isogeny class it says how many there are and the degrees -- information which is already lower down the page but looks nice here.  (Note that individual curves have have had similar information about their isogeny class visible for some time).
   3. Fixed a breadcrumb issue: see http://localhost:37777/EllipticCurve/2.2.17.1/512.7/d/ where there's blank where the field label/name should be on beta.

While writing this I saw that the breadcrumb is still not quite right so the PR will be updated soon.