### PR TITLE
Galois group not found

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -10,7 +10,7 @@ from sage.all import ZZ, latex, gap
 from lmfdb import db
 from lmfdb.app import app
 from lmfdb.utils import (
-    list_to_latex_matrix, 
+    list_to_latex_matrix, flash_error,
     clean_input, prep_ranges, parse_bool, parse_ints, parse_bracketed_posints, parse_restricted,
     search_wrap)
 from lmfdb.number_fields.web_number_field import modules2string
@@ -148,10 +148,11 @@ def render_group_webpage(args):
         label = label.replace('t', 'T')
         data = db.gps_transitive.lookup(label)
         if data is None:
-            bread = get_bread([("Search Error", ' ')])
-            info['err'] = "Group " + label + " was not found in the database."
-            info['label'] = label
-            return search_input_error(info, bread)
+            if re.match(r'^\d+T\d+$', label):
+                flash_error("Group %s was not found in the database.", label)
+            else:
+                flash_error("%s is not a valid label for a Galois group.", label)
+            return redirect(url_for(".index"))
         data['label_raw'] = label.lower()
         title = 'Galois Group: ' + label
         wgg = WebGaloisGroup.from_data(data)

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -7,22 +7,22 @@ class GalGpTest(LmfdbTest):
     # All tests should pass
     #
     def test_search_deg(self):
-		L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=7&t=&count=50')
-		assert 'all 7 matches' in L.data
+        L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=7&t=&count=50')
+        assert 'all 7 matches' in L.data
 
     def test_search_t_solv_prim(self):
-		L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=-1&cyc=0&solv=1&prim=-1&n=&t=18&count=50')
-		assert '14T18' in L.data
-		assert '294' in L.data # order of 21T18
+        L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=-1&cyc=0&solv=1&prim=-1&n=&t=18&count=50')
+        assert '14T18' in L.data
+        assert '294' in L.data # order of 21T18
 
     def test_display_bigpage(self):
-		L = self.tc.get('/GaloisGroup/22T29')
-		assert '22528' in L.data # order of 22T29
+        L = self.tc.get('/GaloisGroup/22T29')
+        assert '22528' in L.data # order of 22T29
 
     def test_search_range(self):
-		L = self.tc.get('GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=8-11&t=3-5&count=50')
-		assert '8T3' in L.data
-		assert '660' in L.data # order of 11T5
+        L = self.tc.get('GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=8-11&t=3-5&count=50')
+        assert '8T3' in L.data
+        assert '660' in L.data # order of 11T5
 
     def test_search_order(self):
         L = self.tc.get('GaloisGroup/?order=18')
@@ -33,3 +33,12 @@ class GalGpTest(LmfdbTest):
         L = self.tc.get('GaloisGroup/?gapid=[60,5]')
         assert '20T15' in L.data
         assert '15T5' in L.data
+
+    def test_bad_jump(self):
+        L = self.tc.get('/GaloisGroup/notagroup', follow_redirects=True)
+        assert 'not a valid label for a Galois group' in L.data
+
+    def test_bad_out_of_range(self):
+        L = self.tc.get('/GaloisGroup/12345T678', follow_redirects=True)
+        assert 'was not found in the database' in L.data
+


### PR DESCRIPTION
This provides better information to the user if they try to search with an invalid galois group label, or use it in a url.  Before, we just say error.   Now there is a flash error and we go to the index page.

Tell the user they have not given a valid label:
  http://beta.lmfdb.org/GaloisGroup/helloworld
  http://127.0.0.1:37777/GaloisGroup/helloworld

Tell the user it is not in the database:
 http://beta.lmfdb.org/GaloisGroup/39T1
 http://127.0.0.1:37777/GaloisGroup/39T1

If the user asks for 2T9, then we say it is not in the database even though there is no such group.  Making this distinction is possible but, in my opinion, not worth it.

In the test file, 2 tests were added and the file was untabified.
