### PR TITLE
improved wording on bmf space pages

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -293,6 +293,9 @@ def render_bmf_space_webpage(field_label, level_label):
                     'cm': cm_info(f.get('CM','?')),
                     } for f in newforms]
                 info['nnewforms'] = len(info['nfdata'])
+                # currently we have newforms of dimension 1 and 2 only (mostly dimension 1)
+                info['nnf1'] = sum(1 for f in info['nfdata'] if f['dim']==1)
+                info['nnf2'] = sum(1 for f in info['nfdata'] if f['dim']==2)
                 properties2 = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
 

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -117,6 +117,7 @@ def bianchi_modular_form_postprocess(res, info, query):
                            ('Search Results', '.')],
              learnmore=learnmore_list,
              properties=lambda: [])
+
 def bianchi_modular_form_search(info, query):
     """Function to handle requests from the top page, either jump to one
     newform or do a search.
@@ -296,10 +297,11 @@ def render_bmf_space_webpage(field_label, level_label):
                 # currently we have newforms of dimension 1 and 2 only (mostly dimension 1)
                 info['nnf1'] = sum(1 for f in info['nfdata'] if f['dim']==1)
                 info['nnf2'] = sum(1 for f in info['nfdata'] if f['dim']==2)
+                info['nnf_missing'] = dim_data['2']['new_dim'] - info['nnf1'] - 2*info['nnf2']
                 properties2 = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
 
-    return render_template("bmf-space.html", info=info, credit=credit, title=t, bread=bread, properties2=properties2, friends=friends)
+    return render_template("bmf-space.html", info=info, credit=credit, title=t, bread=bread, properties2=properties2, friends=friends, learnmore=learnmore_list())
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/')
 def render_bmf_webpage(field_label, level_label, label_suffix):
@@ -325,7 +327,7 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
     except ValueError:
         raise
         info['err'] = "No Bianchi modular form in the database has label {}".format(label)
-    return render_template("bmf-newform.html", title=title, credit=credit, bread=bread, data=data, properties2=properties2, friends=friends, info=info)
+    return render_template("bmf-newform.html", title=title, credit=credit, bread=bread, data=data, properties2=properties2, friends=friends, info=info, learnmore=learnmore_list())
 
 def bianchi_modular_form_by_label(lab):
     if lab == '':

--- a/lmfdb/bianchi_modular_forms/templates/bmf-space.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-space.html
@@ -59,13 +59,24 @@
 
 <p>
 {%if info.nnewforms > 0 %}
+This space contains the following
+{%if info.nnewforms == 1 %}
+newform.
+{%else%}
+newforms.
+{%endif%}
+{%if info.nnf_missing>0 %}
+Newforms of higher dimension are not yet in the database.
+{%endif%}
+
+{#
 There
 {%if info.nnewforms == 1 %}
-is one cuspidal newform
+is one newform
 {%else%}
-are {{info.nnewforms}} cuspidal newforms
+are {{info.nnewforms}} newforms
 {%endif%}
-at this level in the database,
+at this level,
 {%if info.nnf2 == 0 %}
 {%if info.nnf1 == 1 %}which has{%else%}all of which have{%endif%} rational coefficients.
 {%elif info.nnf1 == 0 %}
@@ -74,6 +85,7 @@ at this level in the database,
 {{info.nnf1}} with rational coefficients and
 {{info.nnf2}} with quadratic coefficients.
 {%endif%}
+#}
 <table border=1 class="ntdata">
   <tr>
     <th>{{ KNOWL('mf.bianchi.labels', title='label') }}
@@ -95,7 +107,7 @@ at this level in the database,
   {% endfor%}
 </table>
 {%else %}
-There are no cuspidal newforms at this level in the database.
+There are no newforms at this{%if info.nnf_missing > 0 %} level in the database.{%else%} level.{%endif%}
 {%endif %}
 </p>
 
@@ -106,6 +118,6 @@ There are no cuspidal newforms at this level in the database.
 <hr>
  {{ info }}
 </div>
-{%endif %}
+{%endif%}
 
-{%endblock %}
+{%endblock%}

--- a/lmfdb/bianchi_modular_forms/templates/bmf-space.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-space.html
@@ -61,11 +61,19 @@
 {%if info.nnewforms > 0 %}
 There
 {%if info.nnewforms == 1 %}
-is one rational cuspidal newform
+is one cuspidal newform
 {%else%}
 are {{info.nnewforms}} cuspidal newforms
 {%endif%}
-at this level in the database:
+at this level in the database,
+{%if info.nnf2 == 0 %}
+{%if info.nnf1 == 1 %}which has{%else%}all of which have{%endif%} rational coefficients.
+{%elif info.nnf1 == 0 %}
+{%if info.nnf2 == 1 %}which has{%else%}all of which have{%endif%} quadratic coefficients.
+{%else%}
+{{info.nnf1}} with rational coefficients and
+{{info.nnf2}} with quadratic coefficients.
+{%endif%}
 <table border=1 class="ntdata">
   <tr>
     <th>{{ KNOWL('mf.bianchi.labels', title='label') }}

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -78,7 +78,7 @@ class BMFTest(LmfdbTest):
         r"""
         Check newspace pages
         """
-        self.check_args(base_url+'2.0.3.1/77283.1', 'are 2 cuspidal newforms')
+        self.check_args(base_url+'2.0.3.1/77283.1', 'contains the following\nnewforms')
         self.check_args(base_url+'2.0.11.1/207.6', 'Dimension of new cuspidal subspace:')
         # I don't know why the follwing fails, as the text was copied from the page source:
         #self.check_args(base_url+'2.0.11.1/207.6', '\((2 a + 13) = (\left(a - 1\right))^{2} \cdot (\left(a - 5\right)) \)')


### PR DESCRIPTION
The improves the wording of the preamble to the table showing the Bianchi newforms at a single level.  Almost all the newforms in the database at present have rational coefficients (dim=1) but some over 2.0.4.1 have quadratic coefficients (dim=2).

Examples:

1 rational only:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/200.2

2 rational:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/194.2

1 of each:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/377.1

1 quadratic only:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/485.2

1 rational, 2 quadratic:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/1521.2
