### PR TITLE
Stop lexicographical sorting of record numbers on inventory record pages

### DIFF
--- a/lmfdb/inventory_app/inventory_helpers.py
+++ b/lmfdb/inventory_app/inventory_helpers.py
@@ -146,7 +146,7 @@ def empty_null_record_info(records):
     """Empty null name or description fields in list of records"""
     try:
         for item in records:
-            print item
+            #print item
             item = empty_all_if_null(item)
     except Exception as e:
         log_dest.error(e)

--- a/lmfdb/inventory_app/static/inventory_general.js
+++ b/lmfdb/inventory_app/static/inventory_general.js
@@ -122,6 +122,7 @@ function fetchAndPopulateData(blockList, pageCreator, startVisible=true){
     }else{
 	    populateBlocklist(XHR.blockList, data);
     	pageCreator(XHR.blockList, startVisible=startVisible);
+      $( document ).trigger("dataPopulated");
     }
   });
 

--- a/lmfdb/inventory_app/static/inventory_general.js
+++ b/lmfdb/inventory_app/static/inventory_general.js
@@ -85,7 +85,7 @@ function setNotEditableById(id){
 
 function getBoxTitles(blockList){
   //Returns all the unique box names. Assumes name is all the bit before the final
-  var keys = Object.keys(blockList.blockList).sort();
+  var keys = Object.keys(blockList.blockList);
   var uniq_keys = {};
   for(var i=0; i<keys.length; i++){
     var str = keys[i];

--- a/lmfdb/inventory_app/static/record_viewer.js
+++ b/lmfdb/inventory_app/static/record_viewer.js
@@ -150,8 +150,8 @@ function sortTable(n) {
     switching = false;
     rows = table.getElementsByTagName("TR");
     /* Loop through all table rows (except the
-    first, which contains table headers): */
-    for (i = 1; i < (rows.length - 1); i++) {
+    first two, which contains table headers and dummy row): */
+    for (i = 2; i < (rows.length - 1); i++) {
       // Start by saying there should be no switching:
       shouldSwitch = false;
       /* Get the two elements you want to compare,

--- a/lmfdb/inventory_app/static/record_viewer.js
+++ b/lmfdb/inventory_app/static/record_viewer.js
@@ -1,6 +1,6 @@
 /*jshint esversion: 6 */
 var tooltip_dict = {'dummy': 'Record does not exist', 'extends': 'Schema is displayed as diff from numbered record', 'base' : 'This is the base record which others extend'};
-var vals_to_sort = ['count'];
+var vals_to_sort = ['count']; // and ID, which is done automatically
 
 function BaseRecord(num, name){
   //Holds the info about the base record for the diffed record types
@@ -43,14 +43,23 @@ function populateRecordViewerPage(blockList, startVisible=true){
 
   var table_div = document.createElement('div');
   var table = document.createElement('table');
-  table.class = 'viewerTable';
+  //table.class = 'viewerTable';
+  table.classList.add('tablesorter');
   table.id = 'viewerTable';
   entry_styles = ['table_tag'];
+  var table_head = document.createElement('thead');
 
   base_record = unpackBaseRecord(blockList);
   var row = createRecordRow(blockList, 'Key', '', base_record, header=true);
-  table.appendChild(row);
-  for(var i=0; i < fields.length; i++){
+  table_head.appendChild(row);
+
+  var row0 = createRecordRow(blockList, fields[0].substr(4, fields[0].length), '#'+fields[0]+id_delimiter, base_record);
+  table_head.appendChild(row0);
+
+  table.appendChild(table_head);
+
+  var table_body = document.createElement('tbody');
+  for(var i=1; i < fields.length; i++){
     row = createRecordRow(blockList, fields[i].substr(4, fields[i].length), '#'+fields[i]+id_delimiter, base_record);
     if(row){
       if(!row.classList.contains('viewerTableSpecial')){
@@ -59,9 +68,10 @@ function populateRecordViewerPage(blockList, startVisible=true){
          clas += (i%2 == 0 ? 'Even':'Odd');
          row.classList.add(clas);
       }
-      table.appendChild(row);
+      table_body.appendChild(row);
     }
   }
+  table.appendChild(table_body);
 
   table_div.appendChild(table);
   dataDiv.appendChild(table_div);
@@ -77,7 +87,7 @@ function createRecordRow(blockList, field, id_start, base_record, header=false){
   if(header){
     var table_el = document.createElement('th');
     table_el.innerHTML = 'Record Num';
-    table_el.onclick = function() {sortTable(0) };
+    //table_el.onclick = function() {sortTable(0) }; //DLD TODO remove
   }else{
     var table_el = document.createElement('td');
     table_el.innerHTML = field;
@@ -96,7 +106,8 @@ function createRecordRow(blockList, field, id_start, base_record, header=false){
       table_el.innerHTML = capitalise(record_fields[j]);
       if(record_fields[j] in tooltip_dict) table_el.title = tooltip_dict[record_fields[j]];
       if(vals_to_sort.includes(record_fields[j])){
-        table_el.onclick = function() { sortTable(j) };
+        // DLD TODO remove
+        //table_el.onclick = function() { sortTable(j) };
       }
     }else{
       var block = blockList.getBlock(id_start+record_fields[j]);
@@ -149,8 +160,8 @@ function sortTable(n) {
     // Start by saying: no switching is done:
     switching = false;
     rows = table.getElementsByTagName("TR");
-    /* Loop through all table rows (except the
-    first two, which contains table headers and dummy row): */
+    /* Loop through all table rows (except the first two,
+     * which contains table headers and the dummy row): */
     for (i = 2; i < (rows.length - 1); i++) {
       // Start by saying there should be no switching:
       shouldSwitch = false;

--- a/lmfdb/inventory_app/static/record_viewer.js
+++ b/lmfdb/inventory_app/static/record_viewer.js
@@ -1,6 +1,5 @@
 /*jshint esversion: 6 */
 var tooltip_dict = {'dummy': 'Record does not exist', 'extends': 'Schema is displayed as diff from numbered record', 'base' : 'This is the base record which others extend'};
-var vals_to_sort = ['count']; // and ID, which is done automatically
 
 function BaseRecord(num, name){
   //Holds the info about the base record for the diffed record types
@@ -87,7 +86,6 @@ function createRecordRow(blockList, field, id_start, base_record, header=false){
   if(header){
     var table_el = document.createElement('th');
     table_el.innerHTML = 'Record Num';
-    //table_el.onclick = function() {sortTable(0) }; //DLD TODO remove
   }else{
     var table_el = document.createElement('td');
     table_el.innerHTML = field;
@@ -105,10 +103,6 @@ function createRecordRow(blockList, field, id_start, base_record, header=false){
     if(header){
       table_el.innerHTML = capitalise(record_fields[j]);
       if(record_fields[j] in tooltip_dict) table_el.title = tooltip_dict[record_fields[j]];
-      if(vals_to_sort.includes(record_fields[j])){
-        // DLD TODO remove
-        //table_el.onclick = function() { sortTable(j) };
-      }
     }else{
       var block = blockList.getBlock(id_start+record_fields[j]);
       var text = block ? block.text: '';
@@ -145,60 +139,5 @@ function fillRecordHashMap(data){
     //If this is records, we add entry to the map linking the field to the hash
     var records = ('hash' in contents && 'oschema' in contents);
     recordHashMap.set(field, contents.hash);
-  }
-}
-
-function sortTable(n) {
-  var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
-  table = document.getElementById("viewerTable");
-  switching = true;
-  // Set the sorting direction to ascending:
-  dir = "asc";
-  /* Make a loop that will continue until
-  no switching has been done: */
-  while (switching) {
-    // Start by saying: no switching is done:
-    switching = false;
-    rows = table.getElementsByTagName("TR");
-    /* Loop through all table rows (except the first two,
-     * which contains table headers and the dummy row): */
-    for (i = 2; i < (rows.length - 1); i++) {
-      // Start by saying there should be no switching:
-      shouldSwitch = false;
-      /* Get the two elements you want to compare,
-      one from current row and one from the next: */
-      x = rows[i].getElementsByTagName("TD")[n];
-      y = rows[i + 1].getElementsByTagName("TD")[n];
-      /* Check if the two rows should switch place,
-      based on the direction, asc or desc: */
-      if (dir == "asc") {
-        if (Number(x.innerHTML) > Number(y.innerHTML)) {
-          // If so, mark as a switch and break the loop:
-          shouldSwitch= true;
-          break;
-        }
-      } else if (dir == "desc") {
-        if (Number(x.innerHTML) < Number(y.innerHTML)) {
-          // If so, mark as a switch and break the loop:
-          shouldSwitch= true;
-          break;
-        }
-      }
-    }
-    if (shouldSwitch) {
-      /* If a switch has been marked, make the switch
-      and mark that a switch has been done: */
-      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
-      switching = true;
-      // Each time a switch is done, increase this count by 1:
-      switchcount ++;
-    } else {
-      /* If no switching has been done AND the direction is "asc",
-      set the direction to "desc" and run the while loop again. */
-      if (switchcount == 0 && dir == "asc") {
-        dir = "desc";
-        switching = true;
-      }
-    }
   }
 }

--- a/lmfdb/inventory_app/static/record_viewer.js
+++ b/lmfdb/inventory_app/static/record_viewer.js
@@ -1,6 +1,6 @@
-
 /*jshint esversion: 6 */
 var tooltip_dict = {'dummy': 'Record does not exist', 'extends': 'Schema is displayed as diff from numbered record', 'base' : 'This is the base record which others extend'};
+var vals_to_sort = ['count'];
 
 function BaseRecord(num, name){
   //Holds the info about the base record for the diffed record types
@@ -44,6 +44,7 @@ function populateRecordViewerPage(blockList, startVisible=true){
   var table_div = document.createElement('div');
   var table = document.createElement('table');
   table.class = 'viewerTable';
+  table.id = 'viewerTable';
   entry_styles = ['table_tag'];
 
   base_record = unpackBaseRecord(blockList);
@@ -73,21 +74,30 @@ function createRecordRow(blockList, field, id_start, base_record, header=false){
 //field is the set id, in this case sequential numbers, used as record Num
   var table_row = document.createElement('tr');
   var clas = header ? 'viewerTableHeaders' : 'viewerTableEls';
-  var table_el = document.createElement('td');
   if(header){
+    var table_el = document.createElement('th');
     table_el.innerHTML = 'Record Num';
+    table_el.onclick = function() {sortTable(0) };
   }else{
+    var table_el = document.createElement('td');
     table_el.innerHTML = field;
   }
   table_el.classList.add(clas);
   table_row.appendChild(table_el);
   var is_base = (blockList.getBlock(id_start+'base') ? blockList.getBlock(id_start+'base').text : false);
   for(var j=0; j < record_fields.length; j++){
-    table_el = document.createElement('td');
+    if(header){
+      table_el = document.createElement('th');
+    }else{
+      table_el = document.createElement('td');
+    }
     table_el.classList.add(clas);
     if(header){
       table_el.innerHTML = capitalise(record_fields[j]);
       if(record_fields[j] in tooltip_dict) table_el.title = tooltip_dict[record_fields[j]];
+      if(vals_to_sort.includes(record_fields[j])){
+        table_el.onclick = function() { sortTable(j) };
+      }
     }else{
       var block = blockList.getBlock(id_start+record_fields[j]);
       var text = block ? block.text: '';
@@ -124,5 +134,60 @@ function fillRecordHashMap(data){
     //If this is records, we add entry to the map linking the field to the hash
     var records = ('hash' in contents && 'oschema' in contents);
     recordHashMap.set(field, contents.hash);
+  }
+}
+
+function sortTable(n) {
+  var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+  table = document.getElementById("viewerTable");
+  switching = true;
+  // Set the sorting direction to ascending:
+  dir = "asc";
+  /* Make a loop that will continue until
+  no switching has been done: */
+  while (switching) {
+    // Start by saying: no switching is done:
+    switching = false;
+    rows = table.getElementsByTagName("TR");
+    /* Loop through all table rows (except the
+    first, which contains table headers): */
+    for (i = 1; i < (rows.length - 1); i++) {
+      // Start by saying there should be no switching:
+      shouldSwitch = false;
+      /* Get the two elements you want to compare,
+      one from current row and one from the next: */
+      x = rows[i].getElementsByTagName("TD")[n];
+      y = rows[i + 1].getElementsByTagName("TD")[n];
+      /* Check if the two rows should switch place,
+      based on the direction, asc or desc: */
+      if (dir == "asc") {
+        if (Number(x.innerHTML) > Number(y.innerHTML)) {
+          // If so, mark as a switch and break the loop:
+          shouldSwitch= true;
+          break;
+        }
+      } else if (dir == "desc") {
+        if (Number(x.innerHTML) < Number(y.innerHTML)) {
+          // If so, mark as a switch and break the loop:
+          shouldSwitch= true;
+          break;
+        }
+      }
+    }
+    if (shouldSwitch) {
+      /* If a switch has been marked, make the switch
+      and mark that a switch has been done: */
+      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+      switching = true;
+      // Each time a switch is done, increase this count by 1:
+      switchcount ++;
+    } else {
+      /* If no switching has been done AND the direction is "asc",
+      set the direction to "desc" and run the while loop again. */
+      if (switchcount == 0 && dir == "asc") {
+        dir = "desc";
+        switching = true;
+      }
+    }
   }
 }

--- a/lmfdb/inventory_app/templates/base_edit.html
+++ b/lmfdb/inventory_app/templates/base_edit.html
@@ -2,8 +2,8 @@
   <head>
     <meta charset="UTF-8">
     <title>LMFDB inventory editor</title>
-    <link href="{{ url_for('inventory_app.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ url_for('css') }}" rel="stylesheet" type="text/css" />
+    <link href="{{ url_for('inventory_app.css') }}" rel="stylesheet" type="text/css" />
 
     <script type="text/javascript" src="{{ url_for('static', filename='jquery.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='jquery.watermark.min.js') }}"></script>

--- a/lmfdb/inventory_app/templates/inv_style.css
+++ b/lmfdb/inventory_app/templates/inv_style.css
@@ -124,25 +124,32 @@ div.hide, span.hide{
     display: inline-block;
 }
 
-.viewerTable{
+#viewerTable{
     border: 1px solid black;
     table-layout: auto;
+    font-size: 110%;
 }
 .viewerTableHeaders, .viewerTableEls{
   border: 1px solid black;
+}
+.viewerTableHeaders td, .viewerTableEls td{
   padding : 5px;
 }
-.viewerTableHeaders {
+.tablesorter .viewerTableHeaders {
   font-weight: bold;
+  font-size: 110%;
 }
-.viewerTableOdd{
+table.tablesorter tbody td{
+  background-color: unset;
+}
+table.tablesorter tr:nth-child(2n+2){
     background-color : #e8e8e8;
 }
-.viewerTableEven{
+table.tablesorter tr:nth-child(2n+1){
     background-color : #ffffff;
 }
 .viewerTableSpecial{
-    background-color : #ffe8e8;
+    background-color : #ffe8e8 !important;
 }
 .viewerTableSole{}
 .viewerTableSoleOdd{

--- a/lmfdb/inventory_app/templates/view_records.html
+++ b/lmfdb/inventory_app/templates/view_records.html
@@ -3,6 +3,7 @@
 {% block extra_script %}
 <script type="text/javascript" src="{{ url_for('inventory_app.static', filename='inventory_general.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('inventory_app.static', filename='record_viewer.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='jquery.tablesorter.js') }}"></script>
 <script type="text/javascript">
     //Create a js object of the fields from server.
     var mainBlockList = new BlockList("{{db_name}}", "{{collection_name}}");
@@ -18,10 +19,15 @@
       console.log( "Ready!" );
     }
 
+    function readyTablesorter(){
+          $("#viewerTable").tablesorter();
+    }
+
     $( document ).ready(function(){
       //Fetch content and fill blocklist and DOM
       $( document ).on("blockListReady", onReady); //What to do when blocklist is prepared
       fetchAndPopulateData(mainBlockList, populateRecordViewerPage, startVisible=true);//Start fetching
+      $( document ).on("dataPopulated", readyTablesorter);
     });
 
 </script>

--- a/lmfdb/static/jquery.tablesorter.js
+++ b/lmfdb/static/jquery.tablesorter.js
@@ -1,103 +1,103 @@
 /*
- * 
+ *
  * TableSorter 2.0 - Client-side table sorting with ease!
  * Version 2.0.5b
  * @requires jQuery v1.2.3
- * 
+ *
  * Copyright (c) 2007 Christian Bach
  * Examples and docs at: http://tablesorter.com
  * Dual licensed under the MIT and GPL licenses:
  * http://www.opensource.org/licenses/mit-license.php
  * http://www.gnu.org/licenses/gpl.html
- * 
+ *
  */
 /**
- * 
+ *
  * @description Create a sortable table with multi-column sorting capabilitys
- * 
+ *
  * @example $('table').tablesorter();
  * @desc Create a simple tablesorter interface.
- * 
+ *
  * @example $('table').tablesorter({ sortList:[[0,0],[1,0]] });
  * @desc Create a tablesorter interface and sort on the first and secound column column headers.
- * 
+ *
  * @example $('table').tablesorter({ headers: { 0: { sorter: false}, 1: {sorter: false} } });
- *          
+ *
  * @desc Create a tablesorter interface and disableing the first and second  column headers.
- *      
- * 
+ *
+ *
  * @example $('table').tablesorter({ headers: { 0: {sorter:"integer"}, 1: {sorter:"currency"} } });
- * 
+ *
  * @desc Create a tablesorter interface and set a column parser for the first
  *       and second column.
- * 
- * 
+ *
+ *
  * @param Object
  *            settings An object literal containing key/value pairs to provide
  *            optional settings.
- * 
- * 
+ *
+ *
  * @option String cssHeader (optional) A string of the class name to be appended
  *         to sortable tr elements in the thead of the table. Default value:
  *         "header"
- * 
+ *
  * @option String cssAsc (optional) A string of the class name to be appended to
  *         sortable tr elements in the thead on a ascending sort. Default value:
  *         "headerSortUp"
- * 
+ *
  * @option String cssDesc (optional) A string of the class name to be appended
  *         to sortable tr elements in the thead on a descending sort. Default
  *         value: "headerSortDown"
- * 
+ *
  * @option String sortInitialOrder (optional) A string of the inital sorting
  *         order can be asc or desc. Default value: "asc"
- * 
+ *
  * @option String sortMultisortKey (optional) A string of the multi-column sort
  *         key. Default value: "shiftKey"
- * 
+ *
  * @option String textExtraction (optional) A string of the text-extraction
  *         method to use. For complex html structures inside td cell set this
  *         option to "complex", on large tables the complex option can be slow.
  *         Default value: "simple"
- * 
+ *
  * @option Object headers (optional) An array containing the forces sorting
  *         rules. This option let's you specify a default sorting rule. Default
  *         value: null
- * 
+ *
  * @option Array sortList (optional) An array containing the forces sorting
  *         rules. This option let's you specify a default sorting rule. Default
  *         value: null
- * 
+ *
  * @option Array sortForce (optional) An array containing forced sorting rules.
  *         This option let's you specify a default sorting rule, which is
  *         prepended to user-selected rules. Default value: null
- * 
+ *
  * @option Boolean sortLocaleCompare (optional) Boolean flag indicating whatever
  *         to use String.localeCampare method or not. Default set to true.
- * 
- * 
+ *
+ *
  * @option Array sortAppend (optional) An array containing forced sorting rules.
  *         This option let's you specify a default sorting rule, which is
  *         appended to user-selected rules. Default value: null
- * 
+ *
  * @option Boolean widthFixed (optional) Boolean flag indicating if tablesorter
  *         should apply fixed widths to the table columns. This is usefull when
  *         using the pager companion plugin. This options requires the dimension
  *         jquery plugin. Default value: false
- * 
+ *
  * @option Boolean cancelSelection (optional) Boolean flag indicating if
  *         tablesorter should cancel selection of the table headers text.
  *         Default value: true
- * 
+ *
  * @option Boolean debug (optional) Boolean flag indicating if tablesorter
  *         should display debuging information usefull for development.
- * 
+ *
  * @type jQuery
- * 
+ *
  * @name tablesorter
- * 
+ *
  * @cat Plugins/Tablesorter
- * 
+ *
  * @author Christian Bach/christian.bach@polyester.se
  */
 
@@ -347,7 +347,7 @@
                             tableBody[0].appendChild(r[pos][j]);
                         }
 
-                        // 
+                        //
                     }
                 }
 
@@ -381,7 +381,7 @@
                 }
 
                 var meta = ($.metadata) ? true : false;
-                
+
                 var header_index = computeTableHeaderCellIndexes(table);
 
                 $tableHeaders = $(table.config.selectorHeaders, table).each(function (index) {
@@ -389,8 +389,8 @@
                     this.column = header_index[this.parentNode.rowIndex + "-" + this.cellIndex];
                     // this.column = index;
                     this.order = formatSortingOrder(table.config.sortInitialOrder);
-                    
-					
+
+
 					this.count = this.order;
 
                     if (checkHeaderMetadata(this) || checkHeaderOptions(table, index)) this.sortDisabled = true;
@@ -493,12 +493,12 @@
                 };
                 return false;
             }
-			
+
 			 function checkHeaderOptionsSortingLocked(table, i) {
                 if ((table.config.headers[i]) && (table.config.headers[i].lockedOrder)) return table.config.headers[i].lockedOrder;
                 return false;
             }
-			
+
             function applyWidget(table) {
                 var c = table.config.widgets;
                 var l = c.length;
@@ -727,7 +727,7 @@
                             this.order = this.count++ % 2;
 							// always sort on the locked order.
 							if(this.lockedOrder) this.order = this.lockedOrder;
-							
+
 							// user only whants to sort on one
                             // column
                             if (!e[config.sortMultiSortKey]) {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1196,7 +1196,7 @@ table.tablesorter thead tr th, table.tablesorter tfoot tr th {
 	padding: 4px;
 }
 table.tablesorter thead tr .header {
-	background-image: url(bg.gif);
+	/*background-image: url(bg.gif);*/
 	background-repeat: no-repeat;
 	background-position: center right;
 	cursor: pointer;
@@ -1211,13 +1211,13 @@ table.tablesorter tbody tr.odd td {
     background-color:{{color.knowl_background}};
 }
 table.tablesorter thead tr .headerSortUp {
-	background-image: url(asc.gif);
+	/*background: url('static/images/asc.gif');*/
 }
 table.tablesorter thead tr .headerSortDown {
-	background-image: url(desc.gif);
+	/*background-image: url(desc.gif);*/
 }
 table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSortUp {
-    background-color: {{color.steel_blue}};
+    background-color: {{color.light_grey_2}};
 }
 
 .dataTables_wrapper {


### PR DESCRIPTION
Right now, on the inventory record pages, like

    http://www.lmfdb.org/inventory/numberfields/fields/records/

the records are sorted lexicographically by record number, so that 100 and 101 come before 10 or 1. While it may be desirable to sort this data (perhaps it would be useful to be able to sort by count, for instance), it is certainly not desirable to sort by record number in dictionary order.

This small pull request undoes the lexicographical ordering. I note that by removing the sort function, I am implicitly using that the database returns the information by record number.
