### PR TITLE
Multiplicities in Galois group displays

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -182,8 +182,8 @@ def render_group_webpage(args):
         data['chartable'] = ctable
         data['parity'] = "$%s$" % data['parity']
         data['cclasses'] = conjclasses(G, n)
-        data['subinfo'] = subfield_display(n, data['subs'])
-        data['resolve'] = resolve_display(data['resolve'])
+        data['subinfo'] = subfield_display(n, data['subfields'])
+        data['resolve'] = resolve_display(data['quotients'])
         if data['gapid'] == 0:
             data['gapid'] = "Data not available"
         else:

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -172,10 +172,11 @@ def render_group_webpage(args):
             G = gap.SmallGroup(n, t)
         else:
             G = gap.TransitiveGroup(n, t)
-        if ZZ(order) < ZZ('10000000'):
+        cclasses = conjclasses(G, n)
+        if ZZ(order) < ZZ(10000000) and len(cclasses) < 21:
             ctable = chartable(n, t)
         else:
-            ctable = 'Group too large'
+            ctable = 'Data not available'
         data['gens'] = generators(n, t)
         if n == 1 and t == 1:
             data['gens'] = 'None needed'

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -17,7 +17,7 @@ from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
 from .transitive_group import (
     group_display_pretty, small_group_display_knowl, galois_module_knowl_guts,
-    subfield_display, resolve_display, conjclasses, generators, chartable,
+    subfield_display, resolve_display, generators, chartable,
     group_alias_table, WebGaloisGroup)
 
 # Test to see if this gap installation knows about transitive groups
@@ -155,7 +155,7 @@ def render_group_webpage(args):
             return redirect(url_for(".index"))
         data['label_raw'] = label.lower()
         title = 'Galois Group: ' + label
-        wgg = WebGaloisGroup.from_data(data)
+        wgg = WebGaloisGroup.from_nt(data['n'], data['t'])
         n = data['n']
         t = data['t']
         data['yesno'] = yesno
@@ -168,11 +168,8 @@ def render_group_webpage(args):
         if ZZ(order).is_prime():
             data['ordermsg'] = "$%s$ (is prime)" % order
         pgroup = len(ZZ(order).prime_factors()) < 2
-        if n == 1:
-            G = gap.SmallGroup(n, t)
-        else:
-            G = gap.TransitiveGroup(n, t)
-        cclasses = conjclasses(G, n)
+        G = wgg.gapgroupnt()
+        cclasses = wgg.conjclasses()
         if ZZ(order) < ZZ(10000000) and len(cclasses) < 21:
             ctable = chartable(n, t)
         else:
@@ -182,7 +179,7 @@ def render_group_webpage(args):
             data['gens'] = 'None needed'
         data['chartable'] = ctable
         data['parity'] = "$%s$" % data['parity']
-        data['cclasses'] = conjclasses(G, n)
+        data['cclasses'] = wgg.conjclasses()
         data['subinfo'] = subfield_display(n, data['subfields'])
         data['resolve'] = resolve_display(data['quotients'])
         if data['gapid'] == 0:

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -168,7 +168,6 @@ def render_group_webpage(args):
         if ZZ(order).is_prime():
             data['ordermsg'] = "$%s$ (is prime)" % order
         pgroup = len(ZZ(order).prime_factors()) < 2
-        G = wgg.gapgroupnt()
         cclasses = wgg.conjclasses()
         if ZZ(order) < ZZ(10000000) and len(cclasses) < 21:
             ctable = chartable(n, t)

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -52,6 +52,20 @@ def small_group_data(gapid):
     inf += '</table></p>'
     return inf
 
+def list_with_mult(lis):
+    lis2 = [(j[0], j[1]) for j in lis]
+    diflis = list(set(lis2))
+    diflis.sort()
+    ans = ''
+    for k in diflis:
+        if ans != '':
+            ans += ', '
+        cnt = lis2.count(k)
+        ans += group_display_knowl(k[0], k[1])
+        if cnt>1:
+            ans += " x %d"%cnt
+    return ans
+
 
 ############  Galois group object
 
@@ -103,37 +117,10 @@ class WebGaloisGroup:
         return self._data['name']
 
     def otherrep_list(self):
-        reps = [(j[0], j[1]) for j in self._data['repns']]
-        me = (self.n(), self.t())
-        difreps = list(set(reps))
-        difreps.sort()
-        ans = ''
-        for k in difreps:
-            if ans != '':
-                ans += ', '
-            cnt = reps.count(k)
-            start = 'a'
-            if k == me:
-                start = nextchr(start)
-            if cnt == 1:
-                ans += group_display_knowl(k[0], k[1])
-                if k == me:
-                    ans += 'b'
-            else:
-                for j in range(cnt):
-                    if j > 0:
-                        ans += ', '
-                    ans += "%s%s" % (group_display_knowl(k[0], k[1]), start)
-                    start = nextchr(start)
-        return ans
+        return(list_with_mult(self._data['repns']))
 
     def subfields(self):
-        ans = ''
-        for k in self._data['subs']:
-            if ans != '':
-                ans += ', '
-            ans += group_display_knowl(k[0], k[1])
-        return ans
+        return(list_with_mult(self._data['subs']))
 
 ############  Misc Functions
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -248,9 +248,9 @@ def character_table_display_knowl(n, t, name=None):
     if not name:
         name = 'Character table for '
         name += group_display_short(n, t)
-    group = db.gps_transitive.lookup(base_label(n, t))
+    group = WebGaloisGroup.from_nt(n, t)
     cclasses = group.conjclasses()
-    if ZZ(group['order']) < ZZ(10000000) and len(cclasses) < 21:
+    if ZZ(group.order()) < ZZ(10000000) and len(cclasses) < 21:
         return '<a title = "' + name + ' [gg.character_table.data]" knowl="gg.character_table.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
     return name + ' is not computed'
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -483,9 +483,8 @@ def group_display_inertia(code):
     return ans
 
 def cclasses(n, t):
-    group = db.gps_transitive.lookup(base_label(n,t))
-    G = group.gapgroupnt()
-    cc = G.conjclasses()
+    group = WebGaloisGroup.from_nt(n,t)
+    cc = group.conjclasses()
     html = """<div>
             <table class="ntdata">
             <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -218,7 +218,9 @@ def character_table_display_knowl(n, t, name=None):
         name = 'Character table for '
         name += group_display_short(n, t)
     group = db.gps_transitive.lookup(base_label(n, t))
-    if ZZ(group['order']) < ZZ(10000000):
+    G = gap.TransitiveGroup(n, t)
+    cclasses = conjclasses(G, n)
+    if ZZ(group['order']) < ZZ(10000000) and len(cclasses) < 21:
         return '<a title = "' + name + ' [gg.character_table.data]" knowl="gg.character_table.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
     return name + ' is not computed'
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -52,18 +52,18 @@ def small_group_data(gapid):
     inf += '</table></p>'
     return inf
 
-def list_with_mult(lis):
-    lis2 = [(j[0], j[1]) for j in lis]
-    diflis = list(set(lis2))
-    diflis.sort()
+# Input is a list [[[n1, t1], mult1], [[n2,t2],mult2], ...]
+def list_with_mult(lis, names=True):
     ans = ''
-    for k in diflis:
+    for k in lis:
         if ans != '':
             ans += ', '
-        cnt = lis2.count(k)
-        ans += group_display_knowl(k[0], k[1])
-        if cnt>1:
-            ans += " x %d"%cnt
+        if names:
+            ans += group_display_knowl(k[0][0], k[0][1])
+        else:
+            ans += group_display_knowl(k[0][0], k[0][1], base_label(k[0][0],k[0][1]))
+        if k[1]>1:
+            ans += "<span style='font-size: small'> x %d</span>"% k[1]
     return ans
 
 
@@ -117,10 +117,10 @@ class WebGaloisGroup:
         return self._data['name']
 
     def otherrep_list(self):
-        return(list_with_mult(self._data['repns']))
+        return(list_with_mult(self._data['siblings'], names=False))
 
     def subfields(self):
-        return(list_with_mult(self._data['subs']))
+        return(list_with_mult(self._data['subfields']))
 
 ############  Misc Functions
 
@@ -290,10 +290,14 @@ def galois_group_data(n, t):
     rest += '</blockquote></div>'
 
     rest += '<div><h3>Subfields</h3><blockquote>'
-    rest += subfield_display(n, group['subs'])
+    rest += subfield_display(n, group['subfields'])
     rest += '</blockquote></div>'
     rest += '<div><h3>Other low-degree representations</h3><blockquote>'
-    rest += otherrep_display(n, t, group['repns'])
+    sibs = list_with_mult(group['siblings'], False)
+    if sibs != '':
+        rest += sibs
+    else:
+        rest += 'None'
     rest += '</blockquote></div>'
     rest += '<div align="right">'
     rest += '<a href="/GaloisGroup/%s">%sT%s home page</a>' % (label, str(n), str(t))
@@ -369,9 +373,11 @@ def subfield_display(n, subs):
     for deg in degs:
         substrs[deg] = ''
     for k in subs:
-        if substrs[k[0]] != '':
-            substrs[k[0]] += ', '
-        substrs[k[0]] += group_display_knowl(k[0], k[1])
+        if substrs[k[0][0]] != '':
+            substrs[k[0][0]] += ', '
+        substrs[k[0][0]] += group_display_knowl(k[0][0], k[0][1])
+        if k[1]>1:
+            substrs[k[0][0]] += '<span style="font-size: small"> x %d</span>'%k[1]
     for deg in degs:
         ans += '<p>Degree ' + str(deg) + ': '
         if substrs[deg] == '':
@@ -424,10 +430,12 @@ def resolve_display(resolves):
         else:
             ans += ', '
         k = j[1]
-        name = base_label(k[0], k[1])
         if k[1] == -1:
-            name = '%dT?' % k[0]
-        ans += group_display_knowl(k[0], k[1], name)
+            ans += group_display_knowl(k[0], k[1], '%dT?' % k[0])
+        else:
+            ans += group_display_knowl(k[0], k[1])
+        if j[2]>1:
+            ans += '<span style="font-size: small"> x %d</span>'% j[2]
     if ans != '':
         ans += '</td></tr></table>'
     else:
@@ -501,6 +509,8 @@ def generators(n, t):
     gens = G.SmallGeneratingSet()
     gens = str(gens)
     gens = re.sub("[\[\]]", '', gens)
+    gens = gens.replace(' ', '')
+    gens = gens.replace('),', '), ')
     return gens
 
 


### PR DESCRIPTION
This can wait for 1.2, but it is better to submit it now in case there is feedback.  It addresses issue #3033 

When listing things like resolvents, "subfields", or siblings for a Galois group, we want to explicitly give multiplicities rather than just repeat the item.  This is good when there is a modest number of repeated items, and essential when there is a large number.  It is used on the page displaying a group, on the search result page, and in the knowl for a transitive group.  Some of the examples below time out on beta.  Some probably work on the main site because it does not have the data for permutation representations in degrees bigger than 23.  One way to see the difference is to run with --debug, and then switch branches redisplaying the page.

Other changes: display of actual permutations has better spacing (e.g., list of generators on a group page), and we don't display character tables when the number of conjugacy classes is too large (they are currently computed on the fly, and it takes a long time, plus the display from gap cuts up the table).  This also consolidates some computations, like conjugacy classes, so they don't have to be done several times.

Here are some pages

Search results in degree 16:
  http://127.0.0.1:37777/GaloisGroup/?n=16
The page has multiplicities and contains knowls also showing multiplicities (e.g. C_2^3 which is a subfield of 16T3)

Search results in degree 22:
 http://127.0.0.1:37777/GaloisGroup/?n=22&count=100
probably doesn't load on beta.

A particularly hard group:
  http://127.0.0.1:37777/GaloisGroup/22T28
It is still slow, but not horrendous anymore.  It will speed up if we precompute conjugacy classes and store them in the database.

If/when this is merged, the data will need to be copied to the cloud just before merging it there.  It uses several new columns in the database.
