### PR TITLE
Hide plot that links to broken L-functions

### DIFF
--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -47,7 +47,8 @@ def getAllMaassGraphHtml(degree, signature=""):
     if signature == 'r0r0r0':
         ans += getGroupHtml(signature)
         ans += getOneGraphHtml(["GL3", 1])
-        ans += getOneGraphHtml(["GL3", 4])
+# hiding this because there are missing conjugates for the  eps = +1 non-self dual functions
+#        ans += getOneGraphHtml(["GL3", 4])
     elif signature == 'r0r0r0r0':
         ans += getGroupHtml(signature + 'selfdual')
         ans += getOneGraphHtml(["GSp4", 1])


### PR DESCRIPTION
Hide the "L-functions of conductor 4" plot on
L/degree3/r0r0r0/
because some of the blue links are broken.