### PR TITLE
enhanced functions in check_knowl.py for making various queries about…

### DIFF
--- a/check_knowl.py
+++ b/check_knowl.py
@@ -5,6 +5,7 @@ Initial version (Bristol March 2016)
 
 """
 from lmfdb.knowledge.knowl import knowldb
+from commands import getoutput
 
 cats = knowldb.get_categories()
 print("There are %s categories of knowl in the database" % len(cats))
@@ -18,6 +19,8 @@ def check_knowls(cat='ec', verbose=False):
             print("Checking knowl %s" % k['id'])
         k = knowldb.get_knowl(k['id'])
         cont = k['content']
+        all_content = cont
+        cont = cont.replace("KNOWL ","KNOWL")
         i = 0
         while (i>=0):
             i = cont.find("KNOWL_INC")
@@ -38,8 +41,88 @@ def check_knowls(cat='ec', verbose=False):
                 the_ref = knowldb.get_knowl(ref)
                 if the_ref is None:
                     print("Non-existing reference to %s in knowl %s" % (ref,k['id']))
+                    print("content of {} = ".format(k['id']))
+                    print(all_content)
+                    return False
                 elif verbose:
                     print("--- found")
+    return True
+
+def find_knowl_crossrefs(id, all=True, verbose=False):
+    """Finds knowl(s) which cite the given knowl.
+
+    if verbose, list the citing knowls (or just the first if
+    all=False), otherwise just return True/False according to whether
+    any other knowls cite the given one.
+
+    EXAMPLE:
+
+    sage: find_knowl_crossrefs("ec.q.torsion_order", verbose=True)
+    knowl ec.q.torsion_order is cited by ec.q.bsd_invariants
+    knowl ec.q.torsion_order is cited by ec.q.mordell-weil
+    True
+
+    """
+    found = False
+    for k in knowldb.search():
+        content = knowldb.get_knowl(k['id'])['content']
+        if id in content:
+            found = True
+            if verbose:
+                print("knowl {} is cited by {}".format(id,k['id']))
+            if not all or not verbose:
+                return True
+    return found    
+
+def find_knowl_links(id, base=None, all=True, verbose=False):
+    """Use grep to find the given knowl id in the source tree, assuming
+    that to be based in the directory lmfdb in the current directory
+    unless otherwise specified.
+
+    EXAMPLE:
+
+    sage: find_knowl_links("ec.q.torsion_order")
+    /scratch/home/jcremona/lmfdb/lmfdb/elliptic_curves/templates/ec-isoclass.html:<th>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
+    /scratch/home/jcremona/lmfdb/lmfdb/elliptic_curves/templates/ec-index.html:By {{ KNOWL('ec.q.torsion_order', torsion=t,title="torsion order") }}:
+    /scratch/home/jcremona/lmfdb/lmfdb/elliptic_curves/templates/ec-index.html:          {{ KNOWL('ec.q.torsion_order',title="torsion order") }}
+    /scratch/home/jcremona/lmfdb/lmfdb/elliptic_curves/templates/ec-search-results.html:<td align=left>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</td>
+    /scratch/home/jcremona/lmfdb/lmfdb/elliptic_curves/templates/ec-search-results.html:  <th class="center">{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
+
+    """
+    if base==None:
+        base = "~/lmfdb"
+    found = False
+    for L in getoutput('grep -r "{}" {}'.format(id, base)).splitlines():
+        found = True
+        if verbose:
+            print L
+        if not all or not verbose:
+            return True
+    return found
+
+def uncited_knowls(ignore_top_and_bottom=True):
+    """Lists all knowls not cited by other knowls.
+
+    Knowls whose id ends in "top" or "bottom" are ignored by default.
+
+    NB This lists a lot of knowls which are linked from code or
+    templates so is not so useful by itself.
+
+    """
+    for k in knowldb.search():
+        kid = k['id']
+        if kid.endswith(".top") or kid.endswith(".bottom"):
+            continue
+        crossrefs = find_knowl_crossrefs(kid)
+        links = find_knowl_links(kid)
+        if crossrefs:
+            print("{} is cited by other knowl(s)".format(kid))
+        else:
+            print("No other knowl cites {}".format(kid))
+        if links:
+            print("{} IS mentioned in the source code".format(kid))
+        else:
+            print("{} is NOT mentioned in the source code".format(kid))
 
 """
 Result of running


### PR DESCRIPTION
… knowl citations and cross-links

A while ago I made a simple script to look for broken knowl links.  I just upgraded it to work better, and it can now tell you about knowls which no other knowls cross-reference, knowls which are not mentioned in source code (python or templates).  This is helpful, for example, if one is about to delete a knowl, since one can be confident that nothing refers to it.

As it is a simple script I'll merge it right away.  I know that there are plans to completely rewrite the knowl database but this is useful now.