### PR TITLE
auto add numstats if missing

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -4264,7 +4264,9 @@ class PostgresStatsTable(PostgresBase):
         jcgcols = Json(sorted(ccols.adapted + grouping))
         jcol = Json([col])
         if not self._has_numstats(jcol, jcgcols, cvals, threshold):
-            raise ValueError("Missing numstats")
+            self.logger.info("Missing numstats, adding them")
+            self.add_numstats(col, grouping, constraint, threshold)
+            # raise ValueError("Missing numstats")
         values = [jcol, jcgcols]
         if threshold is None:
             threshold = SQL("threshold IS NULL")


### PR DESCRIPTION
If you browse to a page that requires numstats, and these have not been added, it tries to add them.
However, one shouldn't rely on this to make sure that all numstats are there.
Furthermore, while browsing on the live versions, most likely this won't do anything as gunicorn will timeout.
