### PR TITLE
Fix issue #2671 on the output of from_cyclo in WebNumberField

### DIFF
--- a/lmfdb/WebNumberField.py
+++ b/lmfdb/WebNumberField.py
@@ -231,7 +231,7 @@ class WebNumberField:
         if euler_phi(n) > 23:
             return cls('none')  # Forced to fail
         pol = pari.polcyclo(n)
-        R = PolynomialRing(QQ, 'x')
+        R = PolynomialRing(ZZ, 'x')
         coeffs = R(pol.polredabs()).coefficients(sparse=False)
         return cls.from_coeffs(coeffs)
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -108,7 +108,7 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/1/1')
         assert  '/NumberField/1.1.1.1' in W.data
 
-    def test_dirichletchar11(self):
+    def test_valuefield(self):
         W = self.tc.get('/Character/Dirichlet/13/2')
         assert  'Value Field' in W.data
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -108,6 +108,10 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/1/1')
         assert  '/NumberField/1.1.1.1' in W.data
 
+    def test_dirichletchar11(self):
+        W = self.tc.get('/Character/Dirichlet/13/2')
+        assert  'Value Field' in W.data
+
     #@unittest2.skip("wait for new DirichletConrey")
     def test_dirichletcharbig(self):
         """ nice example to check the Conrey naming scheme


### PR DESCRIPTION
The problem involves data types between sage and python.  Maybe the two servers were running different versions of sage.  To test, look at http://127.0.0.1:37777/Character/Dirichlet/13/2 and see if "Value field" is listed as a related object (it should be).