### PR TITLE
Minor fix to genus 2 curve page formatting

### DIFF
--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -27,6 +27,7 @@ function show_invs(invstyle) {
   }
 </script>
 
+
 {#
 <script src="http://aleph.sagemath.org/embedded_sagecell.js"></script>
 #}

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -210,13 +210,13 @@ function show_invs(invstyle) {
 <p>
 {% if data.rat_pts_v == 1 %}
 {% if data.rat_pts %}
-{{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: <div class="ratpts">{{data.rat_pts}}</div>
+{{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: {{data.rat_pts}}
 {% else %}
 {{ KNOWL('g2c.known_rational_points', title='No rational points known') }}
 {% endif %}
 {% else %}
 {% if data.rat_pts %}
-{{ KNOWL('g2c.all_rational_points', title='All rational points') }}: <div class="ratpts">{{data.rat_pts}}</div>
+{{ KNOWL('g2c.all_rational_points', title='All rational points') }}: {{data.rat_pts}}
 {% else %}
 {{ KNOWL('g2c.all_rational_points', title='There are no rational points') }}
 {% endif %}

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -242,11 +242,13 @@ function show_invs(invstyle) {
 
 <h2 class='subhead'> Invariants of the {{KNOWL('g2c.jacobian', title='Jacobian')}}: </h2>
 
+<p> 
 {% if data.analytic_rank > 1 %}
-<h3 class="inline"> {{ KNOWL('g2c.analytic_rank', title='Analytic rank*') }}: </h3>\({{data.analytic_rank}}\)
+{{ KNOWL('g2c.analytic_rank', title='Analytic rank*') }}: \({{data.analytic_rank}}\)
 {% else %}
-<h3 class="inline"> {{ KNOWL('g2c.analytic_rank', title='Analytic rank') }}: </h3>\({{data.analytic_rank}}\)
+{{ KNOWL('g2c.analytic_rank', title='Analytic rank') }}: \({{data.analytic_rank}}\)
 {% endif %}
+</p>
 
 <!--
 <p>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -212,13 +212,13 @@ function show_invs(invstyle) {
 {% if data.rat_pts %}
 {{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: {{data.rat_pts}}
 {% else %}
-{{ KNOWL('g2c.known_rational_points', title='No rational points known') }}
+{{ KNOWL('g2c.known_rational_points', title='No rational points known') }}.
 {% endif %}
 {% else %}
 {% if data.rat_pts %}
 {{ KNOWL('g2c.all_rational_points', title='All rational points') }}: {{data.rat_pts}}
 {% else %}
-There are {{ KNOWL('g2c.all_rational_points', title='no rational points') }}
+There are {{ KNOWL('g2c.all_rational_points', title='no rational points') }}.
 {% endif %}
 {% endif %}
 {% endif %}

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -210,25 +210,15 @@ function show_invs(invstyle) {
 <p>
 {% if data.rat_pts_v == 1 %}
 {% if data.rat_pts %}
-<p> {{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: </p>
-<div class="ratpts">
-<p>
-{{data.rat_pts}}
-</p>
-</div>
+{{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: <div class="ratpts">{{data.rat_pts}}</div>
 {% else %}
-<p> {{ KNOWL('g2c.known_rational_points', title='No rational points known') }} </p>
+{{ KNOWL('g2c.known_rational_points', title='No rational points known') }}
 {% endif %}
 {% else %}
 {% if data.rat_pts %}
-<p> {{ KNOWL('g2c.all_rational_points', title='All rational points') }}: </p>
-<div class="ratpts">
-<p>
-{{data.rat_pts}}
-</p>
-</div>
+{{ KNOWL('g2c.all_rational_points', title='All rational points') }}: <div class="ratpts">{{data.rat_pts}}</div>
 {% else %}
-<p> {{ KNOWL('g2c.all_rational_points', title='There are no rational points') }} </p>
+{{ KNOWL('g2c.all_rational_points', title='There are no rational points') }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -218,7 +218,7 @@ function show_invs(invstyle) {
 {% if data.rat_pts %}
 {{ KNOWL('g2c.all_rational_points', title='All rational points') }}: {{data.rat_pts}}
 {% else %}
-{{ KNOWL('g2c.all_rational_points', title='There are no rational points') }}
+There are {{ KNOWL('g2c.all_rational_points', title='no rational points') }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -201,7 +201,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('locally_solvable')}}
 </p>
-<h3 class="inline"> This curve is {{ KNOWL('g2c.locally_solvable', title='locally solvable') }} {{data.non_solvable_places}}.</h3>
+<p> This curve is {{ KNOWL('g2c.locally_solvable', title='locally solvable') }} {{data.non_solvable_places}}.</p>
 
 {% if data.rat_pts_v > 0 %}
 <p>
@@ -210,25 +210,25 @@ function show_invs(invstyle) {
 <p>
 {% if data.rat_pts_v == 1 %}
 {% if data.rat_pts %}
-<h3 class="inline"> {{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: </h3>
+<p> {{ KNOWL('g2c.known_rational_points', title='Known rational points') }}: </p>
 <div class="ratpts">
 <p>
 {{data.rat_pts}}
 </p>
 </div>
 {% else %}
-<h3 class="inline"> {{ KNOWL('g2c.known_rational_points', title='No rational points known') }} </h3>
+<p> {{ KNOWL('g2c.known_rational_points', title='No rational points known') }} </p>
 {% endif %}
 {% else %}
 {% if data.rat_pts %}
-<h3 class="inline"> {{ KNOWL('g2c.all_rational_points', title='All rational points') }}: </h3>
+<p> {{ KNOWL('g2c.all_rational_points', title='All rational points') }}: </p>
 <div class="ratpts">
 <p>
 {{data.rat_pts}}
 </p>
 </div>
 {% else %}
-<h3 class="inline"> {{ KNOWL('g2c.all_rational_points', title='There are no rational points') }} </h3>
+<p> {{ KNOWL('g2c.all_rational_points', title='There are no rational points') }} </p>
 {% endif %}
 {% endif %}
 {% endif %}
@@ -237,7 +237,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('num_rat_wpts')}}
 </p>
-<h3 class="inline"> Number of rational {{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}: </h3>\({{data.num_rat_wpts}}\)
+<p> Number of rational {{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}: \({{data.num_rat_wpts}}\)</p>
 
 
 <h2 class='subhead'> Invariants of the {{KNOWL('g2c.jacobian', title='Jacobian')}}: </h2>
@@ -262,27 +262,27 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_selmer')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank') }}: </h3>\({{data.two_selmer_rank}}\)
+<p> {{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank') }}: \({{data.two_selmer_rank}}\)</p>
 
 <p>
 {{place_code('has_square_sha')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.has_square_sha', title='Order of &#1064;*') }}: </h3>{{data.has_square_sha}}
+<p> {{ KNOWL('g2c.has_square_sha', title='Order of &#1064;*') }}: {{data.has_square_sha}}</p>
 
 <p>
 {{place_code('tamagawa')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.tamagawa', title='Tamagawa numbers') }}: </h3>{{data.tama}}
+<p> {{ KNOWL('g2c.tamagawa', title='Tamagawa numbers') }}: {{data.tama}}</p>
 
 <p>
 {{place_code('torsion_subgroup')}}
 </p>
-<h3 class="inline"> {{ KNOWL('g2c.torsion', title='Torsion') }}: </h3>\({{data.torsion_subgroup}}\)
+<p> {{ KNOWL('g2c.torsion', title='Torsion') }}: \({{data.torsion_subgroup}}\)</p>
 
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<h3 class="inline">  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}:</h3> <div style="display: inline">{{data.two_torsion_field_knowl|safe}}</div>
+<p>  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <div style="display: inline">{{data.two_torsion_field_knowl|safe}}</div></p>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -282,7 +282,7 @@ function show_invs(invstyle) {
 <p>
 {{place_code('two_torsion_field')}}
 </p>
-<p>  {{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: <div style="display: inline">{{data.two_torsion_field_knowl|safe}}</div></p>
+<p><div style="display: inline">{{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: {{data.two_torsion_field_knowl|safe}}</div></p>
 
 <h3> {{KNOWL('g2c.st_group', title='Sato-Tate group') }} </h3>
 


### PR DESCRIPTION
For @JohnCremona, remove <h3> subheading level from bottom level one-line displays so that they are not displayed all in green (now only knowl links are).