### PR TITLE
Add search by group order and gap id's to transitive groups

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -103,19 +103,6 @@ def index():
                 ('Galois group labels', url_for(".labels_page"))]
     return render_template("gg-index.html", title="Galois Groups", bread=bread, info=info, credit=GG_credit, learnmore=learnmore)
 
-# FIXME: delete or fix this code
-# Apparently obsolete code that causes a server error if executed
-# @galois_groups_page.route("/search", methods=["GET", "POST"])
-# def search():
-#    if request.method == "GET":
-#        val = request.args.get("val", "no value")
-#        bread = get_bread([("Search for '%s'" % val, url_for('.search'))])
-#        return render_template("gg-search.html", title="Galois Group Search", bread=bread, val=val)
-#    elif request.method == "POST":
-#        return "ERROR: we always do http get to explicitly display the search parameters"
-#    else:
-#        return flask.abort(404)
-
 # For the search order-parsing
 def make_order_key(order):
     order1 = int(ZZ(order).log(10))
@@ -240,7 +227,7 @@ def render_group_webpage(args):
         data['subinfo'] = subfield_display(C, n, data['subs'])
         data['resolve'] = resolve_display(C, data['resolve'])
         if data['gapid'] == 0:
-            data['gapid'] = "No gap id's for groups of this order"
+            data['gapid'] = "Data not available"
         else:
             data['gapid'] = small_group_display_knowl(int(data['order']),int(data['gapid']),C, str([int(data['order']),int(data['gapid'])]))
         data['otherreps'] = wgg.otherrep_list()

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -143,6 +143,7 @@ def galois_group_search(**args):
     try:
         parse_ints(info,query,'n','degree')
         parse_ints(info,query,'t')
+        parse_ints(info,query,'order')
         for param in ('cyc', 'solv', 'prim', 'parity'):
             parse_bool(info,query,param,minus_one_to_zero=(param != 'parity'))
         degree_str = prep_ranges(info.get('n'))
@@ -153,6 +154,9 @@ def galois_group_search(**args):
 
     count = parse_count(info, 50)
     start = parse_start(info)
+    print ''
+    print str(query)
+    print ''
 
     res = C.transitivegroups.groups.find(query).sort([('n', pymongo.ASCENDING), ('t', pymongo.ASCENDING)])
     nres = res.count()

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -243,7 +243,6 @@ def render_group_webpage(args):
             data['gapid'] = "No gap id's for groups of this order"
         else:
             data['gapid'] = small_group_display_knowl(int(data['order']),int(data['gapid']),C, str([int(data['order']),int(data['gapid'])]))
-            #data['gapid'] = '$'+str([int(data['order']), data['gapid']])+'$'
         data['otherreps'] = wgg.otherrep_list()
         ae = wgg.arith_equivalent()
         if ae>0:

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -101,6 +101,15 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 	      <span class="formexample">e.g. 6 or 4,6 or 2..5 or 4,6..8</span>
 	    </td>
           </tr>
+          <tr>
+            <td align="right">
+              {{KNOWL('group.order',title='Order')}} :
+            </td><td><input type="text" name="order" value="" placeholder="24"></td>
+	    <td>
+	      <span class="formexample">e.g. 6 or 4,6 or 2..35 or 4,6..80</span>
+	    </td>
+          </tr>
+
 
           <tr>
           <td> Maximum number of groups to display: </td>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -95,13 +95,18 @@ table.ntdata a {
 
 <tr>
 <td align=left> 
-{{KNOWL('gg.degree',title='Degree')}} :<td align=left> <input type='text' name='n' size=3 value="{{info.n}}">
+{{KNOWL('gg.degree',title='Degree')}} :<td align=left> <input type='text' name='n' size="5" value="{{info.n}}">
 </td>
 
 <td align=left> 
 {{KNOWL('gg.tnumber',title='$t$')}} :
-<td align=left> <input type="text" name="t" size="3" value="{{info.t}}" ></td>
+<td align=left> <input type="text" name="t" size="5" value="{{info.t}}" ></td>
+
+<td align=left> 
+{{KNOWL('group.order',title='Order')}} :
+<td align=left> <input type="text" name="order" size="5" value="{{info.order}}" ></td>
 </tr>
+
 <tr>
 <td align='left' colspan='4'>Maximum number of groups to display <input type='text' name='count' value="{{info.count}}" size='10'>
 </td>
@@ -151,7 +156,7 @@ table.ntdata a {
 <tr>
 <th>Label</th>
 <th>{{KNOWL('gg.simple_name', title='Name')}}</th>
-<th>Order</th>
+<th>{{KNOWL('group.order', title='Order')}}</th>
 <th>{{ KNOWL('gg.parity', 'Parity') }} </th>
 <th>{{ KNOWL('gg.solvable', 'Solvable') }}</th>
 {% if info.show_subs %}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -75,6 +75,7 @@ table.reptable td, table.reptable th {
       <tr><td>Cyclic:<td>&nbsp;&nbsp;<td>{{info.yesno(info.cyc)}}</tr>
       <tr><td>Abelian:<td>&nbsp;&nbsp;<td>{{info.yesno(info.ab)}}</tr>
       <tr><td>Solvable:<td>&nbsp;&nbsp;<td>{{info.yesno(info.solv)}}</tr>
+      <tr><td>Gap ID:<td>&nbsp;&nbsp;<td>{{info.gapid | safe}}</tr>
     </table>
 
     <table>

--- a/lmfdb/transitive_group.py
+++ b/lmfdb/transitive_group.py
@@ -20,8 +20,10 @@ def sgdb():
     return db().sato_tate_groups.small_groups
 
 def small_group_display_knowl(n, k, C, name=None):
+    group = C.sato_tate_groups.small_groups.find_one({'label': '%d.%d'%(n,k)})
+    if group is None:
+        return '$[%d, %d]$'%(n,k)
     if not name:
-        group = C.sato_tate_groups.small_groups.find_one({'label': '%d.%d'%(n,k)})
         name = '$%s$'%group['pretty']
     return '<a title = "' + name + ' [group.small.data]" knowl="group.small.data" kwargs="gapid=' + str(n) + '.' + str(k) + '">' + name + '</a>'
 


### PR DESCRIPTION
In response to issue #2447 this adds searching by group order to the transitive group section.

This raises the question of the best way to order search results.  With the old ordering (by (n,t)), if you search for groups of order 24, S_4 appears many times, but they are not grouped together.  So, I added gap id's to the database (to the extent they exist for these groups).  But, if you always sort results by (order, gap id), then a search with say n=6 will not produce the groups ordered by "t", which seems natural in that case.

So, the code now picks a sort order based on the search.  Usually it is the old order (n,t), unless "order" is specified and "n" is not.  Then it sorts by (order, gap id, n, t).  This is clearly a choice, so open to discussion and opinions.

Testing the search, try searching (n=6), (order=24), (n=6 and order=24), for example.

As long as gap id's are now in the database, we display them on the individual group pages down in the section of pure group invariants (as opposed to invariants of the transitive action).  There are 3 cases: (1) we have the id and it is in our small groups database (order of group < 512 I think) ; (2) we have the id, but the group is **not** in our small groups database; (3) we don't have an id (because magma doesn't have it), probably because there are no ids fixed for that group order.  In case (1) we display a dynamic knowl for the group, in (2) we just display the pair [order, id], and in (3) we say that there is no id.  To see the various options, search with n=9, and then pick groups of various orders (A_9 and S_9 are the only ones of type (3) with n=9).
