### PR TITLE
Get rid of oldporedabs for numberfields.  

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -204,10 +204,7 @@ class WebNumberField:
             chash = hashlib.md5(coeffs).hexdigest()
             f = nfdb().find_one({'coeffhash': chash, 'coeffs': coeffs})
             if f is None:
-                # Check if we have a result of the old polredabs
-                f = nfdb().find_one({'oldpolredabscoeffhash': chash, 'oldpolredabscoeffs': coeffs})
-                if f is None:
-                    return cls('a')  # will initialize data to None
+                return cls('a')  # will initialize data to None
             return cls(f['label'], f)
         else:
             raise Exception('wrong type')


### PR DESCRIPTION
Sage 8.1 computes the new version, so we don't need the extra lookup.

To test, go to the number field web page and search for x^4 - 2*x^3 + x^2 + 2*x + 1, and it will still be found even after this change (this is the old polredabs version of a polynomial).  To create a situation where it is not found is now complicated -- you would need to test against some old version of sage.

There will be a data pull request as well where we delete the two entries from the number field database, but the code and data pull requests can be done in either order.