### PR TITLE
Fix bug in record counts

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -3512,17 +3512,17 @@ class PostgresStatsTable(PostgresBase):
         cur = self._execute(selecter, values)
         nres = cur.fetchone()[0]
         if record:
-            self._record_count(query, nres, suffix, extra)
+            self._record_count(query, nres, split_list, suffix, extra)
         return nres
 
-    def _record_count(self, query, count, suffix='', extra=True):
+    def _record_count(self, query, count, split_list=False, suffix='', extra=True):
         cols, vals = self._split_dict(query)
-        data = [count, cols, vals]
+        data = [count, cols, vals, split_list]
         if self.quick_count(query) is None:
-            updater = SQL("INSERT INTO {0} (count, cols, values, extra) VALUES (%s, %s, %s, %s)")
+            updater = SQL("INSERT INTO {0} (count, cols, values, split, extra) VALUES (%s, %s, %s, %s, %s)")
             data.append(extra)
         else:
-            updater = SQL("UPDATE {0} SET count = %s WHERE cols = %s AND values = %s")
+            updater = SQL("UPDATE {0} SET count = %s WHERE cols = %s AND values = %s AND split = %s")
         try:
             # This will fail if we don't have write permission,
             # for example, if we're running as the lmfdb user


### PR DESCRIPTION
This bug is causing us to rarely use the recorded counts tables.  Fixing it should mean many more search results pages will display the number of results, and will prevent duplicated data in counts tables.