### PR TITLE
Hilbert modular eigenvalue spacing

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -18,7 +18,6 @@ from markupsafe import Markup
 from lmfdb.utils import to_dict, random_value_from_collection, web_latex_split_on_pm
 from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, parse_count, parse_start
 
-from . import hmf_logger
 
 def db_forms():
     hmfs = getDBConnection().hmfs
@@ -94,7 +93,6 @@ def add_space_if_positive(texified_pol):
     >>> add_space_if_positive('-1')
     '-1'
     """
-    hmf_logger.info("texified_pol is {}.".format(texified_pol))
     if texified_pol[0] == '-':
         return texified_pol
     return "\phantom{-}" + texified_pol
@@ -416,7 +414,6 @@ def render_hmf_webpage(**args):
     info['eigs'] = [{'eigenvalue': add_space_if_positive(teXify_pol(eigs[i])),
                      'prime_ideal': teXify_pol(primes[i]),
                      'prime_norm': primes[i][1:primes[i].index(',')]} for i in range(n)]
-    hmf_logger.info("\n".join(k['eigenvalue'] for k in info['eigs'][:10]))
 
     try:
         display_eigs = request.args['display_eigs']

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -18,6 +18,8 @@ from markupsafe import Markup
 from lmfdb.utils import to_dict, random_value_from_collection, web_latex_split_on_pm
 from lmfdb.search_parsing import parse_nf_string, parse_ints, parse_hmf_weight, parse_count, parse_start
 
+from . import hmf_logger
+
 def db_forms():
     hmfs = getDBConnection().hmfs
     return hmfs.forms
@@ -81,6 +83,21 @@ def teXify_pol(pol_str):  # TeXify a polynomial (or other string containing poly
 
     return o_str
 
+def add_space_if_positive(texified_pol):
+    """
+    Add a space if texified_pol is positive to match alignment of positive and
+    negative coefficients.
+
+    Examples:
+    >>> add_space_if_positive('1')
+    '\phantom{-}1'
+    >>> add_space_if_positive('-1')
+    '-1'
+    """
+    hmf_logger.info("texified_pol is {}.".format(texified_pol))
+    if texified_pol[0] == '-':
+        return texified_pol
+    return "\phantom{-}" + texified_pol
 
 @hmf_page.route("/")
 def hilbert_modular_form_render_webpage():
@@ -145,19 +162,19 @@ def hilbert_modular_form_search(**args):
         parse_hmf_weight(info,query,'weight',qfield=('parallel_weight','weight'))
     except ValueError:
         return search_input_error()
-        
+
     if 'cm' in info:
         if info['cm'] == 'exclude':
             query['is_CM'] = 'no'
         elif info['cm'] == 'only':
             query['is_CM'] = 'yes'
-                
+
     if 'bc' in info:
         if info['bc'] == 'exclude':
             query['is_base_change'] = 'no'
         elif info['bc'] == 'only':
             query['is_base_change'] = 'yes'
-                     
+
     count = parse_count(info,100)
     start = parse_start(info)
 
@@ -396,9 +413,10 @@ def render_hmf_webpage(**args):
 
     primes = hmf_field['primes']
     n = min(len(eigs), len(primes))
-    info['eigs'] = [{'eigenvalue': teXify_pol(eigs[i]),
+    info['eigs'] = [{'eigenvalue': add_space_if_positive(teXify_pol(eigs[i])),
                      'prime_ideal': teXify_pol(primes[i]),
                      'prime_norm': primes[i][1:primes[i].index(',')]} for i in range(n)]
+    hmf_logger.info("\n".join(k['eigenvalue'] for k in info['eigs'][:10]))
 
     try:
         display_eigs = request.args['display_eigs']


### PR DESCRIPTION
On lines for eigenvalues that are positive, insert the space for a minus sign to make the column line up nicely. For comparison, look at the eigenvalues on a page like

http://beta.lmfdb.org/ModularForm/GL2/TotallyReal/6.6.1229312.1/holomorphic/6.6.1229312.1-169.1-b

before and after this change.

This resolves #2444 