### PR TITLE
Genus 2 curve search by geometric endomorphism algebra

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -44,6 +44,10 @@ real_geom_end_alg_to_ST0_dict = {
         'R':'USp(4)'
         }
 
+# End_QQbar tensored with QQ
+geom_end_alg_list = ['M_2(CM)', 'M_2(Q)', 'QM', 'CM x CM', 'CM', 'CM x Q', 'Q x Q', 'RM', 'Q']
+geom_end_alg_dict = { x:x for x in geom_end_alg_list }
+
 aut_grp_list = ['[2,1]', '[4,1]', '[4,2]', '[6,2]', '[8,3]', '[12,4]']
 aut_grp_dict = {
         '[2,1]':'C_2',
@@ -101,6 +105,8 @@ def index_Q():
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
+    info["geom_end_alg_list"] = geom_end_alg_list
+    info["geom_end_alg_dict"] = geom_end_alg_dict
     title = 'Genus 2 Curves over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '))
     return render_template("g2c_browse.html", info=info, credit=credit_string, title=title, learnmore=learnmore_list(), bread=bread)

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -277,6 +277,8 @@ def genus2_curve_search(info, query):
     info["aut_grp_dict"] = aut_grp_dict
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
+    info["geom_end_alg_list"] = geom_end_alg_list
+    info["geom_end_alg_to_ST0_dict"] = geom_end_alg_dict
     parse_ints(info,query,'abs_disc','absolute discriminant')
     parse_bool(info,query,'is_gl2_type','is of GL2-type')
     parse_bool(info,query,'has_square_sha','has square Sha')
@@ -299,7 +301,7 @@ def genus2_curve_search(info, query):
         query['g2_inv'] = "['%s','%s','%s']"%(info['g20'], info['g21'], info['g22'])
     if 'class' in info:
         query['class'] = info['class']
-    for fld in ('st_group', 'real_geom_end_alg', 'aut_grp_id', 'geom_aut_grp_id'):
+    for fld in ('st_group', 'real_geom_end_alg', 'aut_grp_id', 'geom_aut_grp_id', 'geom_end_alg'):
         if info.get(fld): query[fld] = info[fld]
     info["curve_url"] = lambda label: url_for_curve_label(label)
     info["class_url"] = lambda label: url_for_isogeny_class_label(label)

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -45,7 +45,7 @@ real_geom_end_alg_to_ST0_dict = {
         }
 
 # End_QQbar tensored with QQ
-geom_end_alg_list = ['M_2(CM)', 'M_2(Q)', 'QM', 'CM x CM', 'CM', 'CM x Q', 'Q x Q', 'RM', 'Q']
+geom_end_alg_list = [ 'Q', 'RM', 'CM', 'QM', 'Q x Q', 'CM x Q', 'CM x CM', 'M_2(Q)', 'M_2(CM)']
 geom_end_alg_dict = { x:x for x in geom_end_alg_list }
 
 aut_grp_list = ['[2,1]', '[4,1]', '[4,2]', '[6,2]', '[8,3]', '[12,4]']

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -278,7 +278,7 @@ def genus2_curve_search(info, query):
     info["geom_aut_grp_list"] = geom_aut_grp_list
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
     info["geom_end_alg_list"] = geom_end_alg_list
-    info["geom_end_alg_to_ST0_dict"] = geom_end_alg_dict
+    info["geom_end_alg_dict"] = geom_end_alg_dict
     parse_ints(info,query,'abs_disc','absolute discriminant')
     parse_bool(info,query,'is_gl2_type','is of GL2-type')
     parse_bool(info,query,'has_square_sha','has square Sha')

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -136,6 +136,13 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td>Maximum number of curves to display</td>
 <td><input type='text' name='count' value=50 size=10></td>
 <td><span class="formexample"> &nbsp;</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-endomorphism algebra') }}</td>
+<td><select name='geom_end_alg' width="122" style="width: 122px">
+        <option ></option>
+    {% for G in info.geom_end_alg_list %}
+        <option value='{{G}}'>{{info.geom_end_alg_dict[G]}}</option>
+    {% endfor %}
+</select></td>
 </tr>
 <tr>
 <td><button type='submit' value='Search'>Search</button></td>

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -103,19 +103,20 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td>{{ KNOWL('g2c.torsion', title='torsion structure')}}</td>
 <td><input type='text' name='torsion' placeholder='[2,2,2]' size=10></td>
 <td><span class="formexample"> e.g. [2,2,2] </span></td>
-<td>{{ KNOWL('g2c.locally_solvable', title='locally solvable') }}</td>
-<td><select name='locally_solvable' width="122" style="width: 122px">
-                   <option ></option>
-                   <option value='True'>True</option>
-                   <option value='False'>False</option>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-endomorphism algebra') }}</td>
+<td><select name='geom_end_alg' width="122" style="width: 122px">
+        <option ></option>
+    {% for G in info.geom_end_alg_list %}
+        <option value='{{G}}'>{{info.geom_end_alg_dict[G]}}</option>
+    {% endfor %}
 </select></td>
 </tr>
 <tr>
 <td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>
 <td><input type='text' name='two_selmer_rank' placeholder='1' size=10></td>
 <td><span class="formexample"> e.g. 1 </span></td>
-<td>{{ KNOWL('g2c.has_square_sha', title='order of &#1064; is square*') }}</td>
-<td><select name='has_square_sha' width="122" style="width: 122px">
+<td>{{ KNOWL('g2c.locally_solvable', title='locally solvable') }}</td>
+<td><select name='locally_solvable' width="122" style="width: 122px">
                    <option ></option>
                    <option value='True'>True</option>
                    <option value='False'>False</option>
@@ -125,8 +126,8 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td>{{ KNOWL('g2c.analytic_rank', title='analytic rank*')}}</td>
 <td><input type='text' name='analytic_rank' placeholder='1' size=10></td>
 <td><span class="formexample"> e.g. 1 </span></td>
-<td>{{ KNOWL('ag.geom_simple', title='geometrically simple') }}</td>
-<td><select name='is_simple_geom' width="122" style="width: 122px">
+<td>{{ KNOWL('g2c.has_square_sha', title='order of &#1064; is square*') }}</td>
+<td><select name='has_square_sha' width="122" style="width: 122px">
                    <option ></option>
                    <option value='True'>True</option>
                    <option value='False'>False</option>
@@ -136,12 +137,11 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 <td>Maximum number of curves to display</td>
 <td><input type='text' name='count' value=50 size=10></td>
 <td><span class="formexample"> &nbsp;</td>
-<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-endomorphism algebra') }}</td>
-<td><select name='geom_end_alg' width="122" style="width: 122px">
-        <option ></option>
-    {% for G in info.geom_end_alg_list %}
-        <option value='{{G}}'>{{info.geom_end_alg_dict[G]}}</option>
-    {% endfor %}
+<td>{{ KNOWL('ag.geom_simple', title='geometrically simple') }}</td>
+<td><select name='is_simple_geom' width="122" style="width: 122px">
+                   <option ></option>
+                   <option value='True'>True</option>
+                   <option value='False'>False</option>
 </select></td>
 </tr>
 <tr>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -74,7 +74,7 @@
 <td>{{ KNOWL('g2c.geom_end_alg', title='\(\mathrm{End}(\mathrm{Jac}(X)_{\overline{\Q}})\otimes\Q\)') }}</td>
 <td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
 <td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
-<td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}$-simple\)') }}</td>
+<td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}\)-simple') }}</td>
 </tr>
 
 <tr>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -72,7 +72,7 @@
 <tr>
 <td></td>
 <td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
-<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-End algebra') }}</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-end algebra') }}</td>
 <td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
 <td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
 <td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}\)-simple') }}</td>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -70,8 +70,9 @@
 </tr>
 
 <tr>
+<td></td>
 <td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
-<td>{{ KNOWL('g2c.geom_end_alg', title='\(\mathrm{End}(\mathrm{Jac}(X)_{\overline{\Q}})\otimes\Q\)') }}</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}}\)-End algebra}}</td>
 <td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
 <td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
 <td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}\)-simple') }}</td>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -72,7 +72,7 @@
 <tr>
 <td></td>
 <td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
-<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-End algebra}}</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-End algebra') }}</td>
 <td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
 <td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
 <td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}\)-simple') }}</td>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -13,10 +13,8 @@
 <td>{{ KNOWL('g2c.abs_discriminant', title='discriminant')}}</td>
 <td>{{ KNOWL('g2c.num_rat_pts', title='rational points') }}</td>
 <td>{{ KNOWL('g2c.num_rat_wpts', title='Weierstrass') }}</td>
-<td>{{ KNOWL('g2c.torsion', title='torsion')}}</td>
 <td>{{ KNOWL('g2c.torsion_order', title='torsion order')}}</td>
-<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>
-<td>{{ KNOWL('g2c.analytic_rank', title='analytic rank*')}}</td>
+<td>{{ KNOWL('g2c.torsion', title='torsion')}}</td>
 </tr>
 
 <tr>
@@ -24,22 +22,23 @@
 <td><input type='text' name='abs_disc' placeholder='169' style="width: 100px" value="{{info.abs_disc}}"></td>
 <td><input type='text' name='num_rat_pts' placeholder='1'  style="width: 100px" value="{{info.num_rat_pts}}">
 <td><input type='text' name='num_rat_wpts' placeholder='1'  style="width: 100px" value="{{info.num_rat_wpts}}">
-<td><input type='text' name='torsion' placeholder='[2,2,2]'  style="width: 100px" value="{{info.torsion}}">
 <td><input type='text' name='torsion_order' placeholder='2'  style="width: 100px" value="{{info.torsion_order}}">
-<td><input type='text' name='two_selmer_rank' placeholder='1'  style="width: 100px" value="{{info.two_selmer_rank}}">
-<td><input type='text' name='analytic_rank' placeholder='1'  style="width: 100px" value="{{info.analytic_rank}}">
+<td><input type='text' name='torsion' placeholder='[2,2,2]'  style="width: 100px" value="{{info.torsion}}">
 </tr>
 
 <tr>
+<td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank')}}</td>
+<td>{{ KNOWL('g2c.analytic_rank', title='analytic rank*')}}</td>
 <td>{{ KNOWL('g2c.gl2type', title='\(\GL_2\)-type') }}</td>
 <td>{{ KNOWL('g2c.st_group', title='\(\mathrm{ST}\)') }}</td>
 <td>{{ KNOWL('g2c.st_group_identity_component', title='\(\mathrm{ST}^0\)') }}</td>
 <td>{{ KNOWL('g2c.aut_grp', title='\(\mathrm{Aut}(X)\)') }}</td>
-<td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
-<td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
-<td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
-<td>{{ KNOWL('ag.geom_simple', title='$\\overline{\\mathbb Q}$-simple') }}</td>
 </tr>
+
+<tr>
+
+<td><input type='text' name='two_selmer_rank' placeholder='1'  style="width: 100px" value="{{info.two_selmer_rank}}">
+<td><input type='text' name='analytic_rank' placeholder='1'  style="width: 100px" value="{{info.analytic_rank}}">
 
 <td><select name='is_gl2_type' style="width: 110px">
   <option ></option>
@@ -68,10 +67,31 @@
     {% endfor %}
 </select></td>
 
+</tr>
+
+<tr>
+<td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\mathrm{End}(\mathrm{Jac}(X)_{\overline{\Q}})\otimes\Q\)') }}</td>
+<td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
+<td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
+<td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}$-simple\)') }}</td>
+</tr>
+
+<tr>
+
+<td class="button"><button type='submit' value='refine' style='min-width: 110px'>Search again</button></td>
+
 <td><select name='geom_aut_grp_id' style="width: 110px">
     <option ></option>
     {% for G in info.geom_aut_grp_list %}
         <option value='{{G}}' {{ "selected" if G == info.geom_aut_grp_id }} >{{info.geom_aut_grp_dict[G]}}</option>
+    {% endfor %}
+</select></td>
+
+<td><select name='geom_end_alg' style="width: 110px">
+    <option ></option>
+    {% for G in info.geom_end_alg_list %}
+        <option value='{{G}}' {{ "selected" if G == info.geom_end_alg }} >{{info.geom_end_alg_dict[G]}}</option>
     {% endfor %}
 </select></td>
 
@@ -96,7 +116,6 @@
 
 </tr>
 
-<tr><td class="button"><button type='submit' value='refine' style='min-width: 110px'>Search again</button></td></tr>
 </table>
 </form>
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -72,7 +72,7 @@
 <tr>
 <td></td>
 <td>{{ KNOWL('g2c.geom_aut_grp',   title='\(\mathrm{Aut}(X_{\overline{\Q}})\)') }}</td>
-<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}}\)-End algebra}}</td>
+<td>{{ KNOWL('g2c.geom_end_alg', title='\(\overline{\Q}\)-End algebra}}</td>
 <td>{{ KNOWL('g2c.locally_solvable',   title='locally solvable') }}</td>
 <td>{{ KNOWL('g2c.has_square_sha',   title='square &#1064;*') }}</td>
 <td>{{ KNOWL('ag.geom_simple', title='\(\overline{\mathbb Q}\)-simple') }}</td>

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -7,7 +7,7 @@ class Genus2Test(LmfdbTest):
     def test_stats(self):
         L = self.tc.get('/Genus2Curve/Q/stats')
         assert 'Sato-Tate groups' in L.data and 'proportion' in L.data
-        
+
     def test_cond_range(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=100000-1000000')
         assert '100000.a.200000.1' in L.data
@@ -27,23 +27,23 @@ class Genus2Test(LmfdbTest):
     def test_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/1369/a/')
         assert '1369.1' in L.data and '50653.1' in L.data and 'G_{3,3}' in L.data
-        
+
     def test_Lfunction_link(self):
         L = self.tc.get('/L/Genus2Curve/Q/1369/a',follow_redirects=True)
         assert 'G_{3,3}' in L.data and 'Motivic weight' in L.data
-        
+
     def test_twist_link(self):
         L = self.tc.get('/Genus2Curve/Q/?g22=1016576&g20=5071050752/9&g21=195344320/9')
         for label in ['576.b.147456.1', '1152.a.147456.1', '2304.b.147456.1', '4608.a.4608.1','4608.b.4608.1']:
             assert label in L.data
-            
+
     def test_by_conductor(self):
         L = self.tc.get('/Genus2Curve/Q/15360/')
         for x in "abcdefghij":
             assert "15360."+x in L.data
         L = self.tc.get('/Genus2Curve/Q/15360/?abs_disc=169')
         assert 'No matches' in L.data
-            
+
     def test_by_url_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/336/a/')
         assert '336.a.172032.1' in L.data
@@ -128,7 +128,7 @@ class Genus2Test(LmfdbTest):
     def test_locally_solvable_serach(self):
         L = self.tc.get('/Genus2Curve/Q/?locally_solvable=False')
         assert '336.a.172032.1' in L.data
-        
+
     def test_sha_search(self):
         L = self.tc.get('/Genus2Curve/Q/?has_square_sha=False')
         assert  '336.a.172032.1' in L.data and not '169.a.169.1' in L.data
@@ -140,13 +140,13 @@ class Genus2Test(LmfdbTest):
         assert '\Z/{29}\Z' in L.data
         L = self.tc.get('/Genus2Curve/Q/118606/a/118606/1')
         assert 'trivial' in L.data
-        
+
     def test_mfhilbert(self):
         L = self.tc.get('/Genus2Curve/Q/12500/a/12500/1')
         assert '2.2.5.1-500.1-a' in L.data
         L = self.tc.get('/Genus2Curve/Q/12500/a/')
         assert '2.2.5.1-500.1-a' in L.data
-        
+
     def test_ratpts(self):
         L = self.tc.get('/Genus2Curve/Q/792079/a/792079/1')
         assert '(-15 : -6579 : 14)' in L.data
@@ -154,4 +154,18 @@ class Genus2Test(LmfdbTest):
         L = self.tc.get('/Genus2Curve/Q/126746/a/126746/1')
         assert 'everywhere' in L.data
         assert 'no rational points' in L.data
-        
+
+    def test_endo_search(self):
+        # first result for every search
+        for endo, text in [
+                ('Q', '249.a.249.1'),
+                ('RM', '529.a.529.1'),
+                ('CM', '3125.a.3125.1'),
+                ('QM', '20736.l.373248.1'),
+                ('Q x Q', '294.a.294.1'),
+                ('CM x Q', '448.a.448.2'),
+                ('CM x CM', 'No matches'),
+                ('M_2(Q)', '169.a.169.1'),
+                ('M_2(CM)', '2916.b.11664.1')]:
+            L = self.tc.get('/Genus2Curve/Q/?geom_end_alg={}'.format(endo))
+            assert text in L.data

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -607,7 +607,7 @@ class WebG2C(object):
             data['end_statement_geom'] = """Endomorphism %s over \(\overline{\Q}\):""" %("ring" if is_curve else "algebra") + \
                 end_statement(data['factorsQQ_geom'], data['factorsRR_geom'], field=r'\overline{\Q}', ring=data['end_ring_geom'] if is_curve else None)
         data['real_geom_end_alg_name'] = real_geom_end_alg_name(curve['real_geom_end_alg'])
-        data['geom_end_alg_name'] = real_geom_end_alg_name(curve['geom_end_alg'])
+        data['geom_end_alg_name'] = geom_end_alg_name(curve['geom_end_alg'])
 
         # Endomorphism data over intermediate fields not already treated (only for curves, not necessarily isogeny invariant):
         if is_curve:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -176,7 +176,7 @@ def eqn_list_to_curve_plot(L,rat_pts):
 # Name conversions for the Sato-Tate and real endomorphism algebras
 ###############################################################################
 
-def end_alg_name(name):
+def real_geom_end_alg_name(name):
     name_dict = {
         "R":"\\R",
         "C":"\\C",
@@ -185,6 +185,23 @@ def end_alg_name(name):
         "C x C":"\\C \\times \\C",
         "M_2(R)":"\\mathrm{M}_2(\\R)",
         "M_2(C)":"\\mathrm{M}_2(\\C)"
+        }
+    if name in name_dict.keys():
+        return name_dict[name]
+    else:
+        return name
+
+def geom_end_alg_name(name):
+    name_dict = {
+        "Q":"\\Q",
+        "RM":"\\mathrm{RM}",
+        "Q x Q":"\\Q \\times \\Q",
+        "CM x Q":"\\mathrm{CM} \\times \\Q",
+        "CM":"\\mathrm{CM}",
+        "CM x CM":"\\mathrm{CM} \\times \\mathrm{CM}",
+        "QM":"\\mathrm{QM}",        
+        "M_2(Q)":"\\mathrm{M}_2(\\Q)",
+        "M_2(CM)":"\\mathrm{M}_2(\\mathrm{CM})"
         }
     if name in name_dict.keys():
         return name_dict[name]
@@ -589,7 +606,8 @@ class WebG2C(object):
             data['gl2_statement_geom'] = gl2_statement_base(data['factorsRR_geom'], r'\(\overline{\Q}\)')
             data['end_statement_geom'] = """Endomorphism %s over \(\overline{\Q}\):""" %("ring" if is_curve else "algebra") + \
                 end_statement(data['factorsQQ_geom'], data['factorsRR_geom'], field=r'\overline{\Q}', ring=data['end_ring_geom'] if is_curve else None)
-        data['real_geom_end_alg_name'] = end_alg_name(curve['real_geom_end_alg'])
+        data['real_geom_end_alg_name'] = real_geom_end_alg_name(curve['real_geom_end_alg'])
+        data['geom_end_alg_name'] = real_geom_end_alg_name(curve['geom_end_alg'])
 
         # Endomorphism data over intermediate fields not already treated (only for curves, not necessarily isogeny invariant):
         if is_curve:
@@ -625,6 +643,7 @@ class WebG2C(object):
         properties += [
             ('Sato-Tate group', data['st_group_link']),
             ('\(\\End(J_{\\overline{\\Q}}) \\otimes \\R\)', '\(%s\)' % data['real_geom_end_alg_name']),
+            ('\(\\End(J_{\\overline{\\Q}}) \\otimes \\Q\)', '\(%s\)' % data['geom_end_alg_name']),
             ('\(\\overline{\\Q}\)-simple', bool_pretty(data['is_simple_geom'])),
             ('\(\mathrm{GL}_2\)-type', bool_pretty(data['is_gl2_type'])),
             ]


### PR DESCRIPTION
As discussed in #2886, this PR adds the ability to search on the geometric endomorphism algebra of the Jacobian of a genus 2 curve by type.  As explained in the newly created knowl http://beta.lmfdb.org/knowledge/show/g2c.geom_end_alg there are nine types, four of which arise for geometrically simple Jacobians (Q, RM, CM, QM).  This knowl could also be linked to from the degree 4 L-function browse page (but this change is not part of this PR, which only touches the genus 2 code).

The type of geometric endomorphism algebra is also shown in the properties box (the exact value of the geometric endomorphism algebra can still be found in the endomorphisms section of the curves home page as before).

While making this change I noticed an inconsistency in the ordering of the search options on the main search and refine search pages which I fixed.

A new column has been added to g2c_curves to support this search; the table needs to copied to proddb before the code is pushed to web (I will take care of this once this PR has been merged, the new data won't have any impact on the old code).