### PR TITLE
updated workshops list with some Warwick meetings

### DIFF
--- a/lmfdb/templates/workshops.html
+++ b/lmfdb/templates/workshops.html
@@ -48,12 +48,64 @@ Sponsored by <a href="https://www.simonsfoundation.org/">Simons Foundation</a>
 <br>
 
 <li>
+  Focussed working group on lattices
+  <br>
+ 31 July - 4 August 2017, <a href="http://www2.warwick.ac.uk/fac/sci/maths">Warwick Mathematics 
+Institute</a>, University of Warwick, Warwick, UK
+<br>
+Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
+<a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+</li>
+
+<br>
+
+<li>
+<a href="https://warwick.ac.uk/fac/sci/maths/research/events/2016-17/nonsymposium/lmfdb">
+  LMFDB Workshop</a>
+<br>
+12-16 June 2017, <a href="http://www2.warwick.ac.uk/fac/sci/maths">Warwick Mathematics 
+Institute</a>, University of Warwick, Warwick, UK
+<br>
+Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
+<a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+</li>
+
+<br>
+
+<li>
+  Focussed working group on modular Galois representations
+  <br>
+ 20-24 March 2017, <a href="http://www2.warwick.ac.uk/fac/sci/maths">Warwick
+Mathematics Institute</a>, University of Warwick, Warwick, UK
+<br>
+Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
+<a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+</li>
+
+<br>
+
+<li>
+  Focussed working group on mod-p modular forms
+<br>
+  11-13 September 2016, <a href="http://www2.warwick.ac.uk/fac/sci/maths">Warwick Mathematics 
+Institute</a>, University of Warwick, Warwick, UK
+<br>
+Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
+<a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+</li>
+
+<br>
+
+
+<li>
 LMFDB workshop, <br>
 May 9-13, 2016, <a href="https://aimath.org/">American Institute of
 Mathematics</a>, San Jose, CA, USA
 <br>
 Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
 <a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+ and by <a href="https://aimath.org/">American Institute of
+Mathematics</a>
 </li>
 
 <br>
@@ -78,6 +130,18 @@ Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
 
 <br>
 
+<li>
+  Focussed working group on classical modular forms
+  <br>
+   14-18 December 2015, <a href="http://www2.warwick.ac.uk/fac/sci/maths">Warwick Mathematics 
+Institute</a>, University of Warwick, Warwick, UK
+<br>
+Sponsored by <i>LMF: L-functions and modular forms</i>, EPSRC reference
+<a href="http://gow.epsrc.ac.uk/NGBOViewGrant.aspx?GrantRef=EP/K034383/1">EP/K034383/1</a>
+</li>
+
+<br>
+
 <li><a href="http://icerm.brown.edu/sp-f15">Computational Aspects of the Langlands Program</a>, <br>
 September 8-December 4, 2015, <a href="http://icerm.brown.edu/home/">Institute for Computational
 and Experimental Research in Mathematics</a>, Providence, RI, USA
@@ -85,7 +149,7 @@ and Experimental Research in Mathematics</a>, Providence, RI, USA
 
 <br>
 
-<li>Genus 2 curves, <br>
+<li>Focussed working group on genus 2 curves, <br>
 March 23-27, 2015, <a href="https://www.ucd.ie/">University College Dublin</a>,
 Dublin, IE
 <br>


### PR DESCRIPTION
I added 4 small "focussed workhops" at Warwick since 2015, the larger LMFDB workshop at Warwick in 2017, and made a few minor changes, notably add AIM to the sponsors for May 2016.

This only changes one template file so I'll merge once tests pass.