### PR TITLE
Add L-function link to degree 3 and 4 browse pages

### DIFF
--- a/lmfdb/lfunctions/templates/Degree3.html
+++ b/lmfdb/lfunctions/templates/Degree3.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div>
-L-functions can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
+{{ KNOWL('lfunction', title='L-functions') }} can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
 All known {{ KNOWL('lfunction.known_degree3', title='degree 3') }} L-functions have a
 functional equation of one of the two forms
 \[

--- a/lmfdb/lfunctions/templates/Degree4.html
+++ b/lmfdb/lfunctions/templates/Degree4.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div>
-L-functions can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
+{{ KNOWL('lfunction', title='L-functions') }} can be organized by {{ KNOWL('lfunction.degree', title='degree') }}.
 All known {{ KNOWL('lfunction.known_degree4', title='degree 4') }} L-functions have a
 functional equation of one of the three forms:
 \[


### PR DESCRIPTION
This is a trivial change to add L-function knowl links to the degree 3 and 4 L-function browse pages (@sehlen already did this for the degree 1 and 2 pages).  I will merge this as soon as Travis finishes.