### PR TITLE
Dirichlet character main page access to character groups

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -96,6 +96,9 @@ def render_DirichletNavigation():
             m,n = int(slabel[0]), int(slabel[1])
             if n < m and gcd(m,n) == 1:
                 return redirect(url_for(".render_Dirichletwebpage", modulus=slabel[0], number=slabel[1]))
+        if re.match(r'^[1-9][0-9]*$', label):
+            return redirect(url_for(".render_Dirichletwebpage", modulus=label), 301)
+
         flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q.", label)
         return render_template('CharacterNavigate.html', **info)
         #FIXME, delete line below?

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -34,11 +34,12 @@
 &nbsp;&nbsp;A <a href="random">random Dirichlet character</a> from the database</td>
 </p>
 
-<h2> Find a specific Dirichlet character by {{KNOWL('character.dirichlet.conrey', title="label") }} </h2>
+<h2> Find a specific  {{KNOWL('character.dirichlet', title="Dirichlet character") }} or {{KNOWL('character.dirichlet.group', title="Dirichlet character group") }}  by
+  {{KNOWL('character.dirichlet.conrey', title="label") }} or {{KNOWL('character.dirichlet.modulus', title="modulus") }} </h2>
 <form>
     <input type='text' name='label' size=10 value="{{args.label}}" placeholder="13.2" required>
     <button type='submit' name='lookup' value='1'> Find  </button>
-    <span class="formexample"> e.g. 13.2 -- represents the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\).</span>
+    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13.</span>
 </form>
 
 <h2> Search for characters </h2>
@@ -72,6 +73,7 @@ Enter criteria into one or more boxes to restrict the search.
     <input type='hidden' name='limit' value='25'/>
 </form>
 
+{#
 <h2> Create a character table </h2>
 <form action="{{ url_for('characters.dirichlet_table') }}" method="get"> 
     <table>
@@ -86,4 +88,5 @@ Enter criteria into one or more boxes to restrict the search.
         <button type='submit' name='create' value='1' > Create </button>
     </td>
 </form>
+#}
 {% endblock %}


### PR DESCRIPTION
As requested by @sanni85 : it was always possible to go to a Dirichlet character group page from the character top page by putting the modulus into the box at the bottom titled "create character table".  I have removed that and replaced it by adding to the functionality of the main "go to" box where you can now give either the label of a single character, or a modulus.  (This is by analogy with the similar box on the elliptic curve top page where you can get to a curve or an isogeny class from the same box).