### PR TITLE
Two small fixes in the Dirichlet character pages

### DIFF
--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -920,7 +920,7 @@ class WebDirichletCharacter(WebSmallDirichletCharacter):
 
     @property
     def codeinducing(self):
-        return { 'sage': 'sage: chi.primitive_character()',
+        return { 'sage': 'chi.primitive_character()',
                  'pari': ['znconreyconductor(g,chi,&chi0)','chi0'] }
 
     @property

--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -843,8 +843,9 @@ class WebSmallDirichletCharacter(WebChar, WebDirichlet):
         mod, num = self.modulus, self.number
         prim = self.isprimitive
         #beware this **must** be a generator
-        orbit = ( power_mod(num, k, mod) for k in xsrange(1, order) if gcd(k, order) == 1) # use xsrange not xrange
-        return ( self._char_desc(num, prim=prim) for num in orbit )
+        orbit = (power_mod(num, k, mod) for k in xsrange(1, order + 1)
+                 if gcd(k, order) == 1)
+        return (self._char_desc(num, prim=prim) for num in orbit)
 
     def symbol_numerator(self):
         """ chi is equal to a kronecker symbol if and only if it is real """

--- a/lmfdb/WebCharacter.py
+++ b/lmfdb/WebCharacter.py
@@ -972,7 +972,7 @@ class WebDirichletCharacter(WebSmallDirichletCharacter):
         chitex = self.char2tex(mod, num, tag=False)
         chitexr = self.char2tex(mod, num, 'r', tag=False)
         deftex = r'\sum_{r\in %s} %s e\left(\frac{%s}{%s}\right)'%(Gtex,chitexr,n,d)
-        return r"\(\displaystyle \tau_{%s}(%s) = %s = %s. \)" % (val, chitex, deftex, g)
+        return r"\(\displaystyle \tau_{%s}(%s) = %s = %s \)" % (val, chitex, deftex, g)
 
     @property
     def codegauss(self):
@@ -995,7 +995,7 @@ class WebDirichletCharacter(WebSmallDirichletCharacter):
         psitex1r = self.char2tex(mod, val, '1-r', tag=False)
         deftex = r'\sum_{r\in %s} %s %s'%(Gtex,chitexr,psitex1r)
         from sage.all import latex
-        return r"\( \displaystyle J(%s,%s) = %s = %s.\)" % (chitex, psitex, deftex, latex(jacobi_sum))
+        return r"\( \displaystyle J(%s,%s) = %s = %s \)" % (chitex, psitex, deftex, latex(jacobi_sum))
 
     @property
     def codejacobi(self):
@@ -1019,7 +1019,7 @@ class WebDirichletCharacter(WebSmallDirichletCharacter):
         \( \displaystyle K(%s,%s,\chi_{%s}(%s,&middot;))
         = \sum_{r \in \Z/%s\Z}
              \chi_{%s}(%s,r) e\left(\frac{%s r + %s r^{-1}}{%s}\right)
-        = %s. \)""" % (a, b, modulus, number, modulus, modulus, number, a, b, modulus, k)
+        = %s \)""" % (a, b, modulus, number, modulus, modulus, number, a, b, modulus, k)
 
     @property
     def codekloosterman(self):


### PR DESCRIPTION
Firstly, I've removed the periods appearing at the ends of the Jacobi, Gauss, and Kloosterman sum equations. (pointed out to me by Alina and Kiran)

Secondly, I've corrected a small typo in the `Show commands for SageMath` sage command for inducing primitive characters, where the word `sage` appeared twice. (pointed out to me by John Voight)