### PR TITLE
small fix to test.sh so it puts inventory log files in the right place

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -58,8 +58,7 @@ echo "Using Sage command $SAGE_COMMAND"
 if [[ -n $WHAT ]]; then
    eval "$SAGE_COMMAND -python -m pytest $ARGS $COVER $WHAT"
 else
-   cd lmfdb
-   eval "$SAGE_COMMAND -python -m pytest $ARGS $COVER"
+   eval "$SAGE_COMMAND -python -m pytest $ARGS $COVER lmfdb/"
 fi
 
 if [[ $PYFLAKES_ERRCNT > 0 ]]; then


### PR DESCRIPTION
The test script used to run from in the subdirectory lmfdb/ with the result that it tried to put inventory logs there which does not work.  This fixes that.  Tested by me and @davidlowryduda 