### PR TITLE
Allow up-to-date version of flask-login

### DIFF
--- a/lmfdb/inventory_app/templates/control_panel.html
+++ b/lmfdb/inventory_app/templates/control_panel.html
@@ -17,7 +17,7 @@ Inventory Control Panel
   <div id='dialog'></div>
   <div class='listing'>
   <div class='unbreaking'>
-      {% if current_user.is_authenticated() %}
+      {% if user_is_authenticated %}
       <h2>General Inventory Control</h2>
         <input type='button' id = 'markgone' title = 'Check which collections are gone and mark' value ='Mark Collections Gone' onclick='sendControlRequest("mark_gone")'>
         </p>

--- a/lmfdb/inventory_app/templates/edit_show_list.html
+++ b/lmfdb/inventory_app/templates/edit_show_list.html
@@ -88,7 +88,7 @@ function updateStatus(newStatus, info){
     {% if db_name is none %}
       <h2 class='link'><a href = {{url_for('inventory_app.show_edit_child', id=item[0])}}>{{item[0]}} </a>-- <span id='{{item[0]}}'>{{item[1]}}</span></h2>
       Contains {{item[2]}} collections</br>
-      {% if current_user.is_authenticated() and not lockout %}
+      {% if user_is_authenticated and not lockout %}
         <input type='button' id = '{{item[1]}}' value ='Edit Nice Name' onclick='promptNiceName(this, "{{item[0]}}", {db:"{{item[0]}}"})'>
       {% else %}
         <input type='button' value ='Edit Nice Name' title ='Please login to edit' disabled class=disabledbutton>
@@ -98,7 +98,7 @@ function updateStatus(newStatus, info){
       <h2 class='link'><a href = {{url_for('inventory_app.show_inventory', id=db_name, id2=item[0])}}>{{item[0]}} </a>-- <span id='{{item[0]}}'>{{item[1]}}</span>
          <span class='status'>{{item[3]}}</span></h2>
       Contains {{item[2][0]}} records of {{item[2][1]}} types </br>
-      {% if current_user.is_authenticated() and not lockout and not item[4] %}
+      {% if user_is_authenticated and not lockout and not item[4] %}
         <input type='button' id = '{{item[1]}}' value ='Edit Nice Name' onclick='promptNiceName(this, "{{item[0]}}", {collection:"{{item[0]}}"})'>
         <input type='button' id = '{{item[1]}}' value ='Edit Status' onclick='promptStatus(this, "{{item[0]}}", {collection:"{{item[0]}}"})'>
         <a href = {{url_for('inventory_app.show_edit_inventory', id=db_name, id2=item[0])}} id=invbutton>Edit Inventory</a>
@@ -106,7 +106,7 @@ function updateStatus(newStatus, info){
         <a href = {{url_for('inventory_app.show_records', id=db_name, id2=item[0])}} id=invbutton>View Records</a>
         <a href = {{url_for('inventory_app.show_edit_records', id=db_name, id2=item[0])}} id=invbutton>Edit Records</a>
         <a href = {{url_for('inventory_app.show_indices', id=db_name, id2=item[0])}} id=invbutton>View Indices</a>
-      {% elif current_user.is_authenticated() and not lockout %}
+      {% elif user_is_authenticated and not lockout %}
           <input type='button' value ='Edit Nice Name' title ='Scraping in progress, please wait' disabled class=disabledbutton>
           <input type='button' value ='Edit Status' title ='Scraping in progress, please wait' disabled class=disabledbutton>
           <input type='button' value ='Edit Inventory' title ='Scraping in progress, please wait' disabled class=disabledbutton>

--- a/lmfdb/inventory_app/templates/scrape_main.html
+++ b/lmfdb/inventory_app/templates/scrape_main.html
@@ -24,14 +24,14 @@
   {% for item in listing %}
   <div class = 'unbreaking'>
     <h2>{{item}}</h2>
-    {% if current_user.is_authenticated() %}
+    {% if user_is_authenticated %}
       <input type='button' id = '{{coll}}' class="scrape_button" value ='Rescan all collections' onclick='rescanAll("{{item}}")'>
     {% else %}
       <input type='button' value ='Rescan all collections' class="scrape_button" title ='Please login to scrape' disabled class=disabledbutton>
     {% endif %}
     <br></br>
     {% for coll in listing[item] %}
-      {% if current_user.is_authenticated() %}
+      {% if user_is_authenticated %}
         <input type='button' id = '{{coll}}' class="scrape_button" value ='Rescan {{coll}}' onclick='rescan("{{item}}", "{{coll}}")'>
       {% else %}
         <input type='button' value ='Rescan {{coll}}' class="scrape_button" title ='Please login to scrape' disabled class=disabledbutton>

--- a/lmfdb/users/__init__.py
+++ b/lmfdb/users/__init__.py
@@ -20,7 +20,6 @@ login_manager.init_app(app)
 app.register_blueprint(login_page, url_prefix="/users")
 
 users_logger = make_logger("users", hl=True)
-users_logger.info("Initializing Artin representations blueprint")
 
 if StrictVersion(FLASK_LOGIN_VERSION) < StrictVersion(FLASK_LOGIN_LIMIT):
     users_logger.warning("DEPRECATION-WARNING: flask-login is older than version {version}. "

--- a/lmfdb/users/__init__.py
+++ b/lmfdb/users/__init__.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from main import login_page, login_manager, admin_required, housekeeping
+from main import (login_page, login_manager, admin_required,
+                  housekeeping, FLASK_LOGIN_VERSION, FLASK_LOGIN_LIMIT)
 assert admin_required # silence pyflakes
 assert housekeeping # silence pyflakes
 
 from lmfdb.base import app
+
+from lmfdb.utils import make_logger
+from distutils.version import StrictVersion
+
 
 # secret key, necessary for sessions, and sessions are
 # in turn necessary for users to login
@@ -13,3 +18,12 @@ app.secret_key = '9af"]ßÄ!_°$2ha€42~µ…010'
 login_manager.init_app(app)
 
 app.register_blueprint(login_page, url_prefix="/users")
+
+users_logger = make_logger("users", hl=True)
+users_logger.info("Initializing Artin representations blueprint")
+
+if StrictVersion(FLASK_LOGIN_VERSION) < StrictVersion(FLASK_LOGIN_LIMIT):
+    users_logger.warning("DEPRECATION-WARNING: flask-login is older than version {version}. "
+          "Versions older than {version} have different functionality and may stop working in the future. "
+          "Consider updating, perhaps through `sage -pip install flask-login`."
+          .format(version=FLASK_LOGIN_LIMIT))

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -48,9 +48,9 @@ def get_username(uid):
 @app.context_processor
 def ctx_proc_userdata():
     userdata = {}
-    userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
-    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
-    userdata['user_is_authenticated'] = current_user.is_authenticated()
+    userdata['userid'] = 'anon' if current_user.is_anonymous else current_user._uid
+    userdata['username'] = 'Anonymous' if current_user.is_anonymous else current_user.name
+    userdata['user_is_authenticated'] = current_user.is_authenticated
     try:
         roles = getDBConnection()['admin'].command(SON({"connectionStatus":int(1)}))
         userdata['user_can_write'] = 'readWrite' in [el['role'] for el in roles['authInfo']['authenticatedUserRoles'] if el['db']=='inventory']

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -54,14 +54,14 @@ def get_username(uid):
 @app.context_processor
 def ctx_proc_userdata():
     userdata = {}
+    userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
+    userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
+
     if StrictVersion(FLASK_LOGIN_VERSION) > StrictVersion(FLASK_LOGIN_LIMIT):
-        userdata['userid'] = 'anon' if current_user.is_anonymous else current_user._uid
-        userdata['username'] = 'Anonymous' if current_user.is_anonymous else current_user.name
         userdata['user_is_authenticated'] = current_user.is_authenticated
     else:
-        userdata['userid'] = 'anon' if current_user.is_anonymous() else current_user._uid
-        userdata['username'] = 'Anonymous' if current_user.is_anonymous() else current_user.name
         userdata['user_is_authenticated'] = current_user.is_authenticated()
+
     try:
         roles = getDBConnection()['admin'].command(SON({"connectionStatus":int(1)}))
         userdata['user_can_write'] = 'readWrite' in [el['role'] for el in roles['authInfo']['authenticatedUserRoles'] if el['db']=='inventory']

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -17,6 +17,7 @@ from distutils.version import StrictVersion
 
 # Read about flask-login if you are unfamiliar with this UserMixin/Login
 from flask.ext.login import UserMixin
+from flask.ext.login import AnonymousUserMixin
 
 
 def get_users():
@@ -237,9 +238,6 @@ def get_user_list():
         ret.append((e['_id'], name))
     return ret
 
-from flask.ext.login import AnonymousUserMixin
-
-
 class LmfdbAnonymousUser(AnonymousUserMixin):
     """
     The sole purpose of this Anonymous User is the 'is_admin' method
@@ -250,6 +248,12 @@ class LmfdbAnonymousUser(AnonymousUserMixin):
 
     def name(self):
         return "Anonymous"
+
+    # For versions of flask_login earlier than 0.3.0,
+    # AnonymousUserMixin.is_anonymous() is callable. For later versions, it's a
+    # property. To match the behavior of LmfdbUser, we make it callable always.
+    def is_anonymous(self):
+        return True
 
 if __name__ == "__main__":
     print "Usage:"

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -12,7 +12,12 @@ __all__ = ['LmfdbUser', 'user_exists']
 fixed_salt = '=tU\xfcn|\xab\x0b!\x08\xe3\x1d\xd8\xe8d\xb9\xcc\xc3fM\xe9O\xfb\x02\x9e\x00\x05`\xbb\xb9\xa7\x98'
 
 from lmfdb import base
-from main import logger
+from main import logger, FLASK_LOGIN_VERSION, FLASK_LOGIN_LIMIT
+from distutils.version import StrictVersion
+
+# Read about flask-login if you are unfamiliar with this UserMixin/Login
+from flask.ext.login import UserMixin
+
 
 def get_users():
     return base.getDBConnection().userdb.users
@@ -61,10 +66,6 @@ def bchash(pwd, existing_hash = None):
     except:
         logger.warning("Failed to return bchash, perhaps bcrypt is not installed");
         return None
-
-# Read about flask-login if you are unfamiliar with this UserMixin/Login
-from flask.ext.login import UserMixin
-
 
 class LmfdbUser(UserMixin):
     """
@@ -137,7 +138,9 @@ class LmfdbUser(UserMixin):
 
     def is_anonymous(self):
         """required by flask-login user class"""
-        return not self.is_authenticated()
+        if StrictVersion(FLASK_LOGIN_VERSION) < StrictVersion(FLASK_LOGIN_LIMIT):
+            return not self.is_authenticated()
+        return not self.is_authenticated
 
     def is_admin(self):
         """true, iff has attribute admin set to True"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
 flask-cache
-flask-login==0.2.11
+flask-login
 flask-markdown
 pymongo
 pyyaml


### PR DESCRIPTION
When flask-login updated to version 0.3.0, they changed `current_user.is_authenticated()` (and similar) to `current_user.is_authenticated`, and one cannot use the `()` version anymore. As noted in #2173, we've used a fixed pre-0.3.0 version for the LMFDB for a long time.

In this pull request, I update the code to work with both pre 0.3.0 and post 0.3.0 versions of flask-login. If one runs the site or the tests with a version of flask-login that is pre 0.3.0, then a WARNING is logged suggesting that it may be a good idea to update flask-login.

This closes #2173