### PR TITLE
Reenable tests

### DIFF
--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -15,7 +15,7 @@ class ArtinRepTest(LmfdbTest):
         assert '2898947' in L.data # prime divisor of one of the conductors in the result
 
     def test_display_page(self):
-        #L = self.tc.get('/ArtinRepresentation/4/3655/1/')
+        L = self.tc.get('/ArtinRepresentation/4/3655/1/')
         L = self.tc.get('/ArtinRepresentation/4.5_17_43.8t44.1c1')
         assert ('Odd' in L.data)
 

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -20,7 +20,6 @@ class ArtinRepTest(LmfdbTest):
         assert ('Odd' in L.data)
 
     # big degree fields ok
-    @unittest2.skip("This Artin representation has gone missing")
     def test_big_degree(self):
         L = self.tc.get('/ArtinRepresentation/2.1951e2.120.1c1')
         assert '24T201' in L.data # Galois group

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -15,7 +15,7 @@ class ArtinRepTest(LmfdbTest):
         assert '2898947' in L.data # prime divisor of one of the conductors in the result
 
     def test_display_page(self):
-        L = self.tc.get('/ArtinRepresentation/4/3655/1/')
+        #L = self.tc.get('/ArtinRepresentation/4/3655/1/')
         L = self.tc.get('/ArtinRepresentation/4.5_17_43.8t44.1c1')
         assert ('Odd' in L.data)
 

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -12,8 +12,8 @@ class NumberFieldTest(LmfdbTest):
         assert '\chi_{1}' in L.data
 
     def test_hard_degree10(self):
-        #L = self.tc.get('/NumberField/10.10.1107649855354064.1')
-        #assert '10T36' in L.data
+        L = self.tc.get('/NumberField/10.10.1107649855354064.1')
+        assert '10T36' in L.data
         L = self.tc.get('/NumberField/10.10.138420300533025695415730492558689.1')
         assert '10T38' in L.data
 


### PR DESCRIPTION
There were two tests which were disabled because of problems in the Artin representation data.  They should now both be fixed.