### PR TITLE
Fix capitalization of "Kissing number" in invariants

### DIFF
--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -17,7 +17,7 @@
     <tr><td align=right>{{ KNOWL('lattice.group_order', title='Group order') }}:</td><td>${{info.aut }}$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.hermite_number', title='Hermite number') }}:</td><td>${{info.hermite }}\dots$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.minimal_vector', title='Minimal vector length')}}:</td><td>${{info.minimum }}$</td></tr>
-    <tr><td align=right>{{ KNOWL('lattice.kissing', title='Kissing Number') }}:</td><td>${{info.kissing }}$</td></tr>
+    <tr><td align=right>{{ KNOWL('lattice.kissing', title='Kissing number') }}:</td><td>${{info.kissing }}$</td></tr>
     <tr><td align=right>{{ KNOWL('lattice.normalized_minimal_vector', title='Normalized minimal vectors')}}:</td>
 <td>
 {% if info.dim == 1 %}


### PR DESCRIPTION
In a list of invariants, the category names are normally displayed with only the first word force-capitalized. So on a lattice page, "Kissing Number" should be "Kissing number"; this makes that one-character change.