### PR TITLE
corrected knowl link on Universe page

### DIFF
--- a/lmfdb/templates/universe.html
+++ b/lmfdb/templates/universe.html
@@ -1,6 +1,6 @@
 {% extends "homepage.html" %} {% block content %} 
 
-The top half of the diagram is based on the {{ KNOWL('lfunctions.langlands', title='Langlands program') }}, which predicts that any motivic object corresponds to an automorphic object via their L-functions.
+The top half of the diagram is based on the {{ KNOWL('lfunction.history.langlands_program', title='Langlands program') }}, which predicts that any motivic object corresponds to an automorphic object via their L-functions.
 
 <div id="svg_main">
     <!-- SVG + Description Boxes -->


### PR DESCRIPTION
To test compare http://localhost:37777/universe (see the knowl on the top line) with http://www.lmfdb.org/universe

When I go to this page locally I get an error message about not finding http://localhost:37777/lmfdbmap/lmfdbmap.svg but I don't know why, and it looks fine.