### PR TITLE
move inventory logs and silence a couple of unnecessary INFO messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lmfdb/.coverage
 .coverage
 .DS_Store
 .idea/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ lmfdb/.coverage
 .coverage
 .DS_Store
 .idea/
-logs/
+LMFDBinventory.log
+LMFDBtransactions_inv.log

--- a/lmfdb/elliptic_curves/__init__.py
+++ b/lmfdb/elliptic_curves/__init__.py
@@ -5,7 +5,7 @@ from flask import Blueprint
 
 ec_page = Blueprint("ec", __name__, template_folder='templates', static_folder="static")
 ec_logger = make_logger(ec_page)
-ec_logger.info("Initializing elliptic curves blueprint")
+#ec_logger.info("Initializing elliptic curves blueprint")
 
 
 @ec_page.context_processor

--- a/lmfdb/inventory_app/lmfdb_inventory.py
+++ b/lmfdb/inventory_app/lmfdb_inventory.py
@@ -198,7 +198,7 @@ def get_type_strings_as_json():
 
 #This is a log of actions, submits, failures etc
 LOG_ID = 'Inv_log'
-LOG_FILE_NAME = "LMFDBinventory.log"
+LOG_FILE_NAME = "logs/LMFDBinventory.log"
 LEVELS = {'debug': logging.DEBUG,
       'info': logging.INFO,
       'warning': logging.WARNING,
@@ -208,7 +208,7 @@ log_dest = None
 
 #This is a list of edit transactions
 TR_LOG_ID = 'Trans_log'
-TR_LOG_FILE_NAME = "LMFDBtransactions_inv.log"
+TR_LOG_FILE_NAME = "logs/LMFDBtransactions_inv.log"
 log_transac = None
 
 #To disable all logging etc, can just replace the filehandler with Nullhandler

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -80,7 +80,7 @@ class HomePageTest(LmfdbTest):
         L = self.tc.get("/Lattice/random").data
         assert 'redirected automatically' in L # random lattice
         L = self.tc.get("/Lattice/random", follow_redirects=True)
-        assert 'Normalized minimal vectors:' in L.data # check redirection
+        assert 'Normalized minimal vectors' in L.data # check redirection
 
     def test_downloadstring(self):
         L = self.tc.get("/Lattice/5.648.12.1.1").data

--- a/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/__init__.py
@@ -21,7 +21,7 @@ EMF_TOP = "Holomorphic Cusp Forms"  # The name to use for the top of this caterg
 EMF = "emf"  # The current blueprint name
 emf = flask.Blueprint(EMF, __name__, template_folder="views/templates", static_folder="views/static")
 emf_logger = make_logger(emf)
-emf_logger.info("Initializing elliptic modular forms blueprint with Sage version %s, emf version %s" % (SAGE_VERSION, emf_version))
+#emf_logger.info("Initializing elliptic modular forms blueprint with Sage version %s, emf version %s" % (SAGE_VERSION, emf_version))
 
 ### Maximum values for computations
 N_max_comp = 50


### PR DESCRIPTION
The inventory creates and writes to a couple of log files which show up in "git status" and the like.  Rather than just add the names of these to .gitignore I created a new directory called "logs", added that to .gitignore (so it exists even though we'll never commit any files in it) and changed the place where these files are created to include "logs/" at the front of the filename.  This seems to work OK.

Anyone finding files called LMFDBinventory.log ot LMFDBtransactions_inv.log can confidently remove them.

At the same time I removed a couple of  INFO messages which always appear at startup when a couple of blueprints start up as these not necessary (probably were put in for some debugging purpose).
 