### PR TITLE
Fix bmf_dims

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -190,7 +190,6 @@ def bmf_field_dim_table(**args):
         query[totaldim] = {'$gt': 0}
     t = ' '.join(['Dimensions of Spaces of {} Bianchi Modular Forms over'.format(info['group']), pretty_field_label])
     data = list(db.bmf_dims.search(query, limit=count, offset=start, info=info))
-    print info
     nres = info['number']
     if not info['exact_count']:
         info['number'] = nres = db.bmf_dims.count(query)

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -190,9 +190,11 @@ def bmf_field_dim_table(**args):
         query[totaldim] = {'$gt': 0}
     t = ' '.join(['Dimensions of Spaces of {} Bianchi Modular Forms over'.format(info['group']), pretty_field_label])
     data = list(db.bmf_dims.search(query, limit=count, offset=start, info=info))
+    print info
     nres = info['number']
     if not info['exact_count']:
-        nres = db.bmf_dims.count(query)
+        info['number'] = nres = db.bmf_dims.count(query)
+        info['exact_count'] = True
     if nres > count or start != 0:
         info['report'] = 'Displaying items %s-%s of %s levels,' % (start + 1, min(nres, start + count), nres)
     else:

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -174,32 +174,27 @@ def bmf_field_dim_table(**args):
     bread = [('Bianchi Modular Forms', url_for(".index")), (
         pretty_field_label, ' ')]
     properties = []
+    query = {}
+    query['field_label'] = field_label
     if gl_or_sl=='gl2_dims':
         info['group'] = 'GL(2)'
         info['bgroup'] = '\GL(2,\mathcal{O}_K)'
     else:
         info['group'] = 'SL(2)'
         info['bgroup'] = '\SL(2,\mathcal{O}_K)'
+    if level_flag == 'all':
+        query[gl_or_sl] = {'$exists': True}
+    else:
+        # Only get records where the cuspdial/new dimension is positive for some weight
+        totaldim = gl_or_sl.replace('dims', level_flag) + '_totaldim'
+        query[totaldim] = {'$gt': 0}
     t = ' '.join(['Dimensions of Spaces of {} Bianchi Modular Forms over'.format(info['group']), pretty_field_label])
-    query = {}
-    query['field_label'] = field_label
-    query[gl_or_sl] = {'$exists': True}
-    data = db.bmf_dims.search(query, limit=count, offset=start, info=info)
+    data = list(db.bmf_dims.search(query, limit=count, offset=start, info=info))
     nres = info['number']
     if nres > count or start != 0:
         info['report'] = 'Displaying items %s-%s of %s levels,' % (start + 1, min(nres, start + count), nres)
     else:
         info['report'] = 'Displaying all %s levels,' % nres
-
-    # convert data to a list and eliminate levels where all
-    # new/cuspidal dimensions are 0.  (This could be done at the
-    # search stage, but that requires adding new fields to each
-    # record.)
-    def filter(dat, flag):
-        dat1 = dat[gl_or_sl]
-        return any([int(dat1[w][flag])>0 for w in dat1])
-    flag = 'cuspidal_dim' if level_flag=='cusp' else 'new_dim'
-    data = [dat for dat in data if level_flag == 'all' or filter(dat, flag)]
 
     info['field'] = field_label
     info['field_pretty'] = pretty_field_label

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -191,6 +191,8 @@ def bmf_field_dim_table(**args):
     t = ' '.join(['Dimensions of Spaces of {} Bianchi Modular Forms over'.format(info['group']), pretty_field_label])
     data = list(db.bmf_dims.search(query, limit=count, offset=start, info=info))
     nres = info['number']
+    if not info['exact_count']:
+        nres = db.bmf_dims.count(query)
     if nres > count or start != 0:
         info['report'] = 'Displaying items %s-%s of %s levels,' % (start + 1, min(nres, start + count), nres)
     else:

--- a/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
@@ -69,11 +69,10 @@ by norm, over \(K=\) {{info.field_pretty}}.
 </p>
 </form>
 
-<form id='next_previous'>
+<form id='re-search'>
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
 <input type="hidden" name="level_flag" value="{{info.level_flag}}"/>
-</form>
 
 <div align=left>
   {% include 'forward_back.html' %}
@@ -119,6 +118,7 @@ by norm, over \(K=\) {{info.field_pretty}}.
 {% include 'forward_back.html' %}
 
 </div>
+</form>
 {% else %}
 <p>
 No data available for {{info.field_pretty}}

--- a/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
@@ -36,7 +36,8 @@ by norm, over \(K=\) {{info.field_pretty}}.
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
 
-<p>{{info.report}}
+{# We don't use matches.html since we want to call the results levels rather than matches #}
+<p>{{info.report | safe}}
                     {# we have to decide which option is preselected
                     based on a judgement of what users will want to
                     switch to, i.e. one of the other two options.  For

--- a/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
+++ b/scripts/bianchi_modular_forms/import_bianchi_dimensions.py
@@ -19,6 +19,9 @@ The "dimensions" collection entries have the following fields:
    - 'sl2_dims':       (dict) each key is a weight (int), with value a
                          dict with keys 'cuspidal_dim', 'new_dim' (and possibly more)
 
+Note (April 2019): when this script is updated to Postgres, make sure to add the columns
+sl2_new_totaldim, sl2_cusp_totaldim, gl2_new_totaldim, and gl2_cusp_totaldim.  See
+PR #2926 for details.
 """
 from sage.all import polygen, QQ, ZZ, NumberField
 


### PR DESCRIPTION
This resolves #2854.  To test, visit http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/gl2dims/2.0.4.1, etc.

The problem was that postgres only returns the first 50 results, which were then filtered away by the BMF code.  I added four columns to the `bmf_dims` table: `sl2_new_totaldim` (the total of the `new_dim` entries of `sl2_dims` for all weights), `sl2_cusp_totaldim`, `gl2_new_totaldim`, and `gl2_cusp_totaldim`.  For our search purposes we only needed whether these were zero or nonzero, but I thought having an integral column might be useful.