### PR TITLE
Timeout Decorator for search queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
     # run nosetests in parallel with the aid of parallel
     # we cannot use the option --processes in nosetests, as MongoDB doesn't support forking
     # usually we have at most 4gb of RAM per test, we should avoid running many jobs at once
-    - ${SAGE} -sh -c 'parallel --joblog joblog --jobs 4 --results nosetests  --progress --verbose -a list ${SAGE_DIR}/local/bin/nosetests -v -s --testmatch=${TESTMATCH} ${COVERAGE}'
+    - ${SAGE} -sh -c 'parallel --joblog joblog --jobs 3 --results nosetests  --progress --verbose -a list ${SAGE_DIR}/local/bin/nosetests -v -s --testmatch=${TESTMATCH} ${COVERAGE}'
 
 after_failure:
     # if some process failed, it will be clear in joblog which one failed

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -11,6 +11,7 @@ from lmfdb.number_fields import nf_page, nf_logger
 from lmfdb.WebNumberField import field_pretty, WebNumberField, nf_knowl_guts, decodedisc, factor_base_factor, factor_base_factorization_latex
 from lmfdb.local_fields.main import show_slope_content
 
+
 from markupsafe import Markup
 
 import re
@@ -21,7 +22,7 @@ from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, primes, pari
 
 from lmfdb.transitive_group import group_display_knowl, cclasses_display_knowl,character_table_display_knowl, group_phrase, group_display_short, group_knowl_guts, group_cclasses_knowl_guts, group_character_table_knowl_guts, aliastable
 
-from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, comma, format_percentage, random_object_from_collection, web_latex_split_on_pm
+from lmfdb.utils import web_latex, to_dict, coeff_to_poly, pol_to_html, comma, format_percentage, random_object_from_collection, web_latex_split_on_pm, search_cursor_timeout_decorator
 from lmfdb.search_parsing import clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_signed_ints, parse_primes, parse_bracketed_posints, parse_count, parse_start, parse_nf_string
 
 NF_credit = 'the PARI group, J. Voight, J. Jones, D. Roberts, J. Kl&uuml;ners, G. Malle'
@@ -673,8 +674,16 @@ def number_field_search(info):
     if 'download' in info and info['download'] != '0':
         return download_search(info, res)
 
-    nres = res.count()
-    res = res.skip(start).limit(count)
+    try:
+        # equivalent to
+        # nres = res.count()
+        # res = res.skip(start).limit(count)
+        nres, res = search_cursor_timeout_decorator(res, start, count);
+    except ValueError:
+        info['err'] = ''
+        return search_input_error(info, bread);
+
+
 
     if(start >= nres):
         start -= (1 + (start - nres) / count) * count

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -674,21 +674,19 @@ def number_field_search(info):
     if 'download' in info and info['download'] != '0':
         return download_search(info, res)
 
+    # equivalent to
+    # nres = res.count()
+    #if(start >= nres):
+    #    start -= (1 + (start - nres) / count) * count
+    #if(start < 0):
+    #    start = 0
+    # res = res.skip(start).limit(count)
     try:
-        # equivalent to
-        # nres = res.count()
-        # res = res.skip(start).limit(count)
-        nres, res = search_cursor_timeout_decorator(res, start, count);
-    except ValueError:
-        info['err'] = ''
-        return search_input_error(info, bread);
+        start, nres, res = search_cursor_timeout_decorator(res, start, count);
+    except ValueError as err:
+        info['err'] = err;
+        return search_input_error(info, bread)
 
-
-
-    if(start >= nres):
-        start -= (1 + (start - nres) / count) * count
-    if(start < 0):
-        start = 0
 
     info['fields'] = res
     info['number'] = nres

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -517,17 +517,8 @@ def search_cursor_timeout_decorator(cursor, skip, limit):
             If the query times out, it raises a ValueError
     """
 
-
-    ctx = ctx_proc_userdata()
-
-    if ctx['BETA']:
-        # 60 seconds should be plenty for beta and development
-        timeout = 60000;
-    else:
-        # 27 seconds timeout, hopefully enough to avoid google's timeout of 30s
-        timeout = 27000;
-
-    cursor = cursor.max_time_ms(timeout)
+    # 25 seconds, timeout, hopefully enough to avoid google's and gunicorn's timeout of 30s
+    cursor = cursor.max_time_ms(25000)
     try:
         ncursor = cursor.count()
 
@@ -539,6 +530,7 @@ def search_cursor_timeout_decorator(cursor, skip, limit):
 
         cursor = cursor.skip(skip).limit(limit)
     except ExecutionTimeout as err:
+        ctx = ctx_proc_userdata()
         flash_error('The search query took longer than expected! Please help us improve by reporting this error  <a href="%s" target=_blank>here</a>.' % ctx['feedbackpage']);
         raise ValueError(err)
 

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -512,7 +512,7 @@ def search_cursor_timeout_decorator(cursor, skip, limit):
             - skip value to pass to cursor (after cursor.count())
             - limit value to pass to cursor (after cursor.count())
     OUTPUT:
-            If the query doesn't time out returns the number of results + the cursor
+            If the query doesn't time out returns the tuple (cursor.count(), cursor.skip(skip).limit(limit))
             If the query times out, raises a ValueError
     """
 

--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -509,10 +509,8 @@ def search_cursor_timeout_decorator(cursor, skip, limit):
     r"""
     INPUT:
             - pymongo cursor
-            - skip value to pass to cursor (after counting)
-            - limit value to pass to cursor (after counting)
-            - endpoint argument for url_for to raise an error
-            - extra values for url_for
+            - skip value to pass to cursor (after cursor.count())
+            - limit value to pass to cursor (after cursor.count())
     OUTPUT:
             If the query doesn't time out returns the number of results + the cursor
             If the query times out, raises a ValueError


### PR DESCRIPTION
Hi,

This is related to #2422.

With the goal of being able to test if searches are performed in a reasonable amount of time and give a better feedback to the user whenever the query takes too long, I wrote a small script that decorates our db queries with `.max_time_ms(timeout)` and should replace the following two lines
```
nres = res.count()
res = res.skip(start).limit(count)
```
present in almost every search handling code.
I have only replaced these two lines for numberfieds, but should be easy to do the same for rest of the search fields.

try it out with: 
http://localhost:37777/NumberField/?start=0&ur_primes=2%2C3%2C5%2C7&ram_quantifier=contained&count=20

In this case, the query times out while trying to do the count:
```
2018-04-22T17:27:03.625+0000 I COMMAND  [conn4343] command numberfields.fields command: count { count: "fields", query: { ramps: { $nin: [ "2", "3", "5", "7" ] } }, maxTimeMS: 60000 } planSummary: IXSCAN { ramps: 1, degree: 1 } keyUpdates:0 writeConflicts:0 exception: operation exceeded time limit code:50 numYields:2373 reslen:89 locks:{ Global: { acquireCount: { r: 4748 } }, Database: { acquireCount: { r: 2374 } }, Collection: { acquireCount: { r: 2374 } } } protocol:op_query 60662ms
```




This isn't perfect.  But I think it is much more helpful to see:
```
Error: The search query took longer than expected! Please help us improve by reporting this error here.
```
than Google's `Error: Server Error`.
Also, if the server is overloaded, the timeout will not help us, as it only limits the CPU cumulative time.

Let me know what you think.