### PR TITLE
Edited documentation to describe new keys

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -118,7 +118,7 @@ Running
   `sage -python -s start-lmfdb.py`
 
 * If you use a local MongoDB instance, specify its port:
-  `sage  -python start-lmfdb.py --debug --dbport 40000`
+  `sage  -python start-lmfdb.py --debug --mongo-port 40000 --mongo-host localhost`
 
 * If several people are running their own version of the webserver on
     the same machine, they cannot all use port 37777 -- if they try,

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -207,7 +207,8 @@ Usage: %s [OPTION]...
   -m, --mongo-client=FILE   config file for connecting to MongoDB (default is "mongoclient.config")
       --logfocus=NAME       name of a logger to focus on
       --debug               enable debug mode
-      --dbport=NUM          bind the MongoDB to the given port (default %d)
+      --mongo-port=NUM      bind the MongoDB to the given port (default %d)
+      --mongo-host=hostname bind the MongoDB to a given hostname
       --dbmon=NAME          monitor MongoDB commands to the specified database (use NAME=* to monitor everything, NAME=~DB to monitor all but DB)
       --help                show this help
 """ % (sys.argv[0], DEFAULT_DB_PORT)
@@ -235,7 +236,6 @@ def get_configuration():
                                        [
                                            "port=",
                                            "host=", 
-                                           "dbport=", 
                                            "log=", 
                                            "logfocus=", 
                                            "dbmon=",
@@ -268,8 +268,6 @@ def get_configuration():
             #FIXME logfile isn't used
             elif opt in ("-l", "--log"):
                 logging_options["logfile"] = arg
-            elif opt in ("--dbport"):
-                mongo_client_options["port"] = int(arg)
             elif opt in ("--dbmon"):
                 mongo_client_options["dbmon"] = arg
             elif opt == "--debug":


### PR DESCRIPTION
Edited gettingstarted.md to refer to new keys in section on running a local copy of the database (previous instructions would not have worked) 

There was a previous 'dbport' parameter to set the database port, but without the ability to specify the hostname as well, this would not work since the change to using the cloud database. Parameter has been removed in favour of new ones.