### PR TITLE
show local root numbers for ecnf if present without failing if not

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -470,7 +470,6 @@ class ECNF(object):
             ld['p'] = web_latex(P)
             ld['norm'] = P.norm()
             ld['kod'] = ld['kod'].replace('\\\\', '\\')
-            ld['kod'] = web_latex(ld['kod']).replace('$', '')
 
         # URLs of self and related objects:
         self.urls = {}

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -469,7 +469,8 @@ class ECNF(object):
         for P,ld in zip(badprimes,local_data):
             ld['p'] = web_latex(P)
             ld['norm'] = P.norm()
-            ld['kod'] = ld['kod'].replace('\\\\', '\\')
+            while '\\\\' in ld['kod']:
+                ld['kod'] = ld['kod'].replace('\\\\', '\\')
 
         # URLs of self and related objects:
         self.urls = {}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -284,7 +284,7 @@ Generators:
 {{pr.p}}
 </td>
 <td align=center>
-{{pr.norm}}
+\({{pr.norm}}\)
 </td>
 <td align=center>
 \({{pr.cp}}\)
@@ -304,11 +304,11 @@ Generators:
 {% endif %}
 </td>
 {% if pr.rootno %}
-<td align=center>{{pr.rootno}}</td>
+<td align=center>\({{pr.rootno}}\)</td>
 {% endif %}
-<td align=center>{{pr.ord_cond}}</td>
-<td align=center>{{pr.ord_disc }}</td>
-<td align=center>{{pr.ord_den_j}}</td>
+<td align=center>\({{pr.ord_cond}}\)</td>
+<td align=center>\({{pr.ord_disc }}\)</td>
+<td align=center>\({{pr.ord_den_j}}\)</td>
 </tr>
 {% endfor %}
 </table>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -271,6 +271,9 @@ Generators:
 <th>{{KNOWL('ec.tamagawa_number', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.reduction_type', title='Reduction type')}}</th>
+{% if ec.local_data.0.rootno %}
+<th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
+{% endif %}
 <th>{{KNOWL('ec.conductor_valuation', title='ord(\(\mathfrak{N}\))')}}</th>
 <th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\mathfrak{D}\))')}}</th>
 <th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
@@ -300,6 +303,9 @@ Generators:
     Good
 {% endif %}
 </td>
+{% if pr.rootno %}
+<td align=center>{{pr.rootno}}</td>
+{% endif %}
 <td align=center>{{pr.ord_cond}}</td>
 <td align=center>{{pr.ord_disc }}</td>
 <td align=center>{{pr.ord_den_j}}</td>


### PR DESCRIPTION
In preparation for adding local root numbers to ec_nfcurves.  This code displays the root numbers when they are in the database, otherwise omits the  column in the Local Data table.