### PR TITLE
Ecnf stats

### DIFF
--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from lmfdb.app import app
-from lmfdb.utils import comma
+from lmfdb.utils import comma, StatsDisplay
 from lmfdb.logger import make_logger
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb import db
+from sage.misc.lazy_attribute import lazy_attribute
+from sage.misc.cachefunc import cached_method
+from collections import defaultdict
 
 def field_data(s):
     r"""
@@ -21,42 +24,109 @@ def sort_field(F):
 
 logger = make_logger("ecnf")
 
-def ecnf_summary():
-    ecnfstats = db.ec_nfcurves.stats
-    ec_knowl = '<a knowl="ec">elliptic curves</a>'
-    iso_knowl = '<a knowl="ec.isogeny_class">isogeny classes</a>'
-    nf_knowl = '<a knowl="nf">number fields</a>'
-    deg_knowl = '<a knowl="nf.degree">degree</a>'
-    data = ecnfstats.get_oldstat('conductor_norm')
-    ncurves = comma(data['ncurves'])
-    nclasses = comma(data['nclasses'])
-    data = ecnfstats.get_oldstat('field_label')
-    nfields = len(data['counts'])
-    data = ecnfstats.get_oldstat('signatures_by_degree')
-    maxdeg = max(int(d) for d in data if d!='_id')
-    return ''.join([r'The database currently contains {} '.format(ncurves),
-                    ec_knowl,
-                    r' in {} '.format(nclasses),
-                    iso_knowl,
-                    r', over {} '.format(nfields),
-                    nf_knowl, ' (not including $\mathbb{Q}$) of ',
-                    deg_knowl,
-                    r' up to {}.'.format(maxdeg)])
-
-def ecnf_field_summary(field):
-    data = db.ec_nfcurves.stats.get_oldstat('conductor_norm_by_field')[field]
-    ncurves = data['ncurves']
-    s = '' if ncurves==1 else 's'
-    ec_knowl = '<a knowl="ec">elliptic curve{}</a>'.format(s)
-    nclasses = data['nclasses']
-    s = '' if nclasses==1 else 'es'
-    iso_knowl = '<a knowl="ec.isogeny_class">isogeny class{}</a>'.format(s)
+class ECNF_stats(StatsDisplay):
+    ec_knowls = '<a knowl="ec">elliptic curves</a>'
+    ec_knowl = '<a knowl="ec">elliptic curve</a>'
+    iso_knowls = '<a knowl="ec.isogeny_class">isogeny classes</a>'
+    iso_knowl = '<a knowl="ec.isogeny_class">isogeny class</a>'
+    nf_knowls = '<a knowl="nf">number fields</a>'
     nf_knowl = '<a knowl="nf">number field</a>'
-    max_norm = data['max_norm']
-    s = '' if max_norm==1 else 's'
-    cond_knowl = '<a knowl="ec.conductor">conductor{}</a>'.format(s)
-    s = '' if max_norm==1 else 'up to '
-    return ''.join([r'The database currently contains {} '.format(ncurves),
+    deg_knowl = '<a knowl="nf.degree">degree</a>'
+    cond_knowls = '<a knowl="ec.conductor">conductors</a>'
+    cond_knowl = '<a knowl="ec.conductor">conductor</a>'
+    @lazy_attribute
+    def ncurves(self):
+        return db.ec_nfcurves.count()
+    @lazy_attribute
+    def nclasses(self):
+        return db.ec_nfcurves.count({'number':1})
+    @lazy_attribute
+    def field_counts(self):
+        return db.ec_nfcurves.stats.column_counts('field_label')
+    @lazy_attribute
+    def field_classes(self):
+        return db.ec_nfcurves.stats.column_counts('field_label', {'number':1})
+    @lazy_attribute
+    def sig_counts(self):
+        return db.ec_nfcurves.stats.column_counts('signature')
+    @lazy_attribute
+    def sig_classes(self):
+        return db.ec_nfcurves.stats.column_counts('signature', {'number':1})
+    @lazy_attribute
+    def deg_counts(self):
+        return db.ec_nfcurves.stats.column_counts('degree')
+    @lazy_attribute
+    def deg_classes(self):
+        return db.ec_nfcurves.stats.column_counts('degree', {'number':1})
+    @lazy_attribute
+    def torsion_counts(self):
+        return db.ec_nfcurves.stats.column_counts('torsion_structure')
+    @lazy_attribute
+    def field_normstats(self):
+        return db.ec_nfcurves.stats.numstats('conductor_norm', ['field_label'])
+    @lazy_attribute
+    def sig_normstats(self):
+        return db.ec_nfcurves.stats.numstats('conductor_norm', ['signature'])
+    @lazy_attribute
+    def deg_normstats(self):
+        return db.ec_nfcurves.stats.numstats('conductor_norm', ['degree'])
+    @lazy_attribute
+    def maxdeg(self):
+        return db.ec_nfcurves.max('degree')
+    @staticmethod
+    def _get_sig(nflabel):
+        d,r = map(int,nflabel.split('.',2)[:2])
+        return '%s,%s'%(r,(d-r)//2)
+    @staticmethod
+    def _get_deg(nflabel):
+        return int(nflabel.split('.',1)[0])
+    def _fields_by(self, func):
+        D = defaultdict(list)
+        for label in self.field_counts:
+            D[func(label)].append(label)
+        for fields in D.values():
+            fields.sort(key=sort_field)
+        return D
+    @lazy_attribute
+    def fields_by_sig(self):
+        return self._fields_by(self._get_sig)
+    @lazy_attribute
+    def fields_by_deg(self):
+        return self._fields_by(self._get_deg)
+    @lazy_attribute
+    def sigs_by_deg(self):
+        def _get_deg_s(sig):
+            r, s = map(int, sig.split(','))
+            return r + 2*s
+        D = defaultdict(list)
+        for sig in self.sig_counts:
+            D[_get_deg_s(sig)].append(sig)
+        for sigs in D.values():
+            sigs.sort()
+        return D
+
+    def summary(self):
+        return ''.join([r'The database currently contains {} '.format(comma(self.ncurves)),
+                        self.ec_knowls,
+                        r' in {} '.format(comma(self.nclasses)),
+                        self.iso_knowls,
+                        r', over {} '.format(len(self.field_counts)),
+                        self.nf_knowls, ' (not including $\mathbb{Q}$) of ',
+                        self.deg_knowl,
+                        r' up to {}.'.format(self.maxdeg)])
+
+    @cached_method
+    def field_summary(self, field):
+        ncurves = self.field_counts[field]
+        nclasses = self.field_classes[field]
+        max_norm = self.field_normstats[field]['max']
+        ec_knowl = self.ec_knowl if ncurves==1 else self.ec_knowls
+        iso_knowl = self.iso_knowl if ncurves==1 else self.iso_knowls
+        nf_knowl = self.nf_knowl if ncurves==1 else self.nf_knowls
+        cond_knowl = self.cond_knowl if ncurves==1 else self.cond_knowls
+        s = '' if max_norm==1 else 'up to '
+        norm_phrase = ' of norm {}{}.'.format(s, max_norm)
+        return ''.join([r'The database currently contains {} '.format(ncurves),
                     ec_knowl,
                     r' defined over the ',
                     nf_knowl,
@@ -66,46 +136,38 @@ def ecnf_field_summary(field):
                     cond_knowl,
                     r' of norm {} {}.'.format(s,data['max_norm'])])
 
-def ecnf_signature_summary(sig):
-    ec_knowl = '<a knowl="ec">elliptic curves</a>'
-    iso_knowl = '<a knowl="ec.isogeny_class">isogeny classes</a>'
-    nf_knowl = '<a knowl="nf">number fields</a>'
-    cond_knowl = '<a knowl="ec.conductor">conductors</a>'
-    r, s = [int(x) for x in sig.split(",")]
-    d = r+2*s
-    data = db.ec_nfcurves.stats.get_oldstat('conductor_norm_by_signature')[sig]
-    ncurves = data['ncurves']
-    nclasses = data['nclasses']
-    max_norm = data['max_norm']
-    return ''.join([r'The database currently contains {} '.format(ncurves),
-                    ec_knowl,
-                    r' defined over ',
-                    nf_knowl,
-                    r' of signature ({}) (degree {}), in {} '.format(sig, d, nclasses),
-                    iso_knowl,
-                    r', with ',
-                    cond_knowl,
-                    r' of norm up to {}.'.format(max_norm)])
+    @cached_method
+    def signature_summary(self, sig):
+        r, s = sig
+        d = r+2*s
+        ncurves = self.sig_counts[r,s]
+        nclasses = self.sig_classes[r,s]
+        max_norm = self.sig_normstats[r,s]['max']
+        return ''.join([r'The database currently contains {} '.format(ncurves),
+                        self.ec_knowls,
+                        r' defined over ',
+                        self.nf_knowls,
+                        r' of signature ({},{}) (degree {}), in {} '.format(r, s, d, nclasses),
+                        self.iso_knowls,
+                        r', with ',
+                        self.cond_knowls,
+                        r' of norm up to {}.'.format(max_norm)])
 
-def ecnf_degree_summary(d):
-    ec_knowl = '<a knowl="ec">elliptic curves</a>'
-    iso_knowl = '<a knowl="ec.isogeny_class">isogeny classes</a>'
-    nf_knowl = '<a knowl="nf">number fields</a>'
-    cond_knowl = '<a knowl="ec.conductor">conductors</a>'
-    data = db.ec_nfcurves.stats.get_oldstat('conductor_norm_by_degree')[str(d)]
-    ncurves = data['ncurves']
-    nclasses = data['nclasses']
-    max_norm = data['max_norm']
-    return ''.join([r'The database currently contains {} '.format(ncurves),
-                    ec_knowl,
-                    r' defined over ',
-                    nf_knowl,
-                    r' of degree {}, in {} '.format(d, nclasses),
-                    iso_knowl,
-                    r', with ',
-                    cond_knowl,
-                    r' of norm up to {}.'.format(max_norm)])
+    @cached_method
+    def degree_summary(self, d):
+        ncurves = self.deg_counts[d]
+        nclasses = self.deg_classes[d]
+        max_norm = self.deg_normstats[d]['max']
+        return ''.join([r'The database currently contains {} '.format(ncurves),
+                        self.ec_knowls,
+                        r' defined over ',
+                        self.nf_knowls,
+                        r' of degree {}, in {} '.format(d, nclasses),
+                        self.iso_knowls,
+                        r', with ',
+                        self.cond_knowls,
+                        r' of norm up to {}.'.format(max_norm)])
 
 @app.context_processor
 def ctx_ecnf_summary():
-    return {'ecnf_summary': ecnf_summary}
+    return {'ecnf_summary': ECNF_stats().summary}

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -140,14 +140,14 @@ class ECNF_stats(StatsDisplay):
         s = '' if max_norm==1 else 'up to '
         norm_phrase = ' of norm {}{}.'.format(s, max_norm)
         return ''.join([r'The database currently contains {} '.format(ncurves),
-                    ec_knowl,
-                    r' defined over the ',
-                    nf_knowl,
-                    r' {}, in {} '.format(field_pretty(field), nclasses),
-                    iso_knowl,
-                    r', with ',
-                    cond_knowl,
-                    r' of norm {} {}.'.format(s,data['max_norm'])])
+                        ec_knowl,
+                        r' defined over the ',
+                        nf_knowl,
+                        r' {}, in {} '.format(field_pretty(field), nclasses),
+                        iso_knowl,
+                        r', with ',
+                        cond_knowl,
+                        norm_phrase])
 
     @cached_method
     def signature_summary(self, sig):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -525,7 +525,7 @@ def browse():
     data = ECNF_stats().sigs_by_deg
     # We could use the dict directly but then could not control the order
     # of the keys (degrees), so we use a list
-    info = [[d,data[d]] for d in sorted(data.keys())]
+    info = [[d,['%s,%s'%sig for sig in data[d]]] for d in sorted(data.keys())]
     credit = 'John Cremona'
     t = 'Elliptic Curves over Number Fields'
     bread = [('Elliptic Curves', url_for("ecnf.index")),

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -19,7 +19,7 @@ from lmfdb.utils import (
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberField
 from lmfdb.ecnf import ecnf_page
-from lmfdb.ecnf.ecnf_stats import ecnf_degree_summary, ecnf_signature_summary, sort_field
+from lmfdb.ecnf.ecnf_stats import ECNF_stats
 from lmfdb.ecnf.WebEllipticCurve import ECNF, web_ainvs, convert_IQF_label
 from lmfdb.ecnf.isog_class import ECNF_isoclass
 
@@ -181,8 +181,8 @@ def index():
     # signatures for a general browse:
 
     ecnfstats = db.ec_nfcurves.stats
-    fields_by_deg = ecnfstats.get_oldstat('fields_by_degree')
-    fields_by_sig = ecnfstats.get_oldstat('fields_by_signature')
+    fields_by_deg = ECNF_stats().fields_by_deg
+    fields_by_sig = ECNF_stats().fields_by_sig
     data['fields'] = []
     # Rationals
     data['fields'].append(['the rational field', (('1.1.1.1', [url_for('ec.rational_elliptic_curves'), '$\Q$']),)])
@@ -523,10 +523,10 @@ def search_input_error(info=None, bread=None):
 
 @ecnf_page.route("/browse/")
 def browse():
-    data = db.ec_nfcurves.stats.get_oldstat('signatures_by_degree')
+    data = ECNF_stats().sigs_by_deg
     # We could use the dict directly but then could not control the order
     # of the keys (degrees), so we use a list
-    info = [[d,data[str(d)]] for d in sorted([int(d) for d in data.keys()])]
+    info = [[d,data[d]] for d in sorted(data.keys())]
     credit = 'John Cremona'
     t = 'Elliptic Curves over Number Fields'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
@@ -540,26 +540,24 @@ def statistics_by_degree(d):
     info = {}
 
     ecnfstats = db.ec_nfcurves.stats
-    sigs_by_deg = ecnfstats.get_oldstat('signatures_by_degree')
-    if not str(d) in sigs_by_deg:
+    sigs_by_deg = ECNF_stats().sigs_by_deg
+    if d not in sigs_by_deg:
         info['error'] = "The database does not contain any elliptic curves defined over fields of degree %s" % d
     else:
         info['degree'] = d
 
-    fields_by_sig = ecnfstats.get_oldstat('fields_by_signature')
-    counts_by_sig = ecnfstats.get_oldstat('conductor_norm_by_signature')
-    counts_by_field = ecnfstats.get_oldstat('conductor_norm_by_field')
+    fields_by_sig = ECNF_stats().fields_by_sig
+    counts_by_sig = ECNF_stats().sig_counts
+    counts_by_field = ECNF_stats().field_counts
 
     def field_counts(f):
-        ff = f.replace(".",":")
-        return [f,counts_by_field[ff]]
+        return [f,counts_by_field[f]]
 
     def sig_counts(sig):
-        sorted_fields = sorted(fields_by_sig[sig], key=sort_field)
-        return [sig, counts_by_sig[sig], [field_counts(f) for f in sorted_fields]]
+        return ['%s,%s'%sig, counts_by_sig[sig], [field_counts(f) for f in fields_by_sig[sig]]]
 
-    info['summary'] = ecnf_degree_summary(d)
-    info['sig_stats'] = [sig_counts(sig) for sig in sigs_by_deg[str(d)]]
+    info['summary'] = ECNF_stats().degree_summary(d)
+    info['sig_stats'] = [sig_counts(sig) for sig in sigs_by_deg[d]]
     credit = 'John Cremona'
     if d==2:
         t = 'Elliptic Curves over Quadratic Number Fields'
@@ -585,8 +583,7 @@ def statistics_by_signature(d,r):
 
     info = {}
 
-    ecnfstats = db.ec_nfcurves.stats
-    sigs_by_deg = ecnfstats.get_oldstat('signatures_by_degree')
+    sigs_by_deg = ECNF_stats().sigs_by_deg
     if not str(d) in sigs_by_deg:
         info['error'] = "The database does not contain any elliptic curves defined over fields of degree %s" % d
     else:
@@ -595,18 +592,17 @@ def statistics_by_signature(d,r):
     if not r in range(d%2,d+1,2):
         info['error'] = "Invalid signature %s" % info['sig']
     s = (d-r)//2
-    info['sig'] = sig = '%s,%s' % (r,s)
-    info['summary'] = ecnf_signature_summary(sig)
+    sig = (r,s)
+    info['sig'] = '%s,%s' % sig
+    info['summary'] = ECNF_stats().signature_summary(sig)
 
-    fields_by_sig = ecnfstats.get_oldstat('fields_by_signature')
-    counts_by_field = ecnfstats.get_oldstat('conductor_norm_by_field')
+    fields_by_sig = ECNF_stats().fields_by_sig
+    counts_by_field = ECNF_stats().field_counts
 
     def field_counts(f):
-        ff = f.replace(".",":")
-        return [f,counts_by_field[ff]]
+        return [f,counts_by_field[f]]
 
-    sorted_fields = sorted(fields_by_sig[sig], key=sort_field)
-    info['sig_stats'] = [field_counts(f) for f in sorted_fields]
+    info['sig_stats'] = [field_counts(f) for f in fields_by_sig[sig]]
     credit = 'John Cremona'
     if info['sig'] == '2,0':
         t = 'Elliptic Curves over Real Quadratic Number Fields'
@@ -629,13 +625,6 @@ def statistics_by_signature(d,r):
               ('Signature (%s)' % info['sig'],' ')]
     return render_template("ecnf-by-signature.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
 
-def get_torsion_structures():
-    ecnfstats = db.ec_nfcurves.stats
-    torsion_structures = [t[0] for t in ecnfstats.get_oldstat('torsion_structure')['counts']]
-    torsion_structures = [[int(str(n)) for n in t.split(",")] for t in torsion_structures if t]
-    torsion_structures.sort()
-    return torsion_structures
-
 def tor_struct_search_nf(prefill="any"):
     def fix(t):
         return t + ' selected = "yes"' if prefill==t else t
@@ -645,7 +634,7 @@ def tor_struct_search_nf(prefill="any"):
         return [fix("[{},{}]".format(m,n)), "C{}&times;C{}".format(m,n)]
     gps = [[fix(""), "any"], [fix("[]"), "trivial"]]
 
-    tors = get_torsion_structures()
+    tors = ECNF_stats().torsion_counts
 
     # The following was the set as of 24/4/2017:
     # assert tors == [[2], [2, 2], [2, 4], [2, 6], [2, 8], [2, 10], [2, 12], [2, 14], [2, 16], [2, 18], [3], [3, 3], [3, 6], [4], [4, 4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18], [19], [20], [21], [22], [25], [27], [37]]

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -189,8 +189,8 @@ def index():
 
     # Real quadratics (sample)
     rqfs = ['2.2.{}.1'.format(d) for d in [5, 89, 229, 497]]
-    niqfs = len(fields_by_sig['0,1'])
-    nrqfs = len(fields_by_sig['2,0'])
+    niqfs = len(fields_by_sig[0,1])
+    nrqfs = len(fields_by_sig[2,0])
     data['fields'].append(['{} real quadratic fields, including'.format(nrqfs),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in rqfs)])
@@ -203,28 +203,28 @@ def index():
 
     # Cubics (sample)
     cubics = ['3.1.23.1'] + ['3.3.{}.1'.format(d) for d in [49,148,1957]]
-    ncubics = len(fields_by_deg['3'])
+    ncubics = len(fields_by_deg[3])
     data['fields'].append(['{} cubic fields, including'.format(ncubics),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in cubics)])
 
     # Quartics (sample)
     quartics = ['4.4.{}.1'.format(d) for d in [725,2777,9909,19821]]
-    nquartics = len(fields_by_deg['4'])
+    nquartics = len(fields_by_deg[4])
     data['fields'].append(['{} totally real quartic fields, including'.format(nquartics),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in quartics)])
 
     # Quintics (sample)
     quintics = ['5.5.{}.1'.format(d) for d in [14641, 24217, 36497, 38569, 65657]]
-    nquintics = len(fields_by_deg['5'])
+    nquintics = len(fields_by_deg[5])
     data['fields'].append(['{} totally real quintic fields, including'.format(nquintics),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in quintics)])
 
     # Sextics (sample)
     sextics = ['6.6.{}.1'.format(d) for d in [300125, 371293, 434581, 453789, 485125]]
-    nsextics = len(fields_by_deg['6'])
+    nsextics = len(fields_by_deg[6])
     data['fields'].append(['{} totally real sextic fields, including'.format(nsextics),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in sextics)])
@@ -547,8 +547,8 @@ def statistics_by_degree(d):
         info['degree'] = d
 
     fields_by_sig = ECNF_stats().fields_by_sig
-    counts_by_sig = ECNF_stats().sig_counts
-    counts_by_field = ECNF_stats().field_counts
+    counts_by_sig = ECNF_stats().sig_normstats
+    counts_by_field = ECNF_stats().field_normstats
 
     def field_counts(f):
         return [f,counts_by_field[f]]
@@ -584,7 +584,7 @@ def statistics_by_signature(d,r):
     info = {}
 
     sigs_by_deg = ECNF_stats().sigs_by_deg
-    if not str(d) in sigs_by_deg:
+    if d not in sigs_by_deg:
         info['error'] = "The database does not contain any elliptic curves defined over fields of degree %s" % d
     else:
         info['degree'] = d
@@ -597,7 +597,7 @@ def statistics_by_signature(d,r):
     info['summary'] = ECNF_stats().signature_summary(sig)
 
     fields_by_sig = ECNF_stats().fields_by_sig
-    counts_by_field = ECNF_stats().field_counts
+    counts_by_field = ECNF_stats().field_normstats
 
     def field_counts(f):
         return [f,counts_by_field[f]]

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -180,7 +180,6 @@ def index():
     # data['fields'] holds data for a sample of number fields of different
     # signatures for a general browse:
 
-    ecnfstats = db.ec_nfcurves.stats
     fields_by_deg = ECNF_stats().fields_by_deg
     fields_by_sig = ECNF_stats().fields_by_sig
     data['fields'] = []
@@ -539,7 +538,6 @@ def statistics_by_degree(d):
         return redirect(url_for("ec.statistics"))
     info = {}
 
-    ecnfstats = db.ec_nfcurves.stats
     sigs_by_deg = ECNF_stats().sigs_by_deg
     if d not in sigs_by_deg:
         info['error'] = "The database does not contain any elliptic curves defined over fields of degree %s" % d

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -20,7 +20,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'debug', 'flash_error', 'cached',
            'ajax_url',
            'image_callback', 'encode_plot',
-           'KeyedDefaultDict', 'range_formatter',
+           'KeyedDefaultDict', 'make_tuple', 'range_formatter',
            'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_rational',
            'parse_rats', 'parse_bracketed_posints', 'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of',
@@ -57,7 +57,7 @@ from .utilities import (
     debug, flash_error, cached,
     ajax_url,  # try to eliminate?
     image_callback, encode_plot,
-    KeyedDefaultDict, range_formatter,
+    KeyedDefaultDict, make_tuple, range_formatter,
     datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)
 
 from .search_parsing import (

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -1185,6 +1185,18 @@ class KeyedDefaultDict(defaultdict):
         self[key] = value = self.default_factory(key)
         return value
 
+def make_tuple(val):
+    """
+    Converts lists and dictionaries into tuples, recursively.  The main application
+    is so that the result can be used as a dictionary key.
+    """
+    if isinstance(val, (list, tuple)):
+        return tuple(make_tuple(x) for x in val)
+    elif isinstance(val, dict):
+        return tuple((make_tuple(a), make_tuple(b)) for a,b in val.items())
+    else:
+        return val
+
 def range_formatter(x):
     if isinstance(x, dict):
         if '$gte' in x:


### PR DESCRIPTION
Switches elliptic curves over number fields to the new statistics functionality.  Based on #2910, which should probably be reviewed first.

To test, check that there are no more references to oldstats in the `ecnf` folder, and that the browse pages such as http://localhost:37777/EllipticCurve/browse/2/ and http://localhost:37777/EllipticCurve/browse/3/3/ look correct and included the 4 curves @JohnCremona recently added (to 2.0.3.1).