### PR TITLE
Debounce knowl clicking

### DIFF
--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -165,8 +165,7 @@ function knowl_click_handler($el) {
  * @see jquery's doc about 'live'! the handler function does the 
  *  download/show/hide magic. also add a unique ID, 
  *  necessary when the same reference is used several times. */
-$(function() {
-  $("body").on("click", "*[knowl]", function(evt) {
+function knowl_handle(evt) {
       evt.preventDefault();
       var $knowl = $(this);
       if(!$knowl.attr("knowl-uid")) {
@@ -175,7 +174,9 @@ $(function() {
         knowl_id_counter++;
       }
       knowl_click_handler($knowl, evt);
-  });
+  }
+$(function() {
+  $("body").on("click", "*[knowl]", debounce(knowl_handle,500, true));
 });
 
 /*** end knowl js section ***/
@@ -254,4 +255,73 @@ function get_count_callback(res) {
         $("#download-msg").html("");
         $("#download-form").show();
     }
+};
+
+
+
+/**
+ * https://github.com/component/debounce
+ * Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered. The function will be called after it stops being called for
+ * N milliseconds. If `immediate` is passed, trigger the function on the
+ * leading edge, instead of the trailing. The function also has a property 'clear' 
+ * that is a function which will clear the timer to prevent previously scheduled executions. 
+ *
+ * @source underscore.js
+ * @see http://unscriptable.com/2009/03/20/debouncing-javascript-methods/
+ * @param {Function} function to wrap
+ * @param {Number} timeout in ms (`100`)
+ * @param {Boolean} whether to execute at the beginning (`false`)
+ * @api public
+ */
+function debounce(func, wait, immediate){
+	var timeout, args, context, timestamp, result;
+	if (null == wait) wait = 100;
+
+	function later() {
+		var last = Date.now() - timestamp;
+
+		if (last < wait && last >= 0) {
+			timeout = setTimeout(later, wait - last);
+		} else {
+			timeout = null;
+			if (!immediate) {
+				result = func.apply(context, args);
+				context = args = null;
+			}
+		}
+	};
+
+	var debounced = function(){
+		context = this;
+		args = arguments;
+		timestamp = Date.now();
+		var callNow = immediate && !timeout;
+		if (!timeout) timeout = setTimeout(later, wait);
+		if (callNow) {
+			result = func.apply(context, args);
+			context = args = null;
+		}
+
+		return result;
+	};
+
+	debounced.clear = function() {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = null;
+		}
+	};
+
+	debounced.flush = function() {
+		if (timeout) {
+			result = func.apply(context, args);
+			context = args = null;
+
+			clearTimeout(timeout);
+			timeout = null;
+		}
+	};
+
+	return debounced;
 };

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -267,12 +267,29 @@ function get_count_callback(res) {
  * leading edge, instead of the trailing. The function also has a property 'clear' 
  * that is a function which will clear the timer to prevent previously scheduled executions. 
  *
- * @source underscore.js
- * @see http://unscriptable.com/2009/03/20/debouncing-javascript-methods/
- * @param {Function} function to wrap
- * @param {Number} timeout in ms (`100`)
- * @param {Boolean} whether to execute at the beginning (`false`)
- * @api public
+ * Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
+ * Reporters & Editors
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
  */
 function debounce(func, wait, immediate){
 	var timeout, args, context, timestamp, result;

--- a/lmfdb/test_root.py
+++ b/lmfdb/test_root.py
@@ -31,7 +31,7 @@ class RootTest(LmfdbTest):
     def test_javscript(self):
         js = self.tc.get("/static/lmfdb.js").data
         # click handler def for knowls
-        assert '''$("body").on("click", "*[knowl]", function(evt)''' in js
+        assert r"""$("body").on("click", "*[knowl]", debounce(knowl_handle,500, true));""" in js
 
     def test_css(self):
         css = self.tc.get("/style.css").data


### PR DESCRIPTION
Currently if a knowl is double clicked quickly it gets messed up (will stop sliding in and out properly and not be visible at all), especially if the internet connection is bad as it needs to finish loading before the second click happens. One can test this using google chrome by setting your connection speed to 3g or something in the developer toolbar. This can happen even with fast internet completely accidentally.

This PR fixes this by "debouncing" the knowl, enforcing a .5s wait before a knowl is clicked again, otherwise nothing happens.

There may be a different way of fixing this by changing the knowl code, but the debounce function might be useful elsewhere so I did it this way.


<http://www.labbookpages.co.uk/electronics/debounce.html>