### PR TITLE
Big char tables

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -161,6 +161,9 @@ def render_group_webpage(args):
         order = data['order']
         data['orderfac'] = latex(ZZ(order).factor())
         orderfac = latex(ZZ(order).factor())
+        print ""
+        print "factored"
+        print ""
         data['ordermsg'] = "$%s=%s$" % (order, latex(orderfac))
         if order == 1:
             data['ordermsg'] = "$1$"
@@ -171,7 +174,7 @@ def render_group_webpage(args):
             G = gap.SmallGroup(n, t)
         else:
             G = gap.TransitiveGroup(n, t)
-        if ZZ(order) < ZZ('10000000000'):
+        if ZZ(order) < ZZ('10000000'):
             ctable = chartable(n, t)
         else:
             ctable = 'Group too large'

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -161,9 +161,6 @@ def render_group_webpage(args):
         order = data['order']
         data['orderfac'] = latex(ZZ(order).factor())
         orderfac = latex(ZZ(order).factor())
-        print ""
-        print "factored"
-        print ""
         data['ordermsg'] = "$%s=%s$" % (order, latex(orderfac))
         if order == 1:
             data['ordermsg'] = "$1$"

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -231,7 +231,10 @@ def character_table_display_knowl(n, t, name=None):
     if not name:
         name = 'Character table for '
         name += group_display_short(n, t)
-    return '<a title = "' + name + ' [gg.character_table.data]" knowl="gg.character_table.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
+    group = db.gps_transitive.lookup(base_label(n, t))
+    if ZZ(group['order']) < ZZ(10000000):
+        return '<a title = "' + name + ' [gg.character_table.data]" knowl="gg.character_table.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
+    return name + ' is not computed'
 
 
 def group_phrase(n, t):


### PR DESCRIPTION
We have a limit on how big a group can be for us to compute the character table on the fly.  This reduces the limit.  Previously, the beta version times out.

  http://beta.lmfdb.org/GaloisGroup/16T1949
  http://127.0.0.1:37777/GaloisGroup/16T1949

On corresponding number field pages, we provide a knowl to show the character table.  This does not show the knowl when the group is too large, e.g., on 

 http://127.0.0.1:37777/NumberField/16.0.404580172361410264596563466649600000000.1
 http://beta.lmfdb.org/NumberField/16.0.404580172361410264596563466649600000000.1

(for the one on beta, don't try to open the knowl).