### PR TITLE
Pulling number field stats from the statistics table.

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -3848,7 +3848,7 @@ class PostgresStatsTable(PostgresBase):
             one_col = False
             cols = sorted(cols)
         if constraint is None:
-            ccols, cvals, allcols = [], [], cols
+            ccols, cvals, allcols = Json([]), Json([]), cols
         else:
             ccols, cvals = self._split_dict(constraint)
             allcols = sorted(list(set(cols + constraint.keys())))

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -243,7 +243,6 @@ def statistics():
     has_hdeg_stats = nfstatdb.column_counts('degree', {'class_number': {'$exists': True}})
     has_hdeg = [has_hdeg_stats[deg+1] for deg in range(23)]
     has_h = sum(has_hdeg[j] for j in range(len(has_hdeg)))
-    # old has_h = fields.count({'class_number': {'$exists': True}})
     hdeg = [[{'cnt': comma(hdeg[nn][j]),
               'prop': format_percentage(hdeg[nn][j], has_hdeg[nn]),
               'query': url_for(".number_field_render_webpage")+'?degree=%d&class_number=%s' % (nn + 1, str(1 + 10**(j - 1)) + '-' + str(10**j))}


### PR DESCRIPTION
This should only affect the number field statistics page.  It should be unchanged except for the last table, which was still displaying information from the old stats table, so totals of numbers of fields has increased in some places.

I attempted to add the needed statistics to the nf_fields.stats table, but every time the page is rendered, there is logger output like:

INFO:nf_fields@2019-05-14 16:33:47,349: SELECT values, count FROM "nf_fields_counts" WHERE cols = '["class_number", "degree"]' AND split = false ran in  0.112394094467s  [database.py:394]

I don't know why, but maybe someone else can figure out how to add the needed data to the nf_fields.stats database.
