### PR TITLE
New contributor, and weight 1 correction

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -67,6 +67,10 @@ name: Sarunas Burdulis
 affil: Dartmouth College
 url: https://math.dartmouth.edu/~sarunas/
 ---
+name: Mirela Ciperiani
+url: https://web.ma.utexas.edu/users/mirela/
+affil: University of Texas, Austin
+---
 name: Henri Cohen
 url: http://www.math.u-bordeaux1.fr/~hecohen/
 affil: University Bordeaux I
@@ -159,6 +163,8 @@ name: William Hart
 affil: Technische Universit&auml;t Kaiserslautern
 ---
 name: Ghaith Hiary
+affil: The Ohio State University
+url: https://people.math.osu.edu/hiary.1/
 ---
 name: Duc Khiem Huynh
 url: http://www.math.uwaterloo.ca/~dkhuynh/
@@ -180,7 +186,6 @@ name: Kamal Khuri-Makdisi
 affil: American University Beirut
 ---
 name: Sally Koutsoliotas
-url: http://www.bucknell.edu/x18772.xml
 affil: Bucknell University
 ---
 name: Patrick Kühn

--- a/lmfdb/lfunctions/templates/Degree2.html
+++ b/lmfdb/lfunctions/templates/Degree2.html
@@ -114,7 +114,7 @@ determine the parity of the central character.</li>
 <li>A self-dual degree 2 L-function with nontrivial character must be CM, in particular
 at least half its prime coefficients $a_p$ must vanish.</li>
 <li>L-functions of Maass forms are (conjecturally) non-arithmetic unless the Maass form has
-eigenvalue $\frac14$, in which case the Maass form is holomorphic.
+eigenvalue $\frac14$.
 <!-- Say something about which Artin representations come from Hecke characters
 (it is those which are not dihedral).
 -->


### PR DESCRIPTION
Added a new contributor from the IAS workshop, adjusted some contributor info,
and omitted an incorrect statement from
/L/degree2/
The last phrase on that page was incorrect:  only in the weight 1 case is a Maass form
with eigenvalue 1/4 holomorphic.  But it is arithmetic for either weight 0 or weight 1.
