### PR TITLE
Update base.py to acknowledge Simons Foundation

### DIFF
--- a/lmfdb/base.py
+++ b/lmfdb/base.py
@@ -229,7 +229,7 @@ def ctx_proc_userdata():
 
     # meta_description appears in the meta tag "description"
     vars['meta_description'] = r'Welcome to the LMFDB, the database of L-functions, modular forms, and related objects. These pages are intended to be a modern handbook including tables, formulas, links, and references for L-functions and their underlying objects.'
-    vars['shortthanks'] = r'This project is supported by <a href="%s">grants</a> from the US National Science Foundation and the UK Engineering and Physical Sciences Research Council.' % (url_for('acknowledgment') + "#sponsors")
+    vars['shortthanks'] = r'This project is supported by <a href="%s">grants</a> from the US National Science Foundation, the UK Engineering and Physical Sciences Research Council, and the Simons Foundation.' % (url_for('acknowledgment') + "#sponsors")
 #    vars['feedbackpage'] = url_for('contact')
     vars['feedbackpage'] = r"https://docs.google.com/spreadsheet/viewform?formkey=dDJXYXBleU1BMTFERFFIdjVXVmJqdlE6MQ"
     vars['LINK_EXT'] = lambda a, b: '<a href="%s" target="_blank">%s</a>' % (b, a)


### PR DESCRIPTION
The footer on the main page currently states: "This project is supported by grants from the US National Science Foundation and the UK Engineering and Physical Sciences Research Council." In light of the size of the Simons Collaboration grant, this edit adds the Simons Foundation to this list.