### PR TITLE
Fixing the usage of embedded_related_objects

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -18,7 +18,7 @@ class CmfTest(LmfdbTest):
         assert '?search_type=Dimensions&dim=1' in data
         assert '?search_type=SpaceDimensions&char_order=1' in data
         assert "./stats" in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions",follow_redirects=True).data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorph/ic/?search_type=SpaceDimensions",follow_redirects=True).data
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/23/12/">229</a>' in data
         data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions&char_order=1", follow_redirects=True).data
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/18/4/a/">1</a>' in data
@@ -340,12 +340,13 @@ class CmfTest(LmfdbTest):
                     assert 'Root' in page.data
 
     def test_embedded_invariants(self):
-        for url in ['/ModularForm/GL2/Q/holomorphic/13/2/e/a/4/1/', '/ModularForm/GL2/Q/holomorphic/13/2/e/a/10/1/']:
+        for url in ['/ModularForm/GL2/Q/holomorphic/13/2/e/a/4/1/',
+                    '/ModularForm/GL2/Q/holomorphic/13/2/e/a/10/1/']:
 
             page = self.tc.get(url)
             # root
             assert 'Root' in page.data
-            assert '0.500000'  in page.data
+            assert '0.500000' in page.data
             assert '0.866025' in page.data
             # p = 13
             for n in ['2.50000', '2.59808', '0.693375', '0.720577']:
@@ -358,7 +359,6 @@ class CmfTest(LmfdbTest):
             assert 'Newspace 13.2.e' in page.data
             assert 'Newform 13.2.e.a' in page.data
             assert 'Dual Form 13.2.e.a.' in page.data
-            assert 'Isogeny class 169.a' in page.data
             assert 'L-function 13.2.e.a.' in page.data
 
             assert '0.103805522628' in page.data

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -18,7 +18,7 @@ class CmfTest(LmfdbTest):
         assert '?search_type=Dimensions&dim=1' in data
         assert '?search_type=SpaceDimensions&char_order=1' in data
         assert "./stats" in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorph/ic/?search_type=SpaceDimensions",follow_redirects=True).data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions",follow_redirects=True).data
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/23/12/">229</a>' in data
         data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions&char_order=1", follow_redirects=True).data
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/18/4/a/">1</a>' in data

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -280,11 +280,11 @@ class WebNewform(object):
                 d_url = nf_url + '/' + self.dual_label.replace('.','/') + '/'
                 res.append(('Dual Form ' + dlabel, d_url))
 
-            m = self.embedding_from_embedding_label(self.embedding_label)
-            # FIXME: try statement to be removed once data has been pushed to prod
+            m = int(self.embedding_from_embedding_label(self.embedding_label))
             try:
                 related_objects = self.embedded_related_objects[m]
             except TypeError:
+
                 related_objects = self.related_objects
         else:
             related_objects = self.related_objects

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -280,14 +280,18 @@ class WebNewform(object):
                 d_url = nf_url + '/' + self.dual_label.replace('.','/') + '/'
                 res.append(('Dual Form ' + dlabel, d_url))
 
-            m = self.embedding_from_embedding_label(self.embedding_label)
-            try:
-                if self.embedded_related_objects:
-                    related_objects = self.embedded_related_objects[int(m) - 1]
-                else:
-                    related_objects = []
-            except TypeError:
+            if self.dim == 1:
+                # use the Galois orbits friends for the unique embedding
                 related_objects = self.related_objects
+            else:
+                m = self.embedding_from_embedding_label(self.embedding_label)
+                try:
+                    if self.embedded_related_objects:
+                        related_objects = self.embedded_related_objects[int(m) - 1]
+                    else:
+                        related_objects = []
+                except TypeError:
+                    related_objects = self.related_objects
         else:
             related_objects = self.related_objects
         if self.sato_tate_group: # FIXME: if statement to be removed once ST are removed

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -280,9 +280,9 @@ class WebNewform(object):
                 d_url = nf_url + '/' + self.dual_label.replace('.','/') + '/'
                 res.append(('Dual Form ' + dlabel, d_url))
 
-            m = int(self.embedding_from_embedding_label(self.embedding_label)) - 1
+            m = self.embedding_from_embedding_label(self.embedding_label)
             try:
-                related_objects = self.embedded_related_objects[m]
+                related_objects = self.embedded_related_objects[int(m) - 1]
             except TypeError:
 
                 related_objects = self.related_objects

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -280,7 +280,7 @@ class WebNewform(object):
                 d_url = nf_url + '/' + self.dual_label.replace('.','/') + '/'
                 res.append(('Dual Form ' + dlabel, d_url))
 
-            m = int(self.embedding_from_embedding_label(self.embedding_label))
+            m = int(self.embedding_from_embedding_label(self.embedding_label)) - 1
             try:
                 related_objects = self.embedded_related_objects[m]
             except TypeError:

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -282,9 +282,11 @@ class WebNewform(object):
 
             m = self.embedding_from_embedding_label(self.embedding_label)
             try:
-                related_objects = self.embedded_related_objects[int(m) - 1]
+                if self.embedded_related_objects:
+                    related_objects = self.embedded_related_objects[int(m) - 1]
+                else:
+                    related_objects = []
             except TypeError:
-
                 related_objects = self.related_objects
         else:
             related_objects = self.related_objects


### PR DESCRIPTION
 A good test case is
citing Drew:

> ```
> sage: db.mf_newforms.lookup("71.1.b.a")["embedded_related_objects"]
> [[u'ArtinRepresentation/2.71.7t2.1c3'],
>   [u'ArtinRepresentation/2.71.7t2.1c1'],
>   [u'ArtinRepresentation/2.71.7t2.1c2']]
> ```
> 
> So on the first embbedded newform home page
> 
>     http://localhost:37777/ModularForm/GL2/Q/holomorphic/71/1/b/a/70/1/
> 
> out of the three Artin representations only 
> ArtinRepresentation/2.71.7t2.1c3
> should appear.

and on http://localhost:37777/ModularForm/GL2/Q/holomorphic/71/1/b/a/ all three should appear