### PR TITLE
several knowl links changed from ec.q.* to ec.* (and redundant ec.q.*…

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -189,7 +189,7 @@ cellpadding="5";
 </div>
 
 <div>
-<h2> {{ KNOWL('ec.mordell-weil', title="Mordell-Weil rank and generators") }} </h2>
+<h2> {{ KNOWL('ec.mordell_weil', title="Mordell-Weil group") }} </h2>
 {% if ec.rk == "?" %}
 {% if ec.rk_bnds != "not available" %}
 <b>Rank</b> \(r\) satisfies \({{ ec.rank_bounds[0] }} \le r \)
@@ -218,9 +218,9 @@ Generators:
 </p>
 <p><b>
 {% if ec.rank_bounds[0] == 1 %}
-Height:
+{{ KNOWL('ec.canonical_height', title="Height") }}:
 {% else %}
-Heights:
+{{ KNOWL('ec.canonical_height', title="Heights") }}:
 {% endif %}</b>
 {% for h in ec.heights %}{%-if loop.index0-%}, {% endif %}{{h}}{% endfor %}
 </p>
@@ -229,7 +229,7 @@ Heights:
  {{ place_code('gens') }}
 
 <p>
-<b>Regulator:</b>
+<b>{{ KNOWL('ec.regulator', title="Regulator") }}:</b>
 {{ ec.reg }}
  {{ place_code('reg') }}
 </p>

--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -17,7 +17,7 @@ def get_stats():
 def elliptic_curve_summary():
     counts = get_stats().counts()
     ecstaturl = url_for('ec.statistics')
-    return r'The database currently contains the Cremona database of all %s <a title="Elliptic curves [ec]" knowl="ec" kwargs="">elliptic curves</a> defined over $\Q$ with <a title="Conductor of an elliptic curve over $\Q$ [ec.q.conductor]" knowl="ec.q.conductor" kwargs="">conductor</a> at most %s, all of which have <a title="Rank of an elliptic curve over $\mathbb{Q}$ [ec.q.rank]" knowl="ec.q.rank" kwargs="">rank</a> $\leq %s$.   Here are some <a href="%s">further statistics</a>.' % (str(counts['ncurves_c']), str(counts['max_N_c']), str(counts['max_rank']), ecstaturl)
+    return r'The database currently contains the Cremona database of all %s <a title="Elliptic curves [ec]" knowl="ec" kwargs="">elliptic curves</a> defined over $\Q$ with <a title="Conductor of an elliptic curve over $\Q$ [ec.q.conductor]" knowl="ec.q.conductor" kwargs="">conductor</a> at most %s, all of which have <a title="Rank of an elliptic curve over $\mathbb{Q}$ [ec.rank]" knowl="ec.rank" kwargs="">rank</a> $\leq %s$.   Here are some <a href="%s">further statistics</a>.' % (str(counts['ncurves_c']), str(counts['max_N_c']), str(counts['max_rank']), ecstaturl)
 
 
 @app.context_processor

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -64,7 +64,7 @@ white-space: pre in order to keep line breaks! #}
     <p> {{ data.data.equation }} </p>
 
 
-    <h2> {{ KNOWL('ec.q.mordell-weil', title='Mordell-Weil group') }} structure</h2>
+    <h2> {{ KNOWL('ec.mordell_weil', title='Mordell-Weil group') }} structure</h2>
    <div>{% if data.mw.rank==1 %}{% if data.mw.tor_order!=1 %} \(\Z\times {{data.mw.tor_struct}}\)
     {%endif%}  {%endif%}     </div>
 
@@ -96,7 +96,7 @@ white-space: pre in order to keep line breaks! #}
     {%endif %}
 
     {% if data.mw.tor_order!=1 %}
-    <h2> {{ KNOWL('ec.q.torsion_generators', title='Torsion generators') }}</h2>
+    <h2> {{ KNOWL('ec.torsion_generators', title='Torsion generators') }}</h2>
       {{ place_code('tors') }}
     <p> {{ data.mw.tor_gens }} </p>
     {%endif %}

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -38,13 +38,13 @@ By {{ KNOWL('ec.q.conductor',title = "conductor")}}:
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('ec.q.rank', title="rank")}}:
+By {{ KNOWL('ec.rank', title="rank")}}:
 {% for r in info.rank_list: %}
 <a href="?rank={{r}}">{{r}}</a>
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('ec.q.torsion_order', torsion=t,title="torsion order") }}:
+By {{ KNOWL('ec.torsion_order', torsion=t,title="torsion order") }}:
 {% for t in info.torsion_list: %}
 <a href="?torsion={{t}}">{{t}}</a>
 {% endfor %}
@@ -96,7 +96,7 @@ Please enter a value or leave blank:
 
    <tr>
    <td>
-    {{ KNOWL('ec.q.rank',title="rank") }}
+    {{ KNOWL('ec.rank',title="rank") }}
     </td>
            <td>
            <input type='text' name='rank' example="0" size=10 value="{{rank}}" />
@@ -117,7 +117,7 @@ Please enter a value or leave blank:
 
     <tr>
           <td>
-          {{ KNOWL('ec.q.torsion_order',title="torsion order") }}
+          {{ KNOWL('ec.torsion_order',title="torsion order") }}
           </td>
           <td>
           <input type='text' name='torsion' example="2" size=10 value="{{torsion}}" />
@@ -127,7 +127,7 @@ Please enter a value or leave blank:
           </td>
 
           <td>
-          {{ KNOWL('ec.q.torsion_subgroup',title="torsion structure") }}
+          {{ KNOWL('ec.torsion_subgroup',title="torsion structure") }}
           </td>
           <td>
             {{ tor_struct_search_Q()|safe }}

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -19,7 +19,7 @@ text-align: center;
 <th>{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
 <th>{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
 <th>{{ KNOWL('ec.q.minimal_weierstrass_equation', title='Weierstrass coefficients') }}</th>
-<th>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
+<th>{{ KNOWL('ec.torsion_order', title='Torsion order') }}</th>
 <th>{{ KNOWL('ec.q.modular_degree', title='Modular degree') }}</th>
 <th>{{ KNOWL('ec.q.optimal', title='Optimality') }}</th>
 </tr>
@@ -45,13 +45,13 @@ text-align: center;
 {% endfor %}
 </table>
 
-<h2>Rank</h2>
+<h2>{{KNOWL('ec.rank', title='Rank')}}</h2>
 {{ place_code('rank') }}
 <p>
 {% if info.ncurves==1 %} The elliptic curve {{info.curves[0].label}} has
 {% else %} The elliptic curves in class {{info.lmfdb_iso}} have
 {% endif %}
-rank \({{ info.rank}}\).
+{{KNOWL('ec.rank', title='rank')}} \({{ info.rank}}\).
 </p>
 
 <h2>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -15,9 +15,9 @@
 <td align=left>{{ KNOWL('ec.q.conductor', title='Conductor') }}</td>
 <td align=left>{{ KNOWL('ec.q.j_invariant', title='j-invariant') }}</td>
 <td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} </td>
-<td align=left>{{ KNOWL('ec.q.rank', title='Rank') }}</td>
-<td align=left>{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</td>
-<td align=left>{{ KNOWL('ec.q.torsion_subgroup', title='Torsion structure') }}</td>
+<td align=left>{{ KNOWL('ec.rank', title='Rank') }}</td>
+<td align=left>{{ KNOWL('ec.torsion_order', title='Torsion order') }}</td>
+<td align=left>{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</td>
 <td align=left>{{ KNOWL('ec.q.analytic_sha_order', title='Analytic order of &#1064;') }}</td>
 </tr>
 
@@ -118,8 +118,8 @@ table td.params {
   <th class="center">{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
   <th class="center">{{ KNOWL('ec.isogeny_class', title='Isogeny class') }}</th>
   <th class="center">{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass Coefficients') }}</th>
-  <th class="center">{{ KNOWL('ec.q.rank', title='Rank') }}</th>
-  <th class="center">{{ KNOWL('ec.q.torsion_order', title='Torsion order') }}</th>
+  <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
+  <th class="center">{{ KNOWL('ec.torsion_order', title='Torsion order') }}</th>
 {% if info.surj_primes or info.nonsurj_primes  %}
   <th class="center">{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}</th>
 {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-stats.html
+++ b/lmfdb/elliptic_curves/templates/ec-stats.html
@@ -5,7 +5,7 @@
 The database currently contains the Cremona database of all
 {{info.counts.ncurves_c}} elliptic curves in {{info.counts.nclasses_c}} isogeny classes,
 with {{ KNOWL('ec.q.conductor',title = "conductor")}} at most
-{{info.counts.max_N_c}}, all of which have {{ KNOWL('ec.q.rank',
+{{info.counts.max_N_c}}, all of which have {{ KNOWL('ec.rank',
 title="rank")}} &le; {{info.counts.max_rank}}.
 </div>
 


### PR DESCRIPTION
… knowls deleted)

Partly in response to issues raised on the bug tracker by Vlad Dokchitser.  Several knowl links changed frrom ec.q.* versions to ec.*.  At the same time I have done a lot of related knowl editing, and some creation.

A few ec.q.* knowls which became redundant as a result have been *deleted*.  I should not have done that until this PR was merged and pushed to dev, sorry.  (One example is that ec.q.rank no longer exists, as it is covered by ec.rank.  But without this PR there are references to ec.q.rank.)