### PR TITLE
NF tidy

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -534,7 +534,8 @@ class WebNumberField:
         cg_list = self._data['class_group']
         if cg_list == []:
             return 'Trivial'
-        return cg_list
+        #return cg_list
+        return '$%s$'%str(cg_list)
 
     def class_group_invariants_raw(self):
         if not self.haskey('class_group'):
@@ -549,7 +550,7 @@ class WebNumberField:
 
     def class_number(self):
         if self.haskey('class_number'):
-            return self._data['class_number']
+            return '$%s$'%str(self._data['class_number'])
         return na_text()
 
     def can_class_number(self):

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -507,15 +507,19 @@ class WebNumberField:
         return na_text()
 
     def units(self):  # fundamental units
+        res = None
         if self.haskey('units'):
-            return ',&nbsp; '.join(self._data['units'])
-        if self.unit_rank() == 0:
-            return ''
-        if self.haskey('class_number'):
+            res = ',&nbsp; '.join(self._data['units'])
+        elif self.unit_rank() == 0:
+            res = ''
+        elif self.haskey('class_number'):
             K = self.K()
             units = [web_latex(u) for u in K.unit_group().fundamental_units()]
             units = ',&nbsp; '.join(units)
-            return units
+            res = units
+        if res:
+            res = res.replace('\\\\', '\\')
+            return res
         return na_text()
 
     def disc_factored_latex(self):

--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -163,7 +163,7 @@ def nf_knowl_guts(label):
     out += '<br>Signature: '
     out += str(wnf.signature())
     out += '<br>Galois group: '+group_display_knowl(wnf.degree(),wnf.galois_t())
-    out += '<br>Class number: %s ' % str(wnf.class_number())
+    out += '<br>Class number: %s ' % str(wnf.class_number_latex())
     if wnf.can_class_number():
         out += wnf.short_grh_string()
     out += '</div>'
@@ -549,10 +549,15 @@ class WebNumberField:
     def class_group(self):
         if self.haskey('class_group'):
             cg_list = self._data['class_group']
-            return str(AbelianGroup(cg_list)) + ', order ' + str(self._data['class_number'])
+            return str(AbelianGroup(cg_list)) + ', order ' + self.class_number_latex()
         return na_text()
 
     def class_number(self):
+        if self.haskey('class_number'):
+            return self._data['class_number']
+        return na_text()
+
+    def class_number_latex(self):
         if self.haskey('class_number'):
             return '$%s$'%str(self._data['class_number'])
         return na_text()

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -332,10 +332,6 @@ class LfunctionTest(LmfdbTest):
         print str(L)
         assert 'OK' in str(L)
 
-    def test_LdedekindZeros(self):
-        L = self.tc.get('/L/Zeros/NumberField/3.1.23.1/')
-        assert '5.1156833288' in L.data
-
     def test_LartinPlot(self):
         L = self.tc.get('/L/Zeros/ArtinRepresentation/2.2e2_17.4t3.2c1/')
         assert 'OK' in str(L)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -45,7 +45,6 @@ def init_nf_count():
         max_deg = db.nf_fields.max('degree')
         init_nf_flag = True
 
-
 def group_cclasses_data(n, t):
     return flask.Markup(group_cclasses_knowl_guts(n, t))
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -341,7 +341,7 @@ def render_field_webpage(args):
 
     info['wnf'] = nf
     data['degree'] = nf.degree()
-    data['class_number'] = nf.class_number()
+    data['class_number'] = nf.class_number_latex()
     ram_primes = nf.ramified_primes()
     t = nf.galois_t()
     n = nf.degree()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -74,6 +74,22 @@ def global_numberfield_summary():
     init_nf_count()
     return r'This database contains %s <a title="global number fields" knowl="nf">global number fields</a> of <a title="degree" knowl="nf.degree">degree</a> $n\leq %d$.  Here are some <a href="%s">further statistics</a>.  In addition, extensive data on <a href="%s">class groups of quadratic imaginary fields</a> is available for download.' %(comma(nfields),max_deg,url_for('number_fields.statistics'), url_for('number_fields.render_class_group_data'))
 
+def learnmore_list():
+    return [(Completename, url_for(".render_discriminants_page")), 
+            ('How data was computed', url_for(".how_computed_page")), 
+            ('Global number field labels', url_for(".render_labels_page")), 
+            ('Galois group labels', url_for(".render_groups_page")), 
+            ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+
+# Return the learnmore list with the matchstring entry removed
+def learnmore_list_remove(matchstring):
+    return filter(lambda t:t[0].find(matchstring) <0, learnmore_list())
+
+#def group_display_shortC(C):
+#    def gds(nt):
+#        return group_display_short(nt['n'], nt['t'], C)
+#    return gds
+
 def poly_to_field_label(pol):
     try:
         wnf = WebNumberField.from_polynomial(pol)
@@ -89,46 +105,37 @@ def NF_redirect():
 @nf_page.route("/HowComputed")
 def how_computed_page():
     info = {}
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), 
-        ('Galois group labels', url_for(".render_groups_page")), 
-        (Completename, url_for(".render_discriminants_page")) ]
+    learnmore = learnmore_list_remove('was computed')
     t = 'How Number Field Data was Computed'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Source', ' ')]
     return render_template("single.html", kid='dq.nf.howcomputed', 
-        credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
+        credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
 
 @nf_page.route("/GaloisGroups")
 def render_groups_page():
     info = {}
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")) ]
+    learnmore = learnmore_list_remove('Galois group')
     t = 'Galois Group Labels'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Galois Group Labels', ' ')]
-    return render_template("galois_groups.html", 
-            al=group_alias_table(), 
-            info=info, credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
-
+    return render_template("galois_groups.html", al=group_alias_table(), info=info, credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
 
 @nf_page.route("/FieldLabels")
 def render_labels_page():
     info = {}
-    info['learnmore'] = [(Completename, url_for(".render_discriminants_page")),
-                         ('How data was computed', url_for(".how_computed_page")),
-                         ('Galois group labels', url_for(".render_groups_page")),
-                         ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
-    t = 'Number Field Labels'
-    bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Global Number Field Labels', '')]
-    return render_template("single.html", info=info, credit=NF_credit, kid='nf.label', title=t, bread=bread, learnmore=info.pop('learnmore'))
+    learnmore = learnmore_list_remove('number field labels')
+    t = 'Labels for Global Number Fields'
+    bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Labels', '')]
+    return render_template("single.html", info=info, credit=NF_credit, kid='nf.label', title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/Discriminants")
 def render_discriminants_page():
     info = {}
-    info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page")), ('Quadratic imaginary class groups', url_for(".render_class_group_data"))]
+    learnmore = learnmore_list_remove('Completeness')
     t = 'Completeness of Global Number Field Data'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Completeness', ' ')]
     return render_template("single.html", kid='dq.nf.completeness', 
-        credit=NF_credit, title=t, bread=bread, learnmore=info.pop('learnmore'))
+        credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/QuadraticImaginaryClassGroups")
@@ -138,7 +145,7 @@ def render_class_group_data():
     #for k in info.keys():
     # nf_logger.info(str(k) + ' ---> ' + str(info[k]))
     #nf_logger.info('******************* ')
-    #info['learnmore'] = [('Global number field labels', url_for(".render_labels_page")), ('Galois group labels', url_for(".render_groups_page")), (Completename, url_for(".render_discriminants_page"))]
+    learnmore = learnmore_list_remove('Quadratic imaginary')
     t = 'Class Groups of Quadratic Imaginary Fields'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), (t, ' ')]
     info['message'] =  ''
@@ -169,7 +176,7 @@ def render_class_group_data():
             info['message'] = 'Invalid congruence requested'
             return class_group_request_error(info, bread)
 
-    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread)
+    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread, learnmore=learnmore)
 
 def class_group_request_error(info, bread):
     t = 'Class Groups of Quadratic Imaginary Fields'
@@ -504,12 +511,9 @@ def render_field_webpage(args):
             resinfo.append(('ae', dnc, len(arith_equiv[1])))
 
     info['resinfo'] = resinfo
-    info['learnmore'] = [('Global number field labels', url_for(
-        ".render_labels_page")), 
-        (Completename, url_for(".render_discriminants_page")),
-        ('How data was computed', url_for(".how_computed_page"))]
-    if info['signature'] == [0,1]:
-        info['learnmore'].append(('Quadratic imaginary class groups', url_for(".render_class_group_data")))
+    learnmore = learnmore_list()
+    #if info['signature'] == [0,1]:
+    #    info['learnmore'].append(('Quadratic imaginary class groups', url_for(".render_class_group_data")))
     # With Galois group labels, probably not needed here
     # info['learnmore'] = [('Global number field labels',
     # url_for(".render_labels_page")), ('Galois group
@@ -523,7 +527,7 @@ def render_field_webpage(args):
         primes = 'primes'
 
     properties2 = [('Label', label),
-                   ('Degree', '%s' % data['degree']),
+                   ('Degree', '$%s$' % data['degree']),
                    ('Signature', '$%s$' % data['signature']),
                    ('Discriminant', '$%s$' % data['disc_factor']),
                    ('Ramified ' + primes + '', '$%s$' % ram_primes),
@@ -532,7 +536,7 @@ def render_field_webpage(args):
                    ('Galois Group', group_display_short(data['degree'], t))
                    ]
     downloads = []
-    for lang in [["Magma","magma"], ["SageMath","sage"], ["GP", "gp"]]:
+    for lang in [["Magma","magma"], ["SageMath","sage"], ["Pari/GP", "gp"]]:
         downloads.append(('Download {} code'.format(lang[0]),
                           url_for(".nf_code_download", nf=label, download_type=lang[1])))
     from lmfdb.artin_representations.math_classes import NumberFieldGaloisGroup
@@ -547,7 +551,7 @@ def render_field_webpage(args):
         info["mydecomp"] = [dopow(x) for x in v]
     except AttributeError:
         pass
-    return render_template("number_field.html", properties2=properties2, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=info.pop('learnmore'), info=info)
+    return render_template("number_field.html", properties2=properties2, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=learnmore, info=info)
 
 def format_coeffs2(coeffs):
     return format_coeffs(string2list(coeffs))

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -459,7 +459,7 @@ def render_field_webpage(args):
             info['friends'].append(('L-function', "/L/NumberField/%s" % label))
     info['friends'].append(('Galois group', "/GaloisGroup/%dT%d" % (n, t)))
     if 'dirichlet_group' in info:
-        info['friends'].append(('Dirichlet group', url_for("characters.dirichlet_group_table",
+        info['friends'].append(('Dirichlet character group', url_for("characters.dirichlet_group_table",
                                                            modulus=int(conductor),
                                                            char_number_list=','.join(
                                                                [str(a) for a in dirichlet_chars]),

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -104,7 +104,6 @@ def NF_redirect():
 
 @nf_page.route("/HowComputed")
 def how_computed_page():
-    info = {}
     learnmore = learnmore_list_remove('was computed')
     t = 'How Number Field Data was Computed'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Source', ' ')]
@@ -130,7 +129,6 @@ def render_labels_page():
 
 @nf_page.route("/Discriminants")
 def render_discriminants_page():
-    info = {}
     learnmore = learnmore_list_remove('Completeness')
     t = 'Completeness of Global Number Field Data'
     bread = [('Global Number Fields', url_for(".number_field_render_webpage")), ('Completeness', ' ')]

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -60,7 +60,7 @@ table.ntdata a {
         <p><h2> {{ KNOWL('nf.integral_basis', title='Integral basis') }} </h2>
 {% endif %}
 {% if info.degree!=1 %}
-        <p><h2> {{ KNOWL('nf.integral_basis', title='Integral basis') }} (with respect to {{ KNOWL('nf.field_generator', title='field generator') }} \(a\))</h2>
+        <p><h2> {{ KNOWL('nf.integral_basis', title='Integral basis') }} (with respect to {{ KNOWL('nf.generator', title='field generator') }} \(a\))</h2>
 {% endif %}
         <p>
             {{ info.integral_basis }}

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -39,7 +39,7 @@ table.ntdata a {
   {% if info.is_abelian %}
             <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>
                 <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>
-            <tr><td>{{ KNOWL('nf.dirichlet_group', title="Dirichlet group") }}:
+            <tr><td>{{ KNOWL('nf.dirichlet_group', title="Dirichlet character group") }}:
                 <td>&nbsp;&nbsp;<td>
                 {% if info.dirichlet_group is defined %}
                 {{info.dirichlet_group|safe}}

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -87,7 +87,7 @@ Enter values into one or more boxes to restrict the search.
 <span class="formexample"> e.g. 2,3</span></td>
 <td>
 <td>
-set of {{KNOWL('nf.ramified_prime', title='ramified primes')}} 
+set of {{KNOWL('nf.ramified_primes', title='ramified primes')}} 
 <select name='ram_quantifier'>
   <option value='contained'>subset of</option>
   <option value='exactly' selected='yes'>equal to</option>

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -23,7 +23,7 @@
 <tr>
 <td align='left'> {{KNOWL('nf.discriminant', title='discriminant')}} range <td align='left' colspan='2'> <input type='text' name='discriminant' size='20' value="{{info.discriminant}}"></td>
 <td align=right colspan="2">
-set of {{KNOWL('nf.ramified_prime', title='ramified primes')}}
+set of {{KNOWL('nf.ramified_primes', title='ramified primes')}}
 {% if info.ram_quantifier == 'contained' %}
 <select name = "ram_quantifier">
   <option value='contained' selected='yes'>subset of</option>


### PR DESCRIPTION
These are mostly changes to global number fields in response to the review document, which are things like knowls and putting in math mode in places.

It also compensates for a change in the postgres migration.  Fundamental units are stored as math mode strings.  I think they were generated with sage, so they use backslash-paren for start/stop of the math mode.  I think the postgres database doubled all of the backslashes.  If you look at say http://postgres.lmfdb.xyz/NumberField/3.3.81.1 vs. the same page on beta, you can see the difference.  This simply replaces double backslash with single backslash which fixes it, and would be innocuous if some database entries have just single backslashes.