### PR TITLE
Deleting alternate to truncate_number

### DIFF
--- a/lmfdb/utils.py
+++ b/lmfdb/utils.py
@@ -202,30 +202,6 @@ def splitcoeff(coeff):
     return answer
 
 
-def truncatenumber(numb, precision):
-    localprecision = precision
-    if numb < 0:
-        localprecision = localprecision + 1
-    truncation = float(10 ** (-1.0*localprecision))
-    if float(abs(numb - 1)) < truncation:
-        return("1")
-    elif float(abs(numb - 2)) < truncation:
-        return("2")
-    elif float(abs(numb - 3)) < truncation:
-        return("3")
-    elif float(abs(numb - 4)) < truncation:
-        return("4")
-    elif float(abs(numb)) < truncation:
-        return("0")
-    elif float(abs(numb + 1)) < truncation:
-        return("-1")
-    elif float(abs(numb + 2)) < truncation:
-        return("-2")
-    elif float(abs(numb - 0.5)) < truncation:
-        return("0.5")
-    elif float(abs(numb + 0.5)) < truncation:
-        return("-0.5")
-    return(str(numb)[0:int(localprecision)])
 
 ################################################################################
 #  display and formatting utilities


### PR DESCRIPTION
There were two similar functions in utils.py, truncate_number() and truncatenumber(). The later file is not used by anything else and is redundant, and it was suggested it be removed by David Lowry-Duda. It has been removed. 