### PR TITLE
Adding warning to beta.lmfdb.org connected to mongodb

### DIFF
--- a/lmfdb/knowledge/templates/knowl-edit.html
+++ b/lmfdb/knowledge/templates/knowl-edit.html
@@ -2,6 +2,13 @@
 {% import 'color.css' as color %}
 {% block content %}
 
+
+<div style="color: red; font-weight: bold; font-size: 150%;">
+    Warning: This legacy server and it is connected to a stale database.<br>
+    Please do not perform any additions or edits on this server, as these not be replicated to the current version of the LMFDB!
+    Please use <a href="http://beta.lmfdb.org">beta.lmfdb.org</a> to edit knowls.
+  </div>
+
 {% if lock %}
     <div style="color: {{color.red}}; font-weight: bold; font-size: 200%;">Concurrent Edit!!!</div>
 


### PR DESCRIPTION
# This PR is meant to be merged at some specific time (TBD)


This PR is meant to add a warning on beta.lmfdb.xyz (and temporarily on beta.lmfdb.org) informing users about the staleness of the mongo database.

This PR should be merged into ***beta*** before we copy one last time the knowl and user collections to the postgres db.

Furthermore, I would appreciate someone could check the language and test it. (I'm on an airplane and can't really do it)

P.S: I'm proposing merging into `beta`, as `prod` and `beta` are not in synchrony anymore (due to #2565)