### PR TITLE
add Inventory to sidebar

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -281,4 +281,11 @@
        url_for: "knowledge.index"
        type: knowl
 
+9Inv:
+   type: single
+   heading:
+       title: Inventory
+       url_for: "inventory_app.show_edit_root"
+       type: knowl
+
 ...

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -2,7 +2,7 @@
 {%- for key, heading, value in sidebar.data -%}
 {%- if BETA or not value.status -%}{# an entire section may be omitted e.g. Motives #}
 
-{% if user_is_authenticated or BETA or key != '9Know' %}
+{% if user_is_authenticated or BETA or key != '9Know' and key != '9Inv' %}
 {{heading | safe}}
 
 {% if value.type == 'L' %}


### PR DESCRIPTION
This adds a link to the Inventory on the sidebar near the bottom just above Knowledge.  As with knowledge it only appears on beta.  This will make it easier for people to get to see (and if authenticated, edit) the inventory.