### PR TITLE
Knowl show quality

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -254,6 +254,14 @@ class Knowl(object):
             a = users.find({"$or": a_query}, ["full_name"])
         return a
 
+    def last_author(self):
+        """
+        Full names for the last authors.
+        (lookup for all full names in just *one* query, hence the or)
+        """
+        users = getDBConnection().userdb.users
+        return users.find_one({'_id': self._last_author}, ["full_name"])["full_name"]
+
     @property
     def id(self):
         return self._id

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -306,7 +306,8 @@ class Knowl(object):
         with "Dirichlet Series" and nothing else.
         """
         title = self._title
-        if self._quality=='beta':
+        from flask import g
+        if self._quality=='beta' and g.BETA:
             title += " (beta status)"
         return title
 

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -305,7 +305,10 @@ class Knowl(object):
         Example: KNOWL('algebra.dirichlet_series') should be replaced
         with "Dirichlet Series" and nothing else.
         """
-        return self._title
+        title = self._title
+        if self._quality=='beta':
+            title += " (beta status)"
+        return title
 
     @title.setter
     def title(self, title):

--- a/lmfdb/knowledge/templates/knowl-show.html
+++ b/lmfdb/knowledge/templates/knowl-show.html
@@ -14,5 +14,8 @@
   {% endfor %}
   </ul>
 </div>
+<div style="margin-top: 30px;">
+  <strong>Knowl review status:</strong> {{ k.quality }}
+</div>
 
 {% endblock %}

--- a/lmfdb/knowledge/templates/knowl-show.html
+++ b/lmfdb/knowledge/templates/knowl-show.html
@@ -15,7 +15,11 @@
   </ul>
 </div>
 <div style="margin-top: 30px;">
-  <strong>Knowl review status:</strong> {{ k.quality }}
+  <strong>Knowl status:</strong>
+  <ul>
+    <li>Review status: {{ k.quality }}
+    <li>Last edited by {{k.last_author()}} on {{ k._timestamp }}
+  </ul>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This PR is to generate discussion rather than asking to be merged now.  With this, when you view a knowl (not as a pop-up, but on its own page such as http://www.lmfdb.org/knowledge/show/mf.bianchi.bianchigroup ), under the list of Authors there is a new section "Knowl status" showing its review status (beta, ok or reviewed) and the last author with datestamp.

Currently there is jusy one "reviewed" knowl (http://www.lmfdb.org/knowledge/?reviewed=on&filter=) and around 15 "ok" ones, but a process has started to review (and where necessary correct) more.  Personally I think the "ok" status is redundant.