### PR TITLE
set max-height for properties-body, and scroll if overflow

### DIFF
--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -392,7 +392,7 @@ body > .debug {
   min-width: 200px;
   border-bottom-left-radius: 10px;
   -moz-border-radius-bottomleft: 10px;
-  max-height: 206px; /* 10 items with padding: 21 + 20*9 + 5 */
+  max-height: 406px; /* 20 items with padding: 21 + 20*19 + 5 */
   overflow-y: auto; /* scrollbar if we overflow */
 }
 .properties-header {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -392,6 +392,8 @@ body > .debug {
   min-width: 200px;
   border-bottom-left-radius: 10px;
   -moz-border-radius-bottomleft: 10px;
+  max-height: 206px; /* 10 items with padding: 21 + 20*9 + 5 */
+  overflow-y: auto; /* scrollbar if we overflow */
 }
 .properties-header {
   border-top-left-radius: 10px;


### PR DESCRIPTION
This will truncate the properties box and add a scrollbar if the friends/properties/origins box has more than 10 items.

I'm not aware of any page that displays more than ~10~ 20  of these at the moment, however, in the after redoing classical modular forms this will be the case.

For clarity, I prefer to submit this as a separate pull request.

ps: properties box with plots are usually around 350px
