### PR TITLE
Fix bugs in genus 2 search results downloads

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -237,6 +237,7 @@ class G2C_download(Downloader):
     table = db.g2c_curves
     title = 'Genus 2 curves'
     columns = 'eqn'
+    column_wrappes = {'eqn':literal_eval}
     data_format = ['[[f coeffs],[h coeffs]]']
     data_description = 'defining the hyperelliptic curve y^2+h(x)y=f(x).'
     function_body = {'magma':['R<x>:=PolynomialRing(Rationals());',

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -237,7 +237,7 @@ class G2C_download(Downloader):
     table = db.g2c_curves
     title = 'Genus 2 curves'
     columns = 'eqn'
-    column_wrappes = {'eqn':literal_eval}
+    column_wrappers = {'eqn':literal_eval}
     data_format = ['[[f coeffs],[h coeffs]]']
     data_description = 'defining the hyperelliptic curve y^2+h(x)y=f(x).'
     function_body = {'magma':['R<x>:=PolynomialRing(Rationals());',

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -241,7 +241,7 @@ class G2C_download(Downloader):
     data_format = ['[[f coeffs],[h coeffs]]']
     data_description = 'defining the hyperelliptic curve y^2+h(x)y=f(x).'
     function_body = {'magma':['R<x>:=PolynomialRing(Rationals());',
-                              'return [HyperellipticCurve(R!r[1],R!r[2]):r in data];'],
+                              'return [HyperellipticCurve(R![c:c in r[1]],R![c:c in r[2]]):r in data];'],
                      'sage':['R.<x>=PolynomialRing(QQ)',
                              'return [HyperellipticCurve(R(r[0]),R(r[1])) for r in data]'],
                      'gp':['[apply(Polrev,c)|c<-data];']}

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -98,15 +98,6 @@
 
 <tr style="height:50px">
 <td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td>
-<td align=left colspan="7">
-<input type="hidden" name="query" value="{{info.query}}"/>
-Download all search results for&nbsp;
-<button type="submit" name="download" value="gp">Pari/GP</button>&nbsp;
-<button type="submit" name="download" value="sage">SageMath</button>&nbsp;
-<button type="submit" name="download" value="magma">Magma</button>&nbsp;
-</td>
-</tr>
-
 </table>
 </form>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -96,8 +96,7 @@
 
 </tr>
 
-<tr><td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
-
+<tr style="height:50px"><td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
 </table>
 </form>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -96,8 +96,8 @@
 
 </tr>
 
-<tr style="height:50px">
-<td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td>
+<tr><td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
+
 </table>
 </form>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -96,7 +96,7 @@
 
 </tr>
 
-<tr style="height:50px"><td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td></tr>
+<tr><td class="button"><button type='submit' value='refine' style='min-width: 110px'>Search again</button></td></tr>
 </table>
 </form>
 


### PR DESCRIPTION
This fixes two problems with genus 2 search downloads:

(1) There were two sets of download buttons but only the bottom set was using the new download object, I removed the top set of download buttons to be consistent with other search results pages in the LMFDB.

(2) The make_data() function in the download scripts was broken because the curve equations are stored as strings and were being blindly copied into the data array.  To address this, there is now an optional column_wrappers attribute has been added to the Downloader class which allows you to specify a mapping function for any particular column (in this case the mapping function is just string_literal)

I also fixed a formatting issue with the search again button in firefox

To test you can compare downloads on

http://www.lmfdb.org/Genus2Curve/Q/?cond=1-1000
http://localhost:37777/Genus2Curve/Q/?cond=1-1000

You should be able to cut/paste the download scripts for Pari/GP, Sage, or Magma into the relevant system and then run make_data to get the list of curves.

Be aware that if you have visited these pages before you may need to clear your browser cache to see the new behavior.
