### PR TITLE
Short label

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -536,7 +536,7 @@ def render_field_webpage(args):
         primes = 'primes'
 
     if len(label)>25:
-        label = label[:11]+'...'+label[-11:]
+        label = label[:16]+'...'+label[-6:]
     properties2 = [('Label', label),
                    ('Degree', '$%s$' % data['degree']),
                    ('Signature', '$%s$' % data['signature']),

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -528,13 +528,6 @@ def render_field_webpage(args):
 
     info['resinfo'] = resinfo
     learnmore = learnmore_list()
-    #if info['signature'] == [0,1]:
-    #    info['learnmore'].append(('Quadratic imaginary class groups', url_for(".render_class_group_data")))
-    # With Galois group labels, probably not needed here
-    # info['learnmore'] = [('Global number field labels',
-    # url_for(".render_labels_page")), ('Galois group
-    # labels',url_for(".render_groups_page")),
-    # (Completename,url_for(".render_discriminants_page"))]
     title = "Global Number Field %s" % info['label']
 
     if npr == 1:
@@ -542,6 +535,8 @@ def render_field_webpage(args):
     else:
         primes = 'primes'
 
+    if len(label)>25:
+        label = label[:11]+'...'+label[-11:]
     properties2 = [('Label', label),
                    ('Degree', '$%s$' % data['degree']),
                    ('Signature', '$%s$' % data['signature']),


### PR DESCRIPTION
When the label of a number field is very long, this replaces part of it with an ellipsis in the properties box.  Otherwise, the properties box gets excessively wide.  The label is still there in its entirety on the page title.

An example:
  http://beta.lmfdb.org/NumberField/22.0.178400853291024459894627.1
  http://127.0.0.1:37777/NumberField/22.0.178400853291024459894627.1

An example which does not change
  http://127.0.0.1:37777/NumberField/3.3.49.1
