### PR TITLE
add top & bottom knowls for ecnf home pages

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -30,6 +30,10 @@
   </style>
 #}
 
+    {% set KNOWL_ID = "ec.%s"|format(ec['label']) %}
+    <h2>{{ KNOWL_INC(KNOWL_ID+'.top',title='') }}</h2>
+
+
 <div>
   <h2>  Base field   {{ ec.field.knowl()|safe }} </h2>
 <p>
@@ -419,6 +423,9 @@ It has not yet been determined whether or not it is a  {{KNOWL('ec.q_curve', '\(
 {% endif %}
 {% endif %}
 </div>
+
+    {% set KNOWL_ID = "ec.%s"|format(ec['label']) %}
+    <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='Additional information') }}</h2>
 
 {% if DEBUG %}
 <hr>


### PR DESCRIPTION
As requested in Issue #1147.
I found it hard to think of curves with any iinteresting properties to test this out on, ending up with http://localhost:37777/EllipticCurve/2.0.11.1/11.1/a/1 and http://localhost:37777/EllipticCurve/6.6.300125.1/1.1/a/2 (the latter is the only curve we have with a rational point of order 37).  With this patch you should see a top knowl for each, and (if logged in) the ability to create top knowls for all other ecnfs and bottom knowls for all.