### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -154,7 +154,7 @@ def ref_to_link(txt):
         elif ref.startswith("doi"):
             ref = ref.replace(":","")  # could be doi:: or doi: or doi
             the_doi = ref[3:]    # remove the "doi"
-            this_link = '{{ LINK_EXT("' + the_doi + '","http://dx.doi.org/' + the_doi + '")| safe }}'
+            this_link = '{{ LINK_EXT("' + the_doi + '","https://doi.org/' + the_doi + '")| safe }}'
         elif ref.lower().startswith("mr"):
             ref = ref.replace(":","")
             the_mr = ref[2:]    # remove the "MR"

--- a/lmfdb/templates/citations_content.html
+++ b/lmfdb/templates/citations_content.html
@@ -2018,7 +2018,7 @@ Audrey Terras.
   sphere, and the Poincar&eacute; upper half-plane</em>.
  Springer, New York, second edition, 2013.
 [&nbsp;<a href="/citation/citations_bib#MR3100414">bib</a>&nbsp;| 
-<a href="http://dx.doi.org/10.1007/978-1-4614-7972-7">DOI</a>&nbsp;]
+<a href="https://doi.org/10.1007/978-1-4614-7972-7">DOI</a>&nbsp;]
 
 </td>
 </tr>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!