### PR TITLE
Lfunc rcs

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -495,18 +495,28 @@ def initLfunction(L, args, request):
     '''
     info = L.info
     info['args'] = args
+    prepath = request.path
+    prepath = re.sub(r'^/L/','',prepath)
+    prepath = re.sub(r'/$','',prepath)
     info['properties2'] = set_gaga_properties(L)
+
+    set_bread_and_friends(info, L, request)
+
     info['learnmore'] = [('Everyone loves number fields', url_for('number_fields.number_field_render_webpage'))]
     if L.fromDB:
         if L._Ltype == 'dirichlet':
             myltype='dirichlet'
+        elif L._Ltype == 'ellipticcurve':
+            myltype='ec'
         else:
             myltype='otherindb'
     else:
-        myltype='onthefly'
-    info['learnmore'] = [('Reliability of the data', url_for('.reliability',ltype=myltype))]
-
-    set_bread_and_friends(info, L, request)
+        if L._Ltype == 'maass':
+            myltype='maass'
+        else:
+            myltype='onthefly'
+    info['learnmore'] = [('Reliability of the data', 
+        url_for('.reliability', prepath=prepath, ltype=myltype))]
 
     (info['zeroslink'], info['plotlink']) = set_zeroslink_and_plotlink(L, args)
     info['navi']= set_navi(L)
@@ -1214,12 +1224,17 @@ def processSymPowerEllipticCurveNavigation(startCond, endCond, power):
     s += '</table>\n'
     return s
 
-@l_function_page.route("/Reliability/<ltype>")
-def reliability(ltype):
+@l_function_page.route("/<path:prepath>/Reliability/<ltype>")
+def reliability(prepath,ltype):
     t = 'Reliability of L-function Data'
-    bread = get_bread([("Reliability", '')])
-    knowlist = {'onthefly': 'rcs.rigor.lfunction.onthefly'}
-    knowl = knowlist[ltype]
+    bread = get_bread(1, [("Reliability", '')])
+    knowlist = {'onthefly': 'rcs.rigor.lfunction.onthefly',
+                'maass': 'rcs.rigor.lfunction.maass',
+                'ec': 'rcs.rigor.lfunction.ec'}
+    if ltype in knowlist.keys():
+        knowl = knowlist[ltype]
+    else:
+        knowl = 'rcs.rigor.lfunction.onthefly'
     return render_template("single.html", kid=knowl, title=t, bread=bread)
 
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1275,4 +1275,3 @@ def source(prepath):
     return render_template("single.html", kid=knowl, title=t, bread=bread,
         learnmore=learnmore_list(prepath, remove='Source'))
 
-

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -496,6 +496,15 @@ def initLfunction(L, args, request):
     info = L.info
     info['args'] = args
     info['properties2'] = set_gaga_properties(L)
+    info['learnmore'] = [('Everyone loves number fields', url_for('number_fields.number_field_render_webpage'))]
+    if L.fromDB:
+        if L._Ltype == 'dirichlet':
+            myltype='dirichlet'
+        else:
+            myltype='otherindb'
+    else:
+        myltype='onthefly'
+    info['learnmore'] = [('Reliability of the data', url_for('.reliability',ltype=myltype))]
 
     set_bread_and_friends(info, L, request)
 
@@ -1204,3 +1213,13 @@ def processSymPowerEllipticCurveNavigation(startCond, endCond, power):
 
     s += '</table>\n'
     return s
+
+@l_function_page.route("/Reliability/<ltype>")
+def reliability(ltype):
+    t = 'Reliability of L-function Data'
+    bread = get_bread([("Reliability", '')])
+    knowlist = {'onthefly': 'rcs.rigor.lfunction.onthefly'}
+    knowl = knowlist[ltype]
+    return render_template("single.html", kid=knowl, title=t, bread=bread)
+
+


### PR DESCRIPTION
This adds rcs knowls to L-function pages.

It for source and rigor, it reads from the database to see which knowls to use.  Note, the database seems to have a typo in source knowl identifier for load_type=Costa.

Unlike other areas, the knowl information is typically specific to an L-function, so we add on to the url and bread.  It is possible we should not do this for Completeness since there is only one such knowl?

To test, look at various L-function pages and click on the rcs links in the learnmore about area.  Most are stubs, but you can look at the identifier of the knowl to check that it is correct.