### PR TITLE
Siegel to beta and GL3Maass to future

### DIFF
--- a/lmfdb/sidebar.yaml
+++ b/lmfdb/sidebar.yaml
@@ -92,18 +92,20 @@
            colspan: onecolumn
      - title: GL(3)
        style: rotate
+       status: beta
        part2:
          - title: Maass
-           url_for: "l_functions.l_function_maass_gln_browse_page"
-           url_args:
-             degree: 'degree3'
+           status: future
+           colspan: onecolumn
          - title: Cohomological
            status: future
            colspan: onecolumn
      - title: Other
        style: rotate
+       status: beta
        part2:
          - title: Siegel
+           status: beta
            url_for: "smf.index"
          - title: U(2,1)
            status: future

--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -116,7 +116,12 @@ _gaq.push(['_trackPageLoadTime']);
 {%- endif %}
 </head>
 
+{%- if BETA -%}
+<body class="beta {{ body_class }}">
+{%- else -%}
 <body class="{{ body_class }}">
+{%- endif -%}
+
 {% block body -%}{%- endblock body %}
 </body>
 </html>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1791,7 +1791,7 @@ div.maassformplot img {
 
 }
 #sidebar h2 {
-      margin: 10px 0px 0px;}
+      margin: 5px 0px 0px;}
 
 p.rotation  {
              -moz-transform: rotate(270deg);

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1794,12 +1794,12 @@ div.maassformplot img {
       margin: 5px 0px 0px;}
 
 p.rotation  {
-             -moz-transform: rotate(270deg);
-             -webkit-transform: rotate(270deg);
-             -o-transform: rotate(270deg);
-             -ms-transform: rotate(270deg);
              transform: rotate(270deg); }
 
+/* temporary over-side for GL(2) on beta */
+body.beta #sidebar table.short:nth-of-type(3) .rotation p.rotation {
+    transform: rotate(0deg)
+}
 
 #sidebar table th, #sidebar table td {
 	text-align: left;


### PR DESCRIPTION
The following changes were decided in August.

Remove from public TOC:
   Modular forms --> GL(3)
and
  Modular forms --> Other

Both remain on beta, but
  Modular forms --> GL(3) --> Maass
has been moved to Future.

Note that the "GL(3)" and the "Other" in the beta TOC will not render properly
(they will not be rotated).  I will fix that as a separate pull request, because my understanding
is that TOC changes should be done individually.  I hope the small CSS change in this pull
request is an acceptable violation of that policy.
