### PR TITLE
No more bananas!

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -263,7 +263,7 @@ def by_label(label):
         validate_label(label)
     except ValueError as err:
         flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label: %s." % (label, str(err))), "error")
-        return redirect(url_for(".index"))
+        return redirect(url_for(".abelian_varieties"))
     g, q, iso = split_label(label)
     return redirect(url_for(".abelian_varieties_by_gqi", g = g, q = q, iso = iso))
 

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -263,7 +263,7 @@ def by_label(label):
         validate_label(label)
     except ValueError as err:
         flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label: %s." % (label, str(err))), "error")
-        return search_input_error()
+        return redirect(url_for(".index"))
     g, q, iso = split_label(label)
     return redirect(url_for(".abelian_varieties_by_gqi", g = g, q = q, iso = iso))
 

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -45,7 +45,7 @@ def parse_artin_label(label):
     if LABEL_RE.match(label):
         return label
     else:
-        raise ValueError("input %s is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1"% label)
+        raise ValueError("input %s is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1")
 
 def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
@@ -73,7 +73,7 @@ def artin_representation_jump(info):
     try:
         label = parse_artin_label(label)
     except ValueError as err:
-        flash_error("%s" % (err))
+        flash_error("%s" % (err),label)
         return redirect(url_for(".index"))
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)
 
@@ -134,7 +134,7 @@ def render_artin_representation_webpage(label):
             flash_error("Artin representation %s is not in database", newlabel)
             return redirect(url_for(".index"))
         except ValueError as err:
-            flash_error("%s" % (err))
+            flash_error("%s" % (err), label)
             return redirect(url_for(".index"))
 
     extra_data = {} # for testing?

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -26,8 +26,8 @@ from lmfdb.classical_modular_forms.web_space import (
     ALdim_table, OLDLABEL_RE as OLD_SPACE_LABEL_RE)
 from lmfdb.classical_modular_forms.download import CMF_download
 
-POSINT_RE = re.compile("[1-9][0-9]*")
-ALPHA_RE = re.compile("[a-z]+")
+POSINT_RE = re.compile("^[1-9][0-9]*$")
+ALPHA_RE = re.compile("^[a-z]+$")
 
 @cached_function
 def learnmore_list():

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -225,7 +225,7 @@ def index():
             return space_search(info, random=True)
         assert False
     info = {"stats": CMF_stats()}
-    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist if label != "random"] for sublist in favorite_newform_labels]
+    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist] for sublist in favorite_newform_labels]
     info["space_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist] for sublist in favorite_space_labels]
     info["weight_list"] = ('1', '2', '3', '4', '5-8', '9-16', '17-32', '33-64', '65-%d' % weight_bound() )
     info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-2000', '2001-4000', '4001-6000', '6001-8000', '8001-%d' % level_bound() )
@@ -475,7 +475,8 @@ POSINT_RE = re.compile("[1-9][0-9]*")
 ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
-    print "url_for_label =", label
+    if label == "random":
+        return url_for("cmf.random_form")
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -476,7 +476,7 @@ ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     if label == "random":
-        return url_for(".random_form")
+        return None
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -423,6 +423,7 @@ def by_url_level(level):
             return redirect(url_for_label(label = level), code=301)
         except ValueError:
             flash_error("%s is not a valid newform or space label", level)
+            return redirect(url_for(".index"))
     info = to_dict(request.args)
     if 'level' in info:
         return redirect(url_for('.index', **request.args), code=307)

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -475,6 +475,8 @@ POSINT_RE = re.compile("[1-9][0-9]*")
 ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
+    if label == "random":
+        return url_for("cmf.random_form")
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -476,7 +476,7 @@ ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     if label == "random":
-        return None
+        return url_for("cmf.random_form")
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"
@@ -500,6 +500,8 @@ def url_for_label(label):
 
 def jump_box(info):
     jump = info.pop("jump").strip()
+    if jump == "random":
+        return random_form()
     errmsg = None
     if OLD_SPACE_LABEL_RE.match(jump):
         jump = convert_spacelabel_from_conrey(jump)

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -420,7 +420,7 @@ def render_full_gamma1_space_webpage(label):
 def by_url_level(level):
     if not POSINT_RE.match(level):
         try:
-            return redirect(url_for_label(label = level), code=301)
+            return redirect(url_for_label(level), code=301)
         except ValueError:
             flash_error("%s is not a valid newform or space label", level)
             return redirect(url_for(".index"))

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -26,6 +26,8 @@ from lmfdb.classical_modular_forms.web_space import (
     ALdim_table, OLDLABEL_RE as OLD_SPACE_LABEL_RE)
 from lmfdb.classical_modular_forms.download import CMF_download
 
+POSINT_RE = re.compile("[1-9][0-9]*")
+ALPHA_RE = re.compile("[a-z]+")
 
 @cached_function
 def learnmore_list():
@@ -416,8 +418,11 @@ def render_full_gamma1_space_webpage(label):
 
 @cmf.route("/<level>/")
 def by_url_level(level):
-    if "." in level:
-        return redirect(url_for_label(label = level), code=301)
+    if not POSINT_RE.match(level):
+        try:
+            return redirect(url_for_label(label = level), code=301)
+        except ValueError:
+            flash_error("%s is not a valid newform or space label", level)
     info = to_dict(request.args)
     if 'level' in info:
         return redirect(url_for('.index', **request.args), code=307)
@@ -470,9 +475,6 @@ def by_url_embedded_newform_label(level, weight, char_orbit_label, hecke_orbit, 
     newform_label = ".".join(map(str, [level, weight, char_orbit_label, hecke_orbit]))
     embedding_label = ".".join(map(str, [conrey_index, embedding]))
     return render_embedded_newform_webpage(newform_label, embedding_label)
-
-POSINT_RE = re.compile("[1-9][0-9]*")
-ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     if label == "random":

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -225,7 +225,7 @@ def index():
             return space_search(info, random=True)
         assert False
     info = {"stats": CMF_stats()}
-    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist] for sublist in favorite_newform_labels]
+    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist if label ne "random"] for sublist in favorite_newform_labels]
     info["space_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist] for sublist in favorite_space_labels]
     info["weight_list"] = ('1', '2', '3', '4', '5-8', '9-16', '17-32', '33-64', '65-%d' % weight_bound() )
     info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-2000', '2001-4000', '4001-6000', '6001-8000', '8001-%d' % level_bound() )

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -225,7 +225,7 @@ def index():
             return space_search(info, random=True)
         assert False
     info = {"stats": CMF_stats()}
-    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist if label ne "random"] for sublist in favorite_newform_labels]
+    info["newform_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist if label != "random"] for sublist in favorite_newform_labels]
     info["space_list"] = [[{'label':label,'url':url_for_label(label),'reason':reason} for label, reason in sublist] for sublist in favorite_space_labels]
     info["weight_list"] = ('1', '2', '3', '4', '5-8', '9-16', '17-32', '33-64', '65-%d' % weight_bound() )
     info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-2000', '2001-4000', '4001-6000', '6001-8000', '8001-%d' % level_bound() )

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -475,9 +475,7 @@ POSINT_RE = re.compile("[1-9][0-9]*")
 ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
-    if label == "random":
-        print "url_for_label returned", url_for("cmf.random_form")
-        return url_for("cmf.random_form")
+    print "url_for_label =", label
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -471,6 +471,8 @@ def by_url_newform_conreylabel_with_embedding(level, weight, char_orbit_label, h
     embedding_label = ".".join(map(str, [conrey_index, embedding]))
     return render_embedded_newform_webpage(newform_label, embedding_label)
 
+POSINT_RE = re.compile("[1-9][0-9]*")
+
 def url_for_label(label):
     slabel = label.split(".")
     if len(slabel) == 6:
@@ -481,7 +483,7 @@ def url_for_label(label):
         func = "cmf.by_url_space_label"
     elif len(slabel) == 2:
         func = "cmf.by_url_full_gammma1_space_label"
-    elif len(slabel) == 1:
+    elif len(slabel) == 1 and POSINT_RE.match(slabel[1]):
         func = "cmf.by_url_level"
     else:
         raise ValueError("Invalid label")

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -499,7 +499,6 @@ def url_for_label(label):
 
 def jump_box(info):
     jump = info.pop("jump").strip()
-    print "jump =", jump
     errmsg = None
     if OLD_SPACE_LABEL_RE.match(jump):
         jump = convert_spacelabel_from_conrey(jump)

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -501,9 +501,6 @@ def url_for_label(label):
 
 def jump_box(info):
     jump = info.pop("jump").strip()
-    if jump == "random":
-        print "random it is"
-        return random_form()
     print "jump =", jump
     errmsg = None
     if OLD_SPACE_LABEL_RE.match(jump):

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -460,11 +460,11 @@ def by_url_newform_conrey5(level, weight, char_orbit_label, hecke_orbit, embeddi
     conrey_index, embedding = embedding_label.split('.')
     if not (conrey_index.isdigit() and embedding.isdigit()):
         return abort(404, "Invalid embedding label: not integers")
-    return redirect(url_for("cmf.by_url_newform_conreylabel_with_embedding", level=level, weight=weight, char_orbit_label=char_orbit_label, hecke_orbit=hecke_orbit, conrey_index=conrey_index, embedding=embedding), code=301)
+    return redirect(url_for("cmf.by_url_embedded_newform_label", level=level, weight=weight, char_orbit_label=char_orbit_label, hecke_orbit=hecke_orbit, conrey_index=conrey_index, embedding=embedding), code=301)
 
 # Embedded modular form
 @cmf.route("/<int:level>/<int:weight>/<char_orbit_label>/<hecke_orbit>/<int:conrey_index>/<int:embedding>/")
-def by_url_newform_conreylabel_with_embedding(level, weight, char_orbit_label, hecke_orbit, conrey_index, embedding):
+def by_url_embedded_newform_label(level, weight, char_orbit_label, hecke_orbit, conrey_index, embedding):
     if conrey_index <= 0 or embedding <= 0:
         return abort(404, "Invalid embedding label: negative values")
     newform_label = ".".join(map(str, [level, weight, char_orbit_label, hecke_orbit]))
@@ -472,22 +472,27 @@ def by_url_newform_conreylabel_with_embedding(level, weight, char_orbit_label, h
     return render_embedded_newform_webpage(newform_label, embedding_label)
 
 POSINT_RE = re.compile("[1-9][0-9]*")
+ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     slabel = label.split(".")
     if len(slabel) == 6:
-        func = "cmf.by_url_newform_conreylabel_with_embedding"
+        func = "cmf.by_url_embedded_newform_label"
     elif len(slabel) == 4:
         func = "cmf.by_url_newform_label"
     elif len(slabel) == 3:
         func = "cmf.by_url_space_label"
     elif len(slabel) == 2:
         func = "cmf.by_url_full_gammma1_space_label"
-    elif len(slabel) == 1 and POSINT_RE.match(slabel[1]):
+    elif len(slabel) == 1:
         func = "cmf.by_url_level"
     else:
         raise ValueError("Invalid label")
     keys = ['level', 'weight', 'char_orbit_label', 'hecke_orbit', 'conrey_index', 'embedding']
+    keytypes = [POSINT_RE, POSINT_RE, ALPHA_RE, ALPHA_RE, POSINT_RE, POSINT_RE]
+    for i in range (len(slabel)):
+        if not keytypes[i].match(slabel[i]):
+            raise ValueError("Invalid label")
     kwds = {keys[i]: val for i, val in enumerate(slabel)}
     return url_for(func, **kwds)
 

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -476,7 +476,7 @@ ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     if label == "random":
-        return url_for("cmf.random_form")
+        return url_for(".random_form")
     slabel = label.split(".")
     if len(slabel) == 6:
         func = "cmf.by_url_embedded_newform_label"

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -476,6 +476,7 @@ ALPHA_RE = re.compile("[a-z]+")
 
 def url_for_label(label):
     if label == "random":
+        print "url_for_label returned", url_for("cmf.random_form")
         return url_for("cmf.random_form")
     slabel = label.split(".")
     if len(slabel) == 6:
@@ -501,7 +502,9 @@ def url_for_label(label):
 def jump_box(info):
     jump = info.pop("jump").strip()
     if jump == "random":
+        print "random it is"
         return random_form()
+    print "jump =", jump
     errmsg = None
     if OLD_SPACE_LABEL_RE.match(jump):
         jump = convert_spacelabel_from_conrey(jump)

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -79,9 +79,9 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
 <h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
 
 <form>
-<input type='text' name='jump' placeholder='3.6.1.a'>
+<input type='text' name='jump' placeholder='3.6.a.a'>
 <button type='submit'>Search by label</button>
-<br><span class="formexample">e.g. 3.6.1.a, 55.3.d or 20.5 </span>
+<br><span class="formexample">e.g. 3.6.a.a, 55.3.d or 20.5 </span>
 </form>
 
 {# SEARCHING #}

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -118,7 +118,7 @@ class CmfTest(LmfdbTest):
     def test_failure(self):
         r"""
         Check that bad inputs are handled correctly
-        """"
+        """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/983/2000/c/a/', follow_redirects=True)
         assert "Level and weight too large" in page.data
         assert "for non trivial character." in page.data

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -115,9 +115,10 @@ class CmfTest(LmfdbTest):
             page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%s" % j, follow_redirects=True)
             assert l in page.data
 
-
-
     def test_failure(self):
+        r"""
+        Check that bad inputs are handled correctly
+        """"
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/983/2000/c/a/', follow_redirects=True)
         assert "Level and weight too large" in page.data
         assert "for non trivial character." in page.data
@@ -130,10 +131,7 @@ class CmfTest(LmfdbTest):
         assert "No matches" in page.data
         assert "Only for weight 1" in page.data
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/maria/', follow_redirects=True)
-        assert "is not a valid input for" in page.data
-
-
-        
+        assert 'maria' in page.data and "is not a valid newform" in page.data   
 
     def test_delta(self):
         r"""

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -276,7 +276,6 @@ def show_ecnf1(nf):
     try:
         nf_label, nf_pretty = get_nf_info(nf)
     except ValueError:
-        flash_error("%s is not a valid number field label",nf)
         return redirect(url_for(".index"))
     if nf_label == '1.1.1.1':
         return redirect(url_for("ec.rational_elliptic_curves", **request.args), 301)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -13,7 +13,7 @@ from lmfdb import db
 from lmfdb.backend.encoding import Json
 from lmfdb.app import app
 from lmfdb.utils import (
-    to_dict
+    to_dict,
     parse_ints, parse_noop, nf_string_to_label, parse_nf_string, parse_nf_elt, parse_bracketed_posints,
     search_wrap)
 from lmfdb.number_fields.number_field import field_pretty

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -267,10 +267,17 @@ def random_curve():
 
 @ecnf_page.route("/<nf>/")
 def show_ecnf1(nf):
+    if "-" in nf:
+        try:
+            nf, cond_label, iso_label, number = split_full_label(label.strip())
+        except ValueError:
+            return redirect(url_for(".index"))
+        return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
     try:
         nf_label, nf_pretty = get_nf_info(nf)
     except ValueError:
-        return search_input_error()
+        flash_error("%s is not a valid number field label")
+        return redirect(url_for(".index"))
     if nf_label == '1.1.1.1':
         return redirect(url_for("ec.rational_elliptic_curves", **request.args), 301)
     info = to_dict(request.args)
@@ -444,7 +451,7 @@ def download_search(info):
 
 def elliptic_curve_jump(info):
     label = info.get('label', '').replace(" ", "")
-    if label == "random":
+    if info.get('jump','') == "random":
         return random_curve()
     # This label should be a full isogeny class label or a full
     # curve label (including the field_label component)
@@ -452,7 +459,7 @@ def elliptic_curve_jump(info):
         nf, cond_label, iso_label, number = split_full_label(label.strip())
     except ValueError:
         info['err'] = ''
-        return redirect(url_for("ecnf.index"), 301)
+        return redirect(url_for(".index"))
 
     return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -271,7 +271,7 @@ def show_ecnf1(nf):
         try:
             nf, cond_label, iso_label, number = split_full_label(label.strip())
         except ValueError:
-            return redirect(url_for(".index"))
+            return redirect(url_for("ecnf.index"))
         return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
     try:
         nf_label, nf_pretty = get_nf_info(nf)
@@ -459,7 +459,7 @@ def elliptic_curve_jump(info):
         nf, cond_label, iso_label, number = split_full_label(label.strip())
     except ValueError:
         info['err'] = ''
-        return redirect(url_for(".index"))
+        return redirect(url_for("ecnf.index"))
 
     return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -13,7 +13,7 @@ from lmfdb import db
 from lmfdb.backend.encoding import Json
 from lmfdb.app import app
 from lmfdb.utils import (
-    to_dict,
+    to_dict, flash_error
     parse_ints, parse_noop, nf_string_to_label, parse_nf_string, parse_nf_elt, parse_bracketed_posints,
     search_wrap)
 from lmfdb.number_fields.number_field import field_pretty

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -13,7 +13,7 @@ from lmfdb import db
 from lmfdb.backend.encoding import Json
 from lmfdb.app import app
 from lmfdb.utils import (
-    to_dict, flash_error
+    to_dict, flash_error,
     parse_ints, parse_noop, nf_string_to_label, parse_nf_string, parse_nf_elt, parse_bracketed_posints,
     search_wrap)
 from lmfdb.number_fields.number_field import field_pretty

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -13,7 +13,7 @@ from lmfdb import db
 from lmfdb.backend.encoding import Json
 from lmfdb.app import app
 from lmfdb.utils import (
-    to_dict, flash_error,
+    to_dict
     parse_ints, parse_noop, nf_string_to_label, parse_nf_string, parse_nf_elt, parse_bracketed_posints,
     search_wrap)
 from lmfdb.number_fields.number_field import field_pretty

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -260,7 +260,7 @@ def index():
                            data=data,
                            bread=bread, learnmore=learnmore_list())
 
-@ecnf_page.route("/random")
+@ecnf_page.route("/random/")
 def random_curve():
     E = db.ec_nfcurves.random(projection=['field_label', 'conductor_label', 'iso_label', 'number'])
     return redirect(url_for(".show_ecnf", nf=E['field_label'], conductor_label=E['conductor_label'], class_label=E['iso_label'], number=E['number']), 307)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -444,6 +444,8 @@ def download_search(info):
 
 def elliptic_curve_jump(info):
     label = info.get('label', '').replace(" ", "")
+    if label == "random":
+        return random_curve()
     # This label should be a full isogeny class label or a full
     # curve label (including the field_label component)
     try:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -450,8 +450,7 @@ def elliptic_curve_jump(info):
         nf, cond_label, iso_label, number = split_full_label(label.strip())
     except ValueError:
         info['err'] = ''
-        bread = [('Elliptic Curves', url_for(".index")), ('Search Results', '.')]
-        return search_input_error(info, bread)
+        return redirect(url_for("ecnf.index"), 301)
 
     return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -269,14 +269,14 @@ def random_curve():
 def show_ecnf1(nf):
     if "-" in nf:
         try:
-            nf, cond_label, iso_label, number = split_full_label(label.strip())
+            nf, cond_label, iso_label, number = split_full_label(nf.strip())
         except ValueError:
             return redirect(url_for("ecnf.index"))
         return redirect(url_for(".show_ecnf", nf=nf, conductor_label=cond_label, class_label=iso_label, number=number), 301)
     try:
         nf_label, nf_pretty = get_nf_info(nf)
     except ValueError:
-        flash_error("%s is not a valid number field label")
+        flash_error("%s is not a valid number field label",nf)
         return redirect(url_for(".index"))
     if nf_label == '1.1.1.1':
         return redirect(url_for("ec.rational_elliptic_curves", **request.args), 301)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -325,7 +325,7 @@ def by_ec_label(label):
 
         data = db.ec_curves.lucky({label_type: label}, projection=1)
         if data is None:
-            return elliptic_curve_jump_error(label, {})
+            return elliptic_curve_jump_error(label, {}, wellformed_label=True, missing_curve=True)
         ec_logger.debug(url_for(".by_ec_label", label=data['lmfdb_label']))
         iso = data['lmfdb_iso'].split(".")[1]
         if number:
@@ -358,7 +358,7 @@ def render_isogeny_class(iso_class):
     if class_data == "Invalid label":
         return elliptic_curve_jump_error(iso_class, {}, wellformed_label=False)
     if class_data == "Class not found":
-        return elliptic_curve_jump_error(iso_class, {}, wellformed_label=True)
+        return elliptic_curve_jump_error(iso_class, {}, wellformed_label=True, missing_curve=True)
     class_data.modform_display = url_for(".modular_form_display", label=class_data.lmfdb_iso+"1", number="")
 
     return render_template("ec-isoclass.html",
@@ -414,11 +414,10 @@ def render_curve_webpage_by_label(label):
     cpt0 = cputime()
     t0 = time.time()
     data = WebEC.by_label(label)
-    print "label", label, "WebEC returned", data
     if data == "Invalid label":
         return elliptic_curve_jump_error(label, {}, wellformed_label=False)
     if data == "Curve not found":
-        return elliptic_curve_jump_error(label, {}, missing_curve=True, wellformed_label=True)
+        return elliptic_curve_jump_error(label, {}, wellformed_label=True, missing_curve=True)
     try:
         lmfdb_label = data.lmfdb_label
     except AttributeError:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -86,10 +86,8 @@ def rational_elliptic_curves(err_args=None):
     }
     t = 'Elliptic Curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
-    err_msg = err_args.pop("err_msg")
-    if err_msg:
-        label = err_args.pop("label")
-        flash_error(err_msg,label)
+    if err_args.get("err_msg"):
+        flash_error(err_args.pop("err_msg"),err_args.pop("label"))
     return render_template("ec-index.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list(), calling_function = "ec.rational_elliptic_curves", **err_args)
 
 @ec_page.route("/random")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -9,7 +9,7 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.backend.encoding import Json
 from lmfdb.utils import (
-    web_latex, to_dict, web_latex_split_on_pm,
+    web_latex, to_dict, web_latex_split_on_pm, flash_error,
     parse_rational, parse_ints, parse_bracketed_posints, parse_primes, parse_element_of,
     search_wrap)
 from lmfdb.elliptic_curves import ec_page, ec_logger
@@ -86,6 +86,10 @@ def rational_elliptic_curves(err_args=None):
     }
     t = 'Elliptic Curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
+    err_msg = err_args.pop("err_msg")
+    if err_msg:
+        label = err_args.pop("label")
+        flash_error(err_msg,label)
     return render_template("ec-index.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list(), calling_function = "ec.rational_elliptic_curves", **err_args)
 
 @ec_page.route("/random")
@@ -136,16 +140,17 @@ def elliptic_curve_jump_error(label, args, wellformed_label=False, cremona_label
     for field in ['conductor', 'torsion', 'rank', 'sha', 'optimal', 'torsion_structure']:
         err_args[field] = args.get(field, '')
     err_args['count'] = args.get('count', '100')
+    err_args['label'] = label
     if wellformed_label:
-        err_args['err_msg'] = "No curve or isogeny class in the database has label %s" % label
+        err_args['err_msg'] = "No curve or isogeny class in the database has label %s"
     # elif cremona_label:
-    #     err_args['err_msg'] = "To search for a Cremona label use 'Cremona:%s'" % label
+    #     err_args['err_msg'] = "To search for a Cremona label use 'Cremona:%s'"
     elif missing_curve:
-        err_args['err_msg'] = "The elliptic curve %s (conductor = %s) is not in the database" % (label, args.get('conductor','?'))
+        err_args['err_msg'] = "The elliptic curve %s is not in the database"
     elif not label:
         err_args['err_msg'] = "Please enter a non-empty label"
     else:
-        err_args['err_msg'] = "%s does not define a recognised elliptic curve over $\mathbb{Q}$" % label
+        err_args['err_msg'] = "%s does not define a recognised elliptic curve over $\mathbb{Q}$"
     return rational_elliptic_curves(err_args)
 
 def elliptic_curve_jump(info):

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -414,7 +414,7 @@ def render_curve_webpage_by_label(label):
     cpt0 = cputime()
     t0 = time.time()
     data = WebEC.by_label(label)
-    print data
+    print "label", label, "WebEC returned", data
     if data == "Invalid label":
         return elliptic_curve_jump_error(label, {}, wellformed_label=False)
     if data == "Curve not found":

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -414,6 +414,7 @@ def render_curve_webpage_by_label(label):
     cpt0 = cputime()
     t0 = time.time()
     data = WebEC.by_label(label)
+    print data
     if data == "Invalid label":
         return elliptic_curve_jump_error(label, {}, wellformed_label=False)
     if data == "Curve not found":

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -416,7 +416,7 @@ def render_curve_webpage_by_label(label):
     if data == "Invalid label":
         return elliptic_curve_jump_error(label, {}, wellformed_label=False)
     if data == "Curve not found":
-        return elliptic_curve_jump_error(label, {}, wellformed_label=True)
+        return elliptic_curve_jump_error(label, {}, missing_curve=True, wellformed_label=True)
     try:
         lmfdb_label = data.lmfdb_label
     except AttributeError:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -88,6 +88,7 @@ def rational_elliptic_curves(err_args=None):
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
     if err_args.get("err_msg"):
         flash_error(err_args.pop("err_msg"),err_args.pop("label"))
+        return redirect(url_for(".rational_elliptic_curves"))
     return render_template("ec-index.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list(), calling_function = "ec.rational_elliptic_curves", **err_args)
 
 @ec_page.route("/random")

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -27,15 +27,13 @@ class EllCurveTest(LmfdbTest):
         assert '/EllipticCurve/Q/12350/s/' in L.data
 
     def test_Cremona_label_mal(self):
-        L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class')
-        print L.data
+        L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class', follow_redirects=True)
         assert '12qx' in L.data and 'does not define a recognised elliptic curve' in L.data
 
     def test_missing_curve(self):
-        L = self.tc.get('/EllipticCurve/Q/13.a1')
-        print L.data
+        L = self.tc.get('/EllipticCurve/Q/13.a1', follow_redirects=True)
         assert '13.a1' in L.data and 'No curve' in L.data
-        L = self.tc.get('/EllipticCurve/Q/13a1')
+        L = self.tc.get('/EllipticCurve/Q/13a1', follow_redirects=True)
         assert '13a1' in L.data and 'No curve' in L.data
 
     def test_Cond_search(self):

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -28,7 +28,7 @@ class EllCurveTest(LmfdbTest):
 
     def test_Cremona_label_mal(self):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class')
-        assert '12qx does not define a recognised elliptic curve' in L.data
+        assert '12qx' in L.data and 'does not define a recognised elliptic curve' in L.data
 
     def test_Cond_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -28,10 +28,12 @@ class EllCurveTest(LmfdbTest):
 
     def test_Cremona_label_mal(self):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class')
+        print L.data
         assert '12qx' in L.data and 'does not define a recognised elliptic curve' in L.data
 
     def test_missing_curve(self):
         L = self.tc.get('/EllipticCurve/Q/13.a1')
+        print L.data
         assert '13.a1' in L.data and 'No curve' in L.data
         L = self.tc.get('/EllipticCurve/Q/13a1')
         assert '13a1' in L.data and 'No curve' in L.data

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -30,6 +30,12 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class')
         assert '12qx' in L.data and 'does not define a recognised elliptic curve' in L.data
 
+    def test_missing_curve(self):
+        L = self.tc.get('/EllipticCurve/Q/13.a1')
+        assert '13.a1' in L.data and 'No curve' in L.data
+        L = self.tc.get('/EllipticCurve/Q/13a1')
+        assert '13a1' in L.data and 'No curve' in L.data
+
     def test_Cond_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
         assert '[0, 1, 0, -2133408, 1198675188]' in L.data

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -144,12 +144,12 @@ class WebEC(object):
             N, iso, number = split_lmfdb_label(label)
             data = db.ec_curves.lucky({"lmfdb_label" : label})
             data['label_type'] = 'LMFDB'
-        except AttributeError:
+        except AttributeError, TypeError:
             try:
                 N, iso, number = split_cremona_label(label)
                 data = db.ec_curves.lucky({"label" : label})
                 data['label_type'] = 'Cremona'
-            except AttributeError:
+            except AttributeError, TypeError:
                 return "Invalid label" # caller must catch this and raise an error
 
         if data:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -144,12 +144,12 @@ class WebEC(object):
             N, iso, number = split_lmfdb_label(label)
             data = db.ec_curves.lucky({"lmfdb_label" : label})
             data['label_type'] = 'LMFDB'
-        except AttributeError, TypeError:
+        except (AttributeError,TypeError):
             try:
                 N, iso, number = split_cremona_label(label)
                 data = db.ec_curves.lucky({"label" : label})
                 data['label_type'] = 'Cremona'
-            except AttributeError, TypeError:
+            except (AttributeError,TypeError):
                 return "Invalid label" # caller must catch this and raise an error
 
         if data:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -143,18 +143,19 @@ class WebEC(object):
         try:
             N, iso, number = split_lmfdb_label(label)
             data = db.ec_curves.lucky({"lmfdb_label" : label})
+            if not data:
+                return "Curve not found" # caller must catch this and raise an error
             data['label_type'] = 'LMFDB'
-        except (AttributeError,TypeError):
+        except AttributeError:
             try:
                 N, iso, number = split_cremona_label(label)
                 data = db.ec_curves.lucky({"label" : label})
+                if not data:
+                    return "Curve not found" # caller must catch this and raise an error
                 data['label_type'] = 'Cremona'
-            except (AttributeError,TypeError):
+            except AttributeError:
                 return "Invalid label" # caller must catch this and raise an error
-
-        if data:
-            return WebEC(data)
-        return "Curve not found" # caller must catch this and raise an error
+        return WebEC(data)
 
     def make_curve(self):
         # To start with the data fields of self are just those from

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -111,7 +111,7 @@ def index_Q():
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', ' '))
     return render_template("g2c_browse.html", info=info, credit=credit_string, title=title, learnmore=learnmore_list(), bread=bread)
 
-@g2c_page.route("/Q/random")
+@g2c_page.route("/Q/random/")
 def random_curve():
     label = db.g2c_curves.random()
     return redirect(url_for_curve_label(label), 307)

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -75,7 +75,7 @@ def split_full_label(lab):
     label_suffix = data[2]
     return (field_label, level_label, label_suffix)
 
-@hmf_page.rout("/lab")
+@hmf_page.route("/lab")
 def hilbert_modular_form_by_label(lab):
     if isinstance(lab, basestring):
         res = db.hmf_forms.lookup(lab, projection=0)

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -75,6 +75,7 @@ def split_full_label(lab):
     label_suffix = data[2]
     return (field_label, level_label, label_suffix)
 
+@hmf_page.rout("/lab")
 def hilbert_modular_form_by_label(lab):
     if isinstance(lab, basestring):
         res = db.hmf_forms.lookup(lab, projection=0)

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -75,7 +75,6 @@ def split_full_label(lab):
     label_suffix = data[2]
     return (field_label, level_label, label_suffix)
 
-@hmf_page.route("/lab")
 def hilbert_modular_form_by_label(lab):
     if isinstance(lab, basestring):
         res = db.hmf_forms.lookup(lab, projection=0)


### PR DESCRIPTION
This PR completes the work to address #3047.  You should now be able to enter "banana" or any other invalid label name into the search by label box on any of the main browse pages and see an error message flashed and no navigation (you should be left right where you were so you can retype the label you mistyped rather than being taken to a search results page where you cannot type a label).

There is one exception to the above statement.  Typing in "random" will yield "random" results: on some pages it will take you to a random object, on others it will complain that random is not a valid label, and on ECNF (for reasons I do not understand) it will do nothing (but any other bad label will flash an error).  I don't see this as a serious issue.

In addition to typing in banana (or other bogus labels) reviewers should also be sure to type in a valid label to make sure that still works (I have tested this but another set of eyes would not hurt).
