### PR TITLE
Catch exceptions in index creation

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2000,6 +2000,7 @@ class PostgresTable(PostgresBase):
             except Exception as err:
                 print "*"*80
                 print "Index creation failed: %s" % (err,)
+                print "*"*80
         print "Created index %s in %.3f secs"%(name, time.time() - now)
 
     def _indexes_touching(self, columns):

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1991,7 +1991,15 @@ class PostgresTable(PostgresBase):
                 raise ValueError("Index %s does not exist in meta_indexes"%(name,))
             type, columns, modifiers, storage_params = cur.fetchone()
             creator = self._create_index_statement(name + suffix, self.search_table + suffix, type, columns, modifiers, storage_params)
-            self._execute(creator, storage_params.values())
+            try:
+                # Reloading indexes can cause crashes in a way we don't understand.
+                # Postgres complains that the index already exists, even though we haven't
+                # created it yet on this table.
+                # As a workaround, we ignore errors in the index creation code and print a big warning
+                self._execute(creator, storage_params.values())
+            except Exception as err:
+                print "*"*80
+                print "Index creation failed: %s" % (err,)
         print "Created index %s in %.3f secs"%(name, time.time() - now)
 
     def _indexes_touching(self, columns):


### PR DESCRIPTION
Edgar and I don't really understand why these statements are failing, but catching the error and printing a warning is better than failing.