### PR TITLE
Genus 2 curve CMF friends

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -634,9 +634,7 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
-        print "checking cmf friends with trace hash", data['Lhash']
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
-            print "potential cmf friend", cmf_friend
             # be selective, only cmfs of the right dimension and conductor get to be our friends
             if cmf_friend["dim"] == 2 and cmf_friend["level"]**2 == data['cond']:
                 add_friend (friends, ("Modular form " + cmf_friend["label"], url_for_cmf(cmf_friend["label"])))

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -634,8 +634,10 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
-        for friend_label in db.mf_newforms.search({'trace_hash':data['Lhash']},"label"):
-            add_friend (friends, ("Modular form " + friend_label, url_for_cmf(friend_label)))
+        for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
+            # be selective, only cmfs of the right dimension and conductor get to be our friends
+            if cmf_friend["dim"] == 2 and cmf_friend["level"]**2 == data['cond']:
+                add_friend (friends, ("Modular form " + friend_label, url_for_cmf(friend_label)))
         if 'split_labels' in data:
             for friend_label in data['split_labels']:
                 if is_curve:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -634,10 +634,12 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
+        print "checking cmf friends"
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
+            print "potential cmf friend", cmf_friend
             # be selective, only cmfs of the right dimension and conductor get to be our friends
             if cmf_friend["dim"] == 2 and cmf_friend["level"]**2 == data['cond']:
-                add_friend (friends, ("Modular form " + friend_label, url_for_cmf(friend_label)))
+                add_friend (friends, ("Modular form " + friend_label, url_for_cmf(cmf_friend["label"])))
         if 'split_labels' in data:
             for friend_label in data['split_labels']:
                 if is_curve:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -10,6 +10,7 @@ from lmfdb.number_fields.web_number_field import nf_display_knowl
 from lmfdb.galois_groups.transitive_group import group_display_knowl
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_logger
+from lmfdb.classical_modular_forms.main import url_for_label as url_for_cmf
 from sage.all import latex, ZZ, QQ, CC, PolynomialRing, factor, implicit_plot, point, real, sqrt, var,  nth_prime
 from sage.plot.text import text
 from flask import url_for
@@ -633,6 +634,8 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
+        for friend_label in db.mf_newforms.search({'trace_hash':data['Lhash']},"label"):
+            add_friend (friends, ("Modular form " + friend_label, url_for_cmf(friend_label)))
         if 'split_labels' in data:
             for friend_label in data['split_labels']:
                 if is_curve:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -639,7 +639,7 @@ class WebG2C(object):
             print "potential cmf friend", cmf_friend
             # be selective, only cmfs of the right dimension and conductor get to be our friends
             if cmf_friend["dim"] == 2 and cmf_friend["level"]**2 == data['cond']:
-                add_friend (friends, ("Modular form " + friend_label, url_for_cmf(cmf_friend["label"])))
+                add_friend (friends, ("Modular form " + cmf_friend["label"], url_for_cmf(cmf_friend["label"])))
         if 'split_labels' in data:
             for friend_label in data['split_labels']:
                 if is_curve:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -634,7 +634,7 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
-        print "checking cmf friends"
+        print "checking cmf friends with trace hash", data['Lhash']
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
             print "potential cmf friend", cmf_friend
             # be selective, only cmfs of the right dimension and conductor get to be our friends


### PR DESCRIPTION
This addresses issue #433.  Genus curves and isogeny classes now list CMF friends as related objects.

Examples:

http://127.0.0.1:37777/Genus2Curve/Q/169/a/
http://127.0.0.1:37777/Genus2Curve/Q/256/a/
http://127.0.0.1:37777/Genus2Curve/Q/4096/e/

vs

http://www.lmfdb.org/Genus2Curve/Q/169/a/
http://www.lmfdb.org/Genus2Curve/Q/256/a/
http://www.lmfdb.org/Genus2Curve/Q/4096/e/

