### PR TITLE
ecnf: no longer hide Q-curves search

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -360,6 +360,11 @@ class ECNF(object):
         # store the factorization of the denominator of j and display
         # that, which is the most interesting part.
 
+        # The equation is stored in the database as a latex string.
+        # Some of these have extraneous double quotes at beginning and
+        # end, shich we fix here:
+        self.equation = self.equation.replace('"','')
+
         # Images of Galois representations
 
         if not hasattr(self,'galois_images'):
@@ -406,17 +411,16 @@ class ECNF(object):
             self.ST = st_link_by_name(1,2,'SU(2)')
 
         # Q-curve / Base change
-        # See Issue #2718
-        self.qc = "not determined"
-        # self.qc = self.q_curve
-        # if self.qc == "?":
-        #     self.qc = "not determined"
-        # elif self.qc == True:
-        #     self.qc = "yes"
-        # elif self.qc == False:
-        #     self.qc = "no"
-        # else: # just in case
-        #     self.qc = "not determined"
+        try:
+            qc = self.q_curve
+            if qc == True:
+                self.qc = "yes"
+            elif qc == False:
+                self.qc = "no"
+            else: # just in case
+                self.qc = "not determined"
+        except AttributeError:
+            self.qc = "not determined"
 
         # Torsion
         self.ntors = web_latex(self.torsion_order)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -489,11 +489,11 @@ def elliptic_curve_search(info, query):
     else:
         info['include_base_change'] = "on"
 
-    # if 'include_Q_curves' in info:
-    #     if info['include_Q_curves'] == 'exclude':
-    #         query['q_curve'] = False
-    #     elif info['include_Q_curves'] == 'only':
-    #         query['q_curve'] = True
+    if 'include_Q_curves' in info:
+        if info['include_Q_curves'] == 'exclude':
+            query['q_curve'] = False
+        elif info['include_Q_curves'] == 'only':
+            query['q_curve'] = True
 
     if 'include_cm' in info:
         if info['include_cm'] == 'exclude':

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -77,7 +77,6 @@ Please enter a value or leave blank:
           {% endfor %}
          </select>
   </td>
-{#
      <td align=right>{{ KNOWL('ec.q_curve',title="Q_curves") }} </td>
   <td>
          <select name='include_Q_curves'>
@@ -86,7 +85,7 @@ Please enter a value or leave blank:
            <option value="only">only</option>
          </select>
   </td>
-#}
+
     </tr>
 
    <tr>

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -21,9 +21,7 @@
 <td align=left>{{ KNOWL('ec.conductor',title = "conductor") }} norm</td>
 <td align=left>{{ KNOWL('ec.isogeny',title="isogenous") }} curves</td>
 <td align=left>{{ KNOWL('ec.base_change',title="base change") }} curves</td>
-{#
 <td align=left>{{ KNOWL('ec.q_curve',title="Q-curves") }}</td>
-#}
 <td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} curves</td>
 </tr>
 
@@ -51,7 +49,6 @@
   </select>
 </td>
 
-{#
 <td>         <select name='include_Q_curves'>
 {% if info.include_Q_curves == "only" %}
            <option value="">include</option>
@@ -70,7 +67,6 @@
 {% endif %}
          </select>
 </td>
-#}
 <td>         <select name='include_cm'>
 {% if info.include_cm == "only" %}
            <option value="">include</option>

--- a/scripts/ecnf/import_ecnf_data.py
+++ b/scripts/ecnf/import_ecnf_data.py
@@ -134,6 +134,7 @@ import os
 import pprint
 from lmfdb import db
 from lmfdb.utils import web_latex
+from lmfdb.backend.encoding import Json
 from sage.all import NumberField, PolynomialRing, EllipticCurve, ZZ, QQ, Set, magma, primes
 from sage.databases.cremona import cremona_to_lmfdb
 from lmfdb.ecnf.ecnf_stats import field_data
@@ -388,7 +389,7 @@ def curves(line, verbose=False):
     edata = {
         'field_label': field_label,
         'degree': deg,
-        'signature': sig,
+        'signature': Json(sig),
         'abs_disc': abs_disc,
         'class_label': class_label,
         'short_class_label': short_class_label,
@@ -409,7 +410,7 @@ def curves(line, verbose=False):
         'torsion_structure': torstruct,
         'torsion_gens': torgens,
         'equation': web_latex(E),
-        'local_data': local_data,
+        'local_data': Json(local_data),
         'minD': minD,
         'non_min_p': non_minimal_primes,
     }
@@ -504,12 +505,12 @@ def read1isogmats(base_path, filename_suffix):
         for n in range(ncurves):
             isogdegs = allisogdegs[n+1]
             label = class_label+str(n+1)
-            data[label] = {'isogeny_degrees': isogdegs,
+            data[label] = {'isogeny_degrees': Json(isogdegs),
                            'class_size': ncurves,
                            'class_deg': maxdeg}
             if n==0:
                 #print("adding isogmat = {} to {}".format(isogmat,label))
-                data[label]['isogeny_matrix'] = isogmat
+                data[label]['isogeny_matrix'] = Json(isogmat)
 
     return data
 
@@ -523,7 +524,7 @@ def split_galois_image_code(s):
 
 def galrep(line):
     r""" Parses one line from a galrep file.  Returns the label and a
-    dict containing two fields: 'non_surjective_primes', a list of
+    dict containing two fields: 'non-surjective_primes', a list of
     primes p for which the Galois representation modulo p is not
     surjective (cut off at p=37 for CM curves for which this would
     otherwise contain all primes), 'galois_images', a list of strings
@@ -558,7 +559,7 @@ def galrep(line):
 #    pr = [ int(s[:2]) if s[1].isdigit() else int(s[:1]) for s in image_codes]
     pr = [ int(split_galois_image_code(s)[0]) for s in image_codes]
     return label, {
-        'non_surjective_primes': pr,
+        'non-surjective_primes': pr,
         'galois_images': image_codes,
     }
 
@@ -830,7 +831,7 @@ def check_database_consistency(table, field=None, degree=None, ignore_ranks=Fals
 #   fields the curves are still being found and uploaded, o we ignore
 #   these keys over degree 6 fields for now.
 #
-    galrep_keys = ['galois_images', 'non_surjective_primes']
+    galrep_keys = ['galois_images', 'non-surjective_primes']
     print("key_set has {} keys".format(len(key_set)))
 
     query = {}

--- a/scripts/ecnf/import_utils.py
+++ b/scripts/ecnf/import_utils.py
@@ -153,20 +153,22 @@ def make_curves_line(ec):
 
     Output line fields (13):
 
-    field_label conductor_label iso_label number conductor_ideal conductor_norm a1 a2 a3 a4 a6 cm base_change
+    field_label conductor_label iso_label number conductor_ideal conductor_norm a1 a2 a3 a4 a6 cm q_curve
 
     Sample output line:
 
     2.0.4.1 65.18.1 a 1 [65,65,-4*w-7] 65 1,1 1,1 0,1 -1,1 -1,0 0 0
     """
     cond_lab = ec['conductor_label']
+    q_curve = ec.get('q_curve', '?')
+    if q_curve!='?': q_curve=str(int(q_curve))
     output_fields = [ec['field_label'],
                      cond_lab,
                      ec['iso_label'],
                      str(ec['number']),
                      ec['conductor_ideal'],
                      str(ec['conductor_norm'])
-                    ]  + ec['ainvs'].split(";") + [str(ec['cm']), '?' if ec['base_change']=='?' else str(int(len(ec['base_change']) > 0))]
+                    ]  + ec['ainvs'].split(";") + [str(ec['cm']), q_curve]
     return " ".join(output_fields)
 
 


### PR DESCRIPTION
This undoes the effect of #2721 (see Issue #2718) now that I have recomputed all Q-curve flags (many were missing), am confident that they are correct (some were not). 

You can see the effect at 
- http://localhost:37777/EllipticCurve/ (search buttons include Q-curve include/exclude/only)
- http://localhost:37777/EllipticCurve/3.3.49.1/ (ditto on a search results page)
- http://localhost:37777/EllipticCurve/3.3.49.1/64.1/a/1 (an individual curve which is a Q-curve nontrivially (an isogenous curve (a3) has rational j)
- http://localhost:37777/EllipticCurve/5.5.14641.1/43.1/a/1 (a nonQ-curve)

AT the same time I added code to fix the equation string which at some point had 3 extraneous double quotes pre- and appended in the database.  Compare the previous curve with http://beta.lmfdb.org/EllipticCurve/5.5.14641.1/43.1/a/1 and also with http://www.lmfdb.org/EllipticCurve/5.5.14641.1/43.1/a/1 to show that it used to be OK.

The scripts file changes can be ignored.