### PR TITLE
Fix sib count

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -400,10 +400,12 @@ class WebNumberField:
     # Get data from group database
     def galois_sib_data(self):
         if 'repdata' not in self._data:
-            repdegs = [z[0] for z in self.gg()._data['repns']]
             numae = self.gg().arith_equivalent()
             galord = int(self.gg().order())
-            repcounts = Counter(repdegs)
+            sibcnts = self.gg()._data['siblings']
+            repcounts = Counter()
+            for s in sibcnts:
+                repcounts[s[0][0]] += s[1]
             gc = 0
             if galord<24:
                 del repcounts[galord]

--- a/scripts/galois_groups/import_gg_data.py
+++ b/scripts/galois_groups/import_gg_data.py
@@ -17,6 +17,33 @@ myfile = open(sys.argv[1])
 
 outrecs=[]
 
+def dosubs(ent):
+    lis = ent['subs']
+    lis2 = [(j[0], j[1]) for j in lis]
+    diflis = list(set(lis2))
+    diflis.sort()
+    ans = [[[j[0], j[1]], lis2.count(j)] for j in diflis]
+    ent['subfields'] = ans
+    del ent['subs']
+
+    lis = ent['repns']
+    lis2 = [(j[0], j[1]) for j in lis]
+    diflis = list(set(lis2))
+    diflis.sort()
+    ans = [[[j[0], j[1]], lis2.count(j)] for j in diflis]
+    ent['siblings'] = ans
+    del ent['repns']
+
+    lis = ent['resolve']
+    lis2 = [(j[0], j[1][0], j[1][1]) for j in lis]
+    diflis = list(set(lis2))
+    diflis.sort()
+    ans = [[j[0], [j[1], j[2]], lis2.count(j)] for j in diflis]
+    ent['quotients'] = ans
+    del ent['resolve']
+
+    return(ent)
+
 for l in myfile:
   v= json.loads(l)
   for dd in v:
@@ -29,6 +56,7 @@ for l in myfile:
       data['gapidfull'] = ""
       if data['gapid']>0:
           data['gapidfull'] = "[%d,%d]"%(data['order'],data['gapid'])
+      data = dosubs(data)
       outrecs.append(data)
 
 if len(outrecs)>0:


### PR DESCRIPTION
Fixes sibling count for number field pages so the page knows what/how many siblings to expect.

A sample page:
  http://127.0.0.1:37777/NumberField/7.3.2007889.1

which shows it separates the arithmetically equivalent field from the other siblings and 

http://127.0.0.1:37777/NumberField/4.0.117.1

shows it still separates its Galois closure
