### PR TITLE
EC/Q labels 

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -264,8 +264,10 @@ def elliptic_curve_search(info, query):
         # fails on 990h3
         query['number'] = 1
 
-    info['curve_url'] = lambda dbc: url_for(".by_triple_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1], number=dbc['lmfdb_number'])
-    info['iso_url'] = lambda dbc: url_for(".by_double_iso_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1])
+    info['curve_url_LMFDB'] = lambda dbc: url_for(".by_triple_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1], number=dbc['lmfdb_number'])
+    info['iso_url_LMFDB'] = lambda dbc: url_for(".by_double_iso_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1])
+    info['curve_url_Cremona'] = lambda dbc: url_for(".by_ec_label", label=dbc['label'])
+    info['iso_url_Cremona'] = lambda dbc: url_for(".by_ec_label", label=dbc['iso'])
 
 ##########################
 #  Specific curve pages

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -84,7 +84,6 @@ def rational_elliptic_curves(err_args=None):
         'counts': counts,
         'stats_url': url_for(".statistics")
     }
-    #credit = 'John Cremona and Andrew Sutherland'
     t = 'Elliptic Curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
     return render_template("ec-index.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list(), calling_function = "ec.rational_elliptic_curves", **err_args)
@@ -110,7 +109,6 @@ def statistics():
         'counts': get_stats().counts(),
         'stats': get_stats().stats(),
     }
-    #credit = 'John Cremona'
     t = 'Elliptic Curves over $\Q$: Statistics'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
              ('$\Q$', url_for(".rational_elliptic_curves")),
@@ -140,8 +138,8 @@ def elliptic_curve_jump_error(label, args, wellformed_label=False, cremona_label
     err_args['count'] = args.get('count', '100')
     if wellformed_label:
         err_args['err_msg'] = "No curve or isogeny class in the database has label %s" % label
-    elif cremona_label:
-        err_args['err_msg'] = "To search for a Cremona label use 'Cremona:%s'" % label
+    # elif cremona_label:
+    #     err_args['err_msg'] = "To search for a Cremona label use 'Cremona:%s'" % label
     elif missing_curve:
         err_args['err_msg'] = "The elliptic curve %s (conductor = %s) is not in the database" % (label, args.get('conductor','?'))
     elif not label:
@@ -158,17 +156,15 @@ def elliptic_curve_jump(info):
             return by_ec_label(label)
         except ValueError:
             return elliptic_curve_jump_error(label, info, wellformed_label=True)
-    elif label.startswith("Cremona:"):
-        label = label[8:]
-        m = match_cremona_label(label)
-        if m:
-            try:
-                return by_ec_label(label)
-            except ValueError:
-                return elliptic_curve_jump_error(label, info, wellformed_label=True)
-    elif match_cremona_label(label):
-        return elliptic_curve_jump_error(label, info, cremona_label=True)
-    elif label:
+    m = match_cremona_label(label)
+    if m:
+        try:
+            return redirect(url_for(".by_ec_label", label=label))
+            #return by_ec_label(label)
+        except ValueError:
+            return elliptic_curve_jump_error(label, info, wellformed_label=True)
+
+    if label:
         # Try to parse a string like [1,0,3,2,4] as valid
         # Weistrass coefficients:
         lab = re.sub(r'\s','',label)
@@ -238,6 +234,7 @@ def download_search(info):
                            ('$\Q$', url_for(".rational_elliptic_curves")),
                            ('Search Results', '.')],
              credit=ec_credit)
+
 def elliptic_curve_search(info, query):
     parse_rational(info,query,'jinv','j-invariant')
     parse_ints(info,query,'conductor')
@@ -324,9 +321,11 @@ def by_ec_label(label):
         ec_logger.debug(url_for(".by_ec_label", label=data['lmfdb_label']))
         iso = data['lmfdb_iso'].split(".")[1]
         if number:
-            return redirect(url_for(".by_triple_label", conductor=N, iso_label=iso, number=data['lmfdb_number']))
+            return render_curve_webpage_by_label(label)
+            #return redirect(url_for(".by_triple_label", conductor=N, iso_label=iso, number=data['lmfdb_number']))
         else:
-            return redirect(url_for(".by_double_iso_label", conductor=N, iso_label=iso))
+            return render_isogeny_class(label)
+            #return redirect(url_for(".by_double_iso_label", conductor=N, iso_label=iso))
 
 
 def by_weierstrass(eqn):

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -70,13 +70,10 @@ class ECisog_class(object):
             if self.label_type == 'Cremona':
                 c['curve_label'] = c['label']
                 _, c_iso, c_number = split_cremona_label(c['label'])
-                print("(C) label = {}, iso={}, number={}".format(c['label'],c_iso, c_number))
             else:
                 c['curve_label'] = c['lmfdb_label']
                 _, c_iso, c_number = split_lmfdb_label(c['lmfdb_label'])
-                print("(L) label = {}, iso={}, number={}".format(c['lmfdb_label'],c_iso, c_number))
             c['short_label'] = "{}{}".format(c_iso,c_number)
-            print("short label = {}".format(c['short_label']))
             
         from sage.matrix.all import Matrix
         if self.label_type == 'Cremona':

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -54,25 +54,44 @@ class ECisog_class(object):
         N, iso, number = split_lmfdb_label(self.lmfdb_iso)
 
         # Extract the size of the isogeny class from the database
-        ncurves = self.class_size
+        self.ncurves = ncurves = self.class_size
         # Create a list of the curves in the class from the database
-        self.curves = [db.ec_curves.lucky({'iso':self.iso, 'lmfdb_number': i+1})
+        number_key = 'number' if self.label_type=='Cremona' else 'lmfdb_number'
+        self.curves = [db.ec_curves.lucky({'iso':self.iso, number_key: i+1})
                           for i in range(ncurves)]
 
         # Set optimality flags.  The optimal curve is number 1 except
         # in one case which is labeled differently in the Cremona tables
         for c in self.curves:
-            c['optimal'] = (c['number']==(3 if self.label == '990h' else 1))
+            c['optimal'] = (c['number']==(3 if self.iso == '990h' else 1))
             c['ai'] = c['ainvs']
-            c['url'] = url_for(".by_triple_label", conductor=N, iso_label=iso, number=c['lmfdb_number'])
-
+            c['curve_url_lmfdb'] = url_for(".by_triple_label", conductor=N, iso_label=iso, number=c['lmfdb_number'])
+            c['curve_url_cremona'] = url_for(".by_ec_label", label=c['label'])
+            if self.label_type == 'Cremona':
+                c['curve_label'] = c['label']
+                _, c_iso, c_number = split_cremona_label(c['label'])
+                print("(C) label = {}, iso={}, number={}".format(c['label'],c_iso, c_number))
+            else:
+                c['curve_label'] = c['lmfdb_label']
+                _, c_iso, c_number = split_lmfdb_label(c['lmfdb_label'])
+                print("(L) label = {}, iso={}, number={}".format(c['lmfdb_label'],c_iso, c_number))
+            c['short_label'] = "{}{}".format(c_iso,c_number)
+            print("short label = {}".format(c['short_label']))
+            
         from sage.matrix.all import Matrix
+        if self.label_type == 'Cremona':
+            # permute rows/cols
+            perm = lambda i: (c for c in self.curves if c['number']==i+1).next()['lmfdb_number']-1
+            self.isogeny_matrix = [[self.isogeny_matrix[perm(i)][perm(j)] for i in range(ncurves)] for j in range(ncurves)]
+
         self.isogeny_matrix = Matrix(self.isogeny_matrix)
+
         self.isogeny_matrix_str = latex(matrix(self.isogeny_matrix))
 
-        # Create isogeny graph:
-        self.graph = make_graph(self.isogeny_matrix)
-        P = self.graph.plot(edge_labels=True)
+        # Create isogeny graph with appropriate vertex labels:
+        
+        self.graph = make_graph(self.isogeny_matrix, [c['short_label'] for c in self.curves])
+        P = self.graph.plot(edge_labels=True, vertex_size=1000)
         self.graph_img = encode_plot(P)
         self.graph_link = '<img src="%s" width="200" height="150"/>' % self.graph_img
 
@@ -96,22 +115,25 @@ class ECisog_class(object):
         if self.newform_exists_in_db:
             self.friends +=  [('Modular form ' + self.newform_label, self.newform_link)]
 
-        self.properties = [('Label', self.lmfdb_iso),
-                           ('Number of curves', str(ncurves)),
-                           ('Conductor', '\(%s\)' % N),
-                           ('CM', '%s' % self.CM),
-                           ('Rank', '\(%s\)' % self.rank),
-                           ('Graph', ''),(None, self.graph_link)
-                           ]
+        if self.label_type == 'Cremona':
+            self.title = "Elliptic Curve Isogeny Class with Cremona label {} (LMFDB label {})".format(self.iso, self.lmfdb_iso)
+            self.iso_label = self.iso
+        else:
+            self.title = "Elliptic Curve Isogeny Class with LMFDB label {} (Cremona label {})".format(self.lmfdb_iso, self.iso)
+            self.iso_label = self.lmfdb_iso
 
+        self.properties = [('Label', self.iso if self.label_type=='Cremona' else self.lmfdb_iso),
+                           ('Number of curves', str(ncurves)),
+                           ('Conductor', '%s' % N),
+                           ('CM', '%s' % self.CM),
+                           ('Rank', '%s' % self.rank)
+                           ]
+        if self.ncurves>1:
+            self.properties += [('Graph', ''),(None, self.graph_link)]
 
         self.downloads = [('Download q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=1000)),
                          ('Download stored data for all curves', url_for(".download_EC_all", label=self.lmfdb_iso))]
 
-        if self.label_type == 'Cremona':
-            self.title = "Elliptic Curve Isogeny Class with Cremona label {} (LMFDB label {})".format(self.iso, self.lmfdb_iso)
-        else:
-            self.title = "Elliptic Curve Isogeny Class with LMFDB label {} (Cremona label {})".format(self.lmfdb_iso, self.iso)
 
         self.bread = [('Elliptic Curves', url_for("ecnf.index")),
                       ('$\Q$', url_for(".rational_elliptic_curves")),
@@ -126,7 +148,7 @@ class ECisog_class(object):
         self.code['matrix'] = {'sage':'E.isogeny_class().matrix()'}
         self.code['plot'] = {'sage':'E.isogeny_graph().plot(edge_labels=True)'}
 
-def make_graph(M):
+def make_graph(M, vertex_labels=None):
     """
     Code extracted from Sage's elliptic curve isogeny class (reshaped
     in the case maxdegree==12)
@@ -204,5 +226,9 @@ def make_graph(M):
                            left[1]:[-0.14,-0.15],right[1]:[0.14,-0.15],
                            left[2]:[-0.14,-0.3],right[2]:[0.14,-0.3]})
 
-    G.relabel(range(1,n+1))
+
+    if vertex_labels:
+        G.relabel(vertex_labels)
+    else:
+        G.relabel(range(1,n+1))
     return G

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -34,12 +34,14 @@ class ECisog_class(object):
             if number:
                 label = ".".join([N,iso])
             data = db.ec_curves.lucky({"lmfdb_iso" : label, 'number':1})
+            data['label_type'] = 'LMFDB'
         except AttributeError:
             try:
                 N, iso, number = split_cremona_label(label)
                 if number:
                     label = "".join([N,iso])
                 data = db.ec_curves.lucky({"iso" : label, 'number':1})
+                data['label_type'] = 'Cremona'
             except AttributeError:
                 return "Invalid label" # caller must catch this and raise an error
 
@@ -106,10 +108,10 @@ class ECisog_class(object):
         self.downloads = [('Download q-expansion', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=1000)),
                          ('Download stored data for all curves', url_for(".download_EC_all", label=self.lmfdb_iso))]
 
-        if self.lmfdb_iso == self.iso:
-            self.title = "Elliptic Curve Isogeny Class %s" % self.lmfdb_iso
+        if self.label_type == 'Cremona':
+            self.title = "Elliptic Curve Isogeny Class with Cremona label {} (LMFDB label {})".format(self.iso, self.lmfdb_iso)
         else:
-            self.title = "Elliptic Curve Isogeny Class %s (Cremona label %s)" % (self.lmfdb_iso, self.iso)
+            self.title = "Elliptic Curve Isogeny Class with LMFDB label {} (Cremona label {})".format(self.lmfdb_iso, self.iso)
 
         self.bread = [('Elliptic Curves', url_for("ecnf.index")),
                       ('$\Q$', url_for(".rational_elliptic_curves")),

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -70,7 +70,7 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 <input type='text' name='label' size=25 example="11.a2">
 <button type='submit' name='jump' value='curve or isogeny class label'
         >curve, label or isogeny class label</button>
-<br><span class="formexample">e.g. 11.a2 or 389.a or Cremona:11a1 or 
+<br><span class="formexample">e.g. 11.a2 or 389.a or 11a1 or 
 [0,1,1,-2,0] or [-3024, 46224]
 </span>
 </form>

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -60,8 +60,9 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 
 
 <h2> Find a specific curve or {{
-  KNOWL('ec.isogeny_class',title="isogeny class") }} by coefficients or 
-  {{ KNOWL('ec.q.lmfdb_label',title="LMFDB label") }} </h2>
+  KNOWL('ec.isogeny_class',title="isogeny class") }} by coefficients,
+  {{ KNOWL('ec.q.lmfdb_label',title="LMFDB label") }}, or 
+  {{ KNOWL('ec.q.cremona_label',title="Cremona label") }} </h2>
 {% if err_msg %}
 <form action={{url_for('ec.rational_elliptic_curves')}}>
 {% else %}
@@ -70,7 +71,7 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 <input type='text' name='label' size=25 example="11.a2">
 <button type='submit' name='jump' value='curve or isogeny class label'
         >curve, label or isogeny class label</button>
-<br><span class="formexample">e.g. 11.a2 or 389.a or 11a1 or 
+<br><span class="formexample">e.g. 11.a2 or 389.a or 11a1 or 389a or 
 [0,1,1,-2,0] or [-3024, 46224]
 </span>
 </form>

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -10,8 +10,7 @@ text-align: center;
 }
 </style>
 
-
-<h2>Elliptic curves in class {{info.lmfdb_iso}}</h2>
+<h2>Elliptic curves in class {{info.iso_label}}</h2>
 {{ place_code('curves') }}
 <table id = "isogeny_class_table">
 <tr>
@@ -28,8 +27,8 @@ text-align: center;
 {% else %}
 <tr>
 {% endif %}
-<td class="center"><a href="{{c.url}}">{{c.lmfdb_label}}</a></td>
-<td class="center">{{c.label}}</td>
+<td class="center"><a href="{{c.curve_url_lmfdb}}">{{c.lmfdb_label}}</a></td>
+<td class="center"><a href="{{c.curve_url_cremona}}">{{c.label}}</a></td>
 <td class="center">{{c.ai}}</td>
 <td align="center">{{c.torsion}}</td>
 <td align="center">
@@ -47,8 +46,8 @@ text-align: center;
 <h2>{{KNOWL('ec.rank', title='Rank')}}</h2>
 {{ place_code('rank') }}
 <p>
-{% if info.ncurves==1 %} The elliptic curve {{info.curves[0].label}} has
-{% else %} The elliptic curves in class {{info.lmfdb_iso}} have
+{% if info.ncurves==1 %} The elliptic curve {{info.curves[0].curve_label}} has
+{% else %} The elliptic curves in class {{info.iso_label}} have
 {% endif %}
 {{KNOWL('ec.rank', title='rank')}} \({{ info.rank}}\).
 </p>
@@ -79,12 +78,15 @@ text-align: center;
 <h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>
 
 {{ place_code('matrix') }}
+<p>The \(i,j\) entry is the smallest degree of a cyclic isogeny between the \(i\)-th and \(j\)-th curve in the isogeny class, in the {{info.label_type}} numbering.
+</p>
 <p>
   \({{info.isogeny_matrix_str}}\)
 </p>
 
 <h2> {{ KNOWL('ec.isogeny_graph', title='Isogeny graph') }} </h2>
 {{ place_code('plot') }}
+<p>The vertices are labelled with {{info.label_type}} labels. </p>
 <center>
   <img src="{{info.graph_img}}" />
 </center>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -113,10 +113,15 @@ table td.params {
 </style>
 
 <table>
+  <tr>
+    <th class="center" colspan=2>Curve</th>
+    <th class="center" colspan=2>{{ KNOWL('ec.isogeny_class', title='Isogeny class') }}</th>
+</tr>
 <tr>
   <th class="center">{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
   <th class="center">{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
-  <th class="center">{{ KNOWL('ec.isogeny_class', title='Isogeny class') }}</th>
+  <th class="center">{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
+  <th class="center">{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
   <th class="center">{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass Coefficients') }}</th>
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.torsion_order', title='Torsion order') }}</th>
@@ -126,9 +131,10 @@ table td.params {
 </tr>
 {% for curve in info.results: %}
 <tr>
-<td class="center"><a href="{{info.curve_url(curve)}}">{{curve.lmfdb_label}}</a></td>
-<td class="center">{{curve.label}}</td>
-<td class="center"><a href="{{info.iso_url(curve)}}">{{curve.lmfdb_iso}}</a></td>
+<td class="center"><a href="{{info.curve_url_LMFDB(curve)}}">{{curve.lmfdb_label}}</a></td>
+<td class="center"><a href="{{info.curve_url_Cremona(curve)}}">{{curve.label}}</a></td>
+<td class="center"><a href="{{info.iso_url_LMFDB(curve)}}">{{curve.lmfdb_iso}}</a></td>
+<td class="center"><a href="{{info.iso_url_Cremona(curve)}}">{{curve.iso}}</a></td>
 <td class="params">{{curve.ainvs}}</td>
 <td class="center">{{curve.rank}}</td>
 <td class="center">{{curve.torsion}}</td>

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from lmfdb.tests import LmfdbTest
 
+
 class EllCurveTest(LmfdbTest):
 
     def check_args_with_timeout(self, path, text):
@@ -98,3 +99,26 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/392/c/1')
         assert ' is strictly larger than ' in L.data
         assert '<a href=/EllipticCurve/3.3.49.1/512.1/e/3>3.3.49.1-512.1-e3</a>' in L.data
+
+    def test_990h(self):
+        """
+        Test the exceptional 990h/990.i optimal labelling.
+        """
+        # The isogeny class 990h (Cremona labelling) or 990.i (LMFDB labelling)
+        # has a different Gamma-optimal curve in its labelling than all others.
+        L = self.tc.get('/EllipticCurve/Q/990/i/')
+        row = '\n'.join([
+          '<td class="center">[1, -1, 1, -1568, -4669]</td>',
+          '<td align="center">6</td>',
+          '<td align="center">',
+          '1728</td>',
+          '<td>\(\Gamma_0(N)\)-optimal</td>'
+        ])
+        self.assertTrue(row in L.data,
+                        "990.i appears to have the wrong optimal curve.")
+
+        L = self.tc.get('EllipticCurve/Q/990h/')
+        print row
+        print L.data
+        self.assertTrue(row in L.data,
+                        "990h appears to have the wrong optimal curve.")

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -247,7 +247,6 @@ class WebEC(object):
                                  if (N*data['ap'][i]) %p !=0]
 
         cond, iso, num = split_lmfdb_label(self.lmfdb_label)
-        self.class_url = url_for(".by_double_iso_label", conductor=N, iso_label=iso)
         self.one_deg = ZZ(self.class_deg).is_prime()
         self.ncurves = db.ec_curves.count({'lmfdb_iso':self.lmfdb_iso})
         isodegs = [str(d) for d in self.isogeny_degrees if d>1]
@@ -293,9 +292,14 @@ class WebEC(object):
         self.newform_exists_in_db = db.mf_newforms.label_exists(self.newform_label)
         self._code = None
 
-        self.class_url = url_for(".by_double_iso_label", conductor=N, iso_label=iso)
+        if self.label_type == 'Cremona':
+            self.class_url = url_for(".by_ec_label", label=self.iso)
+            self.class_name = self.iso
+        else:
+            self.class_url = url_for(".by_double_iso_label", conductor=N, iso_label=iso)
+            self.class_name = self.lmfdb_iso
         self.friends = [
-            ('Isogeny class ' + self.lmfdb_iso, self.class_url),
+            ('Isogeny class ' + self.class_name, self.class_url),
             ('Minimal quadratic twist %s %s' % (data['minq_info'], data['minq_label']), url_for(".by_triple_label", conductor=minq_N, iso_label=minq_iso, number=minq_number)),
             ('All twists ', url_for(".rational_elliptic_curves", jinv=self.jinv)),
             ('L-function', url_for("l_functions.l_function_ec_page", conductor_label = N, isogeny_class_label = iso))]
@@ -322,13 +326,13 @@ class WebEC(object):
 
 
         self.plot_link = '<a href="{0}"><img src="{0}" width="200" height="150"/></a>'.format(self.plot)
-        self.properties = [('Label', self.lmfdb_label),
+        self.properties = [('Label', self.label if self.label_type == 'Cremona' else self.lmfdb_label),
                            (None, self.plot_link),
-                           ('Conductor', '\(%s\)' % data['conductor']),
-                           ('Discriminant', '\(%s\)' % data['disc']),
+                           ('Conductor', '%s' % data['conductor']),
+                           ('Discriminant', '%s' % data['disc']),
                            ('j-invariant', '%s' % data['j_inv_latex']),
                            ('CM', '%s' % data['CM']),
-                           ('Rank', '\(%s\)' % self.mw['rank']),
+                           ('Rank', '%s' % self.mw['rank']),
                            ('Torsion Structure', '\(%s\)' % self.mw['tor_struct'])
                            ]
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -143,10 +143,12 @@ class WebEC(object):
         try:
             N, iso, number = split_lmfdb_label(label)
             data = db.ec_curves.lucky({"lmfdb_label" : label})
+            data['label_type'] = 'LMFDB'
         except AttributeError:
             try:
                 N, iso, number = split_cremona_label(label)
                 data = db.ec_curves.lucky({"label" : label})
+                data['label_type'] = 'Cremona'
             except AttributeError:
                 return "Invalid label" # caller must catch this and raise an error
 
@@ -330,7 +332,10 @@ class WebEC(object):
                            ('Torsion Structure', '\(%s\)' % self.mw['tor_struct'])
                            ]
 
-        self.title = "Elliptic Curve %s (Cremona label %s)" % (self.lmfdb_label, self.label)
+        if self.label_type == 'Cremona':
+            self.title = "Elliptic Curve with Cremona label {} (LMFDB label {})".format(self.label, self.lmfdb_label)
+        else:
+            self.title = "Elliptic Curve with LMFDB label {} (Cremona label {})".format(self.lmfdb_label, self.label)
 
         self.bread = [('Elliptic Curves', url_for("ecnf.index")),
                            ('$\Q$', url_for(".rational_elliptic_curves")),

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -113,7 +113,7 @@ The documents in the mongo collection 'curves' in the database 'elliptic_curves'
    - '2adic_label': (string) Rouse label of the associated modular
       curve (None for CM curves)
    - 'isogeny_matrix': (list of lists of ints) isogeny matrix for
-     curves in the class w.r.t. Cremona ordering
+     curves in the class w.r.t. LMFDB ordering
    - 'isogeny_degrees': (list of ints) degrees of cyclic isogenies from this curve
    - 'class_size': (int) size of isogeny class
    - 'class_deg': (int) max (=lcm) of isogeny degrees in the class


### PR DESCRIPTION
1. allows Cremona labels (of curves or isogeny classes) to be entered into the search box without any prefix.  Try entering 11a1 or 11a into http://localhost:37777/EllipticCurve/Q/
2. adjusts title of an elliptic curve's home page depending on the sort of label used to get there.  Compare http://localhost:37777/EllipticCurve/Q/11a1  (with no rewriting of the URL) and http://localhost:37777/EllipticCurve/Q/11.a2 (whose URL is renamed to http://localhost:37777/EllipticCurve/Q/11/a/2)
3. Same as 2 but for isogeny classes -- to be added in an extra commit, so hold on.