### PR TITLE
Include title on main page

### DIFF
--- a/lmfdb/pages.py
+++ b/lmfdb/pages.py
@@ -80,7 +80,7 @@ def index():
 
     return render_template(tmpl,
         titletag="The L-functions and modular forms database",
-        title="",
+        title="LMFDB - The L-functions and Modular Forms Database",
         bread=bread,
         boxes = boxes)
 


### PR DESCRIPTION
This is to clarify the name of the site beyond the title in the browser tab. This was my first commit and done under the guidance of David Lowry-Duda. 