### PR TITLE
Fix stats of dihedral groups

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -231,7 +231,7 @@ def statistics():
     # t-numbers for D_n
     dn_tlist = [1, 1, 2, 3, 2, 3, 2, 6, 3, 3, 2, 12, 2, 3, 2, 56, 2, 13, 2, 10,
                 5, 3, 2]
-    dn = galstatdict(fields.stats.get_oldstat('dn')['counts'], n, dn_tlist)
+    dn = galstatdict([nt_stats[(j+1,dn_tlist[j])] for j in range(len(dn_tlist))], n, dn_tlist)
 
     h = [fields.count({'class_number': {'$lt': 1+10**j, '$gt': 10**(j-1)}}) for j in range(12)]
     has_h = fields.count({'class_number': {'$exists': True}})


### PR DESCRIPTION
There was a place where the code was pulling numbers from the old_stats, so numbers were wrong.  Compare the line for Galois group D_n on the number field stats page.  Some of the numbers are bigger with this change, and if you click on the number, it does the search for fields showing the new numbers are right.