### PR TITLE
Fix title and bread of degree 3 and 4 L-functions

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1234,11 +1234,15 @@ class Lfunction_Maass(Lfunction):
         # Initiate the dictionary info that contains the data for the webpage
         self.info = self.general_webpagedata()
         self.info['knowltype'] = "mf.maass"
-        R_commas = "(" + self.R.replace("_", ", ") + ")"
-        self.info['title'] = ("L-function of degree %s, " % (self.degree)
+        if self.degree > 2:
+            R_commas = "(" + self.R.replace("_", ", ") + ")"
+            self.info['title'] = ("L-function of degree %s, " % (self.degree)
                       + "conductor %s, and " % (self.level)
                       + "spectral parameters %s" % (R_commas)
                       + title_end)
+        else:
+            self.info['title'] = ("$L(s,f)$, where $f$ is a Maass cusp form with "
+                      + "level %s" % (self.level)) + title_end
 
 #############################################################################
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1160,7 +1160,7 @@ class Lfunction_Maass(Lfunction):
             # Specific properties
             if not self.selfdual:
                 self.dual_link = '/L' + self.lfunc_data.get('conjugate', None)
-            title_end = " on $%s$" % (self.group)
+            title_end = ""  #" on $%s$" % (self.group)
 
         else:   # Generate from Maass form
 
@@ -1234,8 +1234,11 @@ class Lfunction_Maass(Lfunction):
         # Initiate the dictionary info that contains the data for the webpage
         self.info = self.general_webpagedata()
         self.info['knowltype'] = "mf.maass"
-        self.info['title'] = ("$L(s,f)$, where $f$ is a Maass cusp form with "
-                      + "level %s" % (self.level)) + title_end
+        R_commas = "(" + self.R.replace("_", ", ") + ")"
+        self.info['title'] = ("L-function of degree %s, " % (self.degree)
+                      + "conductor %s, and " % (self.level)
+                      + "spectral parameters %s" % (R_commas)
+                      + title_end)
 
 #############################################################################
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -598,9 +598,7 @@ def set_bread_and_friends(info, L, request):
                 info['friends'] = [('Dual L-function', L.dual_link)]
 
             info['bread'] = get_bread(L.degree,
-                                      [('Maass Form', url_for('.l_function_maass_gln_browse_page',
-                                                              degree='degree' + str(L.degree))),
-                                       (L.maass_id.partition('/')[2], request.path)])
+                                      [(L.maass_id.partition('/')[2], request.path)])
 
 
     elif L.Ltype() == 'hilbertmodularform':


### PR DESCRIPTION
The titles of these L-functions are now "pure" L-functions,
and the intermediate "Maass" in the breadcrumbs is now gone.

See for example
/L/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019/
/L/ModularForm/GSp4/Q/Maass/1/1/12.46875_4.720951/1.34260324/
/L/ModularForm/GL3/Q/Maass/4/1/8.239796_2.641226/1.066042 +/

Fixes issue #2820

Still need to implement the new URLs and corresponding breadcrumbs.
Will submit separate issue for that.