### PR TITLE
Replace st_group knowls with more generic group knowls

### DIFF
--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -150,7 +150,7 @@ table.ntdata a {
 <th>{{KNOWL('gg.simple_name', title='Name')}}</th>
 <th>{{KNOWL('group.order', title='Order')}}</th>
 <th>{{ KNOWL('gg.parity', 'Parity') }} </th>
-<th>{{ KNOWL('gg.solvable', 'Solvable') }}</th>
+<th>{{ KNOWL('group.solvable', 'Solvable') }}</th>
 {% if info.show_subs %}
 <th>{{ KNOWL('gg.subfields', title='Subfields') }}</th>
 {% endif %}

--- a/lmfdb/sato_tate_groups/templates/st_display.html
+++ b/lmfdb/sato_tate_groups/templates/st_display.html
@@ -23,8 +23,8 @@
 <h2> {{ KNOWL('st_group.component_group', title='Component Group') }} </h2>
 <table>
     <tr><td>{{ KNOWL('st_group.component_group', title='Name') }}:</td><td>${{info['component_group']}}$</td></tr>
-    <tr><td>{{ KNOWL('st_group.order', title='Order') }}:</td><td>${{info['components']}}$</td></tr>
-    <tr><td>{{ KNOWL('st_group.abelian', title='Abelian') }}:</td><td>${{info['abelian']}}$</td></tr>
+    <tr><td>{{ KNOWL('group.order', title='Order') }}:</td><td>${{info['components']}}$</td></tr>
+    <tr><td>{{ KNOWL('group.abelian', title='Abelian') }}:</td><td>${{info['abelian']}}$</td></tr>
     {% if info['numgens'] > 0 %}
         <tr><td>{{ KNOWL('st_group.generators', title='Generators') }}:</td><td>${{info['gens']}}$</td></tr>
     {% endif %}


### PR DESCRIPTION
While reviewing Sato-Tate knowls, I noticed that some of them are redundant with knowls for arbitrary groups. Without judging the question of whether Sato-Tate groups should be filed under groups, I would propose that we use generic group knowls to refer to properties of generic groups (order, abelian).