### PR TITLE
small change to ecnf import script

### DIFF
--- a/scripts/ecnf/import_ecnf_data.py
+++ b/scripts/ecnf/import_ecnf_data.py
@@ -406,7 +406,7 @@ def curves(line, verbose=False):
         'q_curve': q_curve,
         'base_change': base_change,
         'torsion_order': ntors,
-        'torsion_structure': torstruct,
+        'torsion_structure': Json(torstruct),
         'torsion_gens': torgens,
         'equation': str(latex(E)), # no "\(", "\)"
         'local_data': Json(local_data),


### PR DESCRIPTION
This is necessary to convert a python list of ints into something which is stored correctly in postgres.  Before this, some curves with torsion_structure=[] had it stored as {} and not [].