### PR TITLE
ecnf: hide Q-curve search options while we correct the Q-curve flags …

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -406,15 +406,17 @@ class ECNF(object):
             self.ST = st_link_by_name(1,2,'SU(2)')
 
         # Q-curve / Base change
-        self.qc = self.q_curve
-        if self.qc == "?":
-            self.qc = "not determined"
-        elif self.qc == True:
-            self.qc = "yes"
-        elif self.qc == False:
-            self.qc = "no"
-        else: # just in case
-            self.qc = "not determined"
+        # See Issue #2718
+        self.qc = "not determined"
+        # self.qc = self.q_curve
+        # if self.qc == "?":
+        #     self.qc = "not determined"
+        # elif self.qc == True:
+        #     self.qc = "yes"
+        # elif self.qc == False:
+        #     self.qc = "no"
+        # else: # just in case
+        #     self.qc = "not determined"
 
         # Torsion
         self.ntors = web_latex(self.torsion_order)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -489,11 +489,11 @@ def elliptic_curve_search(info, query):
     else:
         info['include_base_change'] = "on"
 
-    if 'include_Q_curves' in info:
-        if info['include_Q_curves'] == 'exclude':
-            query['q_curve'] = False
-        elif info['include_Q_curves'] == 'only':
-            query['q_curve'] = True
+    # if 'include_Q_curves' in info:
+    #     if info['include_Q_curves'] == 'exclude':
+    #         query['q_curve'] = False
+    #     elif info['include_Q_curves'] == 'only':
+    #         query['q_curve'] = True
 
     if 'include_cm' in info:
         if info['include_cm'] == 'exclude':

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -77,7 +77,8 @@ Please enter a value or leave blank:
           {% endfor %}
          </select>
   </td>
-  <td align=right>{{ KNOWL('ec.q_curve',title="Q_curves") }} </td>
+{#
+     <td align=right>{{ KNOWL('ec.q_curve',title="Q_curves") }} </td>
   <td>
          <select name='include_Q_curves'>
            <option value="" selected>include</option>
@@ -85,6 +86,7 @@ Please enter a value or leave blank:
            <option value="only">only</option>
          </select>
   </td>
+#}
     </tr>
 
    <tr>

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -21,7 +21,9 @@
 <td align=left>{{ KNOWL('ec.conductor',title = "conductor") }} norm</td>
 <td align=left>{{ KNOWL('ec.isogeny',title="isogenous") }} curves</td>
 <td align=left>{{ KNOWL('ec.base_change',title="base change") }} curves</td>
+{#
 <td align=left>{{ KNOWL('ec.q_curve',title="Q-curves") }}</td>
+#}
 <td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} curves</td>
 </tr>
 
@@ -49,6 +51,7 @@
   </select>
 </td>
 
+{#
 <td>         <select name='include_Q_curves'>
 {% if info.include_Q_curves == "only" %}
            <option value="">include</option>
@@ -67,6 +70,7 @@
 {% endif %}
          </select>
 </td>
+#}
 <td>         <select name='include_cm'>
 {% if info.include_cm == "only" %}
            <option value="">include</option>


### PR DESCRIPTION
…in the db.  See Issue 2718

This is only temporary.  See #2718 for details.

I hid (by commenting out part of the templates) the Q-curve search option buttons on the main search/browse page and the follow-up search results page; commented out the associated search code; and replaced the code which gets the q_curve flag from the database so that it always says "not determined".

I will revert this when the database has some q_curve flags correctly set and none which are known to be wrong.  At least for quadratic base field, this should not take too long.