### PR TITLE
added tests for api and changed api examples to ones which work

### DIFF
--- a/lmfdb/api/templates/api.html
+++ b/lmfdb/api/templates/api.html
@@ -63,20 +63,21 @@ where the prefix "-" indicates to sort in descending order.
     <a href='{{ url_for(".api_query", db="elliptic_curves", collection="curves", rank="i2", torsion="i5")}}'><code>?rank=i2&amp;torsion=i5</code></a>.
     </li>
     <li>
-    A list of strings (string encoded integers) for the <code>ainvs</code> parameter of an elliptic curve is
-    <a href='{{ url_for(".api_query", db="elliptic_curves", collection="curves", ainvs="ls0;1;1;-840;39800", _format="yaml", _delim=";")}}'>
-       <code>?ainvs=ls0;1;1;-840;39800&amp;_format=yaml&amp;_delim=;</code></a>,
-    where the delimiter is "<code>;</code>" and the result formatted in YAML.
+    A string encoding a list of integers for the <code>xainvs</code> parameter of an elliptic curve is
+    <a href='{{ url_for(".api_query", db="elliptic_curves", collection="curves", xainvs="s[0,1,1,-840,39800]", _format="yaml")}}'>
+       <code>?xainvs=s[0,1,1,-840,39800]&amp;_format=yaml</code></a>,
+    the result formatted in YAML.
     </li>
+    {#
     <li>
     This query <a href='{{ url_for('.api_query', db="elliptic_curves", collection="curves", isogeny_matrix="py[[1,13],[13,1]]", _format="json") }}'>?isogeny_matrix=py[[1,13],[13,1]]</a>
     returns elliptic curves where the isogeny matrix is $\left(\begin{smallmatrix}1 & 13\\ 13 & 1\end{smallmatrix}\right)$.
     </li>
+    #}
     <li>
-    To see those elliptic curves, where the <code>ainvs</code> list contains the string-encoded integer <code>-769</code>
-    and the field <code>non-surjective_primes</code> contains the integer number 3:
-    {% set kw = {"non-surjective_primes" : "ci3"} %}
-    <a href='{{ url_for(".api_query", db="elliptic_curves", collection="curves", ainvs="cs-769", **kw) }}'>?ainvs=cs-769&amp;non-surjective_primes=ci3</a>.
+    To see those elliptic curves, where the field <code>torsion_structure</code> contains the list  [2,2], encoded as a list of strings:
+    <a href='{{ url_for(".api_query", db="elliptic_curves",
+    collection="curves", torsion_structure="ls2;2", _delim=";")}}'>?torsion_structure=ls2;2&amp;_delim=;</a>.
     </li>
     <li>To only retrieve the fields <code>authors</code> and <code>last_author</code> of the knowl documents,
     query <a href="{{ url_for('.api_query', db='knowledge', collection='knowls', _fields='authors,last_author') }}"</a>?_fields=authors,last_author</a>.

--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -3,6 +3,7 @@ from lmfdb.base import LmfdbTest
 
 class ApiTest(LmfdbTest):
 
+    
     def test_api_home(self):
         r"""
         Check that the top-level api page works

--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from lmfdb.base import LmfdbTest
+
+class ApiTest(LmfdbTest):
+
+    def test_api_home(self):
+        r"""
+        Check that the top-level api page works
+        """
+        data = self.tc.get("/api", follow_redirects=True).data
+        assert "API for accessing the LMFDB Database" in data
+
+    def test_api_databases(self):
+        r"""
+        Check that one collection from each database works
+        """
+        dbs = [ ['HTPicard','picard'], ['Lattices','lat'],
+                ['Lfunctions','Lfunctions'],
+                ['MaassWaveForms','Coefficients'],
+                ['SL2Zsubgroups','groups'], ['abvar','fq_isog'],
+                ['artin','representations'], ['bmfs','forms'],
+                ['curve_automorphisms','passports'],
+                ['elliptic_curves','curves'],
+                ['genus2_curves','curves'],
+                ['halfintegralmf','forms'], ['hgm','motives'],
+                ['hmfs','forms'], ['localfields','fields'],
+                ['mod_l_eigenvalues','modlmf'],
+                ['mod_l_galois','reps'],
+                ['modularforms2','dimension_table'],
+                ['numberfields','fields'],
+                ['sato_tate_groups','st_groups'],
+                ['siegel_modular_forms','dimensions'],['transitivegroups','groups'],
+                ['characters','Dirichlet_char_modl'],
+                ['finite_fields','finite_fields'],
+                ['hecke_algebras','hecke_algebras'],
+                ['embedded_mfs','mfs'], ['belyi','passports']]
+        for db, coll in dbs:
+            data = self.tc.get("/api/{}/{}".format(db,coll), follow_redirects=True).data
+            assert "JSON" in data
+
+    def test_api_examples_html(self):
+        r"""
+        Check that the sample queries on the top page all work (html output)
+        """
+        queries = ['elliptic_curves/curves/?rank=i2&torsion=i5',
+                   #'elliptic_curves/curves/?isogeny_matrix=py[[1,13],[13,1]]', # no index on isogeny_matrix
+                   'elliptic_curves/curves/?xainvs=cs-1215&torsion_structure=ls2;2&_delim=;',
+                   'knowledge/knowls/?_fields=authors,last_author',
+                   'knowledge/knowls/?_fields=content,authors&_sort=timestamp']
+        for query in queries:
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            assert 'Query: <code><a href="/api/' in data
+            assert not "Error:" in data
+
+    def test_api_examples_yaml(self):
+        r"""
+        Check that the sample queries on the top page all work (yaml output)
+        """
+        queries = [#'elliptic_curves/curves/?ainvs=ls0;1;1;-840;39800&_format=yaml&_delim=;', # no index on ainvs
+                   'elliptic_curves/curves/?xainvs=s[0,1,1,-840,39800]&_format=yaml']
+        for query in queries:
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            assert "!!python/unicode 'x-coordinates_of_integral_points': !!python/unicode '[-42,-39,-21,0,15,21,24,42,77,126,231,302,420,609,1560,3444,14595]'" in data
+            assert not "Error:" in data
+
+    def test_api_examples_json(self):
+        r"""
+        Check that the sample queries on the top page all work (json output)
+        """
+        query = 'numberfields/fields/?signature=s2,5&_format=json'
+        data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+        assert '"label": "12.2.167630295667.1"' in data
+
+
+    def test_api_usage(self):
+        r"""
+        Check that the queries used by ODK demo all work
+        """
+        queries = ['transitivegroups/groups?_format=json&label=1T1']
+        for query in queries:
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            assert '"name": "Trivial group"' in data

--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -76,7 +76,14 @@ class ApiTest(LmfdbTest):
         r"""
         Check that the queries used by ODK demo all work
         """
-        queries = ['transitivegroups/groups?_format=json&label=1T1']
+        queries = ['transitivegroups/groups?_format=json&label=1T1',
+                   'transitivegroups/groups?_format=json&label=8T3',
+                   'elliptic_curves/curves?_format=json&label=11a1']
         for query in queries:
             data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
-            assert '"name": "Trivial group"' in data
+            if '1T1' in query:
+                assert '"name": "Trivial group"' in data
+            if '8T3' in query:
+                assert '"name": "E(8)=2[x]2[x]2"' in data
+            if '11a1' in query:
+                assert '"equation": "\\\\( y^2 + y = x^{3} -  x^{2} - 10 x - 20  \\\\)"' in data

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -98,10 +98,10 @@ class NumberFieldTest(LmfdbTest):
         assert 'Class number' in L.data 
 
     def test_signature_search(self):
-        L = self.tc.get('/NumberField/?start=0&signature=%5B0%2C3%5D&count=100', follow_redirects=True)
+        L = self.tc.get('/NumberField/?start=0&degree=6&signature=%5B0%2C3%5D&count=100', follow_redirects=True)
         assert '6.0.61131.1' in L.data
 
-        L = self.tc.get('/NumberField/?start=0&signature=%5B3%2C2%5D&count=100', follow_redirects=True)
+        L = self.tc.get('/NumberField/?start=0&degree=7&signature=%5B3%2C2%5D&count=100', follow_redirects=True)
         assert '7.3.1420409.1' in L.data
 
 


### PR DESCRIPTION
I had been pointed out to me that the Examples listed on the (old) api page no longer all worked because of the restriction we put in to only allow a request for which the keys were included in at least one index.
I added a test file for the api, using these as examples, and adapted some of them to make them work (not all, but the ones on the page should all work).
Test by going to the /api page and clicking on all the examples there.