### PR TITLE
code changes for hmf collection name changes

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -20,16 +20,13 @@ from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, 
 
 def db_forms():
     hmfs = getDBConnection().hmfs
-    if 'hecke' in hmfs.collection_names():
-        return getDBConnection().hmfs.forms.search
+    if 'forms' in hmfs.collection_names():
+        return hmfs.forms
     else:
-        return getDBConnection().hmfs.forms
+        return hmfs.forms.search
 
 def db_fields():
     return getDBConnection().hmfs.fields
-
-def db_search():
-    return getDBConnection().hmfs.forms.search
 
 def db_hecke():
     hmfs = getDBConnection().hmfs
@@ -64,7 +61,7 @@ hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A 
 
 @hmf_page.route("/random")
 def random_hmf():    # Random Hilbert modular form
-    return hilbert_modular_form_by_label( random_value_from_collection( db_search(), 'label' ) )
+    return hilbert_modular_form_by_label( random_value_from_collection( db_forms(), 'label' ) )
 
 def teXify_pol(pol_str):  # TeXify a polynomial (or other string containing polynomials)
     o_str = pol_str.replace('*', '')
@@ -122,7 +119,7 @@ def split_full_label(lab):
 
 def hilbert_modular_form_by_label(lab):
     if isinstance(lab, basestring):
-        res = db_search().find_one({'label': lab},{'label':True})
+        res = db_forms().find_one({'label': lab},{'label':True})
     else:
         res = lab
         lab = res['label']
@@ -171,7 +168,7 @@ def hilbert_modular_form_search(**args):
     start = parse_start(info)
 
     info['query'] = dict(query)
-    res = db_search().find(
+    res = db_forms().find(
         query).sort([('deg', pymongo.ASCENDING), ('disc', pymongo.ASCENDING), ('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)]).skip(start).limit(count)
     nres = res.count()
     if(start >= nres):
@@ -382,7 +379,7 @@ def render_hmf_webpage(**args):
 
     t = "Hilbert Cusp Form %s" % info['label']
 
-    forms_space = db_search().find(
+    forms_space = db_forms().find(
         {'field_label': data['field_label'], 'level_ideal': data['level_ideal']},{'dimension':True})
     dim_space = 0
     for v in forms_space:

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -14,7 +14,11 @@ def field_sort_key(F):
 logger = make_logger("hmf")
 
 def db_forms_stats():
-    return getDBConnection().hmfs.forms.search.stats
+    hmfs = getDBConnection().hmfs
+    if 'forms.stats' in hmfs.collection_names():
+        return hmfs.forms.stats
+    else:
+        return hmfs.forms.search.stats
 
 the_HMFstats = None
 

--- a/scripts/ecnf/hmf_check_find.py
+++ b/scripts/ecnf/hmf_check_find.py
@@ -26,7 +26,11 @@ qcurves = C.elliptic_curves.curves
 
 print "setting hmfs, forms, fields"
 hmfs = C.hmfs
-forms = hmfs.forms.search # contains all data except eigenvalues
+# forms (used to be forms.search) contains all data except eigenvalues
+if 'forms' in hmfs.collection_names():
+    forms = hmfs.forms
+else:
+    forms = hmfs.forms.search
 fields = hmfs.fields
 hecke = hmfs.hecke        # contains eigenvalues
 

--- a/scripts/hmf/check_conjugates.py
+++ b/scripts/hmf/check_conjugates.py
@@ -40,9 +40,13 @@ def authenticate():
 
 print "setting hmfs, fields and forms"
 hmfs = C.hmfs
+# forms (used to be forms.search) contains all data except eigenvalues
+if 'forms' in hmfs.collection_names():
+    forms = hmfs.forms
+else:
+    forms = hmfs.forms.search
 fields = hmfs.fields
-forms = hmfs.forms.search
-hecke = hmfs.hecke
+hecke = hmfs.hecke        # contains eigenvalues
 nfcurves = C.elliptic_curves.nfcurves
 
 # Cache of WebNumberField and FieldData objects to avoid re-creation
@@ -115,7 +119,7 @@ def conjform_label(f, ig, cideals):
 
 def conjform(f, h, g, ig, cideals, cprimes, F):
     """
-    f is a 'short' newform from the forms.search collection;
+    f is a 'short' newform from the forms collection;
     h is its hecke data from the hecke collection
     g is an tuomorphism of the base field, ig it index in auts
     cideals, cprimes are the lists of conjugated ideals and primes

--- a/scripts/hmf/hmf-extra-data-dump.sage
+++ b/scripts/hmf/hmf-extra-data-dump.sage
@@ -31,7 +31,7 @@ for Flabel in fieldlabels:
         vars = {'w':K.0}
         degree = Flabel.split('.')[0]
         assert degree == str(K.degree())
-        res = forms.search.find(query).sort([('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)])
+        res = forms.find(query).sort([('level_norm', pymongo.ASCENDING), ('level_label', pymongo.ASCENDING), ('label_nsuffix', pymongo.ASCENDING)])
         res_labels = [f['label'] for f in res]
         assert len(res_labels) > 0
         for flabel in res_labels:

--- a/scripts/hmf/import_hmf_data.py
+++ b/scripts/hmf/import_hmf_data.py
@@ -14,9 +14,18 @@ import yaml
 pw_dict = yaml.load(open(os.path.join(os.getcwd(), os.extsep, os.extsep, os.extsep, "passwords.yaml")))
 username = pw_dict['data']['username']
 password = pw_dict['data']['password']
-C['hmfs'].authenticate(username, password)
-hmf_forms = C.hmfs.forms
-hmf_fields = C.hmfs.fields
+hmfs = C.hmfs
+hmfs.authenticate(username, password)
+if 'forms' in hmfs.collection_names():
+    hmf_forms = hmfs.forms
+    hmf_stats = hmfs.forms.stats
+    print("Setting hmf_forms to {} and hmf_stats to {}".format('hmfs.forms','hmfs.forms.stats'))
+else:
+    hmf_forms = hmfs.forms.search
+    hmf_stats = hmfs.forms.search.stats
+    print("Setting hmf_forms to {} and hmf_stats to {}".format('hmfs.forms.search','hmfs.forms.search.stats'))
+
+hmf_fields = hmfs.fields
 C['admin'].authenticate('lmfdb', 'lmfdb') # read-only
 fields = C.numberfields.fields
 
@@ -376,48 +385,46 @@ def make_stats_dict():
 
 def make_stats():
     from data_mgt.utilities.rewrite import update_attribute_stats
-    hmfs = C.hmfs
-    form_stats = hmfs.forms.search.stats
 
     print("Updating fields stats")
-    fields = hmfs.fields.distinct('label')
-    degrees = hmfs.fields.distinct('degree')
+    fields = hmf_fields.distinct('label')
+    degrees = hmf_fields.distinct('degree')
     field_sort_key = lambda F: int(F.split(".")[2]) # by discriminant
-    fields_by_degree = dict([(d,sorted(hmfs.fields.find({'degree':d}).distinct('label'),key=field_sort_key)) for d in degrees])
+    fields_by_degree = dict([(d,sorted(hmf_fields.find({'degree':d}).distinct('label'),key=field_sort_key)) for d in degrees])
     print("{} fields in database of degree from {} to {}".format(len(fields),min(degrees),max(degrees)))
 
     print("...summary of counts by degree...")
     entry = {'_id': 'fields_summary'}
-    form_stats.delete_one(entry)
+    hmf_stats.delete_one(entry)
     field_data = {'max': max(degrees),
                   'min': min(degrees),
                   'total': len(fields),
-                  'counts': [[d,hmfs.fields.count({'degree': d})]
+                  'counts': [[d,hmf_fields.count({'degree': d})]
                             for d in degrees]
     }
     entry.update(field_data)
-    form_stats.insert_one(entry)
+    hmf_stats.insert_one(entry)
 
     print("...fields by degree...")
     entry = {'_id': 'fields_by_degree'}
-    form_stats.delete_one(entry)
+    hmf_stats.delete_one(entry)
     for d in degrees:
         entry[str(d)] = {'fields': fields_by_degree[d],
                          'nfields': len(fields_by_degree[d]),
-                         'maxdisc': max(hmfs.fields.find({'degree':d}).distinct('discriminant'))
+                         'maxdisc': max(hmf_fields.find({'degree':d}).distinct('discriminant'))
         }
-    form_stats.insert_one(entry)
+    hmf_stats.insert_one(entry)
 
     print("Updating forms stats")
     print("counts by field degree and by dimension...")
-    update_attribute_stats(hmfs, 'forms.search', 'deg')
-    update_attribute_stats(hmfs, 'forms.search', 'dimension')
+    update_attribute_stats(hmfs, 'forms', 'deg')
+    update_attribute_stats(hmfs, 'forms', 'dimension')
 
     print("counts by field degree and by level norm...")
     entry = {'_id': 'level_norm_by_degree'}
     degree_data = {}
     for d in degrees:
-        res = hmfs.forms.search.find({'deg':d})
+        res = hmf_forms.find({'deg':d})
         nforms = res.count()
         Ns = res.distinct('level_norm')
         min_norm = min(Ns)
@@ -427,16 +434,16 @@ def make_stats():
                           'max_norm':max_norm,
         }
         print("{}: {}".format(d,degree_data[str(d)]))
-    form_stats.delete_one(entry)
+    hmf_stats.delete_one(entry)
     entry.update(degree_data)
-    form_stats.insert_one(entry)
+    hmf_stats.insert_one(entry)
 
     print("counts by field and by level norm...")
     entry = {'_id': 'level_norm_by_field'}
     field_data = {}
     for f in fields:
         ff = f.replace(".",":") # mongo does not allow "." in key strings
-        res = hmfs.forms.search.find({'field_label': f})
+        res = hmf_forms.find({'field_label': f})
         nforms = res.count()
         Ns = res.distinct('level_norm')
         min_norm = min(Ns)
@@ -446,9 +453,9 @@ def make_stats():
                           'max_norm':max_norm,
         }
         #print("{}: {}".format(f,field_data[ff]))
-    form_stats.delete_one(entry)
+    hmf_stats.delete_one(entry)
     entry.update(field_data)
-    form_stats.insert_one(entry)
+    hmf_stats.insert_one(entry)
 
 
 def add_missing_disc_deg_wt(nf):


### PR DESCRIPTION
After this, all HMF code should work whether there exist collections forms or forms.search or both (and similarly with the rand and stats derived collections).  Currently the beta database has both; after this has been tested & merged and pushed to beta I will try temporarily renaming the forms.search* collections and if that works OK as expected they can be dropped.  (forms is now  a direct copy of forms.search).