### PR TITLE
Add try/except on local algebras

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -767,11 +767,12 @@ class WebNumberField:
             R = PolynomialRing(QQ, 'x')
             palg = local_algebra_dict[str(p)]
             palgs = [R(str(s)) for s in palg.split(',')]
-            palgstr = [
+            try:
+                palgstr = [
                     list2string([int(c) for c in pol.coefficients(sparse=False)])
                     for pol in palgs]
-            palgrec = [db.lf_fields.lucky({'p': p, 'coeffs': map(int, c.split(','))}) for c in palgstr]
-            return [
+                palgrec = [db.lf_fields.lucky({'p': p, 'coeffs': map(int, c.split(','))}) for c in palgstr]
+                return [
                     [
                         LF['label'],
                         latex(f),
@@ -784,7 +785,8 @@ class WebNumberField:
                         LF['slopes']
                     ]
                     for LF, f in zip(palgrec, palgs) ]
-        return None
+            except: # we were unable to find the local fields in the database
+                return None
 
     def ramified_algebras_data(self):
         if 'loc_algebras' not in self._data:


### PR DESCRIPTION
On beta, defining polynomials for some local fields are being changed.  A global number field tries to display local algebras at ramified primes, but it looks up the local field by defining polynomial.  Getting the data rewritten is taking longer than expected, so ...

This puts try/except around that code which looks up the local fields in the algebra of a global number field.  If something fails, it catches the error and the output to the user is that the data is not computed.  It is probably a good idea to make the change anyway so it doesn't rely on certain data being in the database.

A sample page where this comes up:
  http://127.0.0.1:37777/NumberField/22.0.178400853291024459894627.1
Currently on beta gives a server error.