### PR TITLE
Change table width CSS in inventory

### DIFF
--- a/lmfdb/inventory_app/templates/inv_style.css
+++ b/lmfdb/inventory_app/templates/inv_style.css
@@ -131,17 +131,18 @@ div.hide, span.hide{
     width: 0px; /* unsets global CSS  width */
 }
 .viewerTableHeaders, .viewerTableEls{
-  border: 1px solid black;
+    border: 1px solid black;
+    padding-left: 4px;
 }
 .viewerTableHeaders td, .viewerTableEls td{
-  padding : 5px;
+    padding : 5px;
 }
 .tablesorter .viewerTableHeaders {
-  font-weight: bold;
-  font-size: 110%;
+    font-weight: bold;
+    font-size: 110%;
 }
 table.tablesorter tbody td{
-  background-color: unset;
+    background-color: unset;
 }
 table.tablesorter tr:nth-child(2n+2){
     background-color : #e8e8e8;

--- a/lmfdb/inventory_app/templates/inv_style.css
+++ b/lmfdb/inventory_app/templates/inv_style.css
@@ -128,6 +128,7 @@ div.hide, span.hide{
     border: 1px solid black;
     table-layout: auto;
     font-size: 110%;
+    width: 0px; /* unsets global CSS  width */
 }
 .viewerTableHeaders, .viewerTableEls{
   border: 1px solid black;


### PR DESCRIPTION
When I made the inventory records sortable, I used class for which the LMFDB has some CSS. This is a minor tweak to make the width *not* take the whole screen, resolving something John pointed out to me.