### PR TITLE
fixing double period

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -16,7 +16,7 @@ from lmfdb.genus2_curves import g2c_page
 from lmfdb.genus2_curves.web_g2c import WebG2C, g2c_db_curves, g2c_db_isogeny_classes_count, list_to_min_eqn, st0_group_name
 from lmfdb.sato_tate_groups.main import st_link_by_name
 
-credit_string = "Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight,  Raymond van Bommel, Dan Yasaki."
+credit_string = "Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight,  Raymond van Bommel, Dan Yasaki"
 
 ###############################################################################
 # global database connection and stats objects


### PR DESCRIPTION
I fixed the double period in:

"Data computed by Andrew Booker, Jeroen Sijsling, Andrew Sutherland, John Voight, Raymond van Bommel, Dan Yasaki.."

pyflakes will fail because of #2496, I fixed that in #2492