### PR TITLE
Browsing Maass forms page revised

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_graph.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_graph.html
@@ -1,14 +1,13 @@
 {% extends "homepage.html" %}
 
 {% block content %}
-<h1>Graph of eigenvalues of Maass forms of levels {{min_level}} to {{max_level}} with ${{min_R}} \leq R\leq {{max_R}}$</h1>
+<h1>Maass forms of levels {{min_level}} to {{max_level}} with ${{min_R}} \leq R\leq {{max_R}}$</h1>
 <p>
    The horizontal axis is the {{KNOWL('mf.maass.mwf.spectralparameter', title='spectral parameter')}} $R$ with the {{KNOWL('mf.maass.mwf.eigenvalue', title='Laplace eigenvalue')}}
 satisying $\lambda=1/4+R²$. The vertical axis is the {{KNOWL('mf.maass.mwf.level', title='level')}} $N$. Each point
 corresponds to a Maass form of {{KNOWL('mf.maass.mwf.weight', title='weight')}} 0 and trivial character on $\Gamma_0(N)$
 with the color showing whether the {{KNOWL('mf.maass.mwf.symmetry', title='symmetry')}} is <b><font color="{{coloreven}}">even</font></b>
-or <b><font color="{{colorodd}}">odd</font></b>. Clicking on a dot takes you
-to the homepage of the Maass form. For $N>100$ there are only results for prime level.
+or <b><font color="{{colorodd}}">odd</font></b>. For $N>100$ there are only results for prime level.
 
 </p>
 <p>
@@ -22,5 +21,8 @@ Examples of some ranges with complete data:
     <li> <a href="{{ url_for('mwf.render_maass_browse_graph',min_level = 100,max_level= 1000,
                             min_R = 0,max_R = 1) }}">$N$ prime and $100< N<1000, \, 0\leq R\leq 1$</a></li>
 </ul>
+
+<p><b>Clicking on a dot takes you
+to the homepage of the Maass form.</p></b>
 {{contents[0]|safe}}
 {% endblock content %}


### PR DESCRIPTION
Though it was explained in a sentence at the end of the top paragraph, it was not immediately obvious how to navigate the Maass form browsing graph. Indeed, from the original subtitle (which had some redundancy with the main title) it wasn't obvious that the graph linked to pages for individual Maass forms at all, rather the page seemed to suggest that all the information available for each Maass form was just the spectral parameter and the level.

I moved the line about "clicking on a dot" so that it would appear right above the graph and so the instructions are made more obvious, I also modified the subtitle to remove some redundancy and to deemphasize that this page is mainly meant to be a graph rather than a browsing portal.