### PR TITLE
ecnf extent knowl -- do not always display on browse page!

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -249,7 +249,7 @@ def index():
     return render_template("ecnf-index.html",
                            title="Elliptic Curves over Number Fields",
                            data=data,
-                           bread=bread, learnmore=learnmore_list_remove('Completeness'))
+                           bread=bread, learnmore=learnmore_list())
 
 @ecnf_page.route("/random")
 def random_curve():

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <div>
-{{ KNOWL_INC('dq.ecnf.extent') }}
+  {{ ecnf_summary()|safe}}
 </div>
 
 <h2> Browse {{ KNOWL('ec',title='elliptic curves')}} defined over:

--- a/lmfdb/ecnf/templates/ecnf-stats.html
+++ b/lmfdb/ecnf/templates/ecnf-stats.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div>
-{{ KNOWL_INC('dq.ecnf.extent') }}
+  {{ ecnf_summary()|safe}}
 </div>
 
 <h3>Browse by field degree or signature:</h3>


### PR DESCRIPTION
Please merge ASAP since I greatly extended the ecnf extent knowl from a single line, but the entire contents of that knowl is displayed on beta (and www) e.g. www.lmfdb.org/EllipticCurve which we do not want!

I would rather not remove all the new knowl text.  After this PR the one-line summary is displayed as before and the full Extent knowl is available under the "Completeness" link.  