### PR TITLE
Fix for #1572 (again)

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -459,6 +459,7 @@ def download_search(info):
     lang = info.get('download','text').strip()
     filename = 'genus2_curves' + download_file_suffix[lang]
     mydate = time.strftime("%d %B %Y")
+    print info
     # reissue query here
     try:
         res = g2c_db_curves().find(literal_eval(info.get('query','{}')),{'_id':False,'eqn':True})

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -460,7 +460,6 @@ def download_search(info):
     lang = info.get('download','text').strip()
     filename = 'genus2_curves' + download_file_suffix[lang]
     mydate = time.strftime("%d %B %Y")
-    return literal_eval(info.get('query'))
     # reissue query here
     try:
         res = g2c_db_curves().find(literal_eval(info.get('query','{}')),{'_id':False,'eqn':True})
@@ -468,6 +467,7 @@ def download_search(info):
         return "Unable to parse query: %s"%err
     c = download_comment_prefix[lang]
     s =  '\n'
+    s += c + literal_eval(info.get('query'))
     s += c + ' Genus 2 curves downloaded from the LMFDB downloaded on %s.\n'% mydate
     s += c + ' Query "%s" returned %d curves.\n\n' %(str(info.get('query')), res.count())
     s += c + ' Below is a list called data. Each entry has the form:\n'

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -467,7 +467,7 @@ def download_search(info):
         return "Unable to parse query: %s"%err
     c = download_comment_prefix[lang]
     s =  '\n'
-    s += c + literal_eval(info.get('query'))
+    s += c + info.get('query')
     s += c + ' Genus 2 curves downloaded from the LMFDB downloaded on %s.\n'% mydate
     s += c + ' Query "%s" returned %d curves.\n\n' %(str(info.get('query')), res.count())
     s += c + ' Below is a list called data. Each entry has the form:\n'

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+# -*- coding: utf8 -*-
 
 import StringIO
 from ast import literal_eval
@@ -459,7 +460,7 @@ def download_search(info):
     lang = info.get('download','text').strip()
     filename = 'genus2_curves' + download_file_suffix[lang]
     mydate = time.strftime("%d %B %Y")
-    print info
+    return literal_eval(info.get('query'))
     # reissue query here
     try:
         res = g2c_db_curves().find(literal_eval(info.get('query','{}')),{'_id':False,'eqn':True})

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -467,7 +467,6 @@ def download_search(info):
         return "Unable to parse query: %s"%err
     c = download_comment_prefix[lang]
     s =  '\n'
-    s += c + info.get('query')
     s += c + ' Genus 2 curves downloaded from the LMFDB downloaded on %s.\n'% mydate
     s += c + ' Query "%s" returned %d curves.\n\n' %(str(info.get('query')), res.count())
     s += c + ' Below is a list called data. Each entry has the form:\n'

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -199,6 +199,7 @@ Download all search results for&nbsp;
 {% endif %}
 
 <form>
+<input type="hidden" name="query" value="{{info.query}}"/>
 Download all search results for&nbsp;
 <button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
 <button type="submit" name="download" value="sage">SageMath</button>&nbsp;

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -146,11 +146,11 @@
 <tr style="height:50px">
 <td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td>
 <td align=left colspan="7">
+<input type="hidden" name="query" value="{{info.query}}"/>
 Download all search results for&nbsp;
 <button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
 <button type="submit" name="download" value="sage">SageMath</button>&nbsp;
 <button type="submit" name="download" value="magma">Magma</button>&nbsp;
-<input type="hidden" name="query" value="{{info.query}}"/>
 </td>
 </tr>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -150,6 +150,7 @@ Download all search results for&nbsp;
 <button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
 <button type="submit" name="download" value="sage">SageMath</button>&nbsp;
 <button type="submit" name="download" value="magma">Magma</button>&nbsp;
+<input type="hidden" name="query" value="{{info.query}}"/>
 </td>
 </tr>
 
@@ -202,9 +203,8 @@ Download all search results for&nbsp;
 <button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
 <button type="submit" name="download" value="sage">SageMath</button>&nbsp;
 <button type="submit" name="download" value="magma">Magma</button>&nbsp;
-</form>
-
 <input type="hidden" name="query" value="{{info.query}}"/>
+</form>
 
 {% endif %}
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -203,7 +203,6 @@ Download all search results for&nbsp;
 <button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
 <button type="submit" name="download" value="sage">SageMath</button>&nbsp;
 <button type="submit" name="download" value="magma">Magma</button>&nbsp;
-<input type="hidden" name="query" value="{{info.query}}"/>
 </form>
 
 {% endif %}


### PR DESCRIPTION
Fixes issue with download on genus 2 search results page.  To test do a query to select a subset of genus 2 curves (e.g. http://127.0.0.1:37777/Genus2Curve/Q/?analytic_rank=4&count=50) then download the results by clicking on any of the sage/pari/magma buttons at either the top or bottom of the list.  Then check that the download file contains only the curves that it should (e.g. just 10 curves for the query above), not all the curves in the database.