### PR TITLE
Convert the degree 3 and 4 Maass L-function pages

### DIFF
--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -78,7 +78,7 @@ def getGroupHtml(group):
         ans += "By permuting and possibly taking the complex conjugate, we may assume \\(\\mu_1 \ge \\mu_2 \ge 0\\), \n"
         ans += "so the functional equation can be represented by a point \\( (\\mu_1, \\mu_2) \\) below "
         ans += "the diagonal in the first quadrant of the Cartesian plane.</div>\n"
-    elif group == 'r0r0r0r0':   # note: signature, not group.  Delete the groups, then change the name
+    elif group == 'r0r0r0r0':
         ans = "<h3 id='r0r0r0r0'>L-functions of signature (0,0,0,0;)</h3>\n"
         ans += "<div>\n"
         ans += "These L-functions satisfy a functional equation with \\(\\Gamma\\)-factors\n"
@@ -103,6 +103,7 @@ def getGroupHtml(group):
         ans += "\\end{equation}\n"
         ans += "with \\(\\mu_j\\) real.  By renaming and rearranging, we may assume \\(0 \\le \\mu_2 \\le \\mu_1\\).</div>\n"
 
+    # groups, soon to be obsolete
     elif group == 'GSp4':
         ans = "<h3 id='GSp4_Q_Maass'>Maass cusp forms for GSp(4)</h3>\n"
         ans += "<div>Currently in the LMFDB, we have data on L-functions associated "

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -33,14 +33,25 @@ def getAllMaassGraphHtml(degree, signature=""):
         groups = [ ["GSp4", [1]], ["GL4", [1]] ] 
     else:
         return ""
+    if signature:
+        groups = []
 
     ans = ""
+    if signature == 'r0r0r0':
+        ans += getGroupHtml(signature)
+        ans += getOneGraphHtml(["GL3", 1])
+        ans += getOneGraphHtml(["GL3", 4])
+    elif signature == 'r0r0r0r0':
+        ans += getGroupHtml(signature + 'selfdual')
+        ans += getOneGraphHtml(["GSp4", 1])
+        ans += getGroupHtml(signature)
+        ans += getOneGraphHtml(["GL4", 1])
+
+#        else:
+#            ans += getGroupHtml(g)
     for i in range(0, len(groups)):
         g = groups[i][0]
-        if signature:
-            ans += getGroupHtml(signature)
-        else:
-            ans += getGroupHtml(g)
+        ans += getGroupHtml(g)
         for j in range(0, len(groups[i][1])):
             l = groups[i][1][j]
             ans += getOneGraphHtml([g, l])
@@ -67,6 +78,31 @@ def getGroupHtml(group):
         ans += "By permuting and possibly taking the complex conjugate, we may assume \\(\\mu_1 \ge \\mu_2 \ge 0\\), \n"
         ans += "so the functional equation can be represented by a point \\( (\\mu_1, \\mu_2) \\) below "
         ans += "the diagonal in the first quadrant of the Cartesian plane.</div>\n"
+    elif group == 'r0r0r0r0':   # note: signature, not group.  Delete the groups, then change the name
+        ans = "<h3 id='r0r0r0r0'>L-functions of signature (0,0,0,0;)</h3>\n"
+        ans += "<div>\n"
+        ans += "These L-functions satisfy a functional equation with \\(\\Gamma\\)-factors\n"
+        ans += "\\begin{equation}"
+        ans += "\\Gamma_\\R(s + i \\mu_1)"
+        ans += "\\Gamma_\\R(s + i \\mu_2)"
+        ans += "\\Gamma_\\R(s + i \\mu_3)"
+        ans += "\\Gamma_\\R(s + i \\mu_4)"
+        ans += "\\end{equation}\n"
+        ans += "with \\(\mu_j\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 + \\mu_4 = 0\\). \n"
+        ans += "By permuting and possibly conjugating, we may assume \\(0\\le \\mu_2 \\le \\mu_1 \\).\n"
+        ans += "</div>\n"
+    elif group == 'r0r0r0r0selfdual':
+        ans = "<h3 id='r0r0r0r0selfdual'>L-functions of signature (0,0,0,0;) with real coefficients</h3>\n"
+        ans += "<div>\n"
+        ans += "These L-functions satisfy a functional equation with \\(\\Gamma\\)-factors\n"
+        ans += "\\begin{equation}"
+        ans += "\\Gamma_\\R(s + i \\mu_1)"
+        ans += "\\Gamma_\\R(s + i \\mu_2)"
+        ans += "\\Gamma_\\R(s - i \\mu_1)"
+        ans += "\\Gamma_\\R(s - i \\mu_2)"
+        ans += "\\end{equation}\n"
+        ans += "with \\(\\mu_j\\) real.  By renaming and rearranging, we may assume \\(0 \\le \\mu_2 \\le \\mu_1\\).</div>\n"
+
     elif group == 'GSp4':
         ans = "<h3 id='GSp4_Q_Maass'>Maass cusp forms for GSp(4)</h3>\n"
         ans += "<div>Currently in the LMFDB, we have data on L-functions associated "

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -26,7 +26,7 @@ from lmfdb.utils import signtocolour
 ## of given degree (gives output for degree 3 and 4). Data is fetched from
 ## the database.
 ## ============================================
-def getAllMaassGraphHtml(degree):
+def getAllMaassGraphHtml(degree, signature=""):
     if degree == 3:
         groups = [ ["GL3", [1 , 4] ] ] 
     elif degree == 4:
@@ -37,7 +37,10 @@ def getAllMaassGraphHtml(degree):
     ans = ""
     for i in range(0, len(groups)):
         g = groups[i][0]
-        ans += getGroupHtml(g)
+        if signature:
+            ans += getGroupHtml(signature)
+        else:
+            ans += getGroupHtml(g)
         for j in range(0, len(groups[i][1])):
             l = groups[i][1][j]
             ans += getOneGraphHtml([g, l])
@@ -51,7 +54,20 @@ def getAllMaassGraphHtml(degree):
 
 
 def getGroupHtml(group):
-    if group == 'GSp4':
+    if group == 'r0r0r0':   # note: signature, not group.  Delete the groups, then change the name
+        ans = "<h3 id='r0r0r0'>L-functions of signature (0,0,0;)</h3>\n"
+        ans += "<div>"
+        ans += "These L-functions satisfy a functional equation with \\(\\Gamma\\)-factors\n"
+        ans += "\\begin{equation}"
+        ans += "\\Gamma_\\R(s + i \\mu_1)"
+        ans += "\\Gamma_\\R(s + i \\mu_2)"
+        ans += "\\Gamma_\\R(s + i \\mu_3)"
+        ans += "\\end{equation}\n"
+        ans += "with \\(\mu_j\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 = 0\\). \n"
+        ans += "By permuting and possibly taking the complex conjugate, we may assume \\(\\mu_1 \ge \\mu_2 \ge 0\\), \n"
+        ans += "so the functional equation can be represented by a point \\( (\\mu_1, \\mu_2) \\) below "
+        ans += "the diagonal in the first quadrant of the Cartesian plane.</div>\n"
+    elif group == 'GSp4':
         ans = "<h3 id='GSp4_Q_Maass'>Maass cusp forms for GSp(4)</h3>\n"
         ans += "<div>Currently in the LMFDB, we have data on L-functions associated "
         ans += "to Maass cusp forms for GSp(4) of level 1. "
@@ -112,13 +128,13 @@ def getGroupHtml(group):
 ## ============================================
 def getOneGraphHtml(gls):
     if len(gls) > 2:
-        ans = ("<h4>Maass cusp forms of level " + str(gls[1]) + " and sign "
+        ans = ("<h4>L-functions of conductor " + str(gls[1]) + " and sign "
                + str(gls[2]) + "</h4>\n")
     else:
-        ans = ("<h4>Maass cusp forms of level " + str(gls[1]) + "</h4>\n")
+        ans = ("<h4>L-functions of conductor " + str(gls[1]) + "</h4>\n")
     ans += "<div>The dots in the plot correspond to L-functions with \\((\\mu_1,\\mu_2)\\) "
-    ans += "in the \\(\\Gamma\\)-factors, colored according to the sign of the functional equation (blue indicates \\(\epsilon=1\\)). These have been found by a computer "
-    ans += "search. Click on any of the dots to get detailed information about "
+    ans += "in the \\(\\Gamma\\)-factors, colored according to the sign of the functional equation (blue indicates \\(\epsilon=1\\)). "
+    ans += "Click on any of the dots for detailed information about "
     ans += "the L-function.</div>\n<br />"
     graphInfo = getGraphInfo(gls)
     ans += ("<embed src='" + graphInfo['src'] + "' width='" +

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -956,3 +956,17 @@ def get_bread(degree, breads=[]):
     for b in breads:
         breadcrumb.append(b)
     return breadcrumb
+
+# Convert  r0r0c1 to (0,0;1), for example
+def parse_codename(text):
+
+    ans = text
+    if 'c' in text:
+        ans = re.sub('c', ';', ans, 1)
+    else:
+        ans += ';'
+    ans = re.sub('r', '', ans, 1)
+    ans = re.sub('(r|c)', ',', ans)
+
+    return '(' + ans + ')'
+

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -18,7 +18,7 @@ from Lfunction import (Lfunction_Dirichlet, Lfunction_EMF, Lfunction_EC, #Lfunct
                        HypergeometricMotiveLfunction, Lfunction_genus2_Q, Lfunction_lcalc,
                        Lfunction_from_db)
 from LfunctionComp import isogeny_class_table, isogeny_class_cm
-from Lfunctionutilities import (p2sage, styleTheSign, get_bread,
+from Lfunctionutilities import (p2sage, styleTheSign, get_bread, parse_codename,
                                 getConductorIsogenyFromLabel)
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db import maass_db
 
@@ -171,7 +171,8 @@ def l_function_genus2_browse_page():
 # def l_function_maass_gln_browse_page(degree):
 def l_function_browse_page(degree, gammasignature):
     degree = get_degree(degree)
-    nice_gammasignature = "(0,0,0;)"  # make it a function of gammasignature
+    nice_gammasignature = parse_codename(gammasignature)
+######    nice_gammasignature = "(0,0,0;)"  # make it a function of gammasignature
     if degree < 0:
         return flask.abort(404)
     contents = LfunctionPlot.getAllMaassGraphHtml(degree, gammasignature)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -172,7 +172,6 @@ def l_function_genus2_browse_page():
 def l_function_browse_page(degree, gammasignature):
     degree = get_degree(degree)
     nice_gammasignature = parse_codename(gammasignature)
-######    nice_gammasignature = "(0,0,0;)"  # make it a function of gammasignature
     if degree < 0:
         return flask.abort(404)
     contents = LfunctionPlot.getAllMaassGraphHtml(degree, gammasignature)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -199,13 +199,13 @@ def set_info_for_start_page():
            {'title': 'Elliptic Curve', 'link': url_for('.l_function_ec_browse_page')}],
 
           [{'title': '', 'link': ''},
-           {'title': 'GL3 Maass Form', 'link': url_for('.l_function_maass_gln_browse_page',
-                                                       degree='degree3')},
+           {'title': 'Signature (0,0,0;)', 'link': url_for('.l_function_browse_page',
+                                                       degree='degree3', gammasignature='r0r0r0')},
            {'title': 'Symmetric Square L-function of Elliptic Curve', 'link': url_for('.l_function_ec_sym2_browse_page')}],
 
-          [{'title': 'GSp4 Maass Form', 'link': url_for('.l_function_maass_gln_browse_page', degree='degree4') + '#GSp4_Q_Maass'},
-           {'title': 'GL4 Maass Form', 'link': url_for('.l_function_maass_gln_browse_page',
-                                                       degree='degree4')},
+          [{'title': 'Signature (0,0,0,0;) and real cofficients', 'link': url_for('.l_function_browse_page', degree='degree4', gammasignature='r0r0r0r0') + '#r0r0r0r0selfdual'},
+           {'title': 'Signature (0,0,0,0;)', 'link': url_for('.l_function_browse_page',
+                                                       degree='degree4', gammasignature='r0r0r0r0')},
            {'title': 'Symmetric Cube L-function of Elliptic Curve', 'link': url_for('.l_function_ec_sym3_browse_page')}]]
 
     info = {

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -166,6 +166,23 @@ def l_function_genus2_browse_page():
     #FIXME info["contents"] = [processGenus2CurveNavigation(169, 700)] # FIX THIS
     return render_template("genus2curve.html", title='L-functions of Genus 2 Curves', **info)
 
+# generic/pure L-function browsing page ##############################################
+@l_function_page.route("/<degree>/<gammasignature>/")
+# def l_function_maass_gln_browse_page(degree):
+def l_function_browse_page(degree, gammasignature):
+    degree = get_degree(degree)
+    nice_gammasignature = "(0,0,0;)"  # make it a function of gammasignature
+    if degree < 0:
+        return flask.abort(404)
+    contents = LfunctionPlot.getAllMaassGraphHtml(degree, gammasignature)
+    if not contents:
+        return flask.abort(404)
+    info = {"bread": get_bread(degree, [(gammasignature, url_for('.l_function_browse_page',
+                                            degree='degree' + str(degree), gammasignature=gammasignature))])}
+    info["contents"] = contents
+    return render_template("MaassformGLn.html",
+                           title='L-functions of degree %s and signature %s' % (degree, nice_gammasignature), **info)
+
 
 ###########################################################################
 #   Helper functions, navigation pages

--- a/lmfdb/lfunctions/templates/Degree3.html
+++ b/lmfdb/lfunctions/templates/Degree3.html
@@ -26,8 +26,8 @@ L(s)=
 \prod_{p\nmid N} \left(1-a_p\, p^{-s}+\chi(p) \, \overline{a_p} \, p^{-2s} -\chi(p) \, p^{-3s}\right)^{-1}.
 \]
 Here $N$ is the {{ KNOWL('lfunction.conductor', title='conductor') }} of the L-function, and $\chi$, known as the central character,
-is a primitive Dirichlet character of conductor dividing&nbsp;$N$.
-The parameters $\nu$ and $\delta$ are integers or half-integers, the parameters
+is a {{ KNOWL('character.dirichlet', title='Dirichlet character') }} mod&nbsp;$N$.
+The parameter $\nu$ is an integer or half-integer, the parameters
 $\mu_j$ and $\mu$ are real, and
 $\delta_j$ is 0 or 1.
 If the central character is even (or odd) then either $2\nu + 1 + \delta$
@@ -45,11 +45,12 @@ search a more complete <a href="/zeros/first/?limit=100&start=0&end=30&degree=3"
 degree 3</a> L-functions, or
 -->
 browse
-by {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
+by {{ KNOWL('lfunction.signature', title='signature') }} 
+or {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 </div>
 
 <p>
-<a href="{{url_for('l_functions.l_function_maass_gln_browse_page', degree = 'degree3')}}">Maass&nbsp;form&nbsp;for&nbsp;$\GL(3)$</a>
+<a href="{{url_for('l_functions.l_function_browse_page', degree='degree3', gammasignature='r0r0r0')}}">Signature (0,0,0;)</a>
 &nbsp;&nbsp;&nbsp;
 <a href="{{url_for('l_functions.l_function_ec_sym2_browse_page')}}">Symmetric&nbsp;square&nbsp;of&nbsp;of&nbsp;an&nbsp;elliptic&nbsp;curve</a>
 &nbsp;&nbsp;&nbsp;

--- a/lmfdb/lfunctions/templates/Degree4.html
+++ b/lmfdb/lfunctions/templates/Degree4.html
@@ -49,11 +49,12 @@ search a more complete <a href="/zeros/first/?limit=100&start=0&end=30&degree=4"
 degree 4</a> L-functions, or
 -->
 browse
-by {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
+by {{ KNOWL('lfunction.signature', title='signature') }}
+or {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 </div>
 
 <p>
-<a href="{{url_for('l_functions.l_function_maass_gln_browse_page', degree = 'degree4')}}">Maass&nbsp;form&nbsp;for&nbsp;$\GL(4)$</a>
+<a href="{{url_for('l_functions.l_function_browse_page', degree='degree4', gammasignature='r0r0r0r0')}}">Signature (0,0,0,0;)</a>
 &nbsp;&nbsp;&nbsp;
 <a href="{{url_for('l_functions.l_function_ec_sym3_browse_page')}}">Symmetric&nbsp;cube&nbsp;of&nbsp;L-function&nbsp;of&nbsp;elliptic&nbsp;curve</a>
 &nbsp;&nbsp;&nbsp;

--- a/lmfdb/lfunctions/templates/LfunctionNavigate.html
+++ b/lmfdb/lfunctions/templates/LfunctionNavigate.html
@@ -1,7 +1,11 @@
 {% extends 'homepage.html' %}
 
 {% block content %}
-<h2> Browse {{KNOWL('lfunction', title='L-functions' )}} by {{KNOWL("lfunction.underlying_object",title="underlying object")}}</h2>
+<h2> Browse {{KNOWL('lfunction', title='L-functions' )}}
+by
+{{ KNOWL('lfunction.signature', title='signature') }}
+or
+{{KNOWL("lfunction.underlying_object",title="underlying object")}}</h2>
 <table>
 {% for i in type_row_list: %}
 <tr>

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -232,7 +232,7 @@ class LfunctionTest(LmfdbTest):
 
     def test_Lmain(self):
         L = self.tc.get('/L/')
-        assert 'Riemann' in L.data
+        assert 'Riemann' in L.data and 'Signature' in L.data
 
     def test_Ldegree1(self):
         L = self.tc.get('/L/degree1/')
@@ -269,16 +269,16 @@ class LfunctionTest(LmfdbTest):
         assert 'Elliptic' in L.data
 
     def test_Ldegree3MaassForm(self):
-        L = self.tc.get('/L/degree3/MaassForm/')
-        assert 'Maass' in L.data
+        L = self.tc.get('/L/degree3/r0r0r0/')
+        assert 'equation' in L.data
 
     def test_Ldegree3EllipticCurve(self):
         L = self.tc.get('/L/degree3/EllipticCurve/SymmetricSquare/')
         assert 'Elliptic' in L.data
 
     def test_Ldegree4MaassForm(self):
-        L = self.tc.get('/L/degree4/MaassForm/')
-        assert 'Maass' in L.data
+        L = self.tc.get('/L/degree4/r0r0r0r0/')
+        assert 'functional' in L.data
 
     def test_Ldegree4EllipticCurve(self):
         L = self.tc.get('/L/degree4/EllipticCurve/SymmetricCube/')


### PR DESCRIPTION
The pages
/L/degree3/MaassForm/
and 
/L/degree4/MaassForm/
are now obsolete, replaced by
/L/degree3/r0r0r0/
and
/L/degree4/r0r0r0r0/

Those pages now refer to L-functions of a particular signature (which is determined by
the Gamma-factors in the functional equation), not as "L-functions of Maass forms on GL(N)"
or "Maass forms on GSp(N)".

This change was decided at the meeting in August, because it is not (yet) a theorem that
those are the source of those L-functions, and we don't have those objects in the LMFDB
anyway.

To see the new pages, go to the degree 3 and degree 4 browsing pages:
/L/degree3  or  /L/degree4
and look for a link like "Signature (0,0,0;)".

The individual L-functions still have URLs that mention "Maass", but it is a lot more work
to convert those, and I would like to discuss the new L-function ID plan before making
those changes.

This is the first step in a longer process to clean up the transcendental L-functions.

I replaced the tests on the old pages by tests on the new pages, because in my next
pull request I will remove all links to the old pages.