### PR TITLE
removed use of oldstats from elliptic_curves (*not* ecnf yet)

### DIFF
--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -46,18 +46,19 @@ class ECstats(object):
         if self._counts:
             return
         logger.debug("Computing elliptic curve counts...")
-        ecdbstats = db.ec_curves.stats
+        ecdb = db.ec_curves
         counts = {}
-        rankstats = ecdbstats.get_oldstat('rank')
-        ncurves = rankstats['total']
+        ncurves = ecdb.count()
+        nclasses = ecdb.count({'number':1})
         counts['ncurves']  = ncurves
         counts['ncurves_c'] = comma(ncurves)
-        nclasses = ecdbstats.get_oldstat('class/rank')['total']
         counts['nclasses'] = nclasses
         counts['nclasses_c'] = comma(nclasses)
-        max_N = ecdbstats.get_oldstat('conductor')['max']
+
+        max_N = ecdb.max('conductor')
+
         # round up to nearest multiple of 1000
-        max_N = 1000*((max_N/1000)+1)
+        max_N = 1000*int((max_N/1000)+1)
         # NB while we only have the Cremona database, the upper bound
         # will always be a multiple of 1000, but it looks funny to
         # show the maximum condictor as something like 399998; there
@@ -66,7 +67,7 @@ class ECstats(object):
 
         counts['max_N'] = max_N
         counts['max_N_c'] = comma(max_N)
-        counts['max_rank'] = int(rankstats['max'])
+        counts['max_rank'] = ecdb.max('rank')
         self._counts  = counts
         logger.debug("... finished computing elliptic curve counts.")
 
@@ -74,34 +75,30 @@ class ECstats(object):
         if self._stats:
             return
         logger.debug("Computing elliptic curve stats...")
-        ecdbstats = db.ec_curves.stats
+        ecdb = db.ec_curves
         counts = self._counts
         stats = {}
+
+        # rank distribution
+        
         rank_counts = []
-        rdict = dict(ecdbstats.get_oldstat('rank')['counts'])
-        crdict = dict(ecdbstats.get_oldstat('class/rank')['counts'])
-        for r in range(counts['max_rank']+1):
-            try:
-                ncu = rdict[str(r)]
-                ncl = crdict[str(r)]
-            except KeyError:
-                ncu = rdict[r]
-                ncl = crdict[r]
+        ranks = range(counts['max_rank']+1)
+        for r in ranks:
+            ncu = ecdb.count({'rank':r})
+            ncl = ecdb.count({'rank':r, 'number':1})
             prop = format_percentage(ncl,counts['nclasses'])
             rank_counts.append({'r': r, 'ncurves': ncu, 'nclasses': ncl, 'prop': prop})
         stats['rank_counts'] = rank_counts
+
+        # torsion distribution
+        
         tor_counts = []
         tor_counts2 = []
         ncurves = counts['ncurves']
-        tdict = dict(ecdbstats.get_oldstat('torsion')['counts'])
-        tsdict = dict(ecdbstats.get_oldstat('torsion_structure')['counts'])
         for t in  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16]:
-            try:
-                ncu = tdict[t]
-            except KeyError:
-                ncu = tdict[str(t)]
+            ncu = ecdb.count({'torsion':t})
             if t in [4,8,12]: # two possible structures
-                ncyc = tsdict[str(t)]
+                ncyc = ecdb.count({'torsion_structure':[t]})
                 gp = "\(C_{%s}\)"%t
                 prop = format_percentage(ncyc,ncurves)
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncyc, 'prop': prop})
@@ -119,23 +116,14 @@ class ECstats(object):
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
         stats['tor_counts'] = tor_counts+tor_counts2
 
-        shadict = dict(ecdbstats.get_oldstat('sha')['counts'])
-        stats['max_sha'] = max([int(s) for s in shadict])
-        sha_counts = []
-        from sage.misc.functional import isqrt
-        sha_is_int = True
-        try:
-            nc = shadict[1]
-        except KeyError:
-            sha_is_int = False
-        for s in range(1,1+isqrt(stats['max_sha'])):
-            s2 = s*s
-            if sha_is_int:
-                nc = shadict.get(s2,0)
-            else:
-                nc = shadict.get(str(s2),0)
-            if nc:
-                sha_counts.append({'s': s, 'ncurves': nc})
+        # Sha distribution
+        
+        max_sha = ecdb.max('sha')
+        stats['max_sha'] = max_sha
+        max_sqrt_sha = max_sha.sqrt() # exact!
+        sha_counts = [{'s':s,'ncurves':ecdb.count({'sha':s**2})} for s in range(1,1+max_sqrt_sha)]
+        # remove values with a count of 0
+        sha_counts = [sc for sc in sha_counts if sc['ncurves']]
         stats['sha_counts'] = sha_counts
         self._stats = stats
         logger.debug("... finished computing elliptic curve stats.")

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -475,8 +475,14 @@ class WebEC(object):
             if d!=lastd:
                 tg1['m'] = len([x for x in tgextra if x['d']==d])
                 lastd = d
-        ## Hard code for now
-        #tg['maxd'] = max(db.ec_curves.stats.get_oldstat('torsion_growth')['degrees'])
+
+        ## Hard-code this for now.  While something like
+        ## max(db.ec_curves.search({},projection='tor_degs')) might
+        ## work, since 'tor_degs' is in the extra table it is very
+        ## slow.  Note that the *only* place where this number is used
+        ## is in the ec-curve template where it says "The number
+        ## fields ... of degree up to {{data.tg.maxd}} such that...".
+        
         tg['maxd'] = 7
 
 

--- a/scripts/elliptic_curves/import_torsion_data.py
+++ b/scripts/elliptic_curves/import_torsion_data.py
@@ -14,7 +14,10 @@ Additional data fields for each elliptic curve over Q
  'tor_gro': u'jsonb',    dictionary, keys are field labels or poly
                          strings, values are structure constants of the larger torsion
 
-
+NB We have hard-coded the maximum degree of number field for which we
+currently have data (currently 7) in lmfdb/elliptic_curves/web_ec.py
+since tor_degs and the other extra columns are in the extr table.  If
+data for higher degrees is uploaded that will need to be changed.
 """
 import os
 from sage.all import ZZ, PolynomialRing, QQ, NumberField


### PR DESCRIPTION
To test this go to http://localhost:37777/EllipticCurve/Q/stats and http://beta.lmfdb.org/EllipticCurve/Q/stats in adjacent tabs so you can switch between them easily and note that the nothing changes.

Also do "git grep -p oldstat | grep elliptic" and see nothing.

The update_stats() script in scripts/elliptic_curves/import_ec_data.py can be run with recount=False to see what is stored, and with recount=True to force several recounts (which only takes a few seconds).

Question for someone who understands stats and counts (e.g. @roed314 ) :  the update_stats() function, when run  with recount=True, uses db.ec_curves.stats._slow_count() to force a new count which is then stored.  That is the point: we need to be able to update the counts when data changes.  But it also uses db.ec_curves.stats._slow_max() to find the max of 4 quantities, which are retrieved in the website code using db.ec_curves.max(); but I think that _slow_max() does *not* store the max value, and the reason why using plain max() in the main code works is that something else has happened, perhaps an add_stats()?   However I could not use add_stats() in the update_stats() script since it (apparently) does not have a forced recompute option.  I think that makes two feature-requests, and without them it may be true that after a call to  db.ec_curves.stats._clear_stats_counts(), the stats page will crash.