### PR TITLE
Allow searching by gap-id

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -8,7 +8,7 @@ from lmfdb import base
 from lmfdb.base import app
 from flask import render_template, request, url_for, redirect
 from lmfdb.utils import to_dict, list_to_latex_matrix, random_object_from_collection
-from lmfdb.search_parsing import clean_input, prep_ranges, parse_bool, parse_ints, parse_count, parse_start
+from lmfdb.search_parsing import clean_input, prep_ranges, parse_bool, parse_ints, parse_count, parse_start, parse_bracketed_posints
 import re
 import bson
 from lmfdb.galois_groups import galois_groups_page, logger
@@ -135,6 +135,7 @@ def galois_group_search(**args):
         parse_ints(info,query,'n','degree')
         parse_ints(info,query,'t')
         parse_ints(info,query,'order', qfield='orderkey', parse_singleton=make_order_key)
+        parse_bracketed_posints(info, query, qfield='gapidfull', split=False, exactlength=2, keepbrackets=True, name='Gap id', field='gapid')
         for param in ('cyc', 'solv', 'prim', 'parity'):
             parse_bool(info,query,param,minus_one_to_zero=(param != 'parity'))
         degree_str = prep_ranges(info.get('n'))

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -26,6 +26,16 @@ Browse by type:
 <a href="?solv=-1">Non-solvable</a>
 <a href="?prim=1">Primitive</a>
 <a href="?prim=-1">Imprimitive</a>
+
+<p>
+Browse by group:
+<a href="?gapid=[6,1]">$S_3$</a>
+<a href="?gapid=[8,3]">$D_4$</a>
+<a href="?gapid=[12,3]">$A_4$</a>
+<a href="?gapid=[24,12]">$S_4$</a>
+<a href="?gapid=[60,5]">$A_5$</a>
+<a href="?gapid=[120,34]">$S_5$</a>
+<a href="?gapid=[168,42]">$\GL(3,2)$</a>
 <p>
 
 <p>
@@ -107,6 +117,15 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
             </td><td><input type="text" name="order" value="" placeholder="24"></td>
 	    <td>
 	      <span class="formexample">e.g. 6 or 4,6 or 2..35 or 4,6..80</span>
+	    </td>
+          </tr>
+
+          <tr>
+            <td align="right">
+              {{KNOWL('curve.highergenus.aut.groupnotation',title='Gap id')}} :
+            </td><td><input type="text" name="gapid" value="" placeholder="[8,3]"></td>
+	    <td>
+	      <span class="formexample">e.g. [8,3] or [16,7]</span>
 	    </td>
           </tr>
 

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -105,6 +105,9 @@ table.ntdata a {
 <td align=left> 
 {{KNOWL('group.order',title='Order')}} :
 <td align=left> <input type="text" name="order" size="5" value="{{info.order}}" ></td>
+<td align=left> 
+{{KNOWL('curve.highergenus.aut.groupnotation',title='Gap id')}} :
+<td align=left><input type="text" name="gapid" size="5" value="{{info.gapid}}" ></td>
 </tr>
 
 <tr>

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -24,3 +24,12 @@ class GalGpTest(LmfdbTest):
 		assert '8T3' in L.data
 		assert '660' in L.data # order of 11T5
 
+    def test_search_order(self):
+        L = self.tc.get('GaloisGroup/?order=18')
+        assert '9T5' in L.data
+        assert 'all 9 matches' in L.data
+
+    def test_search_gapid(self):
+        L = self.tc.get('GaloisGroup/?gapid=[60,5]')
+        assert '20T15' in L.data
+        assert '15T5' in L.data


### PR DESCRIPTION
This addresses issue #2475 allowing searching by gap-id in the transitive group database.  Comments:

- This got its own search field.  Results may be more than one transitive action, so it goes to the search results page, whereas using the search by label box should take you to a individual home page 
- I added another field for the database for this, gapidfull.  Trying to search using the order and id (index) in separately was painful, especially since a user can enter values into the field for order which would have to be merged with the order from the gap id.  The upshot is that we would need another data upload to the cloud before this goes to the production server
- I added to the Browse section of the page, listing some groups which have multiple transitive actions
- There is a function in the general search parsing for gap id's, but it has too many values hard-wired.  Maybe it should be moved to the one file from which it is called.
