### PR TITLE
Change link "minimal vector" to "minimal vector length"

### DIFF
--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -16,7 +16,7 @@
     <tr><td align=right>{{ KNOWL('lattice.density', title='Density') }}:</td><td>${{info.density }}\dots$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.group_order', title='Group order') }}:</td><td>${{info.aut }}$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.hermite_number', title='Hermite number') }}:</td><td>${{info.hermite }}\dots$</td></tr>
-    <tr><td align=right>{{ KNOWL('lattice.minimal_vector', title='Minimal vector')}} length:</td><td>${{info.minimum }}$</td></tr>
+    <tr><td align=right>{{ KNOWL('lattice.minimal_vector', title='Minimal vector length')}}:</td><td>${{info.minimum }}$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.kissing', title='Kissing Number') }}:</td><td>${{info.kissing }}$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.normalized_minimal_vector', title='Normalized minimal vectors')}}:</td>
 <td>


### PR DESCRIPTION
The knowl for "minimal vector" actually defines "minimal vector length" first, so I propose to highlight the whole phrase "Minimal vector length" as the link to the knowl.