### PR TITLE
Artin container

### DIFF
--- a/lmfdb/artin_representations/databases/Dokchitser_databases.py
+++ b/lmfdb/artin_representations/databases/Dokchitser_databases.py
@@ -1,7 +1,7 @@
 artin_location = ("artin", "representations")
 galois_group_location = ("artin", "field_data")
-#artin_location = ("artin", "representations_new")
-#galois_group_location = ("artin", "field_data_new")
+artin_location = ("artin", "representations_new")
+galois_group_location = ("artin", "field_data_new")
 
 from type_generation import String, Array, Dict, Int, Anything
 
@@ -57,6 +57,7 @@ Galois_Conjugate = Dict(
 Dokchitser_ArtinRepresentation = Dict({
     "_id": Anything,
     "Baselabel": String,
+    "Container": Anything,
     "Dim": Int,
     "Indicator": Int,
     "Conductor": TooLargeInt,

--- a/lmfdb/artin_representations/databases/Dokchitser_databases.py
+++ b/lmfdb/artin_representations/databases/Dokchitser_databases.py
@@ -3,6 +3,7 @@ galois_group_location = ("artin", "field_data")
 artin_location = ("artin", "representations_new")
 galois_group_location = ("artin", "field_data_new")
 
+
 from type_generation import String, Array, Dict, Int, Anything
 
 from standard_types import PolynomialAsString, PermutationAsList,\

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -78,7 +78,7 @@ def artin_representation_search(**args):
                          allowed=[1,-1],process=int)
         parse_restricted(info,query,"frobenius_schur_indicator",qfield="Indicator",
                          allowed=[1,0,-1],process=int)
-        parse_container(info,query, 'Container',qfield='Container', name="Smallest permutation representation")
+        parse_container(info,query, 'container',qfield='Container', name="Smallest permutation representation")
         parse_galgrp(info,query,"group",name="Group",qfield="Galois_nt",use_bson=False)
         parse_ints(info,query,'dimension',qfield='Dim')
         parse_ints(info,query,'conductor',qfield='Conductor_key', parse_singleton=make_cond_key)

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -10,7 +10,7 @@ from markupsafe import Markup
 
 from lmfdb.artin_representations import artin_representations_page
 from lmfdb.utils import to_dict, random_object_from_collection
-from lmfdb.search_parsing import parse_primes, parse_restricted, parse_galgrp, parse_ints, parse_count, parse_start, clean_input
+from lmfdb.search_parsing import parse_primes, parse_restricted, parse_galgrp, parse_ints, parse_container, parse_count, parse_start, clean_input
 
 from math_classes import ArtinRepresentation
 from lmfdb.transitive_group import group_display_knowl
@@ -78,6 +78,7 @@ def artin_representation_search(**args):
                          allowed=[1,-1],process=int)
         parse_restricted(info,query,"frobenius_schur_indicator",qfield="Indicator",
                          allowed=[1,0,-1],process=int)
+        parse_container(info,query, 'Container',qfield='Container', name="Smallest permutation representation")
         parse_galgrp(info,query,"group",name="Group",qfield="Galois_nt",use_bson=False)
         parse_ints(info,query,'dimension',qfield='Dim')
         parse_ints(info,query,'conductor',qfield='Conductor_key', parse_singleton=make_cond_key)

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -55,48 +55,48 @@ Enter values into one or more boxes to restrict the search.
 <form id="search" onsubmit="cleanSubmit(this.id)">
   <table>
     <tr>
-        <td align="right">{{ KNOWL('artin.dimension',title="Dimension") }}</td>
+        <td align="left">{{ KNOWL('artin.dimension',title="dimension") }}</td>
         <td><input type='text' name='dimension' placeholder="2" size=15></td>
         <td><span class="formexample"> e.g. 1, 2-4 </span></td>
     </tr>
 
     <tr>
-        <td align="right">{{ KNOWL('artin.conductor',title = "Conductor") }}</td>
+        <td align="left">{{ KNOWL('artin.conductor',title = "conductor") }}</td>
         <td><input type='text' name='conductor' placeholder="50-100,150-210" size=15></td>
         <td><span class="formexample"> e.g. 50, 100-200</span></td>
     </tr>
 
     <tr>
-        <td align="right">{{ KNOWL('artin.gg_quotient',title="Group") }}</td>
+        <td align="left">{{ KNOWL('artin.gg_quotient',title="group") }}</td>
         <td><input type='text' name='group' placeholder="A5" size=15></td>
         <td><span class="formexample"> e.g. C5, or 8T12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
     </tr>
 
     <tr>
-        <td align="right">{{ KNOWL('artin.permutation_container',title="Smallest permutation container") }}</td>
+        <td align="left">{{ KNOWL('artin.permutation_container',title="smallest permutation container") }}</td>
         <td><input type='text' name='container' placeholder="6T13" size=15></td>
         <td><span class="formexample"> e.g. 6T13 or 7T6</span></td>
 
     <tr>
-        <td align="right">{{ KNOWL('artin.ramified_primes', title="Ramified primes") }}</td>
+        <td align="left">{{ KNOWL('artin.ramified_primes', title="ramified primes") }}</td>
         <td><input type='text' name='ramified' placeholder="2" size=15></td>
         <td><span class="formexample"> e.g. 2, 3 (no range allowed)</span></td>
     </tr>
     
     <tr>
-        <td align="right">{{ KNOWL('artin.unramified_primes', title="Unramified primes") }}</td>
+        <td align="left">{{ KNOWL('artin.unramified_primes', title="unramified primes") }}</td>
         <td><input type='text' name='unramified' placeholder="5,7" size=15></td>
         <td><span class="formexample"> e.g. 5, 7, 13  (no range allowed)</span></td>
     </tr>
     
     <tr>
-        <td align="right">{{ KNOWL('artin.root_number',title="Root number") }}</td>
+        <td align="left">{{ KNOWL('artin.root_number',title="root number") }}</td>
         <td><input type='text' name='root_number' placeholder="1" size=15></td>
         <td><span class="formexample"> at the moment, one of 1 or -1 </span></td>
     </tr>
 
     <tr>
-        <td align="right">{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}</td>
+        <td align="left">{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}</td>
         <td><input type='text' name='frobenius_schur_indicator' placeholder="1" size=15></td>
         <td><span class="formexample"> +1 for orthogonal, -1 for symplectic, 0 for non-real character </span></td>
     </tr>

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -73,6 +73,11 @@ Enter values into one or more boxes to restrict the search.
     </tr>
 
     <tr>
+        <td align="right">{{ KNOWL('artin.permutation_container',title="Smallest permutation container") }}</td>
+        <td><input type='text' name='container' placeholder="6T13" size=15></td>
+        <td><span class="formexample"> e.g. 6T13 or 7T6</span></td>
+
+    <tr>
         <td align="right">{{ KNOWL('artin.ramified_primes', title="Ramified primes") }}</td>
         <td><input type='text' name='ramified' placeholder="2" size=15></td>
         <td><span class="formexample"> e.g. 2, 3 (no range allowed)</span></td>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -6,32 +6,36 @@
 <input type="hidden" name="start" value="{{start}}"/>
   <table>
     <tr>
-      <td>{{ KNOWL('artin.dimension',title="Dimension") }}</td>
+      <td>{{ KNOWL('artin.dimension',title="dimension") }}</td>
       <td><input type='text' name='dimension' value="{{req.dimension}}" size=15/></td>
       <td><span class="formexample"> e.g. 1, 2-4 </span></td>
     </tr>
     <tr>
-      <td>{{ KNOWL('artin.conductor',title = "Conductor") }}</td>
+      <td>{{ KNOWL('artin.conductor',title = "conductor") }}</td>
       <td><input type='text' name='conductor' value="{{req.conductor}}" size=15/></td>
       <td><span class="formexample"> e.g. 50, 100-200</span></td>
     </tr>
     <tr>
-        <td>{{ KNOWL('artin.gg_quotient',title="Group") }}</td>
+        <td>{{ KNOWL('artin.gg_quotient',title="group") }}</td>
         <td><input type='text' name='group' value="{{req.group}}" size=15></td>
         <td><span class="formexample"> e.g. C5, or 8T12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
     </tr>
     <tr>
-      <td>Ramified primes</td>
+        <td>{{ KNOWL('artin.permutation_container',title="smallest permutation container") }}</td>
+        <td><input type='text' name='container' value="{{req.container}}" size=15></td>
+        <td><span class="formexample"> e.g. 4T3 or 6T10</span></td>
+    <tr>
+      <td>{{KNOWL('artin.ramified_primes', 'ramified primes')}}</td>
       <td><input type='text' name='ramified' value="{{req.ramified}}" size=15/></td>
       <td><span class="formexample"> e.g. 2, 3 (no range allowed)</span></td>
     </tr>
     <tr>
-      <td>Unramified primes</td>
+      <td>{{KNOWL('artin.unramified_primes', 'unramified primes')}}</td>
       <td><input type='text' name='unramified' value = "{{req.unramified}}" size=15/></td>
       <td><span class="formexample"> e.g. 5, 7, 13  (no range allowed)</span></td>
     </tr>
     <tr>
-      <td>{{ KNOWL('artin.root_number',title="Root number") }}</td>
+      <td>{{ KNOWL('artin.root_number',title="root number") }}</td>
       <td><input type='text' name='root_number' value = "{{req.root_number}}" size=15/></td>
       <td><span class="formexample"> at the moment, one of 1 or -1 </span></td>
     </tr>
@@ -93,7 +97,7 @@
 <div>
 	<table border=1 cellpadding=5 class="ntdata">
 
-	<thead><tr><th>Label</th>
+	<thead><tr><th>{{KNOWL('artin.label', 'Label')}}</th>
         <th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
 	<th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
 	<th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -517,6 +517,15 @@ def parse_nf_elt(inp, query, name, qfield, field_label='field_label'):
     deg = int(query[field_label].split('.')[0])
     query[qfield] = pol_string_to_list(inp, deg=deg)
 
+@search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_container(inp, query, qfield):
+    inp = inp.replace('t','T')
+    format_ok = re.match(r'^\d+(T\d+)?$',inp)
+    if format_ok:
+        query[qfield] = str(inp)
+    else:
+        raise ValueError("You must specify a permutation representation, such as 6T13 for a %s"% name)
+
 @search_parser # see SearchParser.__call__ for actual arguments when calling
 def parse_hmf_weight(inp, query, qfield):
     parallel_field, normal_field = qfield

--- a/lmfdb/search_parsing.py
+++ b/lmfdb/search_parsing.py
@@ -519,12 +519,12 @@ def parse_nf_elt(inp, query, name, qfield, field_label='field_label'):
 
 @search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
 def parse_container(inp, query, qfield):
-    inp = inp.replace('t','T')
-    format_ok = re.match(r'^\d+(T\d+)?$',inp)
+    inp = inp.replace('T','t')
+    format_ok = re.match(r'^\d+(t\d+)?$',inp)
     if format_ok:
         query[qfield] = str(inp)
     else:
-        raise ValueError("You must specify a permutation representation, such as 6T13 for a %s"% name)
+        raise ValueError("You must specify a permutation representation, such as 6T13" )
 
 @search_parser # see SearchParser.__call__ for actual arguments when calling
 def parse_hmf_weight(inp, query, qfield):


### PR DESCRIPTION
This is mostly minor tweaking of search form layout, bringing it in line with other parts of lmfdb (lower case for search box labels, aligned left on the browse page).

We now have completeness results in a knowl.  They are based on group, dimension, and smallest containing permutation representation.  The last item is a good way to distinguish characters with the same group and dimension (does not distinguish Galois conjugates or representations which differ by a group automorphism).  So, this also adds a search box for smallest containing permutation representation.

This meant a new entry to the database, but there has to be a corresponding change in the artin code -- it will crash if the database contains fewer or more entries than it expects in each document.  So, this switches the artin databases to temporary names.  It should work on beta, but those databases would need to be copied to the cloud before this code goes there (but the pull request needs to be accepted first).  Then we go around again changing the names back.

One final note, I will be traveling for around 2 weeks and not have a laptop.  So responses to questions or comments, or changes to the pull request won't happen until then.
