### PR TITLE
Global to Galois

### DIFF
--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -61,7 +61,7 @@
       <tr><td>{{ KNOWL('lf.tame_degree', title='Tame degree')}}:</td><td>${{info.t}}$</td></tr>
       <tr><td>{{ KNOWL('lf.wild_slopes', title='Wild slopes')}}:</td><td>{{info.slopes}}</td></tr>
       <tr><td>{{ KNOWL('lf.galois_mean_slope', title='Galois mean slope')}}:</td><td>${{info.gms}}$</td></tr>
-      <tr><td>{{KNOWL('lf.global_splitting_model', title='Global splitting model')}}:</td><td>{{info.gsm}}</td></tr>
+      <tr><td>{{KNOWL('lf.galois_splitting_model', title='Galois splitting model')}}:</td><td>{{info.gsm}}</td></tr>
     </table>
   </p>
 


### PR DESCRIPTION
Text change of "Global splitting model" to "Galois splitting model".  See, for example, the bottom of

  http://127.0.0.1:37777/LocalNumberField/3.3.4.1
  http://beta.lmfdb.org/LocalNumberField/3.3.4.1

This also involves the renaming of a knowl which is in progress.