### PR TITLE
Handling a generic refused connection for hobbes

### DIFF
--- a/lmfdb/test_acknowlegments.py
+++ b/lmfdb/test_acknowlegments.py
@@ -47,6 +47,7 @@ class HomePageTest(LmfdbTest):
             elif 'Connection refused' in str(e): # not every error comes with a errno
                 pass;
             else:
+                print e
                 print e.errno
                 raise
 

--- a/lmfdb/test_acknowlegments.py
+++ b/lmfdb/test_acknowlegments.py
@@ -44,7 +44,10 @@ class HomePageTest(LmfdbTest):
         except urllib2.URLError, e:
             if e.errno in [errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN]:
                 pass;
+            elif 'Connection refused' in str(e): # not every error comes with a errno
+                pass;
             else:
+                print e.errno
                 raise
 
         self.check_external(homepage,


### PR DESCRIPTION
One more exception to handle connection refused from hobbes.
@jwj61, could you test this? (under the conditions that make this test fail)