### PR TITLE
Fix error handler in Sato-Tate groups search by label

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -203,17 +203,17 @@ def search_by_label(label):
     # check for general labels of the form w.d.name
     if re.match(ST_LABEL_NAME_RE,label):
         slabel = label.split('.')
-        try:
-            rlabel = db.gps_sato_tate.lucky({'weight':int(slabel[0]),'degree':int(slabel[1]),'name':slabel[2]}, 0)
-        except ValueError:
-            rlabel = None
+        rlabel = db.gps_sato_tate.lucky({'weight':int(slabel[0]),'degree':int(slabel[1]),'name':slabel[2]}, "label")
         if not rlabel:
             flash_error("%s is not the label or name of a Sato-Tate group currently in the database", label)
             return redirect(url_for(".index"))
-        label = rlabel
-        return redirect(url_for('.by_label', label=label), 301)
-    flash_error("%s is not a valid Sato-Tate group label", label)
-    return redirect(url_for(".index"))
+        return redirect(url_for('.by_label', label=rlabel), 301)
+    # check for a straight up name
+    rlabel = db.gps_sato_tate.lucky({'name':label}, "label")
+    if not rlabel:
+        flash_error("%s is not the label or name of a Sato-Tate group currently in the database", label)
+        return redirect(url_for(".index"))
+    return redirect(url_for('.by_label', label=rlabel), 301)
 
 # This search function doesn't fit the model of search_wrapper very well,
 # So we don't use it.

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -204,14 +204,16 @@ def search_by_label(label):
     if re.match(ST_LABEL_NAME_RE,label):
         slabel = label.split('.')
         try:
-            label = db.gps_sato_tate.lucky({'weight':int(slabel[0]),'degree':int(slabel[1]),'name':slabel[2]}, 0)
+            rlabel = db.gps_sato_tate.lucky({'weight':int(slabel[0]),'degree':int(slabel[1]),'name':slabel[2]}, 0)
         except ValueError:
-            label = None
-    if label is None:
-        flash_error("%s is not the label or name of a Sato-Tate group currently in the database", label)
-        return redirect(url_for(".index"))
-    else:
+            rlabel = None
+        if not rlabel:
+            flash_error("%s is not the label or name of a Sato-Tate group currently in the database", label)
+            return redirect(url_for(".index"))
+        label = rlabel
         return redirect(url_for('.by_label', label=label), 301)
+    flash_error("%s is not a valid Sato-Tate group label", label)
+    return redirect(url_for(".index"))
 
 # This search function doesn't fit the model of search_wrapper very well,
 # So we don't use it.

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -29,7 +29,8 @@ class SatoTateGroupTest(LmfdbTest):
         assert '1.4.6.1.1a' in L.data
         L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
-        L = self.tc.get('/SatoTateGroup/banana', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/banana')
+        print L.data
         assert 'not a label or name of a Sato-Tate group' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
         assert 'G_{3,3}' in L.data

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -29,7 +29,7 @@ class SatoTateGroupTest(LmfdbTest):
         assert '1.4.6.1.1a' in L.data
         L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
-        L = self.tc.get('/SatoTateGroup/banana')
+        L = self.tc.get('/SatoTateGroup/banana', follow_redirects=True)
         print L.data
         assert 'not a label or name of a Sato-Tate group' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -27,6 +27,10 @@ class SatoTateGroupTest(LmfdbTest):
     def test_direct_access(self):
         L = self.tc.get('/SatoTateGroup/1.4.G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
+        L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
+        assert '1.4.6.1.1a' in L.data
+        L = self.tc.get('/SatoTateGroup/banana')
+        assert 'not a label or name of a Sato-Tate group' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
         assert 'G_{3,3}' in L.data
         L = self.tc.get('/SatoTateGroup/0.1.mu(37)', follow_redirects=True)

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -30,8 +30,7 @@ class SatoTateGroupTest(LmfdbTest):
         L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
         L = self.tc.get('/SatoTateGroup/banana', follow_redirects=True)
-        print L.data
-        assert 'not a label or name of a Sato-Tate group' in L.data
+        assert 'The database currently contains' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
         assert 'G_{3,3}' in L.data
         L = self.tc.get('/SatoTateGroup/0.1.mu(37)', follow_redirects=True)

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -29,7 +29,7 @@ class SatoTateGroupTest(LmfdbTest):
         assert '1.4.6.1.1a' in L.data
         L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
         assert '1.4.6.1.1a' in L.data
-        L = self.tc.get('/SatoTateGroup/banana')
+        L = self.tc.get('/SatoTateGroup/banana', follow_redirects=True)
         assert 'not a label or name of a Sato-Tate group' in L.data
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
         assert 'G_{3,3}' in L.data


### PR DESCRIPTION
This PR fixes a bug in the error handling in the Sato-Tate groups search by label function that was causing infinite recursive redirects on bad input strings and badly formatted error messages in other cases.  It also lets you search directly by name without prefixing the name with the weight and degree.

To test, compare

http://www.lmfdb.org/SatoTateGroup/banana
http://127.0.0.1:37777/SatoTateGroup/banana

http://www.lmfdb.org/SatoTateGroup/1.4.USp(4)
http://127.0.0.1:37777/SatoTateGroup/1.4.USp(4)

http://www.lmfdb.org/SatoTateGroup/USp(4)
http://127.0.0.1:37777/SatoTateGroup/USp(4)

I'm not actually sure when/how this got broken (it certainly used to work), but this fixes the problem.