### PR TITLE
Better handling when user inputs a polynomial when searching for a number field

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -615,7 +615,7 @@ def number_field_search(info):
         query = {'label_orig': info['natural']}
         try:
             parse_nf_string(info,query,'natural',name="Label",qfield='label')
-            return redirect(url_for(".by_label", label= clean_input(query['label_orig'])))
+            return redirect(url_for(".by_label", label=query['label']))
         except ValueError:
             query['err'] = info['err']
             return search_input_error(query, bread)


### PR DESCRIPTION
This fixes issue #2420 .  The program was putting the polynomial in the url, which caused a problem because the polynomial contained a slash.

If a user inputs a polynomial in Z[x] which is in the database, the url is converted to the label anyway.  So, if the polynomial is in the database (after polredabs), we switch to the label right away.  This change also makes the process a little more efficient.  Before, the polynomial would go through polredabs several times.  Now it only happens once.

To test, enter a polynomial such as x^3-1/3 (or the one from the issue) in the number field search page.