### PR TITLE
Server sider cursors

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -5019,12 +5019,12 @@ class PostgresDatabase(PostgresBase):
     def cursor(self, buffered=False):
         """
         Returns a new cursor.
-        If buffered, then it creates a server side cursor that should be manually
+        If buffered, then it creates a server side cursor that must be manually
         closed after done using it.
         """
         if buffered:
             self.server_side_counter += 1
-            return self.conn.cursor(str(self.server_side_counter))
+            return self.conn.cursor(str(self.server_side_counter), withhold=True)
         else:
             return self.conn.cursor()
 

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1550,14 +1550,17 @@ class PostgresTable(PostgresBase):
             if info is not None:
                 # caller is requesting count data
                 info['number'] = self.count(query)
-            return self._search_iterator(cur, search_cols, extra_cols, projection)
+            return self._search_iterator(cur, search_cols,
+                                         extra_cols, projection)
         if nres is None:
             exact_count = (cur.rowcount < prelimit)
             nres = offset + cur.rowcount
         else:
             exact_count = True
         res = cur.fetchmany(limit)
-        res = list(self._search_iterator(res, search_cols, extra_cols, projection))
+        res = list(
+                self._search_iterator(res, search_cols, extra_cols, projection)
+                )
         if info is not None:
             if offset >= nres:
                 offset -= (1 + (offset - nres) / limit) * limit

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1541,7 +1541,7 @@ class PostgresTable(PostgresBase):
                 qstr, values = self._build_query(query, limit, offset, sort)
         tbl = self._get_table_clause(extra_cols)
         selecter = SQL("SELECT {0} FROM {1}{2}").format(vars, tbl, qstr)
-        cur = self._execute(selecter, values, silent=silent, buffered=True,
+        cur = self._execute(selecter, values, silent=silent, buffered=limit is None,
                             slow_note=(self.search_table, "analyze", query, repr(projection), limit, offset))
         if limit is None:
             if info is not None:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1554,7 +1554,7 @@ class PostgresTable(PostgresBase):
         tbl = self._get_table_clause(extra_cols)
         selecter = SQL("SELECT {0} FROM {1}{2}").format(vars, tbl, qstr)
         cur = self._execute(selecter, values, silent=silent,
-                            buffered=limit is None,
+                            buffered=(limit is None),
                             slow_note=(
                                 self.search_table, "analyze", query,
                                 repr(projection), limit, offset))

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -351,7 +351,7 @@ class PostgresBase(object):
             raise TypeError("You must use the psycopg2.sql module to execute queries")
 
         try:
-            cur = self.conn.cursor()
+            cur = self.cursor()
 
             t = time.time()
             if values_list:
@@ -466,7 +466,7 @@ class PostgresBase(object):
         with open(filename, "w") as F:
             try:
                 F.write(header)
-                cur = self.conn.cursor()
+                cur = self.cursor()
                 cur.copy_expert(copyto, F)
             except Exception:
                 self.conn.rollback()
@@ -577,7 +577,7 @@ class PostgresBase(object):
                     alter_table = SQL("ALTER TABLE {0} ALTER COLUMN {1} SET DEFAULT nextval(%s)").format(Identifier(table), Identifier('id'))
                     self._execute(alter_table, [seq_name])
 
-                cur = self.conn.cursor()
+                cur = self.cursor()
                 cur.copy_from(F, table, columns=columns, **kwds)
 
                 if addid:
@@ -729,7 +729,7 @@ class PostgresBase(object):
     def _copy_from_meta(self, meta_name, filename):
         meta_cols, _, _ = _meta_cols_types_jsonb_idx(meta_name)
         try:
-            cur = self.conn.cursor()
+            cur = self.cursor()
             cur.copy_from(filename, meta_name, columns=meta_cols)
         except Exception:
             self.conn.rollback()
@@ -780,8 +780,8 @@ class PostgresBase(object):
             # insert new columns
             with open(filename, "r") as F:
                 try:
-                    cur = self.conn.cursor()
-                    cur.copy_from(F, meta_name, columns = meta_cols)
+                    cur = self.cursor()
+                    cur.copy_from(F, meta_name, columns=meta_cols)
                 except Exception:
                     self.conn.rollback()
                     raise
@@ -794,7 +794,6 @@ class PostgresBase(object):
                 "SELECT {} FROM {} WHERE {} = %s"
                 ).format(cols_sql, meta_name_sql, table_name_sql),
                 [search_table])
-
 
             cols = meta_cols + ('version',)
             cols_sql = SQL(", ").join(map(Identifier, cols))
@@ -1837,7 +1836,7 @@ class PostgresTable(PostgresBase):
             analyzer = SQL("EXPLAIN {0}").format(selecter)
         else:
             analyzer = SQL("EXPLAIN ANALYZE {0}").format(selecter)
-        cur = self.conn.cursor()
+        cur = self.cursor()
         print cur.mogrify(selecter, values)
         cur = self._execute(analyzer, values, silent=True)
         for line in cur:
@@ -3093,7 +3092,7 @@ class PostgresTable(PostgresBase):
                 if addid:
                     cols = ["id"] + cols
                 cols_wquotes = ['"' + col + '"' for col in cols]
-                cur = self.conn.cursor()
+                cur = self.cursor()
                 with open(filename, "w") as F:
                     try:
                         if write_header:
@@ -3254,7 +3253,7 @@ class PostgresTable(PostgresBase):
                 try:
                     try:
                         transfer_file = tempfile.NamedTemporaryFile('w', delete=False)
-                        cur = self.conn.cursor()
+                        cur = self.cursor()
                         with transfer_file:
                             cur.copy_to(transfer_file, self.search_table, columns=['id'] + columns)
                         with open(transfer_file.name) as F:
@@ -4833,7 +4832,7 @@ ORDER BY v.ord LIMIT %s""").format(Identifier(col))
             creator = SQL('CREATE TABLE {0} (_id text COLLATE "C", data jsonb)').format(Identifier(name))
             self._execute(creator)
             self._db.grant_select(name)
-            cur = self.conn.cursor()
+            cur = self.cursor()
             with open(filename) as F:
                 try:
                     cur.copy_from(F, self.search_table + "_oldstats")

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1381,6 +1381,7 @@ class PostgresTable(PostgresBase):
                     yield {k:v for k,v in zip(search_cols + extra_cols, rec) if v is not None}
         finally:
             if isinstance(cur, pg_cursor):
+                print "closing cursor"
                 cur.close()
 
     ##################################################################
@@ -2870,12 +2871,16 @@ class PostgresTable(PostgresBase):
             if countsfile is not None:
                 self.stats._copy_extra_counts_to_tmp()
 
-            if self._id_ordered and resort:
-                extra_table = None if self.extra_table is None else self.extra_table + suffix
-                self.resort(self.search_table + suffix, extra_table)
-            else:
-                # We still need to build primary keys
-                self.restore_pkeys(suffix=suffix)
+            ## a workaround while resort is disabled
+            self.restore_pkeys(suffix=suffix)
+            #if self._id_ordered and resort:
+            #    extra_table = None if self.extra_table is None else self.extra_table + suffix
+            #    self.resort(self.search_table + suffix, extra_table)
+            #else:
+            #    # We still need to build primary keys
+            #    self.restore_pkeys(suffix=suffix)
+            # end of workaround
+
             # update the indexes
             # these are needed before reindexing
             if indexesfile is not None:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -391,9 +391,14 @@ class PostgresBase(object):
                             query = query + str(values)
                     else:
                         query = query.as_string(self.conn)
-                    self.logger.info(query + ' ran in \033[91m {0!s}s \033[0m'.format(t))
+                    self.logger.info(query +
+                                     ' ran in \033[91m {0!s}s \033[0m'.format(t))
                     if slow_note is not None:
-                        self.logger.info("Replicate with db.{0}.{1}({2})".format(slow_note[0], slow_note[1], ", ".join(str(c) for c in slow_note[2:])))
+                        self.logger.info(
+                                "Replicate with db.%s.%s(%s)",
+                                slow_note[0], slow_note[1],
+                                ", ".join(str(c) for c in slow_note[2:])
+                                )
         except (DatabaseError, InterfaceError):
             if self.conn.closed != 0:
                 # If reissued, we need to raise since we're recursing.
@@ -401,8 +406,17 @@ class PostgresBase(object):
                     raise
                 # Attempt to reset the connection
                 self._db.reset_connection()
-                if commit or (commit is None and self._db._nocommit_stack == 0):
-                    return self._execute(query, values=values, silent=silent, values_list=values_list, template=template, slow_note=slow_note, reissued=True)
+                if commit or\
+                        (commit is None and self._db._nocommit_stack == 0):
+                    return self._execute(query,
+                                         values=values,
+                                         silent=silent,
+                                         values_list=values_list,
+                                         template=template,
+                                         commit=commit,
+                                         slow_note=slow_note,
+                                         buffered=buffered,
+                                         reissued=True)
                 else:
                     raise
             else:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -5005,7 +5005,7 @@ class PostgresDatabase(PostgresBase):
         Returns a new server side cursor, with automatic name generation
         """
         self.server_side_counter += 1
-        return self.conn.cursor(int(self.server_side_counter))
+        return self.conn.cursor(str(self.server_side_counter))
 
 
     def login(self):

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1541,8 +1541,11 @@ class PostgresTable(PostgresBase):
                 qstr, values = self._build_query(query, limit, offset, sort)
         tbl = self._get_table_clause(extra_cols)
         selecter = SQL("SELECT {0} FROM {1}{2}").format(vars, tbl, qstr)
-        cur = self._execute(selecter, values, silent=silent, buffered=limit is None,
-                            slow_note=(self.search_table, "analyze", query, repr(projection), limit, offset))
+        cur = self._execute(selecter, values, silent=silent,
+                            buffered=limit is None,
+                            slow_note=(
+                                self.search_table, "analyze", query,
+                                repr(projection), limit, offset))
         if limit is None:
             if info is not None:
                 # caller is requesting count data

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1535,7 +1535,7 @@ class PostgresTable(PostgresBase):
                 qstr, values = self._build_query(query, limit, offset, sort)
         tbl = self._get_table_clause(extra_cols)
         selecter = SQL("SELECT {0} FROM {1}{2}").format(vars, tbl, qstr)
-        cur = self._execute(selecter, values, silent=silent, buffered=True,
+        cur = self._execute(selecter, values, silent=silent, commit = False, buffered=True,
                             slow_note=(self.search_table, "analyze", query, repr(projection), limit, offset))
         if limit is None:
             if info is not None:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -391,8 +391,7 @@ class PostgresBase(object):
                             query = query + str(values)
                     else:
                         query = query.as_string(self.conn)
-                    self.logger.info(query +
-                                     ' ran in \033[91m {0!s}s \033[0m'.format(t))
+                    self.logger.info(query + ' ran in \033[91m {0!s}s \033[0m'.format(t))
                     if slow_note is not None:
                         self.logger.info(
                                 "Replicate with db.%s.%s(%s)",
@@ -406,8 +405,7 @@ class PostgresBase(object):
                     raise
                 # Attempt to reset the connection
                 self._db.reset_connection()
-                if commit or\
-                        (commit is None and self._db._nocommit_stack == 0):
+                if commit or (commit is None and self._db._nocommit_stack == 0):
                     return self._execute(query,
                                          values=values,
                                          silent=silent,


### PR DESCRIPTION
We now provide buffered searches, when the user doesn't specify a limit constraint.
This also speeds up significantly rewrite, and hopefully fully addresses #2881, rewriting `nf_fields` should take about a day based on some measurements on the "writing" to disk part:
We averaged   0.0006s on the first 1.6 million records, 0.003s for several degree 16, and 0.008s for the last couple thousand records.


For example, now 
```
for rec in db.nf_fields.search():
    print  rec
    break
```
is instantaneous, while in the past it first fetched all the records into memory.

Compare against with the current code (this will take about 1min):
```
for rec in db.gps_small.search():
    print  rec
    break
```