### PR TITLE
correct ambiguous html id attribute (LGTM)

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -178,7 +178,7 @@ function show_qexp(qstyle) {
 {% if newform.has_exact_qexp or (newform.embedding_label and newform.has_complex_qexp) %}
 
 <h2 id="qexp-anchor"> {{ KNOWL('cmf.q-expansion',title='$q$-expansion')}}</h2>
-<div id="qexp">
+<div id="qexp-div">
   {% if newform.dim > 1  and not newform.embedding_label %}
     <p>
       {% if not newform.hecke_ring_cyclotomic_generator %}

--- a/lmfdb/templates/bigpicture.html
+++ b/lmfdb/templates/bigpicture.html
@@ -84,9 +84,9 @@ the variety of connections among the various objects.
 
 <svg> <!-- GG and NF to AR -->
 <path class="ARkeep" id="GGAR" d="M 380 888 Q 410 793 545 764" stroke="black" stroke-width="2" fill="none"></path>
-<path class="ARkeep" id="GGAR" d="M 380 888 l 20,-20 m -20,20 l 20,20" stroke="black" stroke-width="2" fill="none" transform="rotate(-70 380 888)"></path>
+<path class="ARkeep" id="GGAR2" d="M 380 888 l 20,-20 m -20,20 l 20,20" stroke="black" stroke-width="2" fill="none" transform="rotate(-70 380 888)"></path>
 <path class="ARkeep" id="NFAR" d="M 270 750 q 160 50 310 5" stroke="black" stroke-width="2" fill="none"></path>
-<path class="ARkeep" id="GGAR" d="M 270 750 l 20,-20 m -20,20 l 20,20" stroke="black" stroke-width="2" fill="none" transform="rotate(15 270 750)"></path>
+<path class="ARkeep" id="GGAR3" d="M 270 750 l 20,-20 m -20,20 l 20,20" stroke="black" stroke-width="2" fill="none" transform="rotate(15 270 750)"></path>
 <defs>
 <path id="arguide1" d="M 380 888 Q 410 793 545 764" stroke-width="0" fill="none" transform="translate(-1,-5)"></path>
 <path id="arguide2" d="M 270 750 q 160 50 310 5" stroke="black" stroke-width="0" fill="none" transform="translate(0,-5)"></path>


### PR DESCRIPTION
There were ambiguous html id attributes. The first is where two different elements had the same id "qexp". This is against the HTML standard and can break depending on browser implementation. It also makes it hard to select elements by id with scripts.

This (pretty small) commit corrects all occurrences of this in the code, and was found using the LGTM static code analysis tool.