### PR TITLE
Knowl renaming to address #3014

### DIFF
--- a/lmfdb/lfunctions/templates/Degree2.html
+++ b/lmfdb/lfunctions/templates/Degree2.html
@@ -73,7 +73,7 @@ will be over-written.  Contact David Farmer is you want to suggest a change. -->
 <tr align="center">
 <th align="center">First&nbsp;complex<br>critical&nbsp;zero</th>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='$N$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='$N$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='$\chi$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/lfunctions/templates/Degree3.html
+++ b/lmfdb/lfunctions/templates/Degree3.html
@@ -66,7 +66,7 @@ or {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 <tr align="center">
 <th align="center">First&nbsp;complex<br>critical&nbsp;zero</th>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='$N$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='$N$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='$\chi$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/lfunctions/templates/Degree4.html
+++ b/lmfdb/lfunctions/templates/Degree4.html
@@ -79,7 +79,7 @@ or {{ KNOWL('lfunction.underlying_object', title='underlying object:') }}
 <tr align="center">
 <td align="center">First&nbsp;complex<br>critical&nbsp;zero</td>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='$N$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='$N$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='$\chi$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -95,7 +95,7 @@ table.ntdata tr.toggle a:hover { background: {{color.table_ntdata_background_c1}
   </tr>
 
   <tr>
-    <td> {{ KNOWL('lfunction.level', title="\( N \)") }} </td>
+    <td> {{ KNOWL('lfunction.conductor', title="\( N \)") }} </td>
     <td>&nbsp;=&nbsp;</td>
     <td> \({{ conductor }}\)
       {% if conductor_factored -%}

--- a/lmfdb/lfunctions/templates/yamltotable2.pl
+++ b/lmfdb/lfunctions/templates/yamltotable2.pl
@@ -47,7 +47,7 @@ print OUTFILE qq|
 <tr align="center">
 <th align="center">First&nbsp;complex<br>critical&nbsp;zero</th>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='\$N\$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='\$N\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='\$\\chi\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/lfunctions/templates/yamltotable3.pl
+++ b/lmfdb/lfunctions/templates/yamltotable3.pl
@@ -42,7 +42,7 @@ print OUTFILE qq|
 <tr align="center">
 <th align="center">First&nbsp;complex<br>critical&nbsp;zero</th>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='\$N\$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='\$N\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='\$\\chi\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/lfunctions/templates/yamltotable4.pl
+++ b/lmfdb/lfunctions/templates/yamltotable4.pl
@@ -47,7 +47,7 @@ print OUTFILE qq|
 <tr align="center">
 <td align="center">First&nbsp;complex<br>critical&nbsp;zero</td>
 <th align="center">{{ KNOWL('lfunction.underlying_object', title='underlying object') }}</th>
-<th align="center">{{ KNOWL('lfunction.level', title='\$N\$') }}</th>
+<th align="center">{{ KNOWL('lfunction.conductor', title='\$N\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.central_character', title='\$\\chi\$') }}</th>
 <th align="center">{{ KNOWL('lfunction.arithmetic', title='arithmetic') }}</th>
 <th align="center">{{ KNOWL('lfunction.self-dual', title='self-dual') }}</th>

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -296,7 +296,7 @@ def render_one_maass_waveform_wp(info, prec=9):
     #                   'prec': 'mf.maass.mwf.precision',
     #                   'mult': 'mf.maass.mwf.dimension',
     #                   'ncoeff': 'mf.maass.mwf.ncoefficients',
-    #                   'fricke': 'mf.maass.mwf.fricke',
+    #                   'fricke': 'cmf.fricke',
     #                   'atkinlehner': 'mf.maass.mwf.atkinlehner'}
     properties = [('Level', [info['MF'].level]),
                   ('Symmetry', [info['MF'].even_odd()]),
@@ -462,7 +462,7 @@ def evs_table2(search, twodarray=False, limit=50, offset=0):
     knowls = ['mf.maass.mwf.level', 'mf.maass.mwf.weight', 'mf.maass.mwf.character',
               'mf.maass.mwf.eigenvalue', 'mf.maass.mwf.symmetry',
               'mf.maass.mwf.precision', 'mf.maass.mwf.dimension',
-              'mf.maass.mwf.ncoefficients', 'mf.maass.mwf.fricke',
+              'mf.maass.mwf.ncoefficients', 'cmf.fricke',
               'mf.maass.mwf.atkinlehner']
     titles = ['Level', 'Weight', 'Char',
               'Eigenvalue', 'Symmetry',

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -297,7 +297,7 @@ def render_one_maass_waveform_wp(info, prec=9):
     #                   'mult': 'mf.maass.mwf.dimension',
     #                   'ncoeff': 'mf.maass.mwf.ncoefficients',
     #                   'fricke': 'cmf.fricke',
-    #                   'atkinlehner': 'mf.maass.mwf.atkinlehner'}
+    #                   'atkinlehner': 'cmf.atkin-lehner'}
     properties = [('Level', [info['MF'].level]),
                   ('Symmetry', [info['MF'].even_odd()]),
                   ('Weight', [info['MF'].the_weight()]),
@@ -463,7 +463,7 @@ def evs_table2(search, twodarray=False, limit=50, offset=0):
               'mf.maass.mwf.eigenvalue', 'mf.maass.mwf.symmetry',
               'mf.maass.mwf.precision', 'mf.maass.mwf.dimension',
               'mf.maass.mwf.ncoefficients', 'cmf.fricke',
-              'mf.maass.mwf.atkinlehner']
+              'cmf.atkin-lehner']
     titles = ['Level', 'Weight', 'Char',
               'Eigenvalue', 'Symmetry',
               'Precision', 'Mult.',

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
@@ -40,7 +40,7 @@ var evTable = $("table#eigenvalues").dataTable(
                   "sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass": "alignLeft","fnRender":"text-align:left"},
                  {"sName": "{{colheads[7]}}","sTitle": '{{KNOWL('mf.maass.mwf.ncoefficients',title='Coeff') |safe}}',
                   "sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass": "alignLeft","fnRender":"text-align:left"},
-                 {"sName": "{{colheads[8]}}","sTitle":'{{KNOWL('mf.maass.mwf.fricke',title='Fricke') |safe}}',
+                 {"sName": "{{colheads[8]}}","sTitle":'{{KNOWL('cmf.fricke',title='Fricke') |safe}}',
                  "sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass":"alignLeft","fnRender":"text-align:left"},
                  {"sName": "{{colheads[9]}}","sTitle": '{{KNOWL('mf.maass.mwf.atkinlehner',title='Atkin-Lehner') |safe}}',
                  "sWidth": "15%", "bSortable":false, "bSearchable": false,"sClass":"alignLeft atkinl","fnRender":"text-align:left"}],

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/templates/mwf_browse_all_eigenvalues.html
@@ -42,7 +42,7 @@ var evTable = $("table#eigenvalues").dataTable(
                   "sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass": "alignLeft","fnRender":"text-align:left"},
                  {"sName": "{{colheads[8]}}","sTitle":'{{KNOWL('cmf.fricke',title='Fricke') |safe}}',
                  "sWidth": "5%", "bSortable": false, "bSearchable": false,"sClass":"alignLeft","fnRender":"text-align:left"},
-                 {"sName": "{{colheads[9]}}","sTitle": '{{KNOWL('mf.maass.mwf.atkinlehner',title='Atkin-Lehner') |safe}}',
+                 {"sName": "{{colheads[9]}}","sTitle": '{{KNOWL('cmf.atkin-lehner',title='Atkin-Lehner') |safe}}',
                  "sWidth": "15%", "bSortable":false, "bSearchable": false,"sClass":"alignLeft atkinl","fnRender":"text-align:left"}],
 
     "bSort":true,


### PR DESCRIPTION
This PR makes the following knowl id changes to all source code and templates:

mf.maass.mwf.fricke -> cmf.fricke
mf.maass.mwf.atkinlehner -> cmf.atkin-lehner
lfunction.level -> lfunction.conductor

Once this is merged and pushed to web, the old knowls will be deleted.