### PR TITLE
Two torsion field

### DIFF
--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -270,15 +270,17 @@ function show_invs(invstyle) {
 <p>
 {{place_code('tamagawa')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.tamagawa', title='Tamagawa numbers') }}: </h3>
-{{data.tama}}
+<h3 class="inline"> {{ KNOWL('g2c.tamagawa', title='Tamagawa numbers') }}: </h3>{{data.tama}}
 
 <p>
 {{place_code('torsion_subgroup')}}
 </p>
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
-<table style="float:right;"><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table> <h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3>
+<p>
+{{place_code('two_torsion_field')}}
+</p>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td valign="bottom">{{data.two_torsion_field_knowl|safe}}</td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -281,7 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> <div>{{data.two_torsion_field_knowl|safe}}</div>
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -281,7 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('torsion_subgroup')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl}}
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> \({{data.two_torsion_field_knowl}}\)
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,8 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:<table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3>
+<h4><table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h4>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -242,6 +242,7 @@ function show_invs(invstyle) {
 
 <h2 class='subhead'> Invariants of the {{KNOWL('g2c.jacobian', title='Jacobian')}}: </h2>
 
+<div>
 {% if data.analytic_rank > 1 %}
 <h3 class="inline"> {{ KNOWL('g2c.analytic_rank', title='Analytic rank*') }}: </h3>\({{data.analytic_rank}}\)
 {% else %}
@@ -279,9 +280,10 @@ function show_invs(invstyle) {
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
 <p>
-{{place_code('torsion_subgroup')}}
+{{place_code('two_torsion_field')}}
 </p>
 <h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
+</div>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -278,6 +278,11 @@ function show_invs(invstyle) {
 </p>
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
+<p>
+{{place_code('torsion_subgroup')}}
+</p>
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl()|safe}}
+
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 
 <p>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,8 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:
-<table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3> <div class="inline">{{data.two_torsion_field_knowl|safe}}</div>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -278,10 +278,11 @@ function show_invs(invstyle) {
 </p>
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
-<p>
-{{place_code('two_torsion_field')}}
-</p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
+<div>
+<table>
+<tr><td><h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3></td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
+</table>
+</div>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td  style="vertical-align:bottom">{{data.two_torsion_field_knowl|safe}}</td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -281,7 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('torsion_subgroup')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl()|safe}}
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl}}
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -242,7 +242,6 @@ function show_invs(invstyle) {
 
 <h2 class='subhead'> Invariants of the {{KNOWL('g2c.jacobian', title='Jacobian')}}: </h2>
 
-<div>
 {% if data.analytic_rank > 1 %}
 <h3 class="inline"> {{ KNOWL('g2c.analytic_rank', title='Analytic rank*') }}: </h3>\({{data.analytic_rank}}\)
 {% else %}
@@ -282,8 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
-</div>
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> <div>{{data.two_torsion_field_knowl|safe}}</div>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3> <div class="inline">{{data.two_torsion_field_knowl|safe}}</div>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3> <div style="display: inline">{{data.two_torsion_field_knowl|safe}}</div>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table" cellpadding="2"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -279,8 +279,8 @@ function show_invs(invstyle) {
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
 <div>
-<table>
-<tr><td><h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3></td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
+<table border="0" cellpadding="0" cellspacing="0">
+<tr><td><h4 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h4></td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
 </table>
 </div>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table" cellpadding="2"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr style="vertical-align:bottom"><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <table><tr style="vertical-align:bottom"><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td valign="bottom">{{data.two_torsion_field_knowl|safe}}</td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td  style="vertical-align:bottom">{{data.two_torsion_field_knowl|safe}}</td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr style="vertical-align:bottom"><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <table><tr style="vertical-align:bottom"><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</div><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></div></h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -281,7 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3><table style="display:inline-table"><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -278,11 +278,7 @@ function show_invs(invstyle) {
 </p>
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
-<div>
-<table  style="margin:0;" >
-<tr><td> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
-</table>
-</div>
+<table style="float:right;"><tr><td>{{data.two_torsion_field_knowl|safe}}</td></tr></table> <h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,7 +280,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</div><table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></div></h3>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:<table style="display:inline-table"><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -281,7 +281,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('torsion_subgroup')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> \({{data.two_torsion_field_knowl}}\)
+<h3 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-Torsion field') }}: </h3> {{data.two_torsion_field_knowl|safe}}
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -280,8 +280,8 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3>
-<h4><table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h4>
+<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:
+<table><tr><td><div>{{data.two_torsion_field_knowl|safe}}</div></td></tr></table></h3>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -279,8 +279,8 @@ function show_invs(invstyle) {
 <h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
 
 <div>
-<table border="0" cellpadding="0" cellspacing="0">
-<tr><td><h4 class="inline"> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: </h4></td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
+<table  style="margin:0;" >
+<tr><td> {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</td><td> {{data.two_torsion_field_knowl|safe}}</td></tr>
 </table>
 </div>
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -6,7 +6,7 @@ from lmfdb.base import getDBConnection
 from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
-from lmfdb.number_fields.number_field import field_pretty nf_display_knowl
+from lmfdb.number_fields.number_field import field_pretty, nf_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -7,7 +7,6 @@ from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.number_fields.number_field import field_pretty
-from lmfdb.WebNumberField import nf_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime
@@ -644,7 +643,7 @@ class WebG2C(object):
                 # data['mw_rank_v'] = ratpts['mw_rank_v']
             else:
                 data['rat_pts_v'] = 0
-            data['two_torsion_field_knowl'] = nf_display_knowl (curve['two_torsion_field'], getDBConnection(), field_pretty(curve['two_torsion_field']))
+            data['two_torsion_field_knowl'] = "<a href=%s>%s</a>" % (url_for("number_fields.by_label",label=curve['two_torsion_field']),field_pretty(curve['two_torsion_field']))
         else:
             # invariants specific to isogeny class
             curves_data = g2c_db_curves().find({"class" : curve['class']},{'_id':int(0),'label':int(1),'eqn':int(1),'disc_key':int(1)}).sort([("disc_key", ASCENDING), ("label", ASCENDING)])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -6,7 +6,8 @@ from lmfdb.base import getDBConnection
 from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
-from lmfdb.number_fields.number_field import field_pretty, nf_display_knowl
+from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.WebNumberField import nf_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -6,7 +6,7 @@ from lmfdb.base import getDBConnection
 from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
-from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.number_fields.number_field import field_pretty nf_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime
@@ -257,7 +257,7 @@ def eqn_list_to_curve_plot(L,rat_pts):
     ymax=max([R[3] for R in plotzones])
     for P in rat_pts:
     	(x,y,z)=eval(P.replace(':',','))
-     	z=ZZ(z)
+        z=ZZ(z)
      	if z: # Do not attempt to plot points at infinity
       		x=ZZ(x)/z
       		y=ZZ(y)/z**3
@@ -643,6 +643,7 @@ class WebG2C(object):
                 # data['mw_rank_v'] = ratpts['mw_rank_v']
             else:
                 data['rat_pts_v'] = 0
+            data['two_torsion_field_knowl'] = nf_display_knowl (data['two_torsion_field'], getDBConnection(), field_pretty(data['two_torsion_field'])
         else:
             # invariants specific to isogeny class
             curves_data = g2c_db_curves().find({"class" : curve['class']},{'_id':int(0),'label':int(1),'eqn':int(1),'disc_key':int(1)}).sort([("disc_key", ASCENDING), ("label", ASCENDING)])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -643,7 +643,7 @@ class WebG2C(object):
                 # data['mw_rank_v'] = ratpts['mw_rank_v']
             else:
                 data['rat_pts_v'] = 0
-            data['two_torsion_field_knowl'] = nf_display_knowl (data['two_torsion_field'], getDBConnection(), field_pretty(data['two_torsion_field'])
+            data['two_torsion_field_knowl'] = nf_display_knowl (data['two_torsion_field'], getDBConnection(), field_pretty(data['two_torsion_field']))
         else:
             # invariants specific to isogeny class
             curves_data = g2c_db_curves().find({"class" : curve['class']},{'_id':int(0),'label':int(1),'eqn':int(1),'disc_key':int(1)}).sort([("disc_key", ASCENDING), ("label", ASCENDING)])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -7,6 +7,7 @@ from lmfdb.utils import web_latex, encode_plot
 from lmfdb.ecnf.main import split_full_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.WebNumberField import nf_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
 from sage.all import latex, ZZ, QQ, CC, NumberField, PolynomialRing, factor, implicit_plot, point, real, sqrt, var, expand, nth_prime
@@ -643,7 +644,8 @@ class WebG2C(object):
                 # data['mw_rank_v'] = ratpts['mw_rank_v']
             else:
                 data['rat_pts_v'] = 0
-            data['two_torsion_field_knowl'] = "<a href=%s>%s</a>" % (url_for("number_fields.by_label",label=curve['two_torsion_field']),field_pretty(curve['two_torsion_field']))
+            data['two_torsion_field_knowl'] = nf_display_knowl (curve['two_torsion_field'], getDBConnection(), field_pretty(curve['two_torsion_field']))
+            # data['two_torsion_field_knowl'] = "<a href=%s>%s</a>" % (url_for("number_fields.by_label",label=curve['two_torsion_field']),field_pretty(curve['two_torsion_field']))
         else:
             # invariants specific to isogeny class
             curves_data = g2c_db_curves().find({"class" : curve['class']},{'_id':int(0),'label':int(1),'eqn':int(1),'disc_key':int(1)}).sort([("disc_key", ASCENDING), ("label", ASCENDING)])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -644,7 +644,7 @@ class WebG2C(object):
                 # data['mw_rank_v'] = ratpts['mw_rank_v']
             else:
                 data['rat_pts_v'] = 0
-            data['two_torsion_field_knowl'] = nf_display_knowl (data['two_torsion_field'], getDBConnection(), field_pretty(data['two_torsion_field']))
+            data['two_torsion_field_knowl'] = nf_display_knowl (curve['two_torsion_field'], getDBConnection(), field_pretty(curve['two_torsion_field']))
         else:
             # invariants specific to isogeny class
             curves_data = g2c_db_curves().find({"class" : curve['class']},{'_id':int(0),'label':int(1),'eqn':int(1),'disc_key':int(1)}).sort([("disc_key", ASCENDING), ("label", ASCENDING)])


### PR DESCRIPTION
This PR partially addresses issue #434 by displaying the 2-torsion field of the Jacobian of a genus 2 curve on its home page. Some examples to look at:

http://127.0.0.1:37777/Genus2Curve/Q/256/a/512/1
http://127.0.0.1:37777/Genus2Curve/Q/1369/a/50653/1
http://127.0.0.1:37777/Genus2Curve/Q/3969/a/3969/1

Scroll down to the "Invariants of the Jacobian" section to see the 2-torsion field, which should display a number field knowl if you click on it.

The 2-torsion field is specified by giving a number field whose Galois closure is the 2-torsion field (in general the 2-torsion field of genus 2 curve can have degree as large as 720, but it can always be specified as the Galois closure of a field of degree at most 9).

When mod-2 Galois representations for GSp(4) become available in the LMFDB we will add a link to the home page of the mod-2 representation as well.