### PR TITLE
Uniformize charsums property in characters

### DIFF
--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -789,7 +789,11 @@ class WebSmallDirichletCharacter(WebChar, WebDirichlet):
     @property
     def indlabel(self):  return None
     def value(self, *args): return None
-    def charsums(self, *args): return False
+
+    @property
+    def charsums(self, *args):
+        return False
+
     def gauss_sum(self, *args): return None
     def jacobi_sum(self, *args): return None
     def kloosterman_sum(self, *args): return None

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -44,7 +44,7 @@ def render_characterNavigation():
 
 def render_DirichletNavigation():
     args = to_dict(request.args)
-    
+
     info = {'args':args}
     info['bread'] = [ ('Characters',url_for(".render_characterNavigation")),
                       ('Dirichlet', url_for(".render_Dirichletwebpage")) ]
@@ -180,14 +180,14 @@ def render_Dirichletwebpage(modulus=None, number=None):
         flash_error ("specified modulus %s is too large, it should be less than $10^{20}$.", modulus)
         return redirect(url_for(".render_Dirichletwebpage"))
 
-        
-    
+
+
     if number == None:
         if modulus < 100000:
             info = WebDirichletGroup(**args).to_dict()
         else:
             info = WebSmallDirichletGroup(**args).to_dict()
-        info['title'] = 'Group of Dirichlet Characters of Modulus ' + str(modulus) 
+        info['title'] = 'Group of Dirichlet Characters of Modulus ' + str(modulus)
         info['bread'] = [('Characters', url_for(".render_characterNavigation")),
                          ('Dirichlet', url_for(".render_Dirichletwebpage")),
                          ('%d'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus))]


### PR DESCRIPTION
This is a minor update to the previous pull request #2471.

It used to be that WebDirichletCharacter and WebSmallDirichletCharacter had different interfaces to the charsums function/property/dictionary. This makes it always available as a property.

This difference caused (the remaining problems in the reopened version of) #2465.