### PR TITLE
fix failing CMF test

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -592,11 +592,14 @@ class CmfTest(LmfdbTest):
         assert '0.5, -2.2282699087' in page.data
         assert '0.406839418685' in page.data
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform/27.2.e.a', follow_redirects=True)
-        assert '[-1, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0]' in page.data # a_2
+        assert '"analytic_rank_proved": true' in page.data
+        assert '[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]' in page.data # a1 (make sure qexp is there)
+        assert '[1, 1, 27, 5, 1, 9, 0]' in page.data # non-trivial inner twist
         assert '-2.2282699087' in page.data
         assert '[0, 12, -6, -6, -6, -3, 0, -6, 6, 0, -3, 3, 12, -6, 15, 9, 0, 9, 9, -3, -3, -12, 3, -12, -18, 3, -30' in page.data
         assert '-0.498394' in page.data
         assert '0.406839418685' in page.data
+        assert '1.2.3.c9' in page.data # Sato-Tate group
 
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_full_space/20.5', follow_redirects = True)


### PR DESCRIPTION
One of the CMF download tests is failing because the basis for the Hecke ring has changed (the order of the generators changed during a reoptimization pass).  This PR fixes that by modifying the test to not depend on the exact representation of q-expansion coefficients.

This is a tiny change that only impacts this test, I will merge once the tests pass.