### PR TITLE
Switching databases back

### DIFF
--- a/lmfdb/artin_representations/databases/Dokchitser_databases.py
+++ b/lmfdb/artin_representations/databases/Dokchitser_databases.py
@@ -1,7 +1,7 @@
 artin_location = ("artin", "representations")
 galois_group_location = ("artin", "field_data")
-artin_location = ("artin", "representations_new")
-galois_group_location = ("artin", "field_data_new")
+#artin_location = ("artin", "representations_new")
+#galois_group_location = ("artin", "field_data_new")
 
 
 from type_generation import String, Array, Dict, Int, Anything

--- a/scripts/artin_representations/import_art_nf.py
+++ b/scripts/artin_representations/import_art_nf.py
@@ -170,4 +170,5 @@ for path in sys.argv[1:]:
       reindex_collection(art, 'field_data', 'field_data_new')
     if case == 'art rep':
       reindex_collection(art, 'representations', 'representations_new')
+    fn.close()
 


### PR DESCRIPTION
This changes the names of the databases for artin representations back to what they were.  Along with this, the collections
  artin.representations
  artin.field_data
  artin.representations.rand
should be copied to the cloud.