### PR TITLE
Remove Future Plans link from sidebar

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -479,7 +479,6 @@ def introduction():
     b = intro_bread()
     return render_template(_single_knowl, title="Introduction", kid='intro', body_class=_bc, bread=b)
 
-
 @app.route("/intro/features")
 def introduction_features():
     b = intro_bread()
@@ -493,7 +492,6 @@ def introduction_zetatour():
     b.append(('Tutorial', url_for("introduction_zetatour")))
     return render_template(_single_knowl, title="A Tour of the Riemann Zeta Function", kid='intro.tutorial', body_class=_bc, bread=b)
 
-
 @app.route("/bigpicture")
 def bigpicture():
     b = [('Big Picture', url_for('bigpicture'))]
@@ -503,13 +501,6 @@ def bigpicture():
 def universe():
     b = [('LMFDB Universe', url_for('universe'))]
     return render_template("universe.html", title="The LMFDB Universe", body_class=_bc, bread=b)
-
-
-@app.route("/roadmap")
-def roadmap():
-    t = "Future Plans"
-    b = [(t, url_for('roadmap'))]
-    return render_template('roadmap.html', title=t, body_class=_bc, bread=b)
 
 @app.route("/news")
 def news():

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -10,8 +10,6 @@
       url_for: "introduction_features"
     - title: Universe
       url_for: "universe"
-    - title: Future Plans
-      url_for: "roadmap"
     - title: News
       url_for: "news"
 


### PR DESCRIPTION
As agreed at the editorial meeting in Princeton, this PR removes the Future Plans link from the sidebar.
(As a separate task we are reviewing existing roadmap knowls to ensure there are corresponding issues on github for items that are still open/relevant as of 1.1, we won't delete the knowls until this work is done).