### PR TITLE
database_gap not needed for Sage >= 8.6

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -32,7 +32,7 @@ Installation
 
    ```
       sage -i gap_packages
-      sage -i database_gap
+      sage -i database_gap # only needed if sage version < 8.6
       sage -i pip
       sage -b
       # in the 'lmfdb/' directory:


### PR DESCRIPTION
Feel free to edit my comment
I just want to be sure that we say something