### PR TITLE
RCS knowls for Bianchi forms

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -22,8 +22,9 @@ bianchi_credit = 'John Cremona, Aurel Page, Alexander Rahm, Haluk Sengun'
 field_label_regex = re.compile(r'2\.0\.(\d+)\.1')
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source of the data', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
+            ('Reliability of the data', url_for(".reliability_page")),
             ('Bianchi newform labels', url_for(".labels_page"))]
 
 # Return the learnmore list with the matchstring entry removed
@@ -353,13 +354,23 @@ def how_computed_page():
 
 @bmf_page.route("/Completeness")
 def completeness_page():
-    t = 'Completeness of the Bianchi Modular Form Data'
+    t = 'Completeness of the Bianchi Modular Form data'
     bread = [('Modular Forms', url_for('mf.modular_form_main_page')),
              ('Bianchi Modular Forms', url_for(".index")),
              ('Completeness', '')]
     credit = 'John Cremona'
     return render_template("single.html", kid='dq.mf.bianchi.extent',
                            credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+
+@bmf_page.route("/Reliability")
+def reliability_page():
+    t = 'Reliability of the Bianchi Modular Form data'
+    bread = [('Modular Forms', url_for('mf.modular_form_main_page')),
+             ('Bianchi Modular Forms', url_for(".index")),
+             ('Relaibility', '')]
+    credit = 'John Cremona'
+    return render_template("single.html", kid='dq.mf.bianchi.reliability',
+                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @bmf_page.route("/Labels")
 def labels_page():

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -2,7 +2,8 @@
 {% block content %}
 
 <div>
-{{ KNOWL_INC('dq.mf.bianchi.extent') }}
+  The database contains information about {{ KNOWL('mf.bianchi.bianchimodularforms', 'Bianchi modular forms') }} over several imaginary quadratic fields including all nine fields of class number $1$,  for a range of levels.
+
 </div>
 
 <h2> Browse {{ KNOWL('mf.bianchi.bianchimodularforms', title='Bianchi


### PR DESCRIPTION

Instead of displaying the entire content of dq.mf.bianchi.extent at beta.lmfdb.org/ModularForm/GL2/ImaginaryQuadratic/
this just shows the first sentence.  The whole knowl is still accessible via the completeness link.

This is just step 1, further work on RCS knowls for Bianchi will follow.