### PR TITLE
Don't include deleted knowls when getting categories

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -620,7 +620,7 @@ class KnowlBackend(PostgresBase):
         """
         Returns a dictionary giving the count of knowls within each category.
         """
-        selecter = SQL("SELECT cat, COUNT(*) FROM (SELECT DISTINCT ON (id) cat FROM kwl_knowls WHERE type = %s) knowls GROUP BY cat")
+        selecter = SQL("SELECT cat, COUNT(*) FROM (SELECT DISTINCT ON (id) cat FROM kwl_knowls WHERE type = %s AND status >= 0) knowls GROUP BY cat")
         cur = self._execute(selecter, [0])
         return {res[0]: res[1] for res in cur}
 

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -618,7 +618,7 @@ class KnowlBackend(PostgresBase):
 
     def get_categories(self):
         """
-        Returns a dictionary giving the count of knowls within each category.
+        Returns a dictionary giving the count of (not deleted) knowls within each category.
         """
         selecter = SQL("SELECT cat, COUNT(*) FROM (SELECT DISTINCT ON (id) cat FROM kwl_knowls WHERE type = %s AND status >= 0) knowls GROUP BY cat")
         cur = self._execute(selecter, [0])


### PR DESCRIPTION
To test, look at http://localhost:37777/knowledge/ and check that some categories with only deleted knowls (e.g. [hecke_algebras](http://beta.lmfdb.org/knowledge/?category=hecke-algebra)) have disappeared and the counts have been updated to not include deleted knowls.