### PR TITLE
knowls: remove addition of (beta status) to titles pending a correct …

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -307,8 +307,8 @@ class Knowl(object):
         """
         title = self._title
         from flask import g
-        if self._quality=='beta' and g.BETA:
-            title += " (beta status)"
+        # if self._quality=='beta' and g.BETA:
+        #     title += " (beta status)"
         return title
 
     @title.setter


### PR DESCRIPTION
…way of doing it.

This just stops the addition of the string " (beta status)" to the display of the knowl title, pending someone working out how to do it without changing the stored title (which of course was never the intention).  See #2495 