### PR TITLE
Load L-functions from database for HMF and Artin when available

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -42,6 +42,12 @@ from LfunctionDatabase import (
     get_instance_by_url, getHmfData, getHgmData,
     getEllipticCurveData, get_multiples_by_Lhash)
 
+def artin_url(label):
+    return "ArtinRepresentation/" + label
+
+def hmf_url(label):
+    "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
+
 def validate_required_args(errmsg, args, *keys):
     missing_keys = [key for key in keys if not key in args]
     if len(missing_keys):
@@ -1260,7 +1266,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
         self.label = kwargs['label']
         self.origin_label = self.label
         self._Ltype = "hilbertmodularform"
-        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
+        self.url = hmf_url(self.label)
         Lfunction_from_db.__init__(self, url = self.url)
 
 class Lfunction_HMF(Lfunction):
@@ -1672,7 +1678,7 @@ class ArtinLfunctionDB(Lfunction_from_db):
         self.label = kwargs['label']
         self.origin_label = self.label
         self._Ltype = "artin"
-        self.url = "ArtinRepresentation/" + self.label
+        self.url = artin_url(self.label)
         Lfunction_from_db.__init__(self, url = self.url)
 
     @lazy_attribute

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1265,11 +1265,15 @@ class Lfunction_HMFDB(Lfunction_from_db):
     def __init__(self, **kwargs):
         constructor_logger(self, kwargs)
 
-        validate_required_args ('Unable to construct L-function.', kwargs, 'label')
+        validate_required_args ('Unable to construct Hilbert modular form ' +
+                                'L-function.', args, 'label', 'number', 'character')
+        validate_integer_args ('Unable to construct Hilbert modular form L-function.',
+                               args, 'character','number')
+        
         self.label = kwargs['label']
         self.origin_label = self.label
         self._Ltype = "hilbertmodularform"
-        self.url = hmf_url(self.label)
+        self.url = hmf_url(args['label'],args['character'],args['number'])
         Lfunction_from_db.__init__(self, url = self.url)
 
 class Lfunction_HMF(Lfunction):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1259,16 +1259,16 @@ class Lfunction_HMFDB(Lfunction_from_db):
         constructor_logger(self, kwargs)
 
         validate_required_args ('Unable to construct Hilbert modular form ' +
-                                'L-function.', args, 'label', 'number', 'character')
+                                'L-function.', kwargs, 'label', 'number', 'character')
         validate_integer_args ('Unable to construct Hilbert modular form L-function.',
-                               args, 'character','number')
+                               kwargs, 'character','number')
 
         self._Ltype = "hilbertmodularform"
 
         # Put the arguments into the object dictionary
-        self.label = args['label']
-        self.number = int(args['number'])
-        self.character= int(args['character'])
+        self.label = kwargs['label']
+        self.number = int(kwargs['number'])
+        self.character= int(kwargs['character'])
         if self.character != 0:
             raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1675,6 +1675,10 @@ class ArtinLfunctionDB(Lfunction_from_db):
         self.url = "ArtinRepresentation/" + self.label
         Lfunction_from_db.__init__(self, url = self.url)
 
+    @lazy_attribute
+    def bread(self):
+        return get_bread(2, [('Cusp Form', url_for('.l_function_cuspform_browse_page', degree='degree2'))])
+
 
 class ArtinLfunction(Lfunction):
     """Class representing the Artin L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -46,7 +46,7 @@ def artin_url(label):
     return "ArtinRepresentation/" + label
 
 def hmf_url(label):
-    "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
+    return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
 
 def validate_required_args(errmsg, args, *keys):
     missing_keys = [key for key in keys if not key in args]

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1263,7 +1263,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         # Put the arguments into the object dictionary
         self.label = kwargs['label']
-        self.hmf_label = self.label
+        self.origin_label = self.label
 
         # check instances
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
@@ -1274,10 +1274,6 @@ class Lfunction_HMFDB(Lfunction_from_db):
     @lazy_attribute
     def _Ltype(self):
         return  "Hilbert modular form"
-
-    @lazy_attribute
-    def origin_label(self):
-        return self.label
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+#_ -*- coding: utf-8 -*-
 # The class Lfunction is defined in Lfunction_base and represents an L-function
 # We subclass it here:
 # RiemannZeta, Lfunction_Dirichlet, Lfunction_EC_Q, Lfunction_CMF,
@@ -1256,16 +1256,12 @@ class Lfunction_HMFDB(Lfunction_from_db):
     def __init__(self, **kwargs):
         constructor_logger(self, kwargs)
 
-        validate_required_args ('Unable to construct Hilbert modular form ' + 'L-function.', kwargs, 'label')
-        self._Ltype = "hilbertmodularform"
+        validate_required_args ('Unable to construct L-function.', kwargs, 'label')
         self.label = kwargs['label']
         self.origin = self.label
+        self._Ltype = "hilbertmodularform"
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
         Lfunction_from_db.__init__(self, url = self.url)
-
-    @lazy_attribute
-    def _Ltype(self):
-        return  "Hilbert modular form"
 
     @lazy_attribute
     def origin_label(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1277,7 +1277,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def origin_label(self):
-        return self.hmf_label
+        return self.label
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1256,20 +1256,13 @@ class Lfunction_HMFDB(Lfunction_from_db):
     def __init__(self, **kwargs):
         constructor_logger(self, kwargs)
 
-        validate_required_args ('Unable to construct Hilbert modular form ' +
-                                'L-function.', kwargs, 'label')
-
+        validate_required_args ('Unable to construct Hilbert modular form ' + 'L-function.', kwargs, 'label')
         self._Ltype = "hilbertmodularform"
 
-        # Put the arguments into the object dictionary
         self.label = kwargs['label']
         self.origin = self.label
-
-        # check instances
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
         Lfunction_from_db.__init__(self, url = self.url)
-
-        self.numcoeff = 30
 
     @lazy_attribute
     def _Ltype(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1287,12 +1287,12 @@ class Lfunction_HMFDB(Lfunction_from_db):
         return self.label
 
     @lazy_attribute
-    def knowltype(self):
-        return "mf"
+    def bread(self):
+        return get_bread(self.degree, [(self.label, '')])
 
     @lazy_attribute
-    def bread(self):
-        return get_bread(4, [('Cusp Form', url_for('.l_function_cuspform_browse_page', degree='degree4'))])
+    def knowltype(self):
+        return "mf"
 
     @property
     def friends(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1263,7 +1263,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         # Put the arguments into the object dictionary
         self.label = kwargs['label']
-        self.origin_label = self.label
+        self.origin = self.label
 
         # check instances
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
@@ -1274,6 +1274,10 @@ class Lfunction_HMFDB(Lfunction_from_db):
     @lazy_attribute
     def _Ltype(self):
         return  "Hilbert modular form"
+
+    @lazy_attribute
+    def origin_label(self):
+        return self.origin
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1267,7 +1267,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         # Put the arguments into the object dictionary
         self.label = kwargs['label']
-        print self.label
+        self.hmf_label = self.label
         self.number = int(kwargs['number'])
         self.character= int(kwargs['character'])
         if self.character != 0:
@@ -1285,8 +1285,8 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def origin_label(self):
-        print "origin_label",self.label
-        return self.label
+        print "origin_label",self.hmf_label
+        return self.hmf_label
 
     @lazy_attribute
     def knowltype(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1657,6 +1657,25 @@ class DedekindZeta(Lfunction):
 
 #############################################################################
 
+
+class ArtinLfunctionDB(Lfunction_from_db):
+    """Class representing a Hilbert modular form L-function stored in the database
+
+    Compulsory parameters: label
+
+    """
+
+    def __init__(self, **kwargs):
+        constructor_logger(self, kwargs)
+
+        validate_required_args ('Unable to construct L-function.', kwargs, 'label')
+        self.label = kwargs['label']
+        self.origin_label = self.label
+        self._Ltype = "artin"
+        self.url = "ArtinRepresentation/" + self.label
+        Lfunction_from_db.__init__(self, url = self.url)
+
+
 class ArtinLfunction(Lfunction):
     """Class representing the Artin L-function
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1273,7 +1273,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
             raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
 
         # check instances
-        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label.replace(".","/")
+        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
         Lfunction_from_db.__init__(self, url = self.url)
 
         self.numcoeff = 30

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1274,6 +1274,15 @@ class Lfunction_HMF(Lfunction):
         if self.character != 0:
             raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
 
+        # check instances
+        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label.replace(".","/")
+        try:
+            Lfunction_from_db.__init__(self, url = self.url)
+            self.numcoeff = 30
+            return
+        except:
+            pass
+
         # Load form (f) from database
         (f, F_hmf) = getHmfData(self.label)
         if f is None:

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1263,14 +1263,14 @@ class Lfunction_HMFDB(Lfunction_from_db):
     """
 
     def __init__(self, **kwargs):
-        constructor_logger(self, kwargs)
+        constructor_logger(self, args)
 
         validate_required_args ('Unable to construct Hilbert modular form ' +
                                 'L-function.', args, 'label', 'number', 'character')
         validate_integer_args ('Unable to construct Hilbert modular form L-function.',
                                args, 'character','number')
-        
-        self.label = kwargs['label']
+
+        self.label = args['label']
         self.origin_label = self.label
         self._Ltype = "hilbertmodularform"
         self.url = hmf_url(args['label'],args['character'],args['number'])

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1258,14 +1258,10 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         validate_required_args ('Unable to construct L-function.', kwargs, 'label')
         self.label = kwargs['label']
-        self.origin = self.label
+        self.origin_label = self.label
         self._Ltype = "hilbertmodularform"
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
         Lfunction_from_db.__init__(self, url = self.url)
-
-    @lazy_attribute
-    def origin_label(self):
-        return self.origin
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1284,11 +1284,11 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def origin_label(self):
-        return ".".join(map(str, self.label))
+        return self.label
 
     @lazy_attribute
-    def bread(self):
-        return get_bread(2, [('Cusp Form', url_for('.l_function_cuspform_browse_page', degree='degree4'))])
+    def knowltype(self):
+        return "mf"
 
     @property
     def friends(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1255,6 +1255,25 @@ class Lfunction_Maass(Lfunction):
 
 #############################################################################
 
+class Lfunction_BMF(Lfunction_from_db):
+    """Class representing a Bianchi modular form L-function stored in the database
+
+    Compulsory parameters: label
+
+    """
+
+    def __init__(self, **args):
+        constructor_logger(self, args)
+
+        validate_required_args ('Unable to construct Bianchi modular form L-function.', args, 'field', 'level', 'suffix')
+
+        self.label = '-'.join([args["field"], args["level"], args["suffix"]])
+        self.origin_label = self.label
+        self._Ltype = "bianchimodularform"
+        self.url = "ModularForm/GL2/ImaginaryQuadratic/" + self.label.replace('-','/')
+
+        Lfunction_from_db.__init__(self, url = self.url)
+
 class Lfunction_HMFDB(Lfunction_from_db):
     """Class representing a Hilbert modular form L-function stored in the database
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1251,27 +1251,19 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     Compulsory parameters: label
 
-    Possible parameters: number, character
-
     """
 
     def __init__(self, **kwargs):
         constructor_logger(self, kwargs)
 
         validate_required_args ('Unable to construct Hilbert modular form ' +
-                                'L-function.', kwargs, 'label', 'number', 'character')
-        validate_integer_args ('Unable to construct Hilbert modular form L-function.',
-                               kwargs, 'character','number')
+                                'L-function.', kwargs, 'label')
 
         self._Ltype = "hilbertmodularform"
 
         # Put the arguments into the object dictionary
         self.label = kwargs['label']
         self.hmf_label = self.label
-        self.number = int(kwargs['number'])
-        self.character= int(kwargs['character'])
-        if self.character != 0:
-            raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
 
         # check instances
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label
@@ -1281,21 +1273,11 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def _Ltype(self):
-        return  "hilbert modular form"
+        return  "Hilbert modular form"
 
     @lazy_attribute
     def origin_label(self):
         return self.hmf_label
-
-    @lazy_attribute
-    def knowltype(self):
-        return "mf"
-
-    @property
-    def friends(self):
-        """The 'related objects' to show on webpage."""
-        lfriends = Lfunction_from_db.friends.fget(self)
-        return lfriends
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1267,6 +1267,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         # Put the arguments into the object dictionary
         self.label = kwargs['label']
+        print self.label
         self.number = int(kwargs['number'])
         self.character= int(kwargs['character'])
         if self.character != 0:
@@ -1284,11 +1285,8 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def origin_label(self):
+        print "origin_label",self.label
         return self.label
-
-    @lazy_attribute
-    def bread(self):
-        return get_bread(self.degree, [(self.label, '')])
 
     @lazy_attribute
     def knowltype(self):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1246,6 +1246,55 @@ class Lfunction_Maass(Lfunction):
 
 #############################################################################
 
+class Lfunction_HMFDB(Lfunction_from_db):
+    """Class representing a Hilbert modular form L-function stored in the database
+
+    Compulsory parameters: label
+
+    Possible parameters: number, character
+
+    """
+
+    def __init__(self, **kwargs):
+        constructor_logger(self, kwargs)
+
+        validate_required_args ('Unable to construct Hilbert modular form ' +
+                                'L-function.', args, 'label', 'number', 'character')
+        validate_integer_args ('Unable to construct Hilbert modular form L-function.',
+                               args, 'character','number')
+
+        self._Ltype = "hilbertmodularform"
+
+        # Put the arguments into the object dictionary
+        self.label = args['label']
+        self.number = int(args['number'])
+        self.character= int(args['character'])
+        if self.character != 0:
+            raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
+
+        # check instances
+        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label.replace(".","/")
+        Lfunction_from_db.__init__(self, url = self.url)
+
+        self.numcoeff = 30
+
+    @lazy_attribute
+    def _Ltype(self):
+        return  "hilbert modular form"
+
+    @lazy_attribute
+    def origin_label(self):
+        return ".".join(map(str, self.label))
+
+    @lazy_attribute
+    def bread(self):
+        return get_bread(2, [('Cusp Form', url_for('.l_function_cuspform_browse_page', degree='degree4'))])
+
+    @property
+    def friends(self):
+        """The 'related objects' to show on webpage."""
+        lfriends = Lfunction_from_db.friends.fget(self)
+        return lfriends
 
 class Lfunction_HMF(Lfunction):
     """Class representing a Hilbert modular form L-function
@@ -1273,17 +1322,6 @@ class Lfunction_HMF(Lfunction):
         self.character= int(args['character'])
         if self.character != 0:
             raise KeyError('L-function of Hilbert form of non-trivial character not implemented yet.')
-
-        # check instances
-        self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label.replace(".","/")
-        try:
-            print self.url
-            Lfunction_from_db.__init__(self, url = self.url)
-            self.numcoeff = 30
-            return
-        except Exception as e:
-            print e
-            pass
 
         # Load form (f) from database
         (f, F_hmf) = getHmfData(self.label)

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -45,8 +45,11 @@ from LfunctionDatabase import (
 def artin_url(label):
     return "ArtinRepresentation/" + label
 
-def hmf_url(label):
-    return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
+def hmf_url(label, character, number):
+    if (not character and not number) or (character == '0' and number == '0'):
+        return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
+    else
+        return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label + "/" + character + "/" + number
 
 def validate_required_args(errmsg, args, *keys):
     missing_keys = [key for key in keys if not key in args]

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1285,7 +1285,6 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     @lazy_attribute
     def origin_label(self):
-        print "origin_label",self.hmf_label
         return self.hmf_label
 
     @lazy_attribute

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1262,7 +1262,7 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **args):
         constructor_logger(self, args)
 
         validate_required_args ('Unable to construct Hilbert modular form ' +
@@ -1678,11 +1678,11 @@ class ArtinLfunctionDB(Lfunction_from_db):
 
     """
 
-    def __init__(self, **kwargs):
-        constructor_logger(self, kwargs)
+    def __init__(self, **args):
+        constructor_logger(self, args)
 
-        validate_required_args ('Unable to construct L-function.', kwargs, 'label')
-        self.label = kwargs['label']
+        validate_required_args ('Unable to construct L-function.', args, 'label')
+        self.label = args['label']
         self.origin_label = self.label
         self._Ltype = "artin"
         self.url = artin_url(self.label)

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1258,7 +1258,6 @@ class Lfunction_HMFDB(Lfunction_from_db):
 
         validate_required_args ('Unable to construct Hilbert modular form ' + 'L-function.', kwargs, 'label')
         self._Ltype = "hilbertmodularform"
-
         self.label = kwargs['label']
         self.origin = self.label
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -48,7 +48,7 @@ def artin_url(label):
 def hmf_url(label, character, number):
     if (not character and not number) or (character == '0' and number == '0'):
         return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label
-    else
+    else:
         return "ModularForm/GL2/TotallyReal/" + label.split("-")[0] + "/holomorphic/" + label + "/" + character + "/" + number
 
 def validate_required_args(errmsg, args, *keys):

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1277,10 +1277,12 @@ class Lfunction_HMF(Lfunction):
         # check instances
         self.url = "ModularForm/GL2/TotallyReal/" + self.label.split("-")[0] + "/holomorphic/" + self.label.replace(".","/")
         try:
+            print self.url
             Lfunction_from_db.__init__(self, url = self.url)
             self.numcoeff = 30
             return
-        except:
+        except Exception as e:
+            print e
             pass
 
         # Load form (f) from database

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1290,6 +1290,10 @@ class Lfunction_HMFDB(Lfunction_from_db):
     def knowltype(self):
         return "mf"
 
+    @lazy_attribute
+    def bread(self):
+        return get_bread(4, [('Cusp Form', url_for('.l_function_cuspform_browse_page', degree='degree4'))])
+
     @property
     def friends(self):
         """The 'related objects' to show on webpage."""

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -12,7 +12,8 @@ import LfunctionPlot
 
 from Lfunction import (Lfunction_Dirichlet, Lfunction_EC, #Lfunction_EC_Q, Lfunction_EMF,
                        Lfunction_CMF, Lfunction_CMF_orbit,
-                       Lfunction_HMF, Lfunction_Maass, Lfunction_SMF2_scalar_valued,
+                       Lfunction_HMF, Lfunction_HMFDB,
+                       Lfunction_Maass, Lfunction_SMF2_scalar_valued,
                        RiemannZeta, DedekindZeta, ArtinLfunction, SymmetricPowerLfunction,
                        HypergeometricMotiveLfunction, Lfunction_genus2_Q,
                        Lfunction_from_db)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -16,7 +16,7 @@ from Lfunction import (Lfunction_Dirichlet, Lfunction_EC, #Lfunction_EC_Q, Lfunc
                        Lfunction_Maass, Lfunction_SMF2_scalar_valued,
                        RiemannZeta, DedekindZeta, ArtinLfunction, ArtinLfunctionDB,
                        SymmetricPowerLfunction, HypergeometricMotiveLfunction,
-                       Lfunction_genus2_Q, Lfunction_from_db)
+                       Lfunction_genus2_Q, Lfunction_from_db, artin_url, hmf_url)
 from LfunctionComp import isogeny_class_table
 from Lfunctionutilities import (p2sage, styleTheSign, get_bread, parse_codename,
                                 getConductorIsogenyFromLabel)
@@ -357,11 +357,7 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
-    try:
-        return render_single_Lfunction(Lfunction_HMFDB, args, request)
-    except:
-        pass
-    return render_single_Lfunction(Lfunction_HMF, args, request)
+    return render_single_Lfunction(Lfunction_HMFDB if db.lfunc_instances.lucky({'url': hmf_url(label)}) else Lfunction_HMF, args, request)
 
 
 @l_function_page.route("/ModularForm/GL2/TotallyReal/<field>/holomorphic/<label>/<character>/")
@@ -412,11 +408,7 @@ def l_function_nf_page(label):
 # L-function of Artin representation    ########################################
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
-    try:
-        return render_single_Lfunction(ArtinLfunctionDB, {'label': label}, request)
-    except:
-        pass
-    return render_single_Lfunction(ArtinLfunction, {'label': label}, request)
+    render_single_Lfunction(ArtinLfunctionDB if db.lfunc_instances.lucky({'url': artin_url(label)}) else ArtinLfunction, {'label': label}, request)
 
 # L-function of hypergeometric motive   ########################################
 @l_function_page.route("/Motive/Hypergeometric/Q/<label>/<t>")

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -357,7 +357,9 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
-    return render_single_Lfunction(Lfunction_HMFDB if db.lfunc_instances.lucky({'url': hmf_url(label)}) else Lfunction_HMF, args, request)
+    in_database = db.lfunc_instances.lucky({'url': hmf_url(label)})
+    print label,hmf_url(label), in_database
+    return render_single_Lfunction(Lfunction_HMFDB if in_database else Lfunction_HMF, args, request)
 
 
 @l_function_page.route("/ModularForm/GL2/TotallyReal/<field>/holomorphic/<label>/<character>/")

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -356,6 +356,11 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
+    try:
+        render_single_Lfunction(Lfuncion_HMFDB, args, request)
+    except Exception as e:
+        print e
+        pass
     return render_single_Lfunction(Lfunction_HMF, args, request)
 
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -959,11 +959,11 @@ def generateLfunctionFromUrl(*args, **kwds):
             return Lfunction_CMF_orbit(level=args[4], weight=args[5], char_orbit_label=args[6], hecke_orbit=args[7])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'TotallyReal' and args[4] == 'holomorphic':  # Hilbert modular form
-        try:
-            return Lfunction_HMFDB(label=args[5], character=args[6], number=args[7])
-        except:
-            pass    
-        return Lfunction_HMF(label=args[5], character=args[6], number=args[7])
+        instance = db.lfunc_instances.lucky({'url': hmf_url(args[6], args[6], args[7])})
+        return Lfunction_HMFDB(label=args[5], character=args[6], number=args[7]) if instance else Lfunction_HMF(label=args[5], character=args[6], number=args[7])
+
+    elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'ImaginaryQuadratic':  # Bianchi modular form
+        return Lfunction_BMF(field=args[5], level=args[6], suffix=args[7])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'Q' and args[3] == 'Maass':
         maass_id = args[4]
@@ -980,11 +980,8 @@ def generateLfunctionFromUrl(*args, **kwds):
         return DedekindZeta(label=str(args[1]))
 
     elif args[0] == "ArtinRepresentation":
-        try:
-            return ArtinLfunctionDB(label=str(args[1]))
-        except:
-            pass
-        return ArtinLfunction(label=str(args[1]))
+        instance = db.lfunc_instances.lucky({'url': artin_url(args[1])})
+        return ArtinLfunctionDB(label=str(args[1])) if instance else ArtinLfunction(label=str(args[1]))
 
     elif args[0] == "SymmetricPower":
         return SymmetricPowerLfunction(power=args[1], underlying_type=args[2], field=args[3],

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -357,7 +357,7 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
-    instance = db.lfunc_instances.lucky({'url': hmf_url(label)})
+    instance = db.lfunc_instances.lucky({'url': hmf_url(label, character, number)})
     return render_single_Lfunction(Lfunction_HMFDB if instance else Lfunction_HMF, args, request)
 
 
@@ -410,8 +410,7 @@ def l_function_nf_page(label):
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
     instance = db.lfunc_instances.lucky({'url': artin_url(label)})
-    print label, artin_url(label), instance
-    render_single_Lfunction(ArtinLfunctionDB if instance else ArtinLfunction, {'label': label}, request)
+    return render_single_Lfunction(ArtinLfunctionDB if instance else ArtinLfunction, {'label': label}, request)
 
 # L-function of hypergeometric motive   ########################################
 @l_function_page.route("/Motive/Hypergeometric/Q/<label>/<t>")

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -14,9 +14,9 @@ from Lfunction import (Lfunction_Dirichlet, Lfunction_EC, #Lfunction_EC_Q, Lfunc
                        Lfunction_CMF, Lfunction_CMF_orbit,
                        Lfunction_HMF, Lfunction_HMFDB,
                        Lfunction_Maass, Lfunction_SMF2_scalar_valued,
-                       RiemannZeta, DedekindZeta, ArtinLfunction, SymmetricPowerLfunction,
-                       HypergeometricMotiveLfunction, Lfunction_genus2_Q,
-                       Lfunction_from_db)
+                       RiemannZeta, DedekindZeta, ArtinLfunction, ArtinLfunctionDB,
+                       SymmetricPowerLfunction, HypergeometricMotiveLfunction,
+                       Lfunction_genus2_Q, Lfunction_from_db)
 from LfunctionComp import isogeny_class_table
 from Lfunctionutilities import (p2sage, styleTheSign, get_bread, parse_codename,
                                 getConductorIsogenyFromLabel)
@@ -359,7 +359,7 @@ def l_function_hmf_page(field, label, character, number):
             'number': number}
     try:
         return render_single_Lfunction(Lfunction_HMFDB, args, request)
-    except Exception as e:
+    except:
         pass
     return render_single_Lfunction(Lfunction_HMF, args, request)
 
@@ -412,6 +412,10 @@ def l_function_nf_page(label):
 # L-function of Artin representation    ########################################
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
+    try:
+        return render_single_Lfunction(ArtinLfunctionDB, {'label': label}, request)
+    except:
+        pass
     return render_single_Lfunction(ArtinLfunction, {'label': label}, request)
 
 # L-function of hypergeometric motive   ########################################

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -360,7 +360,6 @@ def l_function_hmf_page(field, label, character, number):
     try:
         return render_single_Lfunction(Lfunction_HMFDB, args, request)
     except Exception as e:
-        print e
         pass
     return render_single_Lfunction(Lfunction_HMF, args, request)
 
@@ -949,6 +948,10 @@ def generateLfunctionFromUrl(*args, **kwds):
             return Lfunction_CMF_orbit(level=args[4], weight=args[5], char_orbit_label=args[6], hecke_orbit=args[7])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'TotallyReal' and args[4] == 'holomorphic':  # Hilbert modular form
+        try:
+            return Lfunction_HMFDB(label=args[5], character=args[6], number=args[7])
+        except:
+            pass    
         return Lfunction_HMF(label=args[5], character=args[6], number=args[7])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'Q' and args[3] == 'Maass':

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -357,7 +357,7 @@ def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
     try:
-        render_single_Lfunction(Lfuncion_HMFDB, args, request)
+        render_single_Lfunction(Lfunction_HMFDB, args, request)
     except Exception as e:
         print e
         pass

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -974,7 +974,7 @@ def generateLfunctionFromUrl(*args, **kwds):
 
     elif args[0] == "ArtinRepresentation":
         try:
-            return ArtinLfunctionDB(ArtinLfunctionDB,label=str(args[1]))
+            return ArtinLfunctionDB(label=str(args[1]))
         except:
             pass
         return ArtinLfunction(label=str(args[1]))

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -358,7 +358,7 @@ def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
     try:
-        render_single_Lfunction(Lfunction_HMFDB, args, request)
+        return render_single_Lfunction(Lfunction_HMFDB, args, request)
     except Exception as e:
         print e
         pass

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -973,6 +973,10 @@ def generateLfunctionFromUrl(*args, **kwds):
         return DedekindZeta(label=str(args[1]))
 
     elif args[0] == "ArtinRepresentation":
+        try:
+            return render_single_Lfunction(ArtinLfunctionDB,labe=str(args[1]))
+        except:
+            pass
         return ArtinLfunction(label=str(args[1]))
 
     elif args[0] == "SymmetricPower":

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -974,7 +974,7 @@ def generateLfunctionFromUrl(*args, **kwds):
 
     elif args[0] == "ArtinRepresentation":
         try:
-            return render_single_Lfunction(ArtinLfunctionDB,labe=str(args[1]))
+            return render_single_Lfunction(ArtinLfunctionDB,label=str(args[1]))
         except:
             pass
         return ArtinLfunction(label=str(args[1]))

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -974,7 +974,7 @@ def generateLfunctionFromUrl(*args, **kwds):
 
     elif args[0] == "ArtinRepresentation":
         try:
-            return render_single_Lfunction(ArtinLfunctionDB,label=str(args[1]))
+            return ArtinLfunctionDB(ArtinLfunctionDB,label=str(args[1]))
         except:
             pass
         return ArtinLfunction(label=str(args[1]))

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -353,7 +353,7 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 
 
 # L-function of Bianchi modular form ###########################################
-@l_function_page.route("/ModularForm/GL2/ImaginaryQuadratic/<field>/<level>/<suffix>")
+@l_function_page.route("/ModularForm/GL2/ImaginaryQuadratic/<field>/<level>/<suffix>/")
 def l_function_bmf_page(field,level,suffix):
     args = {'field': field, 'level': level, 'suffix': suffix}
     return render_single_Lfunction(Lfunction_BMF, args, request)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -12,7 +12,7 @@ import LfunctionPlot
 
 from Lfunction import (Lfunction_Dirichlet, Lfunction_EC, #Lfunction_EC_Q, Lfunction_EMF,
                        Lfunction_CMF, Lfunction_CMF_orbit,
-                       Lfunction_HMF, Lfunction_HMFDB,
+                       Lfunction_HMF, Lfunction_HMFDB, Lfunction_BMF,
                        Lfunction_Maass, Lfunction_SMF2_scalar_valued,
                        RiemannZeta, DedekindZeta, ArtinLfunction, ArtinLfunctionDB,
                        SymmetricPowerLfunction, HypergeometricMotiveLfunction,

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -357,9 +357,8 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
 def l_function_hmf_page(field, label, character, number):
     args = {'field': field, 'label': label, 'character': character,
             'number': number}
-    in_database = db.lfunc_instances.lucky({'url': hmf_url(label)})
-    print label,hmf_url(label), in_database
-    return render_single_Lfunction(Lfunction_HMFDB if in_database else Lfunction_HMF, args, request)
+    instance = db.lfunc_instances.lucky({'url': hmf_url(label)})
+    return render_single_Lfunction(Lfunction_HMFDB if instance else Lfunction_HMF, args, request)
 
 
 @l_function_page.route("/ModularForm/GL2/TotallyReal/<field>/holomorphic/<label>/<character>/")
@@ -410,7 +409,9 @@ def l_function_nf_page(label):
 # L-function of Artin representation    ########################################
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
-    render_single_Lfunction(ArtinLfunctionDB if db.lfunc_instances.lucky({'url': artin_url(label)}) else ArtinLfunction, {'label': label}, request)
+    instance = db.lfunc_instances.lucky({'url': artin_url(label)})
+    print label, artin_url(label), instance
+    render_single_Lfunction(ArtinLfunctionDB if instance else ArtinLfunction, {'label': label}, request)
 
 # L-function of hypergeometric motive   ########################################
 @l_function_page.route("/Motive/Hypergeometric/Q/<label>/<t>")

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -352,11 +352,17 @@ def l_function_cmf_orbit_redirecit_aa(level, weight):
                                   char_orbit_label='a', hecke_orbit="a", ), code=301)
 
 
+# L-function of Bianchi modular form ###########################################
+@l_function_page.route("/ModularForm/GL2/ImaginaryQuadratic/<field>/<level>/<suffix>")
+def l_function_bmf_page(field,level,suffix):
+    args = {'field': field, 'level': level, 'suffix': suffix}
+    return render_single_Lfunction(Lfunction_BMF, args, request)
+
+
 # L-function of Hilbert modular form ###########################################
 @l_function_page.route("/ModularForm/GL2/TotallyReal/<field>/holomorphic/<label>/<character>/<number>/")
 def l_function_hmf_page(field, label, character, number):
-    args = {'field': field, 'label': label, 'character': character,
-            'number': number}
+    args = {'field': field, 'label': label, 'character': character, 'number': number}
     instance = db.lfunc_instances.lucky({'url': hmf_url(label, character, number)})
     return render_single_Lfunction(Lfunction_HMFDB if instance else Lfunction_HMF, args, request)
 
@@ -603,6 +609,13 @@ def set_bread_and_friends(info, L, request):
             info['bread'] = get_bread(L.degree,
                                       [(L.maass_id.partition('/')[2], request.path)])
 
+    elif L.Ltype() == 'bianchimodularform':
+        friendlink = '/'.join(friendlink.split('/')[:-1])
+        info['friends'] = [('Bianchi modular form ' + L.label, friendlink.rpartition('/')[0])]
+        if L.degree == 4:
+            info['bread'] = get_bread(4, [(L.label, request.path)])
+        else:
+            info['bread'] = [('L-functions', url_for('.l_function_top_page'))]
 
     elif L.Ltype() == 'hilbertmodularform':
         friendlink = '/'.join(friendlink.split('/')[:-1])


### PR DESCRIPTION
This PR partially addresses #2754 and #2873 by having the L-function code check the instances database when displaying HMF and Artin L-functions.  If the L-function is stored in the database it will be used, otherwise it will revert to computing them on the fly as it does now.  To keep the code changes minimal and isolated I created a new L-function class Lfunction_HMFDB that loads the L-function from the database and will fail if it is not present -- this is called from the routing function l_function_hmf_page inside a try/except and will catch the error and ignore it (this is a small hack that will go away once all HMF functions are stored in the database.  The case of Artin L-functions is handled similarly.

To test, compare:

http://127.0.0.1:37777/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-500.1-a/0/0/
http://beta.lmfdb.org/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-500.1-a/0/0/

and also try clicking from the L-function page to the HMF and back, test the bread, click through to different origins and then back via the origin page L-function links etc. (other than the URL the L-function page should look the same now matter which origin you came from).  In particular, the L-function page should list all the related objects now matter how the page was reached.

Note that this change does not only impact HMFs whose L-functions arise as genus 2 L-functions that are in the database, it also catches L-functions of elliptic curves over number fields, e.g. compare

http://127.0.0.1:37777/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/
http://beta.lmfdb.org/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/

For an Artin L-function example, compare

http://127.0.0.1:37777/L/ArtinRepresentation/2.23.3t2.1c1/
http://beta.lmfdb.org/L/ArtinRepresentation/2.23.3t2.1c1/

(again clicking through to the Artin rep and back should work).  Note that this is currently the only Artin L-function for which I have added an instance record, but I will be adding more later today (this doesn't involve any code changes so you can test the PR now).

Examples of L-function pages that should not change (i.e. they should still be rendered on the fly) because we have not precomputed them via another origin:

http://127.0.0.1:37777/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-101.2-a/0/0/
http://beta.lmfdb.org/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-101.2-a/0/0/

http://127.0.0.1:37777/L/ArtinRepresentation/2.2e8_3e2.8t5.2c1
http://beta.lmfdb.org/L/ArtinRepresentation/3.229.4t5.1c1/

