### PR TITLE
Fixed abvar to no longer use oldstats, add reliability knowl

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -4,6 +4,7 @@ import ast, re, StringIO, time
 
 from flask import flash, render_template, url_for, request, redirect, send_file
 from markupsafe import Markup
+from collections import defaultdict
 from sage.rings.all import PolynomialRing, ZZ
 
 from lmfdb import db
@@ -40,6 +41,7 @@ def ECFq_redirect():
 def learnmore_list():
     return [('Completeness of the data', url_for(".completeness_page")),
             ('Source of the data', url_for(".how_computed_page")),
+            ('Reliability of the data', url_for(".reliability_page")),
             ('Labels', url_for(".labels_page"))]
 
 # Return the learnmore list with the matchstring entry removed
@@ -230,7 +232,7 @@ def abelian_variety_browse(**args):
         else:
             qmin = table_params['q'].get('$gte',min(qs) if qs else table_params['q'].get('$lte',0))
             qmax = table_params['q'].get('$lte',max(qs) if qs else table_params['q'].get('$gte',1000))
-    info['table'] = {}
+    info['table'] = defaultdict(lambda: defaultdict(int))
     if gmin == gmax:
         info['table_dimension_range'] = "{0}".format(gmin)
     else:
@@ -240,16 +242,9 @@ def abelian_variety_browse(**args):
     else:
         info['table_field_range'] = "{0}-{1}".format(qmin, qmax)
 
-    for q in qs:
-        if q < qmin or q > qmax:
-            continue
-        info['table'][q] = {}
-        L = av_stats._counts[q]
-        for g in xrange(gmin, gmax+1):
-            if g < len(L):
-                info['table'][q][g] = L[g]
-            else:
-                info['table'][q][g] = 0
+    for (g,q), cnt in av_stats._counts.items():
+        if qmin <= q <= qmax and gmin <= g <= gmax:
+            info['table'][q][g] = cnt
 
     info['col_heads'] = [q for q in qs if q >= qmin and q <= qmax]
     info['row_heads'] = [g for g in gs if g >= gmin and g <= gmax]
@@ -284,6 +279,13 @@ def completeness_page():
     bread = get_bread(('Completeness', '.'))
     return render_template("single.html", kid='dq.av.fq.extent',
                            credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+
+@abvarfq_page.route("/Reliability")
+def reliability_page():
+    t = 'Reliability of the Weil Polynomial Data'
+    bread = get_bread(('Reliability', '.'))
+    return render_template("single.html", kid='dq.av.fq.reliability',
+                           credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @abvarfq_page.route("/Source")
 def how_computed_page():

--- a/lmfdb/abvar/fq/stats.py
+++ b/lmfdb/abvar/fq/stats.py
@@ -1,32 +1,25 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 from lmfdb import db
-from lmfdb.utils import comma
+from lmfdb.utils import comma, StatsDisplay
 from lmfdb.logger import make_logger
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.misc.lazy_attribute import lazy_attribute
 
 logger = make_logger("abvarfq")
 
-class AbvarFqStats(UniqueRepresentation):
-    def __init__(self):
-        logger.debug("Constructing AbvarFqStats")
-
+class AbvarFqStats(StatsDisplay):
     @lazy_attribute
     def _counts(self):
-        logger.debug("Looking up abelian variety counts")
-        D = {}
-        for q, L in db.av_fqisog.stats.get_oldstat('counts').iteritems():
-            D[int(q)] = L
-        return D
+        return db.av_fqisog.stats.column_counts(['g', 'q'])
 
     @lazy_attribute
     def qs(self):
-        return sorted(self._counts.keys())
+        return sorted(set(q for g,q in self._counts))
 
     @lazy_attribute
     def gs(self):
-        maxg = max(len(L)-1 for L in self._counts.values())
-        return range(1, maxg+1)
+        return sorted(set(g for g,q in self._counts))
 
     @lazy_attribute
     def counts(self):
@@ -35,24 +28,18 @@ class AbvarFqStats(UniqueRepresentation):
         counts['nclasses_c'] = comma(ncurves)
         counts['gs'] = self.gs
         counts['qs'] = qs = self.qs
-        counts['qg_count'] = {}
-        for q in qs:
-            counts['qg_count'][q] = {}
-            L = self._counts[q]
-            for g in xrange(1,self.maxg[None]+1):
-                if g < len(L):
-                    counts['qg_count'][q][g] = L[g]
-                else:
-                    counts['qg_count'][q][g] = 0
+        counts['qg_count'] = defaultdict(lambda: defaultdict(int))
+        for (g,q), cnt in self._counts.items():
+            counts['qg_count'][q][g] = cnt
         return counts
 
     @lazy_attribute
     def maxq(self):
-        return {g: max(q for q in self.qs if len(self._counts[q]) > g) for g in self.gs}
+        return {g: max(q for gg,q in self._counts if g==gg) for g in self.gs}
 
     @lazy_attribute
     def maxg(self):
-        maxg = {q: len(self._counts[q]) - 1 for q in self.qs}
+        maxg = {q: max(g for g,qq in self._counts if q==qq) for q in self.qs}
         # maxg[None] used in decomposition search
         maxg[None] = max(self.gs)
         return maxg

--- a/lmfdb/abvar/fq/stats.py
+++ b/lmfdb/abvar/fq/stats.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from lmfdb import db
 from lmfdb.utils import comma, StatsDisplay
 from lmfdb.logger import make_logger
-from sage.structure.unique_representation import UniqueRepresentation
 from sage.misc.lazy_attribute import lazy_attribute
 
 logger = make_logger("abvarfq")
@@ -27,7 +26,7 @@ class AbvarFqStats(StatsDisplay):
         counts['nclasses'] = ncurves = sum(sum(L) for L in self._counts.itervalues())
         counts['nclasses_c'] = comma(ncurves)
         counts['gs'] = self.gs
-        counts['qs'] = qs = self.qs
+        counts['qs'] = self.qs
         counts['qg_count'] = defaultdict(lambda: defaultdict(int))
         for (g,q), cnt in self._counts.items():
             counts['qg_count'][q][g] = cnt

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -53,8 +53,8 @@ class AVHomeTest(LmfdbTest):
         r"""
         Check that we can change the table range
         """
-        self.check_args("/Variety/Abelian/Fq/?table_field_range=32-100&table_dimension_range=2-4",'6408')
-        self.check_args("/Variety/Abelian/Fq/?table_field_range=4..7&table_dimension_range=2..4",'2944')
+        self.check_args("/Variety/Abelian/Fq/?table_field_range=32-100&table_dimension_range=2-4",'6409')
+        self.check_args("/Variety/Abelian/Fq/?table_field_range=4..7&table_dimension_range=2..4",'2953')
         # and that it deals with invalid input
         self.check_args("/Variety/Abelian/Fq/?table_field_range=2-27&table_dimension_range=1%2C3%2C5",'Error: You cannot use commas in the table ranges.')
         self.check_args("/Variety/Abelian/Fq/?table_field_range=2-27&table_dimension_range=x",'not a valid input')
@@ -187,7 +187,7 @@ class AVHomeTest(LmfdbTest):
         self.not_check_args("/Variety/Abelian/Fq/?q=3&g=2&jacobian=no",'2.3.ae_i')
         self.not_check_args("/Variety/Abelian/Fq/?q=3&g=2&jacobian=no",'2.3.ae_i')
         # unknowns
-        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=not_yes&polarizable=yes",'3.2.a_ad_a')
+        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=not_yes&polarizable=yes",'3.3.a_ad_a')
         self.check_args("/Variety/Abelian/Fq/?q=2&g=3&p_rank=0&jacobian=not_no",'3.2.c_c_c')
 
     def test_search_princpol(self):

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -187,7 +187,7 @@ class AVHomeTest(LmfdbTest):
         self.not_check_args("/Variety/Abelian/Fq/?q=3&g=2&jacobian=no",'2.3.ae_i')
         self.not_check_args("/Variety/Abelian/Fq/?q=3&g=2&jacobian=no",'2.3.ae_i')
         # unknowns
-        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=not_yes&polarizable=yes",'No matches')
+        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=not_yes&polarizable=yes",'3.2.a_ad_a')
         self.check_args("/Variety/Abelian/Fq/?q=2&g=3&p_rank=0&jacobian=not_no",'3.2.c_c_c')
 
     def test_search_princpol(self):
@@ -251,4 +251,4 @@ class AVHomeTest(LmfdbTest):
         self.check_args("/Variety/Abelian/Fq/?initial_coefficients=%5B1%2C-1%2C3%2C9%5D&abvar_point_count=%5B75%2C7125%5D", 'No matches')
         # Combining unknown fields on Jacobian and Principal polarization.
         self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=no&polarizable=not_no", '3.2.a_a_ae')
-        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=no&polarizable=yes", 'No matches')
+        self.check_args("/Variety/Abelian/Fq/?g=3&jacobian=no&polarizable=yes", '3.2.a_ac_a')


### PR DESCRIPTION
To see the difference visit http://localhost:37777/Variety/Abelian/Fq/ and note that there is a Reliability link in the Learnmore box, and that there are 35 isogeny classes for g=q=2 rather than 34.

Once this is merged, I think we can push to web and resolve #2451.