### PR TITLE
Prevent user login if database cannot be written to

### DIFF
--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -7,7 +7,8 @@ import pymongo
 ASC = pymongo.ASCENDING
 import flask
 from functools import wraps
-from lmfdb.base import app, getDBConnection, _mongo_user
+from lmfdb.base import app, getDBConnection
+from bson.son import SON
 from flask import render_template, request, Blueprint, url_for, make_response
 from flask.ext.login import login_required, login_user, current_user, logout_user
 
@@ -50,7 +51,11 @@ def ctx_proc_userdata():
     userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
     userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
     userdata['user_is_authenticated'] = current_user.is_authenticated()
-    userdata['user_can_write'] = lmfdb.base._mongo_user != 'lmfdb'
+    try:
+        roles = getDBConnection()['admin'].command(SON({"connectionStatus":int(1)}))
+        userdata['user_can_write'] = 'readWrite' in [el['role'] for el in roles['authInfo']['authenticatedUserRoles'] if el['db']=='inventory']
+    except:
+        userdata['user_can_write'] = False
     userdata['user_is_admin'] = current_user.is_admin()
     userdata['get_username'] = get_username # this is a function
     return userdata

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -7,7 +7,7 @@ import pymongo
 ASC = pymongo.ASCENDING
 import flask
 from functools import wraps
-from lmfdb.base import app, getDBConnection
+from lmfdb.base import app, getDBConnection, _mongo_user
 from flask import render_template, request, Blueprint, url_for, make_response
 from flask.ext.login import login_required, login_user, current_user, logout_user
 
@@ -50,6 +50,7 @@ def ctx_proc_userdata():
     userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
     userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
     userdata['user_is_authenticated'] = current_user.is_authenticated()
+    userdata['user_can_write'] = lmfdb.base._mongo_user != 'lmfdb'
     userdata['user_is_admin'] = current_user.is_admin()
     userdata['get_username'] = get_username # this is a function
     return userdata

--- a/lmfdb/users/templates/user-info.html
+++ b/lmfdb/users/templates/user-info.html
@@ -29,7 +29,7 @@
     </table>
   </form>
   {% else %}
-    This server is running with an unprivileged connection. You cannot log in since write access to the database is require for features behind the log in system
+    This server is running with an unprivileged connection. You cannot log in since write access to the database is required for features behind the log in system
   {% endif %}
 {% endif %}
 

--- a/lmfdb/users/templates/user-info.html
+++ b/lmfdb/users/templates/user-info.html
@@ -9,6 +9,8 @@
 
 {% else %}
   <h1>You are not logged in</h1>
+  {% if user_can_write %}
+ 
 {#  <div style="margin-bottom: 20px">New user? 
      <a href="{{ url_for('.register_new') }}">Register here</a>
   </div>
@@ -26,6 +28,9 @@
       <tr><td /><td><button name="submit" type="submit">Login</button></td></tr>
     </table>
   </form>
+  {% else %}
+    This server is running with an unprivileged connection. You cannot log in since write access to the database is require for features behind the log in system
+  {% endif %}
 {% endif %}
 
 {% if user_is_authenticated %}


### PR DESCRIPTION
Fix as suggested in #2407. Prevent user from logging in at all if database cannot be written to. Since almost all features behind the login system are useless without write access to the database and there are oddities with the user information change, the knowl editing and a few bits of the inventory system this fixes several problems.