### PR TITLE
Show Knowledge in sidebar always, not just on beta

### DIFF
--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -2,7 +2,7 @@
 {%- for key, heading, value in sidebar.data -%}
 {%- if BETA or not value.status -%}{# an entire section may be omitted e.g. Motives #}
 
-{% if user_is_authenticated or BETA or key != '9Know' and key != '9Inv' %}
+{% if user_is_authenticated or BETA or key != '9Inv' %}
 {{heading | safe}}
 
 {% if value.type == 'L' %}


### PR DESCRIPTION
As decided this morning in Princeton. 

Before: the Knowledge sidebar entry (near the bottom) only appears in beta mode (i.e. on beta or debug mode)  (e.g. start with sage -python start-lmfdb.py --debug), not otherwise (e.g. start without the --debug).

After: it always appears.

Reason (for the record): now we have a good system of reviewing knowl contents, and unreviewed knowls are clearly marked as such, it is less of a risk to show possibly incorrect content on the main website.