### PR TITLE
Add CMF friends to Artin reps

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -48,6 +48,15 @@ def parse_artin_label(label):
     else:
         raise ValueError("Error parsing input %s.  It is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1"% label)
 
+def add_lfunction_friends(friends, label):
+    rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
+    if rec:
+        for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
+            if r['type'] == 'CMF':
+                s = r['url'].split('/')
+                cmf_label = '.'.join(s[4:])
+                friends.append(("Modular form " + cmf_label, r['url']))
+    return friends
 
 @artin_representations_page.route("/")
 def index():
@@ -158,6 +167,7 @@ def render_artin_representation_webpage(label):
         else:
             detrep = the_rep.central_character_as_artin_rep()
             friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
+    add_lfunction_friends(friends,label)
 
     # once the L-functions are in the database, the link can always be shown
     #if the_rep.dimension() <= 6:

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -55,7 +55,9 @@ def add_lfunction_friends(friends, label):
             if r['type'] == 'CMF':
                 s = r['url'].split('/')
                 cmf_label = '.'.join(s[4:])
+                print "Adding CMF friend " + cmf_label + " with URL " + r['url']
                 friends.append(("Modular form " + cmf_label, r['url']))
+    print friends
     return friends
 
 @artin_representations_page.route("/")

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -52,8 +52,9 @@ def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
     if rec:
         for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
-            if r['type'] == 'CMF':
-                s = r['url'].split('/')
+            s = r['url'].split('/')
+            # only friend embedded CMFs
+            if r['type'] == 'CMF' and len(s) == 10:
                 cmf_label = '.'.join(s[4:])
                 url = r['url'] if r['url'][0] == '/' else '/' + r['url']
                 friends.append(("Modular form " + cmf_label, url))

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -55,9 +55,8 @@ def add_lfunction_friends(friends, label):
             if r['type'] == 'CMF':
                 s = r['url'].split('/')
                 cmf_label = '.'.join(s[4:])
-                print "Adding CMF friend " + cmf_label + " with URL " + r['url']
-                friends.append(("Modular form " + cmf_label, r['url']))
-    print friends
+                url = r['url'] if r['url'][0] == '/' else '/' + r['url']
+                friends.append(("Modular form " + cmf_label, url))
     return friends
 
 @artin_representations_page.route("/")


### PR DESCRIPTION
This PR addresses issue #2754 by adding related object links on Artin rep home pages to corresponding weight one modular forms.  Each conjugate Artiin rep links to the embedded weight-one form with the same L-function (note that the orderings of conjugate Artin rep labels and embedded newform labels need not agree).

single conjugate example:

http://127.0.0.1:37777/ArtinRepresentation/2.23.3t2.1c1
http://beta.lmfdb.org/ArtinRepresentation/2.23.3t2.1c1

two conjugate example:

http://127.0.0.1:37777/ArtinRepresentation/2.2e2_13.6t5.1c1
http://beta.lmfdb.org/ArtinRepresentation/2.2e2_13.6t5.1c1

three conjugate example:

http://beta.lmfdb.org/ArtinRepresentation/2.71.7t2.1c1
http://127.0.0.1:37777/ArtinRepresentation/2.71.7t2.1c1

Currently embedded newforms show related object links for all the conjugate Artin reps, but this will change shortly (this requires a data update and a small PR from @edgarcosta).

Note that in this PR the artin rep L-function link goes to a dynamically computed L-function, but it should still match the CMF L-function up to the last few digits of precision (you can compare zeros fairly reliably). PR #2929 addresses changes the Artin rep L-functions to load from the database when present (in which case it will be exactly the same as the CMF L-function).
