### PR TITLE
Beta sidebar changes for Release 1.1

### DIFF
--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -50,7 +50,7 @@
           url_for: "zeta zeros.zetazeros"
         - title: Operations
           url_for: "tensor_products.index"
-          status: beta
+          status: future
         - title: dummy
           status: future
         - title: Local L-functions

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -65,6 +65,7 @@
    parts:
      - title: GL(2)
        style: rotate
+       status:
        part2:
          - title: Classical
            url_for: "cmf.index"
@@ -84,13 +85,13 @@
            url_for: "modlmf.modlmf_render_webpage"
            status: future
            colspan: onecolumn
-         - title: Hecke Algebra 
+         - title: Hecke algebra 
            url_for: "hecke_algebras.hecke_algebras_render_webpage"
            status: future
            colspan: onecolumn
      - title: GL(3)
        style: rotate
-       status: beta
+       status: future_rotated
        part2:
          - title: Maass
            status: future
@@ -100,14 +101,12 @@
            colspan: onecolumn
      - title: Other
        style: rotate
-       status: beta
+       status: future_rotated
        part2:
          - title: Siegel
            status: beta
            url_for: "smf.index"
          - title: U(2,1)
-           status: future
-         - title: Other
            status: future
 
 4Var:
@@ -128,9 +127,6 @@
              - title: /NumberFields
                url_for: "ecnf.index"
                colspan: onecolumn
-             - title: $\Q$-curves
-               status: future
-               colspan: onecolumn
            colspan: onecolumn
          - title: "Genus 2:"
            part3:
@@ -142,11 +138,24 @@
                status: future
                colspan: onecolumn
            colspan: onecolumn
+         - title: "Genus 3:"
+           status: future
+           part3:
+             - title: $/\Q$
+               status: future
+             - title: $/\F_{q}(t)$
+               status: future
+             - title: /NumberFields
+               status: future
+               colspan: onecolumn
+           colspan: onecolumn
+         - title: Shimura
+           status: future
+           colspan: onecolumn
          - title: Belyi
            status: beta
            url_for: "belyi.index"
-         - title: Shimura
-           status: future
+           colspan: onecolumn
          - title: "Higher genus:"
            part3:
              - title: Families
@@ -170,8 +179,6 @@
          - title: Shimura varieties
            status: future
            colspan: onecolumn
-         - title: Higher
-           status: future
      - title: ""
        style: rotate
        part2:
@@ -211,7 +218,7 @@
            url_for:  "characters.render_Dirichletwebpage"
          - title: Hecke
            url_for:  "characters.render_Heckewebpage"
-           status: beta
+           status: future
       colspan: onecolumn
     - title: "Galois:"
       status: future
@@ -264,14 +271,18 @@
       colspan: onecolumn
     - title: Lattices
       url_for: "lattice.lattice_render_webpage"
-      status:  beta
-    - title: Subgroups of
+      status: beta
+      colspan: onecolumn
+    - title: Small groups
+      status: future
+      colspan: onecolumn
+    - title: Finite subgroups of
       part2:
-         - title: $\SL(2)$
+         - title: $\GL(n,\F_q)$
            status:  future
-         - title: dummy
+         - title: $\GL(n,\Z)$
            status: future
-         - title: $\GL(2,\F_p)$
+         - title: $\GL(n,\C)$
            status:  future
       status: future
       colspan: onecolumn

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -149,10 +149,10 @@
                status: future
                colspan: onecolumn
            colspan: onecolumn
-         - title: Shimura
+         - title: Shimura curves
            status: future
            colspan: onecolumn
-         - title: Belyi
+         - title: Belyi maps
            status: beta
            url_for: "belyi.index"
            colspan: onecolumn

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -65,7 +65,6 @@
    parts:
      - title: GL(2)
        style: rotate
-       status:
        part2:
          - title: Classical
            url_for: "cmf.index"


### PR DESCRIPTION
This PR makes some minor changes to the beta sidebar for Release 1.1 (there are no changes to the production sidebar).

The only functional changes are that Hecke characters and L-function operations have been reverted to future status -- neither of these pages are currently functional so there is no reason to provide links to them.  Both pages are still accessible via URL at http://beta.lmfdb.org/Character/Hecke/ and http://beta.lmfdb.org/TensorProducts/) and they can easily be restored to beta status once they are in a working state.