### PR TITLE
Switch Lattices back to beta status

### DIFF
--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -266,6 +266,7 @@
       colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"
+      status:  beta
     - title: Subgroups of
       part2:
          - title: $\SL(2)$


### PR DESCRIPTION
As agreed by managing editors at the Princeton workkshop.

This undoes #PR1108 of 29 April 2016.