### PR TITLE
Genus 2 friend finder

### DIFF
--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -169,3 +169,37 @@ class Genus2Test(LmfdbTest):
                 ('M_2(CM)', '2916.b.11664.1')]:
             L = self.tc.get('/Genus2Curve/Q/?geom_end_alg={}'.format(endo))
             assert text in L.data
+
+    def test_related_objects(self):
+        for url, friends in [
+                ('/Genus2Curve/Q/20736/i/373248/1',
+                    ('L-function',
+                        'Isogeny class 20736.i',
+                        'Elliptic curve 576.f3',
+                        'Elliptic curve 36.a4',
+                        'EC isogeny class 2.0.8.1-324.3-a',
+                        'Bianchi MF 324.3.a',
+                        'Hilbert MF 2.2.24.1-36.1-a',
+                        'EC isogeny class 2.2.24.1-36.1-a',
+                        'Twists',)
+                    ),
+                ('/Genus2Curve/Q/20736/i/',
+                    ('L-function',
+                        'EC isogeny class 576.f',
+                        'EC isogeny class 36.a',
+                        'EC isogeny class 2.0.8.1-324.3-a',
+                        'Bianchi MF 324.3.a',
+                        'Hilbert MF 2.2.24.1-36.1-a',
+                        'EC isogeny class 2.2.24.1-36.1-a',)
+                    ),
+                ('/Genus2Curve/Q/576/a/',
+                    ('L-function',
+                        'EC isogeny class 2.2.8.1-9.1-a',
+                        'Modular form 24.2.d.a',
+                        'Hilbert MF 2.2.8.1-9.1-a',)
+                    )
+                ]:
+            data = self.tc.get(url).data
+            for friend in friends:
+                assert friend in data
+

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -435,6 +435,7 @@ def lfunction_friend_from_url(url):
 
 # add new friend to list of friends, but only if really new (don't add an elliptic curve and its isogeny class)
 def add_friend(friends,friend):
+    print "Attempting to add friend",friend,"to friends",friends
     for oldfriend in friends:
         if oldfriend[0] == friend[0] or oldfriend[1] in friend[1] or friend[1] in oldfriend[1]:
             return
@@ -443,6 +444,7 @@ def add_friend(friends,friend):
         newdots = ".".join(friend[1].split("/"))
         if olddots in newdots or newdots in olddots:
             return
+    printf "Added friend",friend
     friends.append(friend)
 
 ###############################################################################

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -419,6 +419,8 @@ def lfunction_friend_from_url(url):
     if parts[0] == "EllipticCurve":
         cond = convert_IQF_label(parts[1],parts[2])
         label = parts[1] + "-" + cond + "-" + parts[3]
+        print "cond",cond
+        print "label",label
         return ("EC isogeny class " + label, "/" + url)
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -664,6 +664,14 @@ class WebG2C(object):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
                 add_friend (friends, lfunction_friend_from_url(friend_url))
+        # Hack to deal with the fact that currently the same L-function can appear more than once in db.lfunc_lfunctions and we want to friend instances of all of them
+        for Lhash in db.lfunc_lfunctions.search({"trace_hash":data["Lhash"]},"Lhash"):
+            for friend_url in db.lfunc_instances.search({'Lhash':Lhash}, 'url'):
+                if '|' in friend_url:
+                    for url in friend_url.split('|'):
+                        add_friend (friends, lfunction_friend_from_url(url))
+                else:
+                    add_friend (friends, lfunction_friend_from_url(friend_url))           
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
             # be selective, only cmfs of the right dimension and conductor get to be our friends
             if cmf_friend["dim"] == 2 and cmf_friend["level"]**2 == data['cond']:

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -444,7 +444,7 @@ def add_friend(friends,friend):
         newdots = ".".join(friend[1].split("/"))
         if olddots in newdots or newdots in olddots:
             return
-    printf "Added friend",friend
+    print "Added friend",friend
     friends.append(friend)
 
 ###############################################################################

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -423,8 +423,8 @@ def lfunction_friend_from_url(url):
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]
         return ("Hilbert MF " + label, "/" + url)
-    if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "Q" and parts[4] == "holomorphic":
-        label = parts[5]
+    if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "Q" and parts[3] == "holomorphic":
+        label = parts[4]
         return ("Modular form " + label, "/" + url)
     return (url, "/" + url)
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -663,6 +663,7 @@ class WebG2C(object):
         if is_curve:
             friends.append(('Isogeny class %s.%s' % (data['slabel'][0], data['slabel'][1]), url_for(".by_url_isogeny_class_label", cond=data['slabel'][0], alpha=data['slabel'][1])))
         if 'split_labels' in data:
+            print "adding split friends",data["split_labels"]
             for friend_label in data['split_labels']:
                 if is_curve:
                     add_friend (friends, ("Elliptic curve " + friend_label, url_for_ec(friend_label)))
@@ -670,17 +671,21 @@ class WebG2C(object):
                     add_friend (friends, ("EC isogeny class " + ec_label_class(friend_label), url_for_ec_class(friend_label)))
         for friend_url in db.lfunc_instances.search({'Lhash':data['Lhash']}, 'url'):
             if '|' in friend_url:
+                print "adding lfunc factor friends",friend_url
                 for url in friend_url.split('|'):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
+                print "adding lfunc friend",friend_url
                 add_friend (friends, lfunction_friend_from_url(friend_url))
         # Hack to deal with the fact that currently the same L-function can appear more than once in db.lfunc_lfunctions and we want to friend instances of all of them
         for Lhash in db.lfunc_lfunctions.search({"trace_hash":data["Lhash"]},"Lhash"):
             for friend_url in db.lfunc_instances.search({'Lhash':Lhash}, 'url'):
                 if '|' in friend_url:
+                    print "adding lfunc2 factor friends",friend_url
                     for url in friend_url.split('|'):
                         add_friend (friends, lfunction_friend_from_url(url))
                 else:
+                    print "adding lfunc2 friends",friend_url
                     add_friend (friends, lfunction_friend_from_url(friend_url))           
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
             # be selective, only cmfs of the right dimension and conductor get to be our friends

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -424,7 +424,7 @@ def lfunction_friend_from_url(url):
         label = parts[5]
         return ("Hilbert MF " + label, "/" + url)
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "Q" and parts[3] == "holomorphic":
-        label = parts[4]
+        label = '.'.join(parts[4:8])
         return ("Modular form " + label, "/" + url)
     return (url, "/" + url)
 

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -423,6 +423,9 @@ def lfunction_friend_from_url(url):
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]
         return ("Hilbert MF " + label, "/" + url)
+    if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "Q" and parts[4] == "holomorphic":
+        label = parts[5]
+        return ("Modular form " + label, "/" + url)
     return (url, "/" + url)
 
 # add new friend to list of friends, but only if really new (don't add an elliptic curve and its isogeny class)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -227,8 +227,8 @@ def st0_group_name(name):
 
 def gl2_statement_base(factorsRR, base):
     if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
-        return "of \(\GL_2\)-type over " + base
-    return "not of \(\GL_2\)-type over " + base
+        return "Of \(\GL_2\)-type over " + base
+    return "Not of \(\GL_2\)-type over " + base
 
 def gl2_simple_statement(factorsQQ, factorsRR):
     if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
@@ -419,8 +419,6 @@ def lfunction_friend_from_url(url):
     if parts[0] == "EllipticCurve":
         cond = convert_IQF_label(parts[1],parts[2])
         label = parts[1] + "-" + cond + "-" + parts[3]
-        print "cond",cond
-        print "label",label
         return ("EC isogeny class " + label, "/" + url)
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]
@@ -435,7 +433,6 @@ def lfunction_friend_from_url(url):
 
 # add new friend to list of friends, but only if really new (don't add an elliptic curve and its isogeny class)
 def add_friend(friends,friend):
-    print "Attempting to add friend",friend,"to friends",friends
     for oldfriend in friends:
         if oldfriend[0] == friend[0] or oldfriend[1] in friend[1] or friend[1] in oldfriend[1]:
             return
@@ -444,7 +441,6 @@ def add_friend(friends,friend):
         newdots = ".".join(friend[1].split("/"))
         if olddots in newdots or newdots in olddots:
             return
-    print "Added friend",friend
     friends.append(friend)
 
 ###############################################################################
@@ -663,7 +659,6 @@ class WebG2C(object):
         if is_curve:
             friends.append(('Isogeny class %s.%s' % (data['slabel'][0], data['slabel'][1]), url_for(".by_url_isogeny_class_label", cond=data['slabel'][0], alpha=data['slabel'][1])))
         if 'split_labels' in data:
-            print "adding split friends",data["split_labels"]
             for friend_label in data['split_labels']:
                 if is_curve:
                     add_friend (friends, ("Elliptic curve " + friend_label, url_for_ec(friend_label)))
@@ -671,21 +666,17 @@ class WebG2C(object):
                     add_friend (friends, ("EC isogeny class " + ec_label_class(friend_label), url_for_ec_class(friend_label)))
         for friend_url in db.lfunc_instances.search({'Lhash':data['Lhash']}, 'url'):
             if '|' in friend_url:
-                print "adding lfunc factor friends",friend_url
                 for url in friend_url.split('|'):
                     add_friend (friends, lfunction_friend_from_url(url))
             else:
-                print "adding lfunc friend",friend_url
                 add_friend (friends, lfunction_friend_from_url(friend_url))
         # Hack to deal with the fact that currently the same L-function can appear more than once in db.lfunc_lfunctions and we want to friend instances of all of them
         for Lhash in db.lfunc_lfunctions.search({"trace_hash":data["Lhash"]},"Lhash"):
             for friend_url in db.lfunc_instances.search({'Lhash':Lhash}, 'url'):
                 if '|' in friend_url:
-                    print "adding lfunc2 factor friends",friend_url
                     for url in friend_url.split('|'):
                         add_friend (friends, lfunction_friend_from_url(url))
                 else:
-                    print "adding lfunc2 friends",friend_url
                     add_friend (friends, lfunction_friend_from_url(friend_url))           
         for cmf_friend in db.mf_newforms.search({'trace_hash':data['Lhash']},["label","dim","level"]):
             # be selective, only cmfs of the right dimension and conductor get to be our friends

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -417,7 +417,8 @@ def lfunction_friend_from_url(url):
         label = parts[2] + "." + parts[3]
         return ("EC isogeny class " + label, "/" + url)
     if parts[0] == "EllipticCurve":
-        label = parts[1] + "-" + parts[2] + "-" + parts[3]
+        cond = convert_IQF_label(parts[1],parts[2])
+        label = parts[1] + "-" + cond + "-" + parts[3]
         return ("EC isogeny class " + label, "/" + url)
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -423,6 +423,9 @@ def lfunction_friend_from_url(url):
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "TotallyReal" and parts[4] == "holomorphic":
         label = parts[5]
         return ("Hilbert MF " + label, "/" + url)
+    if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "ImaginaryQuadratic":
+        label = '.'.join(parts[4:6])
+        return ("Bianchi MF " + label, "/" + url)
     if parts[0] == "ModularForm" and parts[1] == "GL2" and parts[2] == "Q" and parts[3] == "holomorphic":
         label = '.'.join(parts[4:8])
         return ("Modular form " + label, "/" + url)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -3,7 +3,8 @@
 from ast import literal_eval
 from lmfdb import db
 from lmfdb.utils import web_latex, encode_plot, list_to_factored_poly_otherorder
-from lmfdb.ecnf.main import split_full_label
+from lmfdb.ecnf.main import split_full_label as split_ecnf_label
+from lmfdb.ecnf.WebEllipticCurve import convert_IQF_label
 from lmfdb.elliptic_curves.web_ec import split_lmfdb_label
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.number_fields.web_number_field import nf_display_knowl
@@ -39,12 +40,9 @@ def url_for_ec(label):
     if not '-' in label:
         return url_for('ec.by_ec_label', label = label)
     else:
-        (nf, conductor_label, class_label, number) = split_full_label(label)
-        url = url_for('ecnf.show_ecnf', nf = nf, conductor_label = conductor_label, class_label = class_label, number = number)
-        # fixup conductor norm labels for the form "[a,b,c]" that have been converted to urls to ensure friend matching works
-        url.replace("%5B","[")
-        url.replace("%2C",".")
-        url.replace("%5D","]")
+        (nf, cond, isog, num) = split_ecnf_label(label)
+        cond = convert_IQF_label(nf,cond)
+        url = url_for('ecnf.show_ecnf', nf = nf, conductor_label = cond, class_label = isog, number = num)
         return url
 
 def url_for_ec_class(ec_label):
@@ -52,8 +50,9 @@ def url_for_ec_class(ec_label):
         (cond, iso, num) = split_lmfdb_label(ec_label)
         return url_for('ec.by_double_iso_label', conductor=cond, iso_label=iso)
     else:
-        (nf, cond, iso, num) = split_full_label(ec_label)
-        return url_for('ecnf.show_ecnf_isoclass', nf=nf, conductor_label=cond, class_label=iso)
+        (nf, cond, isog, num) = split_ecnf_label(ec_label)
+        cond = convert_IQF_label(nf,cond)
+        return url_for('ecnf.show_ecnf_isoclass', nf=nf, conductor_label=cond, class_label=isog)
 
 def ec_label_class(ec_label):
     x = ec_label


### PR DESCRIPTION
This PR addresses issue #2873 by making genus 2 curves and isogeny classes look harder for friends, now any object with the same rational L-function stored in the database will appear as a friend; in particular this means that HMF and BMF friends that were missing are now found (but note that the HMF "friend" example given in the description of #2873 does not actually fit this description; as noted by @edgarcosta its rational L-function has degree 8 and is the square of a genus 2 L-function, and for the moment this means it does not meet our current bar for friendship).  Once this PR is merged I will close #2873 -- we will have an opportunity to revisit L-function friends more broadly when we migrate to an origin and Lhash/trace_hash independent L-function labeling system.

In the course of implementing this I converted the elliptic curve over imaginary field labels stored in g2c_endomorphisms (as factors of the base change of the Jacobian) to the new ecnf labelling system (which uses our newer bracket-free conductor labels).  I did not modify any of the ecnf labels in lfunc_instances, instead the genus 2 code uses the ecnf utility function convert_IQF_label to convert them, but eventually we should update these also.

To see the difference, look at an L-function like

http://beta.lmfdb.org/L/Genus2Curve/Q/20736/i/

which has 4 origins: an HMF, a corresponding ECNF isogeny class, a dimension 2 CMF, and a genus 2 isogeny class.  The HMF and CMF both all their friends, but the genus 2 isogeny class (and the curve in it) does not know the HMF, but with this PR it now does

http://beta.lmfdb.org/Genus2Curve/Q/576/a/
http://127.0.0.1:37777/Genus2Curve/Q/576/a/

with the change it know does.  Note that the L-function pages 

http://beta.lmfdb.org/L/Genus2Curve/Q/576/a/
http://beta.lmfdb.org/L/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-9.1-a/0/0/

are different versions of the same L-function (one has zeros computed to higher precision, and in general the Z-plots may get flipped).  Dealing with duplications like this is a separate issue that cannot be properly dealt with until we complete the switch to origin-independent L-function labels.

Also note that the ECNF only knows its HMF friend, this will be fixed in a separate (Release 1.1) PR

For a more complicated example, try

http://beta.lmfdb.org/L/Genus2Curve/Q/20736/i/

where you will see that there are 5 origins, a BMF, and HMF, an imaginary quadratic EC isogeny class, a real quadratic EC isogeny class, and a genus 2 isogeny class (the two elliptic curves are both base changes of a pair of Qbar-isogenous elliptic curves over Q).  Then compare

http://beta.lmfdb.org/Genus2Curve/Q/20736/i/
http://beta.lmfdb.org/Genus2Curve/Q/20736/i/373248/1

to 

http://127.0.0.1:37777/L/EllipticCurve/2.2.8.1/9.1/a/
http://127.0.0.1:37777/Genus2Curve/Q/20736/i/373248/1

Before this PR neither the genus 2 curve or its isogeny class knew about either the HMF or BMF, now they both do.




