### PR TITLE
Number fields: adds search/display for CM and root discriminant

### DIFF
--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -41,6 +41,11 @@ discriminant:
   pari:  K.disc
   magma: Discriminant(K);
 
+rd:
+  sage: (K.disc().abs())^(1./K.degree())
+  pari: abs(K.disc)^(1/poldegree(K.pol))
+  magma: Abs(Discriminant(K))^(1/Degree(K));
+
 ramified_primes:
   sage:  K.disc().support()
   pari:  factor(abs(K.disc))[,1]~

--- a/lmfdb/number_fields/templates/number_field.html
+++ b/lmfdb/number_fields/templates/number_field.html
@@ -50,6 +50,11 @@ table.ntdata a {
   {% else %}
             <tr><td colspan="3">This field is not Galois over $\Q$.</tr>
   {% endif %}
+  {% if nf.is_cm_field() %}
+  <tr><td colspan="3">This is a {{ KNOWL('nf.cm_field', title="CM field") }}.</tr>
+  {% else %}
+  <tr><td colspan="3">This is not a {{ KNOWL('nf.cm_field', title="CM field") }}.</tr>
+  {% endif %}
 
           </table>
         </p>

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -75,6 +75,18 @@ Enter values into one or more boxes to restrict the search.
 <td colspan="4"><input type='text' name='discriminant' size=10 size=10 example='-1000..-1'> 
 <span class="formexample"> e.g. -3, or a range such as 1000..2000 or 1000-2000 or -1000..-1</span></td>
 </tr>
+<tr>
+<td align=left>{{KNOWL('nf.root_discriminant', title='root discriminant')}}
+<td colspan="2"><input type='text' name='discriminant' size=10 size=10 example='1..4.3'> 
+<span class="formexample"> e.g. a range such as 1..4.3 or 3..10</span></td>
+
+  <td>{{ KNOWL('nf.cm_field', title='CM field') }}</td>
+  <td><select name='cm_field' width="105" style="width: 105px">
+     <option ></option>
+     <option value='True'>True</option>
+     <option value='False'>False</option>
+  </select></td>
+</tr>
 
 <tr>
 <td align=left>{{KNOWL('nf.galois_group', title='Galois group')}} 

--- a/lmfdb/number_fields/templates/number_field_all.html
+++ b/lmfdb/number_fields/templates/number_field_all.html
@@ -77,7 +77,7 @@ Enter values into one or more boxes to restrict the search.
 </tr>
 <tr>
 <td align=left>{{KNOWL('nf.root_discriminant', title='root discriminant')}}
-<td colspan="2"><input type='text' name='discriminant' size=10 size=10 example='1..4.3'> 
+<td colspan="2"><input type='text' name='rd' size=10 size=10 example='1..4.3'> 
 <span class="formexample"> e.g. a range such as 1..4.3 or 3..10</span></td>
 
   <td>{{ KNOWL('nf.cm_field', title='CM field') }}</td>

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -46,12 +46,31 @@ set of {{KNOWL('nf.ramified_primes', title='ramified primes')}}
  <td align=left> <input type='text' name='ram_primes' size=5 value="{{info.ram_primes}}"></td>
 
 </tr>
-
+<tr>
+<td align='left'> {{KNOWL('nf.root_discriminant', title='root discriminant')}} range <td align='left' colspan='2'> <input type='text' name='rd' size='20' value="{{info.rd}}"></td>
+<td align='left'>
+   <td>{{ KNOWL('nf.cm_field', title='CM field') }}</td>
+     <td><select name='cm_field' width="105" style="width: 105px">
+  {% if info.cm_field == 'True' %} 
+      <option ></option>
+      <option value='True' selected='yes'>True</option>
+      <option value='False'>False</option>
+{% elif info.cm_field == 'False' %}
+      <option ></option>
+      <option value='True'>True</option>
+      <option value='False' selected='yes'>False</option>
+{% else %}
+      <option ></option>
+      <option value='True'>True</option>
+      <option value='False'>False</option>
+{% endif %}
+      </select></td>
+{# 
 <tr>
 <td align='left' colspan='4'>Maximum number of fields to display <input type='text' name='count' value="{{info.count}}" size='10'>
 </td>
 </tr>
-
+#}
 
 <tr> 
 <td class="button" align=left><button type='submit' value='refine'>Search again</button></td> 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -306,9 +306,8 @@ class WebNumberField:
     def ramified_primes(self):
         return [int(str(j)) for j in self._data['ramps']]
 
+    # Even rd is in the database, that does not low precision for searching
     def rd(self):
-        if self.haskey('rd'):
-            return self._data['rd']
         return RealField(300)(ZZ(self._data['disc_abs'])).nth_root(self.degree())
 
     # Return a nice string for the Galois group

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -4,7 +4,7 @@ import os, yaml
 
 from flask import url_for
 from sage.all import (
-    gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap,
+    gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap, RealField,
     AbelianGroup, QQ, gp, NumberField, PolynomialRing, latex, pari, cached_function)
 
 from lmfdb import db
@@ -306,6 +306,11 @@ class WebNumberField:
     def ramified_primes(self):
         return [int(str(j)) for j in self._data['ramps']]
 
+    def rd(self):
+        if self.haskey('rd'):
+            return self._data['rd']
+        return RealField(300)(ZZ(self._data['disc_abs'])).nth_root(self.degree())
+
     # Return a nice string for the Galois group
     def galois_string(self):
         if not self.haskey('galt'):
@@ -563,6 +568,9 @@ class WebNumberField:
             res = res.replace('\\\\', '\\')
             return res
         return na_text()
+
+    def is_cm_field(self):
+        return self._data['cm']
 
     def disc_factored_latex(self):
         D = self.disc()

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -397,12 +397,10 @@ def _parse_subset(inp, query, qfield, mode, radical, product):
             return
         inp = sorted(inp)
         if inp:
-            print inp
             dup_free = [inp[0]]
             for i,x in enumerate(inp[1:]):
                 if x != inp[i]:
                     dup_free.append(x)
-            print dup_free
         else:
             dup_free = []
         if qfield in query:


### PR DESCRIPTION
From the search page for number fields, you can pick CM, not-CM, or leave blank, and can put in a range for the root discriminant of a field.

On the page of a number field, we say if the field is CM or not.  The root discriminant is listed on the page and in the properties box.  If it is larger than 9999, we put commas in the root discriminant.  For example

http://127.0.0.1:37777/NumberField/11.11.779296860357698534095483320599059601917194890273797415048589282424956242368505315786699569648072067627971942731199225.1

On this page on beta

http://beta.lmfdb.org/NumberField/11.11.779296860357698534095483320599059601917194890273797415048589282424956242368505315786699569648072067627971942731199225.1

notice that in the list of ramified primes, the big prime has an L at the end (courtesy of python).  That has been removed in this pull request.

Also on this page, the properties box is quite wide because the label is so long.  One solution would be to put an ellipses in the middle if the label has more than 30 characters.  It is already at the top of the page, so it would not be a big loss.