### PR TITLE
Minor formatting change to simplify cmf newform pages

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -37,36 +37,26 @@
   {% if newform.is_self_dual is not none %}
   <tr>
     <td> {{ KNOWL('lfunction.self-dual', title='Self dual') }}: </td>
-    <td> </td>
-    <td> </td>
     <td>{% if newform.is_self_dual %}Yes{% else %}No{% endif %}</td>
   </tr>
   {% endif %}
   <tr>
-    <td> {{ KNOWL('mf.elliptic.analytic_conductor', title='Analytic Conductor') }} </td>
-    <td> \(A\) </td>
-    <td>=</td>
+    <td> {{ KNOWL('mf.elliptic.analytic_conductor', title='Analytic Conductor'): }} </td>
     <td>\({{ newform.analytic_conductor }}\)</td>
   </tr>
   {% if newform.has_analytic_rank %}
   <tr>
     <td> {{ KNOWL('mf.elliptic.analytic_rank', title='Analytic rank') }}: </td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.analytic_rank }}\){% if not newform.analytic_rank_proved %}\(^*\){% endif %}</td>
   </tr>
   {% endif %}
   <tr>
     <td> {{ KNOWL('mf.elliptic.dimension', title='Dimension') }}: </td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.dim }}\)</td>
   </tr>
   {% if newform.char_degree > 1 and newform.rel_dim > 1 %}
   <tr>
     <td> {{ KNOWL('mf.elliptic.relative_dimension', title='Relative dimension') }}: </td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.rel_dim }}\) over {{ newform.cyc_display() | safe }}</td>
   </tr>
   {% endif %}
@@ -74,95 +64,69 @@
   <!-- Coefficient code depends on existence of form -->
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_field',title='Coefficient field') }}: </td>
-    <td> {{ newform.Qnu() }} </td>
-    <td> {{ newform.Qeq() }} </td>
     <td> {{ newform.field_display() | safe }}</td>
   </tr>
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_ring',title='Coefficient ring') }}: </td>
-    <td> </td>
-    <td> </td>
     <td> {{ newform.ring_display() | safe }}</td>
   </tr>
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_ring',title='Coefficient ring index') }}: </td>
-    <td> </td>
-    <td> </td>
     <td> {{ newform.ring_index_display() | safe }}</td>
   </tr>
   {% elif newform.dim == 1 %}
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_field',title='Coefficient field') }}: </td>
-    <td> </td>
-    <td> </td>
     <td> \(\mathbb{Q}\)</td>
   </tr>
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_ring',title='Coefficient ring') }}: </td>
-    <td> </td>
-    <td> </td>
     <td> \(\mathbb{Z}\)</td>
   </tr>
   <tr>
     <td> {{ KNOWL('mf.elliptic.coefficient_ring',title='Coefficient ring index') }}: </td>
-    <td> </td>
-    <td> </td>
     <td> {{ newform.ring_index_display() | safe }}</td>
   </tr>
   {% endif %}
   {% if newform.char_order == 1 %}
   <tr>
     <td> {{ KNOWL('mf.elliptic.fricke', title='Fricke sign') }}: </td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.fricke_eigenval }}\)</td>
   </tr>
   {% endif %}
   {% if newform.projective_image %}
   <tr>
     <td>{{ KNOWL('mf.elliptic.projective_image', title='Projective image')}}</td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.projective_image_latex }}\)</td>
   </tr>
   {% endif %}
   {% if newform.projective_field %}
   <tr>
     <td>{{ KNOWL('mf.elliptic.projective_field', title='Projective field')}}</td>
-    <td> </td>
-    <td> </td>
     <td>Galois closure of {{ newform.projective_field_display | safe }}</td>
   </tr>
   {% endif %}
   {% if newform.artin_degree %}
   <tr>
     <td>{{ KNOWL('mf.elliptic.artin_image', title='Artin image size') }}</td>
-    <td> </td>
-    <td> </td>
     <td>\({{ newform.artin_degree }}\)</td>
   </tr>
   {% endif %}
   {% if newform.artin_image %}
   <tr>
     <td>{{ KNOWL('mf.elliptic.artin_image', title='Artin image') }}</td>
-    <td> </td>
-    <td> </td>
     <td>{{ newform.artin_image_knowl() | safe }}</td>
   </tr>
   {% endif %}
   {% if newform.artin_field %}
   <tr>
     <td>{{ KNOWL('mf.elliptic.artin_field', title='Artin field')}}</td>
-    <td> </td>
-    <td> </td>
     <td>Galois closure of {{ newform.artin_field_display | safe }}</td>
   </tr>
   {% endif %}
   {% if newform.weight > 1 %}
   <tr>
-    <td>{{ KNOWL('mf.elliptic.sato_tate', title='Sato-Tate group') }}</td>
-    <td>\(\operatorname{ST}(f)\)</td>
-    <td>\(=\)</td>
+    <td>{{ KNOWL('mf.elliptic.sato_tate', title='Sato-Tate group') }}: </td>
     <td>{{ newform.sato_tate_display() | safe }}</td>
   </tr>
   {% endif %}

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -41,7 +41,7 @@
   </tr>
   {% endif %}
   <tr>
-    <td> {{ KNOWL('mf.elliptic.analytic_conductor', title='Analytic Conductor'): }} </td>
+    <td> {{ KNOWL('mf.elliptic.analytic_conductor', title='Analytic Conductor') }}: </td>
     <td>\({{ newform.analytic_conductor }}\)</td>
   </tr>
   {% if newform.has_analytic_rank %}


### PR DESCRIPTION
Based on feedback, the newform invariants section now omits the symbol column which was used for only a handful of invariants -- A for analytic conductor, ST(f) for Sato-Tate group, Q(\nu) for coefficient field.  These symbols did not add much value and are either not used or defined elsewhere.

Compare:

http://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/11/2/a/a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/11/2/a/a/

http://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/87/1/d/a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/87/1/d/a/

http://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/41/2/a/a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/41/2/a/a/

http://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/31/2/g/a/
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/31/2/g/a/

