### PR TITLE
Fixing typo in inserting into column defines in knowls

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -108,7 +108,7 @@ def normalize_define(term):
     return ' '.join(term.lower().replace('"', '').replace("'", "").split())
 
 def extract_defines(content):
-    return sorted(set(x[0].strip() for x in defines_finder_re.findall(content)))
+    return sorted(set(x.strip() for x in defines_finder_re.findall(content)))
 
 # We don't use the PostgresTable from lmfdb.backend.database
 # since it's aimed at constructing queries for mathematical objects
@@ -118,10 +118,10 @@ class KnowlBackend(PostgresBase):
     def __init__(self):
         PostgresBase.__init__(self, 'db_knowl', db)
         self._rw_knowldb = db.can_read_write_knowls()
-        #FIXME this should be moved to the config file
+        # we cache knowl titles for 10s
         self.caching_time = 10
-        self.cached_titles_timestamp = 0;
-        self.cached_defines_timestamp = 0;
+        self.cached_titles_timestamp = 0
+        self.cached_defines_timestamp = 0
         self.cached_titles = {}
 
     @property


### PR DESCRIPTION
This is the column where we store the terms defined in the content of the knowl, without this change, we were only inserting the first letter of such term.

You can try it yourself:
```
import  lmfdb.backend.database
db = lmfdb.backend.database.db
SQL = lmfdb.backend.database.SQL
db._execute(SQL("SELECT defines FROM kwl_knowls WHERE id = 'cmf.embedding_label';")).fetchall()
>>> [([u'label'],), ([u'l'],), ([u'label'],)]
```

The first entry was introduced in the conversion, the `l` is what I get when eddited in beta, and `label` is what you get when edditing with this PR

Once this is merged, we will fix all previous entries with a SQL script.