### PR TITLE
missing degree on get_instances_by_trace_hash

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1096,7 +1096,8 @@ class Lfunction_genus2_Q(Lfunction_from_db):
                     for factor_Lhash in  elt.split(","):
                         trace_hash = db.lfunc_lfunctions.lucky({'Lhash': factor_Lhash}, projection = 'trace_hash')
                         if trace_hash is not None:
-                            instancesf = get_instances_by_trace_hash(str(trace_hash))
+                            instancesf = get_instances_by_trace_hash(
+                                                            2, str(trace_hash))
                         else:
                             instancesf = get_instances_by_Lhash(factor_Lhash)
                         instances.extend(instancesf)


### PR DESCRIPTION
We were missing the degree argument in `get_instances_by_trace_hash` for Genus 2 Curves.

An example of a broken link is: http://beta.lmfdb.org/L/Genus2Curve/Q/2916/a/

I also added a test to be sure we don't break this page in the future.