### PR TITLE
Fix ecnf download typo

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -378,7 +378,7 @@ def show_ecnf(nf, conductor_label, class_label, number):
                            learnmore=learnmore_list())
 
 def download_search(info):
-    dltype = info['submit']
+    dltype = info['Submit']
     delim = 'bracket'
     com = r'\\'  # single line comment start
     com1 = ''  # multiline comment start


### PR DESCRIPTION
Resolves #2973.  To test, visit http://localhost:37777/EllipticCurve/?conductor_norm=1 and click on the download to Magma link.