### PR TITLE
Populating friends for BMFs and HMFs using L-functions

### DIFF
--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -98,3 +98,31 @@ class BMFTest(LmfdbTest):
         self.check_args(base_url+'2.0.11.1/256.1/a/', 'Elliptic curve isogeny class 2.0.11.1-256.1-a');
         # A dimension 2 example
         self.check_args(base_url+'2.0.4.1/377.1/a2', 'The Hecke eigenfield is \(\Q(z)\) where  $z$ is a root of the defining');
+
+
+    def test_friends(self):
+        for url, texts, notitself in [
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1-44.3-a',
+                    ('Bianchi modular form 2.0.7.1-44.4-a',
+                        'Isogeny class 2.0.7.1-44.3-a',
+                        'Isogeny class 2.0.7.1-44.4-a'),
+                    'Bianchi modular form 2.0.7.1-44.3-a'),
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1-44.4-a',
+                    ('Bianchi modular form 2.0.7.1-44.3-a',
+                        'Isogeny class 2.0.7.1-44.3-a',
+                        'Isogeny class 2.0.7.1-44.4-a'),
+                    'Bianchi modular form 2.0.7.1-44.4-a'),
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1-32.1-a',
+                    ('Hilbert modular form 2.2.8.1-32.1-a',
+                        'Isogeny class 2.0.8.1-32.1-a',
+                        'Isogeny class 2.2.8.1-32.1-a'),
+                    'Bianchi modular form 2.0.8.1-32.1-a')
+                    ]:
+                L = self.tc.get(url)
+                for t in texts:
+                assert t in L.data
+
+            # this test isn't very specific
+            # but the goal is to test that itself doesn't show in the friends list
+            assert notitself not in L.d
+

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -118,8 +118,8 @@ class BMFTest(LmfdbTest):
                         'Isogeny class 2.2.8.1-32.1-a'),
                     'Bianchi modular form 2.0.8.1-32.1-a')
                     ]:
-                L = self.tc.get(url)
-                for t in texts:
+            L = self.tc.get(url)
+            for t in texts:
                 assert t in L.data
 
             # this test isn't very specific

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -102,17 +102,17 @@ class BMFTest(LmfdbTest):
 
     def test_friends(self):
         for url, texts, notitself in [
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1-44.3-a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.3/a',
                     ('Bianchi modular form 2.0.7.1-44.4-a',
                         'Isogeny class 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.4-a'),
                     'Bianchi modular form 2.0.7.1-44.3-a'),
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1-44.4-a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.4/a',
                     ('Bianchi modular form 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.4-a'),
                     'Bianchi modular form 2.0.7.1-44.4-a'),
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1-32.1-a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1/32.1/a',
                     ('Hilbert modular form 2.2.8.1-32.1-a',
                         'Isogeny class 2.0.8.1-32.1-a',
                         'Isogeny class 2.2.8.1-32.1-a'),

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -124,5 +124,5 @@ class BMFTest(LmfdbTest):
 
             # this test isn't very specific
             # but the goal is to test that itself doesn't show in the friends list
-            assert notitself not in L.d
+            assert notitself not in L.data
 

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -92,10 +92,10 @@ class BMFTest(LmfdbTest):
         base_url = '/ModularForm/GL2/ImaginaryQuadratic/'
         self.check_args(base_url+'2.0.11.1/207.6/b', 'Base change')
         self.check_args(base_url+'2.0.11.1/207.6/b', '2.0.11.1-207.6-b')
-        self.check_args(base_url+'2.0.3.1/44332.1/a/', 'Elliptic curve isogeny class 2.0.3.1-44332.1-a')
+        self.check_args(base_url+'2.0.3.1/44332.1/a/', 'Isogeny class 2.0.3.1-44332.1-a')
         self.check_args(base_url+'2.0.3.1/44332.1/a/', '-238 a + 76')
         self.check_args(base_url+'2.0.11.1/256.1/a/', 'no, but is a twist of the base-change of a form over');
-        self.check_args(base_url+'2.0.11.1/256.1/a/', 'Elliptic curve isogeny class 2.0.11.1-256.1-a');
+        self.check_args(base_url+'2.0.11.1/256.1/a/', 'Isogeny class 2.0.11.1-256.1-a');
         # A dimension 2 example
         self.check_args(base_url+'2.0.4.1/377.1/a2', 'The Hecke eigenfield is \(\Q(z)\) where  $z$ is a root of the defining');
 

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -121,6 +121,7 @@ class BMFTest(LmfdbTest):
             L = self.tc.get(url)
             for t in texts:
                 assert t in L.data
+            assert 'L-function' in L.data
 
             # this test isn't very specific
             # but the goal is to test that itself doesn't show in the friends list

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -102,17 +102,17 @@ class BMFTest(LmfdbTest):
 
     def test_friends(self):
         for url, texts, notitself in [
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.3/a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.3/a/',
                     ('Bianchi modular form 2.0.7.1-44.4-a',
                         'Isogeny class 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.4-a'),
                     'Bianchi modular form 2.0.7.1-44.3-a'),
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.4/a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.4/a/',
                     ('Bianchi modular form 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.3-a',
                         'Isogeny class 2.0.7.1-44.4-a'),
                     'Bianchi modular form 2.0.7.1-44.4-a'),
-                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1/32.1/a',
+                ('/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1/32.1/a/',
                     ('Hilbert modular form 2.2.8.1-32.1-a',
                         'Isogeny class 2.0.8.1-32.1-a',
                         'Isogeny class 2.2.8.1-32.1-a'),

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -185,6 +185,8 @@ class WebBMF(object):
             # remove itself
             self.friends.remove(
                     ('Bianchi modular form {}'.format(self.label), '/' + url))
+            self.friends.append(('L-function', '/L/'+url))
+            
         else:
             # old code
             if self.dimension == 1:

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -4,15 +4,13 @@ from lmfdb.logger import make_logger
 from lmfdb.number_fields.web_number_field import nf_display_knowl, field_pretty
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.nfutils.psort import primes_iter, ideal_from_label, ideal_label
-from lmfdb.utils import web_latex
+from lmfdb.utils import web_latex, names_and_urls
+from lmfdb.lfunctions.LfunctionDatabase import (get_instances_by_Lhash,
+        get_instances_by_trace_hash, get_lfunction_by_url)
 from flask import url_for
 from sage.all import QQ, PolynomialRing, NumberField
 
 logger = make_logger("bmf")
-
-
-def is_bmf_in_db(label):
-    return db.bmf_forms.lookup(label, projection=0) is not None
 
 
 class WebBMF(object):
@@ -172,13 +170,29 @@ class WebBMF(object):
         self.properties2.append(('Analytic rank', self.anrank))
 
         self.friends = []
-        if self.dimension==1:
-            if self.ec_status == 'exists':
-                self.friends += [('Elliptic curve isogeny class {}'.format(self.label), self.ec_url)]
-            elif self.ec_status == 'missing':
-                self.friends += [('Elliptic curve {} missing'.format(self.label), "")]
-            else:
-                self.friends += [('No elliptic curve', "")]
+        self.friends += [('Newspace {}'.format(self.newspace_label),self.newspace_url)]
+        url = 'ModularForm/GL2/ImaginaryQuadratic/{}'.format(
+                self.label.replace('-', '/'))
+        Lfun = get_lfunction_by_url(url)
+        if Lfun:
+            # first by Lhash
+            instances = get_instances_by_Lhash(Lfun['Lhash'])
+            # then by trace_hash
+            instances += get_instances_by_trace_hash(Lfun['degree'], Lfun['trace_hash'])
 
-        self.friends += [ ('Newspace {}'.format(self.newspace_label),self.newspace_url)]
-        self.friends += [ ('L-function not available','')]
+            # This will also add the EC/G2C, as this how the Lfun was computed
+            self.friends = names_and_urls(instances)
+            # remove itself
+            self.friends.remove(
+                    ('Bianchi modular form {}'.format(self.label), '/' + url))
+        else:
+            # old code
+            if self.dimension == 1:
+                if self.ec_status == 'exists':
+                    self.friends += [('Elliptic curve isogeny class {}'.format(self.label), self.ec_url)]
+                elif self.ec_status == 'missing':
+                    self.friends += [('Elliptic curve {} missing'.format(self.label), "")]
+                else:
+                    self.friends += [('No elliptic curve', "")]
+
+            self.friends += [ ('L-function not available','')]

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -191,9 +191,9 @@ class WebBMF(object):
             # old code
             if self.dimension == 1:
                 if self.ec_status == 'exists':
-                    self.friends += [('Elliptic curve isogeny class {}'.format(self.label), self.ec_url)]
+                    self.friends += [('Isogeny class {}'.format(self.label), self.ec_url)]
                 elif self.ec_status == 'missing':
-                    self.friends += [('Elliptic curve {} missing'.format(self.label), "")]
+                    self.friends += [('Isogeny class {} missing'.format(self.label), "")]
                 else:
                     self.friends += [('No elliptic curve', "")]
 

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -5,7 +5,6 @@ from lmfdb.utils import web_latex, encode_plot
 from lmfdb.logger import make_logger
 from lmfdb.ecnf.WebEllipticCurve import web_ainvs, FIELD
 from lmfdb.number_fields.web_number_field import field_pretty, nf_display_knowl
-from lmfdb.bianchi_modular_forms.web_BMF import is_bmf_in_db
 from sage.all import latex, Matrix, ZZ, Infinity
 
 logger = make_logger("ecnf")
@@ -131,7 +130,7 @@ class ECNF_isoclass(object):
             if "CM" in self.label:
                 self.friends += [('Bianchi Modular Form is not cuspidal', '')]
             else:
-                if is_bmf_in_db(self.bmf_label):
+                if db.bmf_forms.label_exists(self.bmf_label):
                     self.friends += [('Bianchi Modular Form %s' % self.bmf_label, self.bmf_url)]
                 else:
                     self.friends += [('Bianchi Modular Form %s not available' % self.bmf_label, '')]

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -14,6 +14,8 @@ from lmfdb.number_fields.web_number_field import WebNumberField
 from lmfdb.hilbert_modular_forms import hmf_page
 from lmfdb.hilbert_modular_forms.hilbert_field import findvar
 from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, get_counts, hmf_degree_summary
+from lmfdb.utils import names_and_urls
+from lmfdb.lfunctions.LfunctionDatabase import get_lfunction_by_url, get_instances_by_Lhash, get_instances_by_trace_hash
 
 
 def get_hmf(label):
@@ -305,18 +307,48 @@ def render_hmf_webpage(**args):
         ('Modular form to Magma', url_for(".render_hmf_webpage_download", field_label=info['field_label'], label=info['label'], download_type='magma')),
         ('Eigenvalues to Sage', url_for(".render_hmf_webpage_download", field_label=info['field_label'], label=info['label'], download_type='sage'))
         ]
-    if hmf_field['narrow_class_no'] == 1 and nf.disc()**2 * data['level_norm'] < 40000:
-        info['friends'] = [('L-function',
+
+
+    # figure out friends
+    # first try to see if there is an instance of this HMF on Lfun db
+    url = 'ModularForm/GL2/TotallyReal/{}/holomorphic/{}'.format(
+            info['field_label'],
+            info['label'])
+    Lfun = get_lfunction_by_url(url)
+    if Lfun:
+        # first by Lhash
+        instances = get_instances_by_Lhash(Lfun['Lhash'])
+        # then by trace_hash
+        instances += get_instances_by_trace_hash(Lfun['degree'], Lfun['trace_hash'])
+
+        # This will also add the EC/G2C, as this how the Lfun was computed
+        info['friends'] = names_and_urls(instances)
+        # remove itself
+        info['friends'].remove(
+                ('Hilbert modular form {}'.format(info['label']), '/' + url))
+
+        info['friends'] += [('L-function',
                             url_for("l_functions.l_function_hmf_page", field=info['field_label'], label=info['label'], character='0', number='0'))]
+
     else:
-        info['friends'] = [('L-function not available', "")]
-    if data['dimension'] == 1:   # Try to attach associated elliptic curve
-        lab = split_class_label(info['label'])
-        ec_from_hmf = db.ec_nfcurves.lookup(label + '1')
-        if ec_from_hmf is None:
-            info['friends'] += [('Elliptic curve not available', "")]
+        # if there is no instance
+        # old code
+        if hmf_field['narrow_class_no'] == 1 and nf.disc()**2 * data['level_norm'] < 40000:
+            info['friends'] = [('L-function',
+                                url_for("l_functions.l_function_hmf_page", field=info['field_label'], label=info['label'], character='0', number='0'))]
         else:
-            info['friends'] += [('Isogeny class ' + info['label'], url_for("ecnf.show_ecnf_isoclass", nf=lab[0], conductor_label=lab[1], class_label=lab[2]))]
+            info['friends'] = [('L-function not available', "")]
+
+
+        if data['dimension'] == 1:   # Try to attach associated elliptic curve
+            lab = split_class_label(info['label'])
+            ec_from_hmf = db.ec_nfcurves.lookup(label + '1')
+            if ec_from_hmf is None:
+                info['friends'] += [('Elliptic curve not available', "")]
+            else:
+                info['friends'] += [('Isogeny class ' + info['label'], url_for("ecnf.show_ecnf_isoclass", nf=lab[0], conductor_label=lab[1], class_label=lab[2]))]
+
+
 
     bread = [("Modular Forms", url_for('mf.modular_form_main_page')), ('Hilbert Modular Forms', url_for(".hilbert_modular_form_render_webpage")),
         ('%s' % data['label'], ' ')]

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -110,20 +110,25 @@ class HMFTest(LmfdbTest):
         for url, texts, notitself in [
                 ('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a',
                     ('Hilbert modular form 2.2.5.1-31.2-a',
-                     'Isogeny class 2.2.5.1-31.1-a',
-                     'Isogeny class 2.2.5.1-31.2-a'),
+                        'Isogeny class 2.2.5.1-31.1-a',
+                        'Isogeny class 2.2.5.1-31.2-a'),
                     'Hilbert modular form 2.2.5.1-31.1-a'),
                 ('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.2-a',
                     ('Hilbert modular form 2.2.5.1-31.1-a',
-                     'Isogeny class 2.2.5.1-31.1-a',
-                     'Isogeny class 2.2.5.1-31.2-a'),
+                        'Isogeny class 2.2.5.1-31.1-a',
+                        'Isogeny class 2.2.5.1-31.2-a'),
                     'Hilbert modular form 2.2.5.1-31.2-a'),
                 ('/ModularForm/GL2/TotallyReal/2.2.497.1/holomorphic/2.2.497.1-1.1-a',
                     ('Isogeny class 2.0.7.1-5041.1-CMa',
-                    'Isogeny class 2.0.7.1-5041.3-CMa',
-                    'Isogeny class 2.2.497.1-1.1-a',
-                    'Modular form 497.2.b.a'),
-                    'Hilbert modular form 2.2.497.1-1.1-a')
+                        'Isogeny class 2.0.7.1-5041.3-CMa',
+                        'Isogeny class 2.2.497.1-1.1-a',
+                        'Modular form 497.2.b.a'),
+                    'Hilbert modular form 2.2.497.1-1.1-a'),
+                ('/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-32.1-a',
+                    ('Bianchi modular form 2.0.8.1-32.1-a',
+                        'Isogeny class 2.0.8.1-32.1-a',
+                        'Isogeny class 2.2.8.1-32.1-a'),
+                    'Hilbert modular form 2.2.8.1-32.1-a',)
                 ]:
             L = self.tc.get(url)
             for t in texts:

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -128,11 +128,12 @@ class HMFTest(LmfdbTest):
                     ('Bianchi modular form 2.0.8.1-32.1-a',
                         'Isogeny class 2.0.8.1-32.1-a',
                         'Isogeny class 2.2.8.1-32.1-a'),
-                    'Hilbert modular form 2.2.8.1-32.1-a',)
+                    'Hilbert modular form 2.2.8.1-32.1-a')
                 ]:
             L = self.tc.get(url)
             for t in texts:
                 assert t in L.data
+            assert 'L-function' in L.data
 
             # this test isn't very specific
             # but the goal is to test that itself doesn't show in the friends list

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -18,8 +18,8 @@ class HMFTest(LmfdbTest):
 
     def test_EC(self): #778
         L = self.tc.get('ModularForm/GL2/TotallyReal/5.5.126032.1/holomorphic/5.5.126032.1-82.1-b')
-        assert 'EllipticCurve/5.5.126032.1/82.1/b/' in L.data   
-        
+        assert 'EllipticCurve/5.5.126032.1/82.1/b/' in L.data
+
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.89.1/holomorphic/2.2.89.1-2.1-a')
         assert 'Isogeny class' in L.data
         assert 'EllipticCurve/2.2.89.1/2.1/a' in L.data
@@ -49,11 +49,11 @@ class HMFTest(LmfdbTest):
     def test_search_CM(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?start=0&field_label=&deg=5&disc=&weight=2&level_norm=&dimension=&cm=only&bc=include&count=100')
         assert '121.1-b' in L.data
-        
+
     def test_search_base_change(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?start=0&field_label=&deg=5&disc=&cm=include&bc=exclude&count=100')
         assert '/ModularForm/GL2/TotallyReal/5.5.14641.1/holomorphic/5.5.14641.1-67.5-a' in L.data
-            
+
     def test_hmf_page(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.73.1/holomorphic/2.2.73.1-48.4-b')
         assert 'no' in L.data
@@ -103,5 +103,33 @@ class HMFTest(LmfdbTest):
         assert 'The Atkin-Lehner eigenvalues for this form are not in the database' in L.data
 
     def test_level_one_AL(self):
-        L = self.tc.get('ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a')
+        L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a')
         assert 'This form has no Atkin-Lehner eigenvalues' in L.data
+
+    def test_friends(self):
+        for url, texts, notitself in [
+                ('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a',
+                    ('Hilbert modular form 2.2.5.1-31.2-a',
+                     'Isogeny class 2.2.5.1-31.1-a',
+                     'Isogeny class 2.2.5.1-31.2-a'),
+                    'Hilbert modular form 2.2.5.1-31.1-a'),
+                ('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.2-a',
+                    ('Hilbert modular form 2.2.5.1-31.1-a',
+                     'Isogeny class 2.2.5.1-31.1-a',
+                     'Isogeny class 2.2.5.1-31.2-a'),
+                    'Hilbert modular form 2.2.5.1-31.2-a'),
+                ('/ModularForm/GL2/TotallyReal/2.2.497.1/holomorphic/2.2.497.1-1.1-a',
+                    ('Isogeny class 2.0.7.1-5041.1-CMa',
+                    'Isogeny class 2.0.7.1-5041.3-CMa',
+                    'Isogeny class 2.2.497.1-1.1-a',
+                    'Modular form 497.2.b.a'),
+                    'Hilbert modular form 2.2.497.1-1.1-a')
+                ]:
+            L = self.tc.get(url)
+            for t in texts:
+                assert t in L.data
+
+            # this test isn't very specific
+            # but the goal is to test that itself doesn't show in the friends list
+            assert notitself not in L.data
+

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -987,7 +987,7 @@ def generateLfunctionFromUrl(*args, **kwds):
         return Lfunction_HMFDB(label=args[5], character=args[6], number=args[7]) if instance else Lfunction_HMF(label=args[5], character=args[6], number=args[7])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'ImaginaryQuadratic':  # Bianchi modular form
-        return Lfunction_BMF(field=args[5], level=args[6], suffix=args[7])
+        return Lfunction_BMF(field=args[3], level=args[4], suffix=args[5])
 
     elif args[0] == 'ModularForm' and args[1] == 'GL2' and args[2] == 'Q' and args[3] == 'Maass':
         maass_id = args[4]


### PR DESCRIPTION
Trying to make friends consistent across BMFs and HMFs and add the link to the L-function when available from db.

If the L-function is not in the database, it serves the old code.

Compare:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.3/a/
http://beta.lmfdb.org/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/44.3/a/

http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.497.1/holomorphic/2.2.497.1-1.1-a
http://beta.lmfdb.org/ModularForm/GL2/TotallyReal/2.2.497.1/holomorphic/2.2.497.1-1.1-a

http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-32.1-a
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1/32.1/a/
vs
http://beta.lmfdb.org/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-32.1-a
http://beta.lmfdb.org/ModularForm/GL2/ImaginaryQuadratic/2.0.8.1/32.1/a/


This (partially) addresses #2873,  #2768, #2662, #2262
