### PR TITLE
Fix to #1820

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -115,7 +115,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                 if len(s) != 2:
                     flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])
                     return render_template('mwf_navigate.html', **info)
-                if not re.match(FLOAT_RE,s[0]) or not re.match(FLOAR_RE,s[1]):
+                if not re.match(FLOAT_RE,s[0]) or not re.match(FLOAT_RE,s[1]):
                     flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])
                     return render_template('mwf_navigate.html', **info)
         search = get_search_parameters(info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -112,6 +112,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
             if not re.match(FLOAT_RE,info['ev_range']):
                 if "-" in info['ev_range']:
                     info['ev_range'] = "..".join(info['ev_range'].split("-"))
+                print "ev_range =",info['ev_range']
                 s = info['ev_range'].split("..")
                 if len(s) != 2:
                     flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -90,7 +90,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
         if info['character']:
             if info.get('level_range') and not re.match(POSINT_RE, info['level_range']):
                 flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
-            N = int(info.get('level_range','0')
+            N = int(info.get('level_range','0'))
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -54,6 +54,11 @@ def learnmore_list_remove(matchstring):
 
 met = ['GET', 'POST']
 maxNumberOfResultsToShow = 500
+INT_RE = re.compile(r'^(\d*)$')
+POSINT_RE = re.compile(r'^(\d+)$')
+POSINT_RANGE_RE = re.compile(r'^(\d+\.\.\d+)$')
+FLOAT_RE = re.compile(r'((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?')
+
 
 @mwf.route("/", methods=met)
 @mwf.route("/<int:level>/", methods=met)
@@ -63,7 +68,7 @@ maxNumberOfResultsToShow = 500
 @mwf.route("/<int:level>/<int:weight>/<int:character>/<float:r1>/<float:r2>/", methods=met)
 def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds):
     info = get_args_mwf(level=level, weight=weight, character=character, r1=r1, r2=r2, **kwds)
-
+    print info
     info["credit"] = ""
     info["learnmore"] = learnmore_list()
     mwf_logger.debug("args=%s" % request.args)
@@ -74,8 +79,29 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
     if info.get('maass_id', None) and info.get('db', None):
         return render_one_maass_waveform_wp(**info)
     if info['search'] or (info['browse'] and int(info['weight']) != 0):
-        flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
-        return render_template('mwf_navigate.html', **info)
+        if info['level']:
+            if not re.match(POSINT_RE, info['level']):
+                if "-" in info['level']:
+                    info['level'] = "..".join(info['level'].split("-"))
+                if not re.match(POSINT_RANGE_RE, info['level']):
+                    flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level'])
+                    return render_template('mwf_navigate.html', **info)
+        if info['character']:
+            if info['level'] and not re.match(POSINT_RE, info['level']):
+                flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
+            N = int(info['level']) if info['level'] else 0
+            if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
+                flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                return render_template('mwf_navigate.html', **info)
+            slabel = label.split('.')
+            q,n = int(slabel[0]), int(slabel[1])
+            if n > q or gcd(q,n) != 1 or (N > 0 and q ne N)
+                flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                return render_template('mwf_navigate.html', **info)
+        if info['weight']:
+            if not re.match(INT_RE, info['weight']):
+                flash_error("%s is not a valid weight.  It should be a nonnegative integer.", info['weight'])
+                return render_template('mwf_navigate.html', **info)
         search = get_search_parameters(info)
         mwf_logger.debug("search=%s" % search)
         return render_search_results_wp(info, search)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -80,17 +80,17 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
     if info.get('maass_id', None) and info.get('db', None):
         return render_one_maass_waveform_wp(**info)
     if info['search'] or (info['browse'] and int(info['weight']) != 0):
-        if info['level']:
-            if not re.match(POSINT_RE, info['level']):
-                if "-" in info['level']:
-                    info['level'] = "..".join(info['level'].split("-"))
-                if not re.match(POSINT_RANGE_RE, info['level']):
-                    flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level'])
+        if info['level_range']:
+            if not re.match(POSINT_RE, info['level_range']):
+                if "-" in info['level_range']:
+                    info['level'] = "..".join(info['level_range'].split("-"))
+                if not re.match(POSINT_RANGE_RE, info['level_range']):
+                    flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
         if info['character']:
-            if info['level'] and not re.match(POSINT_RE, info['level']):
+            if info['level_range'] and not re.match(POSINT_RE, info['level_range']):
                 flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
-            N = int(info['level']) if info['level'] else 0
+            N = int(info['level_range']) if info['level'] else 0
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -71,6 +71,8 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
     if info.get('maass_id', None) and info.get('db', None):
         return render_one_maass_waveform_wp(**info)
     if info['search'] or (info['browse'] and int(info['weight']) != 0):
+        flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+        return render_template('mwf_navigate.html', **info)
         search = get_search_parameters(info)
         mwf_logger.debug("search=%s" % search)
         return render_search_results_wp(info, search)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -89,9 +89,11 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
         if info['character'] != -1:
-            if info.get('level_range') and ("." in info['level_range'] or not re.match(POSINT_RE, info['level_range'])):
+            try:
+                N = int(info.get('level_range','0'))
+            except:
                 flash_error("Character %s cannot be specified in combination with a range of levels.", info['character'])
-            N = int(info.get('level_range','0'))
+                return render_template('mwf_navigate.html', **info)
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -89,7 +89,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
         if info['character'] != -1:
-            if info.get('level_range') and not re.match(POSINT_RE, info['level_range']):
+            if info.get('level_range') and ("." in info['level_range'] or not re.match(POSINT_RE, info['level_range'])):
                 flash_error("Character %s cannot be specified in combination with a range of levels.", info['character'])
             N = int(info.get('level_range','0'))
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -80,14 +80,15 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
     if info.get('maass_id', None) and info.get('db', None):
         return render_one_maass_waveform_wp(**info)
     if info['search'] or (info['browse'] and int(info['weight']) != 0):
+        # This isn't the right place to do input validation, but it is easier to flash errors here (this is a hack to address issue #1820)
         if info.get('level_range'):
             if not re.match(POSINT_RE, info['level_range']):
                 if "-" in info['level_range']:
-                    info['level'] = "..".join(info['level_range'].split("-"))
+                    info['level_range'] = "..".join(info['level_range'].split("-"))
                 if not re.match(POSINT_RANGE_RE, info['level_range']):
                     flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
-        if info['character']:
+        if info['character'] != -1:
             if info.get('level_range') and not re.match(POSINT_RE, info['level_range']):
                 flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
             N = int(info.get('level_range','0'))
@@ -99,7 +100,9 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
             if n > q or gcd(q,n) != 1 or (N > 0 and q != N):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)
-        if info['weight']:
+            info['level_range'] = str(q)
+            info['character'] = str(n)
+        if info['weight'] != -1:
             if not re.match(INT_RE, info['weight']):
                 flash_error("%s is not a valid weight.  It should be a nonnegative integer.", info['weight'])
                 return render_template('mwf_navigate.html', **info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -58,7 +58,7 @@ maxNumberOfResultsToShow = 500
 INT_RE = re.compile(r'^(\d*)$')
 POSINT_RE = re.compile(r'^(\d+)$')
 POSINT_RANGE_RE = re.compile(r'^(\d+\.\.\d+)$')
-FLOAT_RE = re.compile(r'((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?')
+FLOAT_RE = re.compile(r'(\d+([.]\d*)')
 
 
 @mwf.route("/", methods=met)
@@ -69,7 +69,6 @@ FLOAT_RE = re.compile(r'((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?')
 @mwf.route("/<int:level>/<int:weight>/<int:character>/<float:r1>/<float:r2>/", methods=met)
 def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds):
     info = get_args_mwf(level=level, weight=weight, character=character, r1=r1, r2=r2, **kwds)
-    print info
     info["credit"] = ""
     info["learnmore"] = learnmore_list()
     mwf_logger.debug("args=%s" % request.args)
@@ -112,7 +111,6 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
             if not re.match(FLOAT_RE,info['ev_range']):
                 if "-" in info['ev_range']:
                     info['ev_range'] = "..".join(info['ev_range'].split("-"))
-                print "ev_range =",info['ev_range']
                 s = info['ev_range'].split("..")
                 if len(s) != 2:
                     flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -95,7 +95,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                 return render_template('mwf_navigate.html', **info)
             slabel = label.split('.')
             q,n = int(slabel[0]), int(slabel[1])
-            if n > q or gcd(q,n) != 1 or (N > 0 and q ne N)
+            if n > q or gcd(q,n) != 1 or (N > 0 and q != N)
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)
         if info['weight']:

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -58,8 +58,7 @@ maxNumberOfResultsToShow = 500
 INT_RE = re.compile(r'^(\d*)$')
 POSINT_RE = re.compile(r'^(\d+)$')
 POSINT_RANGE_RE = re.compile(r'^(\d+\.\.\d+)$')
-FLOAT_RE = re.compile(r'^(\d+([.]\d*))$')
-
+FLOAT_RE = re.compile(r'^(\d+|\d+\.\d)$')
 
 @mwf.route("/", methods=met)
 @mwf.route("/<int:level>/", methods=met)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -23,8 +23,9 @@ AUTHORS:
 
 import flask
 from flask import render_template, url_for, request, send_file
-from lmfdb import db
-from lmfdb.utils import flash_error, parse_ints, parse_floats
+from lmfdb import re
+from lmfdb.utils import flash_error
+from sage.all import gcd
 
 import StringIO
 from lmfdb.modular_forms.maass_forms.maass_waveforms import MWF, mwf_logger, mwf
@@ -93,9 +94,9 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)
-            slabel = label.split('.')
-            q,n = int(slabel[0]), int(slabel[1])
-            if n > q or gcd(q,n) != 1 or (N > 0 and q != N)
+            s = info['character'].split('.')
+            q,n = int(s[0]), int(s[1])
+            if n > q or gcd(q,n) != 1 or (N > 0 and q != N):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)
         if info['weight']:

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -90,7 +90,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     return render_template('mwf_navigate.html', **info)
         if info['character'] != -1:
             if info.get('level_range') and not re.match(POSINT_RE, info['level_range']):
-                flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
+                flash_error("Character %s cannot be specified in combination with a range of levels.", info['character'])
             N = int(info.get('level_range','0'))
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -23,7 +23,7 @@ AUTHORS:
 
 import flask
 from flask import render_template, url_for, request, send_file
-from lmfdb import re
+import re
 from lmfdb.utils import flash_error
 from sage.all import gcd
 

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -108,6 +108,17 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
             if not re.match(INT_RE, info['weight']):
                 flash_error("%s is not a valid weight.  It should be a nonnegative integer.", info['weight'])
                 return render_template('mwf_navigate.html', **info)
+        if info.get('ev_range'):
+            if not re.match(FLOAT_RE,info['ev_range']):
+                if "-" in info['ev_range']:
+                    info['ev_range'] = "..".join(info['ev_range'].split("-"))
+                s = info['ev_range'].split("..")
+                if len(s) != 2:
+                    flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])
+                    return render_template('mwf_navigate.html', **info)
+                if not re.match(FLOAT_RE,s[0]) or not re.match(FLOAR_RE,s[1]):
+                    flash_error("%s is not a valid eigenvalue range.  It should be postive real interval.", info['ev_range'])
+                    return render_template('mwf_navigate.html', **info)
         search = get_search_parameters(info)
         mwf_logger.debug("search=%s" % search)
         return render_search_results_wp(info, search)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -58,7 +58,7 @@ maxNumberOfResultsToShow = 500
 INT_RE = re.compile(r'^(\d*)$')
 POSINT_RE = re.compile(r'^(\d+)$')
 POSINT_RANGE_RE = re.compile(r'^(\d+\.\.\d+)$')
-FLOAT_RE = re.compile(r'(\d+([.]\d*)')
+FLOAT_RE = re.compile(r'^(\d+([.]\d*))$')
 
 
 @mwf.route("/", methods=met)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -80,7 +80,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
     if info.get('maass_id', None) and info.get('db', None):
         return render_one_maass_waveform_wp(**info)
     if info['search'] or (info['browse'] and int(info['weight']) != 0):
-        if info['level_range']:
+        if info.get('level_range'):
             if not re.match(POSINT_RE, info['level_range']):
                 if "-" in info['level_range']:
                     info['level'] = "..".join(info['level_range'].split("-"))
@@ -88,9 +88,9 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
         if info['character']:
-            if info['level_range'] and not re.match(POSINT_RE, info['level_range']):
+            if info.get('level_range') and not re.match(POSINT_RE, info['level_range']):
                 flash_error("Character cannot be specified in combination with a range of levels.", info['character'])
-            N = int(info['level_range']) if info['level'] else 0
+            N = int(info.get('level_range','0')
             if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                 flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                 return render_template('mwf_navigate.html', **info)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -23,6 +23,9 @@ AUTHORS:
 
 import flask
 from flask import render_template, url_for, request, send_file
+from lmfdb import db
+from lmfdb.utils import flash_error, parse_ints, parse_floats
+
 import StringIO
 from lmfdb.modular_forms.maass_forms.maass_waveforms import MWF, mwf_logger, mwf
 from lmfdb.modular_forms.maass_forms.maass_waveforms.backend.maass_forms_db import maass_db


### PR DESCRIPTION
Adds some input validation to the Maass forms search page in an effort to address #1820.  Not perfect, but a lot better than what was there (it is now much harder to generate a server error).  To test go to 

http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/

and try various combination of input (especially invalid input)