### PR TITLE
fix failing api test by removing commas so order is irrelevant

### DIFF
--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -77,5 +77,5 @@ class ApiTest(LmfdbTest):
             if '8T3' in query:
                 assert '"name": "E(8)=2[x]2[x]2"' in data
             if '11a1' in query:
-                assert '"lmfdb_label": "11.a2",' in data
-                assert '"jinv": "-122023936/161051",' in data
+                assert '"lmfdb_label": "11.a2"' in data
+                assert '"jinv": "-122023936/161051"' in data


### PR DESCRIPTION
 See #2913.  The only reason the test was failing was because it was looking for some commas in the output which made the test sensitive to the order of columns.

This fix was borrowed from #2913 which is still under review (as it has more substantial changes) so that other PR's do not fail spuriously.  This one can be merged as soon as tests have passed.