### PR TITLE
added code download for ecnf

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -574,6 +574,14 @@ class ECNF(object):
 
         self._code = None # will be set if needed by get_code()
 
+        self.downloads = [('Download all stored data', url_for(".download_ECNF_all", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number))]
+        for lang in [["Magma","magma"], ["SageMath","sage"], ["GP", "gp"]]:
+            self.downloads.append(('Download {} code'.format(lang[0]),
+                                   url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
+                                           class_label=self.iso_label, number=self.number, download_type=lang[1])))
+
+
+
     def code(self):
         if self._code == None:
             self.make_code_snippets()

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -93,4 +93,4 @@ localdata:
   sage:
     E.local_data()
   magma:
-    LocalInformation(E)
+    LocalInformation(E);

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.base import LmfdbTest
 
 class EllCurveTest(LmfdbTest):
@@ -61,6 +61,21 @@ class EllCurveTest(LmfdbTest):
         assert '1490902050625' in L.data
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1') # Test factorisation
         assert '8798344145175011328000' in L.data
+
+    def test_download(self):
+        r"""
+        Check that the code download links work
+        """
+        L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
+        assert 'Download Magma code' in L.data
+        assert 'Download SageMath code' in L.data
+        assert 'Download GP code' in L.data
+        L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/magma')
+        assert 'Magma code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
+        L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/sage')
+        assert 'SageMath code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
+        L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/gp')
+        assert 'Pari/GP code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
 
     def test_search(self):
         r"""

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -319,7 +319,7 @@ class WebEC(object):
         self.downloads = [('Download coefficients of q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=1000)),
                           ('Download all stored data', url_for(".download_EC_all", label=self.lmfdb_label)),
                           ('Download Magma code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
-                          ('Download Sage code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
+                          ('Download SageMath code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
                           ('Download GP code', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp'))
         ]
 


### PR DESCRIPTION
Home pages of elliptic curves over Q have download buttons (on the right-hand side) for downloading all data and also for downloading all the code snippets.  This PR adds the same for elliptic curves over number fields.
To test, go to a random elliptic curve page and then click on each of the 4 Download links.  Even better, run Magma/Sage/GP on the files thus obtained.  I did this for a few random curves and perhaps I was lucky since there must be many curves here for which Sage or Magma will have difficulty computing the rank (for example); but that is no reason not to have this.  There are far fewer code snippets for GP (and perhaps new versions can do more).
I added a new test function too.