### PR TITLE
Remove second link to Gram matrix knowl

### DIFF
--- a/lmfdb/lattice/templates/lattice-index.html
+++ b/lmfdb/lattice/templates/lattice-index.html
@@ -88,7 +88,7 @@ Some of our favourite {{ KNOWL('lattice.definition', title='integral lattices') 
 <tr>
 <td align= right>{{ KNOWL('lattice.gram', title='Gram matrix') }}:</td>
 <td><input type='text' name='gram' placeholder='[5,1,23]' size=10>
-<td><span class="formexample"> e.g. $[5,1,23]$ for the {{ KNOWL('lattice.gram', title='Gram matrix') }} $\begin{pmatrix}5 & 1\\ 1& 23\end{pmatrix}$</td>
+<td><span class="formexample"> e.g. $[5,1,23]$ for the matrix $\begin{pmatrix}5 & 1\\ 1& 23\end{pmatrix}$</td>
 </tr>
 <tr>
 <td align= right>{{ KNOWL('lattice.minimal_vector', title='Minimal vector')}} length:</td>


### PR DESCRIPTION
The search box for "Gram matrix" is of course labeled with a knowl, but then the explanatory text includes the phrase "Gram matrix" again with a second link to the knowl. This seems redundant to me.