### PR TITLE
Zeta value at half

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -430,13 +430,13 @@ class RiemannZeta(Lfunction):
         self.texnamecompleted1ms = "\\xi(1-s)"
         self.credit = 'Sage'
 
+        # Generate a function to do computations
+        self.sageLfunction = lc.Lfunction_Zeta()
+
         # Initiate the dictionary info that contains the data for the webpage
         self.info = self.general_webpagedata()
         self.info['knowltype'] = "riemann"
         self.info['title'] = "Riemann Zeta-function: $\\zeta(s)$"
-
-        # Generate a function to do computations
-        self.sageLfunction = lc.Lfunction_Zeta()
 
 #############################################################################
 

--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -197,6 +197,10 @@ class Lfunction(object):
             info['rank'] = self.order_of_vanishing
             info['motivic_weight'] = r'\(%d\)' % self.motivic_weight
 
+        elif self.Ltype() == "riemann":
+            info['sv_edge'] = r"\[\zeta(1) \approx $\infty$\]"
+            info['sv_critical'] = r"\[\zeta(1/2) \approx -1.460354508\]"
+
         elif self.Ltype() != "artin" or (self.Ltype() == "artin" and self.sign != 0):
             try:
                 info['sv_edge'] = specialValueString(self, 1, '1')

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -704,6 +704,7 @@ def specialValueTriple(L, s, sLatex_analytic, sLatex_arithmetic):
             val = "not computed"
         else:
             val = L.sageLfunction.value(s)
+            logger.warning("a value of an L-function has been computed on the fly")
 
     if sLatex_arithmetic:
         lfunction_value_tex_arithmetic = L.texname_arithmetic.replace('s)',  sLatex_arithmetic + ')')


### PR DESCRIPTION
In #2691, John Voight noted that we say that L(1/2) hasn't been computed for the Riemann zeta function on http://www.lmfdb.org/L/Riemann/. This pull request fixes that.

But I also noticed something while looking at this issue. The code to compute the value at 1/2 on the fly (using lcalc) was there, but a small bug prevented this from running. I first resolved this bug, but then replaced the lcalc call with the value itself.

I wondered whether other places use lcalc to compute values of L-functions on the fly. To accomplish this, I added a `debug.warning` that triggers when a value of an L-function is computed on the fly. During our test suite, I notice this is triggered several times. I'll raise an issue about that.