### PR TITLE
Fix jumps in link suggestion mode

### DIFF
--- a/lmfdb/knowledge/templates/knowl-edit.html
+++ b/lmfdb/knowledge/templates/knowl-edit.html
@@ -190,7 +190,7 @@ var all_defines = {
 };
 
 $("body").on("click", ".insert_klink", insert_klink);
-$("body").on("mouseenter", ".insert_klink", hover_klink);
+$("body").on("click", ".select_klink", select_klink);
 
 /* register keyhandlers */
 $(function() {


### PR DESCRIPTION
Resolves #2832.  To test, edit a knowl with lots of link suggestions.  The layout of the suggestions has changed, and there is now a separate link to highlight the text rather than have it be on the hover.