### PR TITLE
Local gsm

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -222,9 +222,9 @@ def render_field_webpage(args):
         else:
             rffriend = "/LocalNumberField/%s" % rflabel
         gsm = data['gsm']
-        if gsm == '0':
+        if gsm == [0]:
             gsm = 'Not computed'
-        elif gsm == '-1':
+        elif gsm == [-1]:
             gsm = 'Does not exist'
         else:
             gsm = web_latex(coeff_to_poly(gsm))

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -67,8 +67,8 @@ table,td {
       <tr><td>{{ KNOWL('lf.unramified_degree', title='Unramified degree')}}:</td><td>${{info.u}}$</td></tr>
       <tr><td>{{ KNOWL('lf.tame_degree', title='Tame degree')}}:</td><td>${{info.t}}$</td></tr>
       <tr><td>{{ KNOWL('lf.wild_slopes', title='Wild slopes')}}:</td><td>{{info.slopes}}</td></tr>
-      <tr><td>{{ KNOWL('lf.galois_mean_slope', title='Galois Mean Slope')}}:</td><td>${{info.gms}}$</td></tr>
-      <tr><td>{{KNOWL('lf.global_splitting_model', title='Global Splitting Model')}}:</td><td>{{info.gsm}}</td></tr>
+      <tr><td>{{ KNOWL('lf.galois_mean_slope', title='Galois mean slope')}}:</td><td>${{info.gms}}$</td></tr>
+      <tr><td>{{KNOWL('lf.global_splitting_model', title='Global splitting model')}}:</td><td>{{info.gsm}}</td></tr>
     </table>
   </p>
 

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -21,3 +21,11 @@ class LocalFieldTest(LmfdbTest):
 		L = self.tc.get('/LocalNumberField/11.6.4.2')
 		assert 'x^{2} - x + 7' in L.data # bad (not robust) test, but it's the best i was able to find...
 		assert 'x^{3} - 11 t' in L.data # bad (not robust) test, but it's the best i was able to find...
+
+    def test_global_splitting_models(self):
+	# The first one will have to change if we compute a GSM for it
+        L = self.tc.get('/LocalNumberField/163.8.7.2')
+        assert 'Not computed' in L.data
+        L = self.tc.get('/LocalNumberField/2.8.0.1')
+        assert 'Does not exist' in L.data
+


### PR DESCRIPTION
There are two special cases of Global splitting models (in the normal case, it is a polynomial).  In one, such as 
  http://www.lmfdb.org/LocalNumberField/163.8.7.2
we have not computed one yet.  In
  http://www.lmfdb.org/LocalNumberField/2.8.0.1
it is a theorem that it does not exist.  Going to postgres changed how these special cases were stored in the database.  This updates the code to recognize the two special values.

It also makes a minor capitalization adjustment for consistency, and adds tests for the cases above.