### PR TITLE
Placeholder css

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -48,8 +48,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	  <tr>
 	    <td>
 	  Search by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}
-          <input type="text" name="jump_to" value=""
-        placeholder="2.12-4.0.2-2-2-3">
+          <input type="text" name="jump_to" value="" placeholder="2.12-4.0.2-2-2-3">
 	    </td>
 	    <td>
           <button type="submit" value="Find">Find</button>
@@ -69,8 +68,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
           <tr align=left>
             <td align=right>
              {{KNOWL('ag.curve.genus',title='Genus')}}:
-            </td><td><input type="integer" name="genus" value=""
-      placeholder="3"></td>
+            </td><td><input type="integer" name="genus" value="" placeholder="3"></td>
       <td>
 	<span class="formexample">e.g. 4, or a range like 3..5</span>
       </td>

--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -186,8 +186,7 @@ are blank for combinations of weight and degree which cannot occur.
 	  <tr>
 	    <td>
 	  Search by {{KNOWL('hgm.label',title="label")}}
-          <input type="text" name="jump_to" value=""
-        placeholder="A2.2_B1.1_t1.2">
+          <input type="text" name="jump_to" value="" placeholder="A2.2_B1.1_t1.2">
 	    </td>
 	    <td>
           <button type="submit" value="Find">Find</button>

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -81,8 +81,7 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
 	  <tr>
 	    <td>
 	  Search by {{KNOWL('lf.field.label',title="label")}}
-          <input type="text" name="jump_to" value=""
-        placeholder="2.4.6.7">
+          <input type="text" name="jump_to" value="" placeholder="2.4.6.7">
 	    </td>
 	    <td>
           <button type="submit" value="Find">Find</button>
@@ -102,8 +101,7 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
           <tr align=left>
             <td align=right>
           {{KNOWL('lf.degree',title='Degree')}}:
-            </td><td><input type="text" name="n" value=""
-      placeholder="6">
+            </td><td><input type="text" name="n" value="" placeholder="6">
       <td>
 	<span class="formexample">e.g. 6, or a range like 3..5</span>
           <tr>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2222,7 +2222,7 @@ table.qexp-table td.output {
     font-family: MJX_Math;
 }
 
-input::-webkit-input-placeholder {
+input::placeholder {
     color: #cccccc;
 }
 


### PR DESCRIPTION
Fixes issue #2582 in all browsers.  See any page with placeholders in the input field of a form,
such as
   /EllipticCurve/Q/

See issue #2915 for an explanation why this was needed.