### PR TITLE
Galois names

### DIFF
--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -4,7 +4,7 @@ from lmfdb import db
 from lmfdb.utils import url_for, pol_to_html
 from lmfdb.typed_data.standard_types import PolynomialAsSequenceTooLargeInt
 from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField, RealField, log, I, factor, crt, euler_phi, primitive_root, mod, next_prime
-from lmfdb.galois_groups.transitive_group import group_display_knowl, group_display_short, tryknowl
+from lmfdb.galois_groups.transitive_group import group_display_knowl, group_display_short
 from lmfdb.number_fields.web_number_field import WebNumberField
 from lmfdb.characters.web_character import WebSmallDirichletCharacter
 
@@ -210,7 +210,7 @@ class ArtinRepresentation(object):
         galnt = self.smallest_gal_t()
         if len(galnt)==1:
             return galnt[0]
-        return tryknowl(galnt[0],galnt[1])
+        return group_display_knowl(galnt[0],galnt[1])
 
     def is_ramified(self, p):
         return self.number_field_galois_group().discriminant() % p == 0

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -7,8 +7,6 @@ from sage.all import ZZ, gap
 
 from lmfdb.utils import list_to_latex_matrix, display_multiset
 
-MAX_GROUP_DEGREE = 23
-
 def small_group_display_knowl(n, k, name=None):
     group = db.gps_small.lookup('%s.%s'%(n,k))
     if group is None:
@@ -114,14 +112,14 @@ class WebGaloisGroup:
             if k == me:
                 start = nextchr(start)
             if cnt == 1:
-                ans += tryknowl(k[0], k[1])
+                ans += group_display_knowl(k[0], k[1])
                 if k == me:
                     ans += 'b'
             else:
                 for j in range(cnt):
                     if j > 0:
                         ans += ', '
-                    ans += "%s%s" % (tryknowl(k[0], k[1]), start)
+                    ans += "%s%s" % (group_display_knowl(k[0], k[1]), start)
                     start = nextchr(start)
         return ans
 
@@ -130,7 +128,7 @@ class WebGaloisGroup:
         for k in self._data['subs']:
             if ans != '':
                 ans += ', '
-            ans += tryknowl(k[0], k[1])
+            ans += group_display_knowl(k[0], k[1])
         return ans
 
 ############  Misc Functions
@@ -154,14 +152,10 @@ def nextchr(c):
 
 
 def trylink(n, t):
-    if n <= MAX_GROUP_DEGREE:
+    label = base_label(n, t)
+    group = db.gps_transitive.lookup(label)
+    if group:
         return '<a href="/GaloisGroup/%dT%d">%dT%d</a>' % (n, t, n, t)
-    return '%dT%d' % (n, t)
-
-
-def tryknowl(n, t):
-    if n <= MAX_GROUP_DEGREE:
-        return group_display_knowl(n, t, '%dT%d' % (n, t))
     return '%dT%d' % (n, t)
 
 
@@ -362,10 +356,7 @@ def subfield_display(n, subs):
     for k in subs:
         if substrs[k[0]] != '':
             substrs[k[0]] += ', '
-        if k[0] <= MAX_GROUP_DEGREE:
-            substrs[k[0]] += group_display_knowl(k[0], k[1])
-        else:
-            substrs[k[0]] += str(k[0]) + 'T' + str(k[1])
+        substrs[k[0]] += group_display_knowl(k[0], k[1])
     for deg in degs:
         ans += '<p>Degree ' + str(deg) + ': '
         if substrs[deg] == '':
@@ -389,20 +380,14 @@ def otherrep_display(n, t, reps):
         if k == me:
             start = chr(ord(start) + 1)
         if cnt == 1:
-            if k[0] <= MAX_GROUP_DEGREE:
-                ans += group_display_knowl(k[0], k[1], name)
-            else:
-                ans += name
+            ans += group_display_knowl(k[0], k[1], name)
             if k == me:
                 ans += 'b'
         else:
             for j in range(cnt):
                 if j > 0:
                     ans += ', '
-                if k[0] <= MAX_GROUP_DEGREE:
-                    ans += "%s%s" % (group_display_knowl(k[0], k[1], name), start)
-                else:
-                    ans += "%s%s" % (name, start)
+                ans += "%s%s" % (group_display_knowl(k[0], k[1], name), start)
                 start = chr(ord(start) + 1)
 
     if ans == '':
@@ -425,12 +410,10 @@ def resolve_display(resolves):
             ans += ', '
         k = j[1]
         name = str(k[0]) + 'T' + str(k[1])
-        if k[0] <= MAX_GROUP_DEGREE:
-            ans += group_display_knowl(k[0], k[1], name)
-        else:
-            if k[1] == -1:
-                name = '%dT?' % k[0]
-            ans += name
+        if k[1] == -1:
+            name = '%dT?' % k[0]
+        label = base_label(k[0], k[1])
+        ans += group_display_knowl(k[0], k[1], name)
     if ans != '':
         ans += '</td></tr></table>'
     else:

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -8,12 +8,16 @@ from sage.all import ZZ, gap
 from lmfdb.utils import list_to_latex_matrix, display_multiset
 
 def small_group_display_knowl(n, k, name=None):
+    if not name:
+        myname = '$[%d, %d]$'%(n,k)
+    else:
+        myname = name
     group = db.gps_small.lookup('%s.%s'%(n,k))
     if group is None:
-        return '$[%d, %d]$'%(n,k)
+        return myname
     if not name:
-        name = '$%s$'%group['pretty']
-    return '<a title = "' + name + ' [group.small.data]" knowl="group.small.data" kwargs="gapid=' + str(n) + '.' + str(k) + '">' + name + '</a>'
+        myname = '$%s$'%group['pretty']
+    return '<a title = "' + myname + ' [group.small.data]" knowl="group.small.data" kwargs="gapid=' + str(n) + '.' + str(k) + '">' + myname + '</a>'
 
 def small_group_label_display_knowl(label, name=None):
     if not name:
@@ -174,6 +178,28 @@ def group_display_pretty(n, t):
         return group['pretty']
     return ""
 
+def group_pretty_and_nTj(n, t, useknowls=False):
+    label = base_label(n, t)
+    string = label
+    group = db.gps_transitive.lookup(label)
+    if useknowls and group is not None:
+        ntj = '<a title = "' + label + ' [nf.galois_group.data]" knowl="nf.galois_group.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + label + '</a>'
+    else:
+        ntj = label
+    if group is not None and group.get('pretty',None) is not None:
+        pretty = group['pretty']
+        # modify if we use knowls and have the gap id
+        if useknowls:
+            gapid = "%d.%d"%(group['order'],group['gapid'])
+            gapgroup = db.gps_small.lookup(gapid)
+            if gapgroup is not None:
+                print "gapgroup not none"
+                pretty = small_group_display_knowl(group['order'], group['gapid'], name=group['pretty'])
+        string = pretty + ' (as ' + ntj + ')'
+    else:
+        string = ntj
+    return string
+
 def group_display_knowl(n, t, name=None):
     label = base_label(n, t)
     group = db.gps_transitive.lookup(label)
@@ -181,7 +207,7 @@ def group_display_knowl(n, t, name=None):
         if group is not None and group.get('pretty',None) is not None:
             name = group['pretty']
         else:
-            name = "%dT%d"%(n,t)
+            name = label
     if group is None:
         return name
     return '<a title = "' + name + ' [nf.galois_group.data]" knowl="nf.galois_group.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -435,10 +435,9 @@ def resolve_display(resolves):
         else:
             ans += ', '
         k = j[1]
-        name = str(k[0]) + 'T' + str(k[1])
+        name = base_label(k[0], k[1])
         if k[1] == -1:
             name = '%dT?' % k[0]
-        label = base_label(k[0], k[1])
         ans += group_display_knowl(k[0], k[1], name)
     if ans != '':
         ans += '</td></tr></table>'

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -14,7 +14,7 @@ from lmfdb.utils import (
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.galois_groups.transitive_group import (
     group_display_short, group_display_knowl, group_display_inertia,
-    small_group_data, WebGaloisGroup)
+    group_pretty_and_nTj, small_group_data, WebGaloisGroup)
 
 LF_credit = 'J. Jones and D. Roberts'
 
@@ -75,7 +75,7 @@ def local_field_data(label):
     ans += 'Ramification index $e$: %s<br>' % str(f['e'])
     ans += 'Residue field degree $f$: %s<br>' % str(f['f'])
     ans += 'Discriminant ideal:  $(p^{%s})$ <br>' % str(f['c'])
-    ans += 'Galois group $G$: %s<br>' % group_display_knowl(gn, gt)
+    ans += 'Galois group $G$: %s<br>' % group_pretty_and_nTj(gn, gt, True)
     ans += '<div align="right">'
     ans += '<a href="%s">%s home page</a>' % (str(url_for("local_fields.by_label", label=label)),label)
     ans += '</div>'
@@ -160,7 +160,7 @@ def local_field_search(info,query):
     parse_ints(info,query,'c',name='Discriminant exponent c')
     parse_ints(info,query,'e',name='Ramification index e')
     parse_rats(info,query,'topslope',qfield='top_slope',name='Top slope', process=ratproc)
-    info['group_display'] = group_display_short
+    info['group_display'] = group_pretty_and_nTj
     info['display_poly'] = format_coeffs
     info['slopedisp'] = show_slope_content
 
@@ -196,7 +196,7 @@ def render_field_webpage(args):
             ('e', '\(%s\)' % e),
             ('f', '\(%s\)' % f),
             ('c', '\(%s\)' % cc),
-            ('Galois group', group_display_short(gn, gt)),
+            ('Galois group', group_pretty_and_nTj(gn, gt)),
         ]
         # Look up the unram poly so we can link to it
         unramlabel = db.lf_fields.lucky({'p': p, 'n': f, 'c': 0}, projection=0)
@@ -254,7 +254,7 @@ def render_field_webpage(args):
                     'base': lf_display_knowl(str(p)+'.1.0.1', name='$%s$'%Qp),
                     'hw': data['hw'],
                     'slopes': show_slopes(data['slopes']),
-                    'gal': group_display_knowl(gn, gt),
+                    'gal': group_pretty_and_nTj(gn, gt, True),
                     'gt': gt,
                     'inertia': group_display_inertia(data['inertia']),
                     'unram': unramp,

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -13,7 +13,7 @@ from lmfdb.utils import (
     search_wrap)
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.galois_groups.transitive_group import (
-    group_display_short, group_display_knowl, group_display_inertia,
+    group_display_knowl, group_display_inertia,
     group_pretty_and_nTj, small_group_data, WebGaloisGroup)
 
 LF_credit = 'J. Jones and D. Roberts'

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -16,8 +16,8 @@ from lmfdb.utils import (
     search_wrap)
 from lmfdb.local_fields.main import show_slope_content
 from lmfdb.galois_groups.transitive_group import (
-    group_display_knowl, cclasses_display_knowl,character_table_display_knowl,
-    group_phrase, group_display_short, galois_group_data, 
+    cclasses_display_knowl,character_table_display_knowl,
+    group_phrase, galois_group_data, 
     group_cclasses_knowl_guts, group_pretty_and_nTj,
     group_character_table_knowl_guts, group_alias_table)
 from lmfdb.number_fields import nf_page, nf_logger

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -17,7 +17,8 @@ from lmfdb.utils import (
 from lmfdb.local_fields.main import show_slope_content
 from lmfdb.galois_groups.transitive_group import (
     group_display_knowl, cclasses_display_knowl,character_table_display_knowl,
-    group_phrase, group_display_short, galois_group_data, group_cclasses_knowl_guts,
+    group_phrase, group_display_short, galois_group_data, 
+    group_cclasses_knowl_guts, group_pretty_and_nTj,
     group_character_table_knowl_guts, group_alias_table)
 from lmfdb.number_fields import nf_page, nf_logger
 from lmfdb.number_fields.web_number_field import (
@@ -372,7 +373,7 @@ def render_field_webpage(args):
             factored_conductor = factor_base_factor(data['conductor'], ram_primes)
             factored_conductor = factor_base_factorization_latex(factored_conductor)
             data['conductor'] = "\(%s=%s\)" % (str(data['conductor']), factored_conductor)
-    data['galois_group'] = group_display_knowl(n, t)
+    data['galois_group'] = group_pretty_and_nTj(n,t,True)
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
     data['class_group'] = nf.class_group()
@@ -544,7 +545,7 @@ def render_field_webpage(args):
                    ('Ramified ' + primes + '', '$%s$' % ram_primes),
                    ('Class number', '%s %s' % (data['class_number'], grh_lab)),
                    ('Class group', '%s %s' % (data['class_group_invs'], grh_lab)),
-                   ('Galois Group', group_display_short(data['degree'], t))
+                   ('Galois Group', group_pretty_and_nTj(data['degree'], t))
                    ]
     downloads = []
     for lang in [["Magma","magma"], ["SageMath","sage"], ["Pari/GP", "gp"]]:
@@ -720,6 +721,7 @@ def number_field_search(info, query):
     #    if label:
     #        return redirect(url_for(".by_label", label=clean_input(label)))
     info['wnf'] = WebNumberField.from_data
+    info['gg_display'] = group_pretty_and_nTj
 
 def search_input_error(info, bread):
     return render_template("number_field_search.html", info=info, title='Global Number Field Search Error', bread=bread)

--- a/lmfdb/number_fields/templates/number_field_search.html
+++ b/lmfdb/number_fields/templates/number_field_search.html
@@ -96,7 +96,6 @@ set of {{KNOWL('nf.ramified_primes', title='ramified primes')}}
 <td align='left'><a href="/NumberField/{{field.label}}">{{field.label}}</a></td>
 <td>{{ wnf.web_poly() | safe }}</td>
 <td>\( {{ wnf.disc_factored_latex() }} \)</td>
-{# <td>{{ info.group_display(field.galois) }}</td> #}
 <td>{{ wnf.galois_string() }}</td>
 {# {% if field.class_group is defined %} #}
 {% if wnf.haskey('class_group') %}

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -11,7 +11,7 @@ from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,
         display_multiset, factor_base_factor, factor_base_factorization_latex)
 from lmfdb.logger import make_logger
-from lmfdb.galois_groups.transitive_group import group_display_short, WebGaloisGroup, group_display_knowl, galois_module_knowl
+from lmfdb.galois_groups.transitive_group import group_display_short, WebGaloisGroup, group_display_knowl, galois_module_knowl, group_pretty_and_nTj
 wnflog = make_logger("WNF")
 
 dir_group_size_bound = 10000
@@ -204,7 +204,7 @@ def nf_knowl_guts(label):
     out += Dfact
     out += '<br>Signature: '
     out += str(wnf.signature())
-    out += '<br>Galois group: '+group_display_knowl(wnf.degree(),wnf.galois_t())
+    out += '<br>Galois group: '+group_pretty_and_nTj(wnf.degree(),wnf.galois_t(), True)
     out += '<br>Class number: %s ' % str(wnf.class_number_latex())
     if wnf.can_class_number():
         out += wnf.short_grh_string()
@@ -312,7 +312,7 @@ class WebNumberField:
             return 'Not computed'
         n = self._data['degree']
         t = self._data['galt']
-        return group_display_short(n, t)
+        return group_pretty_and_nTj(n, t)
 
     # Just return the t-number of the Galois group
     def galois_t(self):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -11,7 +11,7 @@ from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,
         display_multiset, factor_base_factor, factor_base_factorization_latex)
 from lmfdb.logger import make_logger
-from lmfdb.galois_groups.transitive_group import group_display_short, WebGaloisGroup, group_display_knowl, galois_module_knowl, group_pretty_and_nTj
+from lmfdb.galois_groups.transitive_group import WebGaloisGroup, group_display_knowl, galois_module_knowl, group_pretty_and_nTj
 wnflog = make_logger("WNF")
 
 dir_group_size_bound = 10000


### PR DESCRIPTION
When a Galois group appears with a "pretty" name X, we now (often) show it as "X (as nTj)".  This is used the properties box for an individual local or global field, on the main page for either type of field (using knowls, if possible, for both the abstract group and the nTj) and on search results pages for these two areas.  It is also used in dynamic field knowls for local or global number fields.

I did not touch the Artin section since the abstract group takes precedence -- we may produce as a permutation group acting on roots of a low degree polynomial, but we are really less interested in the particular permutation representation.

I also did not use it on Galois group pages since it seems that it would be more cumbersome there (e.g., when listing resolvents and other representations).  Sample pages below.

Galois group of a local field (group is in small group database so both pretty name and nTj are knowls):
  http://beta.lmfdb.org/LocalNumberField/5.8.0.1
  http://127.0.0.1:37777/LocalNumberField/5.8.0.1
Galois group of a global field (but the group is not in the small group database):
  http://beta.lmfdb.org/NumberField/9.1.32344469.1
  http://127.0.0.1:37777/NumberField/9.1.32344469.1
Global field search page (all S_4, but with 2 different nTj showing for it):
  http://beta.lmfdb.org/NumberField/?degree=6&galois_group=S4&ram_quantifier=exactly
  http://127.0.0.1:37777/NumberField/?degree=6&galois_group=S4&ram_quantifier=exactly
Global field where the Galois group does not have a pretty name (so just like before):
  http://beta.lmfdb.org/NumberField/21.3.3960879820606443846053527.1
  http://127.0.0.1:37777/NumberField/21.3.3960879820606443846053527.1

Also in this pull request are two invisible changes.  I removed a function which was no longer needed for displaying transitive groups, and fixed a potential bug when displaying a small group (if the function is fed a name to use, it sometimes did not use it -- I don't know of an instance where this currently comes up, but better to get it right).

This does not deal with error messages when searching.  It is a bit different, so will leave that for a separate pull request.