### PR TITLE
Add order of root of unity on number field page

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -449,10 +449,13 @@ def render_field_webpage(args):
     info.update(data)
     if nf.degree() > 1:
         gpK = nf.gpK()
-        rootof1coeff = gpK.nfrootsof1()[2]
-        rootofunity = Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))
+        rootof1coeff = gpK.nfrootsof1()
+        rootofunityorder = int(rootof1coeff[1])
+        rootof1coeff = rootof1coeff[2]
+        rootofunity = web_latex(Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))) 
+        rootofunity += ' (order $%d$)' % rootofunityorder
     else:
-        rootofunity = Ra('-1')
+        rootofunity = web_latex(Ra('-1'))+ ' (order $2$)'
 
     info.update({
         'label': pretty_label,
@@ -462,7 +465,7 @@ def render_field_webpage(args):
         'integral_basis': zk,
         'regulator': web_latex(nf.regulator()),
         'unit_rank': nf.unit_rank(),
-        'root_of_unity': web_latex(rootofunity),
+        'root_of_unity': rootofunity,
         'fund_units': nf.units(),
         'grh_label': grh_label,
         'loc_alg': loc_alg

--- a/scripts/number_fields/prep.gp
+++ b/scripts/number_fields/prep.gp
@@ -1,15 +1,16 @@
 allocatemem(2^30);
 default(realprecision,1000);
 default(new_galois_format, 1);
+read("generate.gp");
 
-/* timeouts */
-shortt = 30; /* in seconds */
-longt = 3*60;
-/*
-shortt = 2;
-longt = 5;
+/* timeouts in seconds */
+/*shortt = 5; 
+longt = 10;
 */
-savetime=500; /* in milliseconds */
+shortt = 40;
+longt = 10;
+
+savetime=0; /* in milliseconds */
 
 assoc(entry, lis, bnd=-1) =my(b);b=#lis;if(bnd>-1,b=bnd);for(j=1,b,if(lis[j]==entry,return(j)));return(0);
 
@@ -41,11 +42,68 @@ getsubs(pol)=
   return(mult(sbs));
 }
 
+load(p,n)=return(read(Str("/home/jj/data/localfields-lmfdb/file-src/p"p"d"n"all")));
+
+onealg(pol,p)=
+{
+  my(fp,degs,loc,lpols);
+  if(p>200,return([]));
+  fp=lift((factorpadic(pol,p,1000)[,1]~)*Mod(1,p^1000));
+  degs=vecsort(apply(poldegree,fp));
+  lpols=vector(#fp);
+  if(last(degs)>15, return([]));
+  for(j=1,#fp,
+    loc=iferr(load(p,poldegree(fp[j])),E,0);
+    if(loc==0, return([]);lpols[j]=fake(fp[j],p),
+      lpols[j]=findinlist(fp[j],loc)[1]);
+  );
+  return(vector(#lpols,h,Str(lpols[h])));
+}
+
+
 doit(pol)=
 {
     my(nf,bnf=0,elapsed=0,nogrh=0,h=-1,clgp=[],reg=0,fu="",extras=0,subs,zk);
+    my(localg,rmps);
     nf=nfinit(pol);
     zk=nfbasis(pol);
+    a='a;
+    zk=subst(zk,x,a);
+    zk=apply(z->Str(z), zk);
+    rmps=factor(abs(nf.disc))[,1]~;
+    gettime();
+    iferr(alarm(shortt,bnf=bnfinit(nf,1)),E,1);
+    if(bnf,
+        alarm(longt, iferr(if(bnfcertify(bnf)==0,1/0,nogrh=1), E,1));
+        elapsed = gettime();
+        h= bnf.clgp[1];
+        clgp=bnf.clgp[2];
+        if(elapsed>savetime,
+            reg = bnf.reg;
+            fu = lift(bnf.fu);
+            fu = subst(fu,x,a);
+            fu = apply(z->Str(z), fu);
+            extras=1;
+        );
+    );
+    localg = apply(z->onealg(pol,z), rmps);
+    subs = getsubs(nf);
+    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps,localg]);
+    /* reg and units if slow */
+    /* grh if certify is too slow */
+}
+
+doit1(ll)=
+{
+    my(pol=ll[1],rmps=Set(ll[2]),nf,bnf=0,elapsed=0,nogrh=0,h=-1,clgp=[],reg=0,fu="",extras=0,subs,zk,ramli);
+    ramli=getramli(ll);
+    pol=polredabsx(ll);
+    my(pd=poldisc(pol), nps);
+    a='a;
+    nf=nfinit([pol,ramli]);
+    if(#nfcertify(nf)>0, error("Did not certify number field"));
+    zk=nfbasis([pol,ramli]);
+    rmps = vecsort(select(z->valuation(nf.disc,z)>0,ramli));
     zk=subst(zk,x,a);
     zk=apply(z->Str(z), zk);
     gettime();
@@ -63,20 +121,40 @@ doit(pol)=
             extras=1;
         );
     );
-    subs = getsubs(pol);
-    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk]);
+    localg = apply(z->onealg(pol,z), rmps);
+    subs = getsubs(nf);
+    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps, localg]);
     /* reg and units if slow */
     /* grh if certify is too slow */
 }
 
 doall(li)=
 {
-    my(ans=vector(#li));
+    my(ans=vector(#li),len=length(li));
     for(j=1,#li,
         ans[j]=doit(li[j]);
+        print1(".");
+        if(j%50==0, print(" ", j, " ", floor(100*j/len), "%"))
+    );
+    return(ans);
+}
+
+doall1(li)=
+{
+    my(ans=vector(#li));
+    for(j=1,#li,
+        ans[j]=doit1(li[j]);
         print1(".");
         if(j%50==0, print(" ", j))
     );
     return(ans);
+}
+
+dofix(li)=
+{
+  my(l2);
+  l2 =apply(z->[z[2],z[1][2]], li);
+  l2= doall1(l2);
+  return(vector(#l2,h,[Vecrev(li[h][1][1]),l2[h]]));
 }
 


### PR DESCRIPTION
Addresses issue #2527 by displaying the order of the root of unity on individual pages of number fields.