### PR TITLE
fix superfluous backslashes in ec Kodaira symbols

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -470,6 +470,7 @@ class ECNF(object):
         for P,ld in zip(badprimes,local_data):
             ld['p'] = web_latex(P)
             ld['norm'] = P.norm()
+            ld['kod'] = ld['kod'].replace('\\\\', '\\')
             ld['kod'] = web_latex(ld['kod']).replace('$', '')
 
         # URLs of self and related objects:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -184,6 +184,8 @@ class WebEC(object):
         data['equation'] = self.equation
         local_data = self.local_data
         D = self.signD * prod([ld['p']**ld['ord_disc'] for ld in local_data])
+        for ld in local_data:
+            ld['kod'] = ld['kod'].replace("\\\\","\\")
         data['disc'] = D
         Nfac = Factorization([(ZZ(ld['p']),ld['ord_cond']) for ld in local_data])
         Dfac = Factorization([(ZZ(ld['p']),ld['ord_disc']) for ld in local_data], unit=ZZ(self.signD))


### PR DESCRIPTION
On ec and ecnf curve homepages (e.g. EllipticCurve/2.0.3.1/86016.1/x/4 and EllipticCurve/Q/129779/a/1) the Kodaira symbols display incorrectly in the Local Data tables.  This PR fixes this.
 
However the problem is cause by the new database having too many backslashes in the stored strings, which was not the case in the old database ("\\" have become "\\\\").  Hence a better solution would be (1) to fix the new database entries, and (2) see what caused this to happen in the data migration scripts.  Could there be other places where this happened?

I wrote the fix so that nothing bad will happen after such fixes to the data.