### PR TITLE
LMFDB Release 1.1

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -85,7 +85,7 @@ def ctx_proc_userdata():
     vars['title'] = r'LMFDB'
 
     # LMFDB version number displayed in footer
-    var['version'] = LMFDB_VERSION
+    vars['version'] = LMFDB_VERSION
 
     # meta_description appears in the meta tag "description"
     vars['meta_description'] = r'Welcome to the LMFDB, the database of L-functions, modular forms, and related objects. These pages are intended to be a modern handbook including tables, formulas, links, and references for L-functions and their underlying objects.'

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -8,6 +8,8 @@ from sage.env import SAGE_VERSION
 from lmfdb.logger import logger_file_handler, critical
 from lmfdb.homepage import load_boxes, contribs
 
+LMFDB_VERSION = "LMFDB Release 1.1"
+
 ############################
 #         Main app         #
 ############################
@@ -81,6 +83,9 @@ def ctx_proc_userdata():
 
     # default title
     vars['title'] = r'LMFDB'
+
+    # LMFDB version number displayed in footer
+    var['version'] = LMFDB_VERSION
 
     # meta_description appears in the meta tag "description"
     vars['meta_description'] = r'Welcome to the LMFDB, the database of L-functions, modular forms, and related objects. These pages are intended to be a modern handbook including tables, formulas, links, and references for L-functions and their underlying objects.'

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -293,6 +293,8 @@ The function which was called for this page is: {{calling_function}}
       {{ latest_changeset|safe }}
       &middot;
       {{ sage_version|safe }}
+      &middot;
+      {{ version|safe }}
     </div>
 </div>
 


### PR DESCRIPTION
This PR adds an LMFDB version number to the footer (now set to Release 1.1).  This PR should be merged after #2961 and #3069.