### PR TITLE
Remove yourself from authorship

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -614,6 +614,13 @@ class KnowlBackend(PostgresBase):
         cur = self._execute(selecter, [0])
         return {res[0]: res[1] for res in cur}
 
+    def remove_author(self, kid, uid):
+        """
+        Remove an author from all versions of a knowl.
+        """
+        updater = SQL("UPDATE kwl_knowls SET authors = array_remove(authors, %s) WHERE id = %s")
+        self._execute(updater, [uid, kid])
+
 knowldb = KnowlBackend()
 
 def knowl_title(kid):

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -394,10 +394,22 @@ def show(ID):
     return render_template(u"knowl-show.html",
                            title=title,
                            k=k,
+                           cur_username=current_user.get_id(),
                            render=r,
                            bread=b)
 
-
+@knowledge_page.route("/remove_author/<ID>")
+@login_required
+def remove_author(ID):
+    k = Knowl(ID)
+    uid = current_user.get_id()
+    if uid not in k.authors:
+        flash("You are not an author on %s"%(k.id), "error")
+    elif len(k.authors) == 1:
+        flash("You cannot remove yourself unless there are other authors", "error")
+    else:
+        knowldb.remove_author(ID, uid)
+    return redirect(url_for(".show", ID=ID))
 
 @knowledge_page.route("/content/<ID>/<int:timestamp>")
 def content(ID, timestamp):

--- a/lmfdb/knowledge/templates/knowl-show.html
+++ b/lmfdb/knowledge/templates/knowl-show.html
@@ -25,7 +25,7 @@
   <strong>Authors:</strong>
   <ul>
   {% for a in k.author_links() %}
-    <li><a href="{{ url_for('users.profile', userid=a['username']) }}">{{ a['full_name'] or a['username'] }}</a></li>
+    <li><a href="{{ url_for('users.profile', userid=a['username']) }}">{{ a['full_name'] or a['username'] }}</a>{% if a['username'] == cur_username and (k.author_links() | length) > 1 %} (<a href="{{ url_for('.remove_author', ID=k.id) }}">Remove</a>){% endif %}</li>
   {% endfor %}
   </ul>
 </div>

--- a/lmfdb/knowledge/templates/knowl-show.html
+++ b/lmfdb/knowledge/templates/knowl-show.html
@@ -25,7 +25,7 @@
   <strong>Authors:</strong>
   <ul>
   {% for a in k.author_links() %}
-    <li><a href="{{ url_for('users.profile', userid=a['username']) }}">{{ a['full_name'] or a['username'] }}</a>{% if a['username'] == cur_username and (k.author_links() | length) > 1 %} (<a href="{{ url_for('.remove_author', ID=k.id) }}">Remove</a>){% endif %}</li>
+    <li><a href="{{ url_for('users.profile', userid=a['username']) }}">{{ a['full_name'] or a['username'] }}</a>{% if a['username'] == cur_username and (k.author_links() | length) > 1 %} (<a onclick='return confirm("Remove yourself as an author of this knowl?  This cannot easily be undone.")' href="{{ url_for('.remove_author', ID=k.id) }}">Remove</a>){% endif %}</li>
   {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
This was a feature request last week.  To test, log in and navigate to a knowl that you've made a minor edit on but don't consider yourself to be an author.  There will be a Remove link next to your name in the author list; click it and you're no longer an author (after a confirmation popup).