### PR TITLE
remove refs to holo cusp forms having trivial character

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -95,7 +95,7 @@ def l_function_degree_page(degree):
     return render_template("DegreeNavigateL.html", title='Degree ' + str(degree) + ' L-functions', **info)
 
 
-# L-function of holomorphic cusp form with trivial character browsing page ##############################################
+# L-function of holomorphic cusp form browsing page ##############################################
 @l_function_page.route("/<degree>/CuspForm/")
 def l_function_cuspform_browse_page(degree):
     deg = get_degree(degree)
@@ -198,7 +198,7 @@ def set_info_for_start_page():
     tt = [[{'title': 'Riemann Zeta Function', 'link': url_for('.l_function_riemann_page')},
            {'title': 'Dirichlet L-function', 'link': url_for('.l_function_dirichlet_browse_page')}],
 
-          [{'title': 'Holomorphic Cusp Form with Trivial Character', 'link': url_for('.l_function_cuspform_browse_page',degree='degree2')},
+          [{'title': 'Holomorphic Cusp Form', 'link': url_for('.l_function_cuspform_browse_page',degree='degree2')},
            {'title': 'GL2 Maass Form', 'link': url_for('.l_function_maass_browse_page')},
            {'title': 'Elliptic Curve', 'link': url_for('.l_function_ec_browse_page')}],
 

--- a/lmfdb/lfunctions/templates/DegreeNavigateL.html
+++ b/lmfdb/lfunctions/templates/DegreeNavigateL.html
@@ -35,7 +35,7 @@ L-functions can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
 
 
 By {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
-<a href="{{url_for('l_functions.l_function_cuspform_browse_page',degree='degree2')}}">HOLOmorphic cusp form with trivial character</a>
+<a href="{{url_for('l_functions.l_function_cuspform_browse_page',degree='degree2')}}">HOLOmorphic cusp form</a>
 &nbsp; <a href="{{url_for('l_functions.l_function_maass_browse_page')}}">Maass form of weight $0$ for $\GL(2)$</a> &nbsp;
 <a href="{{url_for('l_functions.l_function_ec_browse_page')}}">Elliptic curve</a>
 


### PR DESCRIPTION
A couple of places in the code still refer to cusp forms having trivial character, only 1 of these is visible to the end user which is in http://www.lmfdb.org/L/ . This fixes this as we now have all the forms!