### PR TITLE
Switch to using joins for extra columns

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -169,7 +169,7 @@ def api_query(table, id = None):
     if fields:
         fields = ['id'] + fields.split(DELIM)
     else:
-        fields = 1.1
+        fields = 3
 
     if sortby:
         sortby = sortby.split(DELIM)

--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -77,5 +77,5 @@ class ApiTest(LmfdbTest):
             if '8T3' in query:
                 assert '"name": "E(8)=2[x]2[x]2"' in data
             if '11a1' in query:
-                assert '"lmfdb_label": "11.a2",' in data
-                assert '"jinv": "-122023936/161051",' in data
+                assert '"lmfdb_label": "11.a2"' in data
+                assert '"jinv": "-122023936/161051"' in data


### PR DESCRIPTION
This PR includes one trivial change, one minor change and one substantial change.

* #2905 introduced an importance column to `meta_tables`, but the schema at the top of `database.py` wasn't updated.  We add the new column.
* The `projection` keyword for `search` and `lucky` supported `projection=1.1` if you wanted to include the `id` (1 indicates all search columns, and 2 all search and extra columns).  Using a floating point value to indicate this option is silly.  This option was used in the api, where the only reason we didn't return all fields (both search and extras) was a limitation of the search functionality.  Since it's now feasible to do so, we switch to an option 3 which includes all search and extra columns, plus `id`.
* The main change in this PR is that we use a join between search and extra columns (on `id`, which was specifically designed for this purpose) when returning search results, rather than doing a new SELECT.  This change simplifies the code and will greatly speed up searches when columns from the extra table are needed.

This PR should resolve #2881.