### PR TITLE
Various backend things

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2067,16 +2067,17 @@ class PostgresTable(PostgresBase):
                 raise ValueError("Index %s does not exist in meta_indexes"%(name,))
             type, columns, modifiers, storage_params = cur.fetchone()
             creator = self._create_index_statement(name + suffix, self.search_table + suffix, type, columns, modifiers, storage_params)
-            try:
+            if self._index_exists(name + suffix):
                 # Reloading indexes can cause crashes in a way we don't understand.
                 # Postgres complains that the index already exists, even though we haven't
                 # created it yet on this table.
-                # As a workaround, we ignore errors in the index creation code and print a big warning
+                # As a workaround, we avoid errors in the index creation code and print a big warning
+                print "*"*80
+                print "Index restoration failed for {}".format(name + suffix)
+                print "*"*80
+                return
+            else:
                 self._execute(creator, storage_params.values())
-            except Exception as err:
-                print "*"*80
-                print "Index creation failed: %s" % (err,)
-                print "*"*80
         print "Created index %s in %.3f secs"%(name, time.time() - now)
 
     def _indexes_touching(self, columns):

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -530,9 +530,9 @@ class PostgresBase(object):
                 deprecated_name = name[:64 - len(depsuffix)] + depsuffix
 
             self._execute(begin_renamer + end_renamer.format(
-                Identifier(name + suffix, deprecated_name)))
+                Identifier(name + suffix), Identifier(deprecated_name)))
 
-            command = begin_command + end_command.format(deprecated_name)
+            command = begin_command + end_command.format(Identifier(deprecated_name))
 
             logging.warning("{} with name {} ".format(kind, name + suffix) +
                             "already exists. " +

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -4750,7 +4750,7 @@ class PostgresStatsTable(PostgresBase):
                         "{:d} rows were just inserted to".format(len(to_add)) +
                         " into {}, ".format(self.counts + suffix) +
                         "all with with cols = {}. ".format(jallcols) +
-                        "This might decrease the counts table performance" +
+                        "This might decrease the counts table performance " +
                         "significantly! Consider clearing all the stats " +
                         "db.{}.stats._clear_stats_counts()".format(self.search_table) +
                         " and rebuilding the stats more carefully."

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -454,10 +454,8 @@ class PostgresBase(object):
                 return table[0]
 
     def _relation_exists(self, name):
-        # if the relation does not exist, returns a NULL value
-        # otherwise, the name of the relation
-        cur = self._execute(SQL("SELECT to_regclass(%s)"), [name], silent=True)
-        return cur.fetchone()[0] is not None
+        cur = self._execute(SQL('SELECT 1 FROM pg_class where relname = %s'), [name])
+        return cur.fetchone() is not None
 
     def _constraint_exists(self, constraintname, tablename=None):
         if tablename:
@@ -479,7 +477,7 @@ class PostgresBase(object):
         # if we look into information_schema.table_constraints
         # we also get internal constraints, I'm not sure why
         # Alternatively, we do a triple join to get the right answer
-        cur = self._execute(SQL("SELECT con.con.conname "
+        cur = self._execute(SQL("SELECT con.conname "
                                "FROM pg_catalog.pg_constraint con "
                                "INNER JOIN pg_catalog.pg_class rel "
                                "           ON rel.oid = con.conrelid "

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2054,7 +2054,7 @@ class PostgresTable(PostgresBase):
         for line in cur:
             print line[0]
 
-    def _list_indexes(self):
+    def _list_built_indexes(self):
         """
         Lists built indexes names on the search table
         """
@@ -2067,7 +2067,7 @@ class PostgresTable(PostgresBase):
          - not necessarily all built
          - not necessarily a supset of all the built indexes.
 
-        For the current built indexes on the search table, see _list_indexes
+        For the current built indexes on the search table, see _list_built_indexes
         """
         selecter = SQL("SELECT index_name, type, columns, modifiers FROM meta_indexes WHERE table_name = %s")
         cur = self._execute(selecter, [self.search_table], silent=True)
@@ -2383,7 +2383,7 @@ class PostgresTable(PostgresBase):
         command = SQL("ALTER TABLE {0} ADD CONSTRAINT {1} PRIMARY KEY (id)")
         self._pkey_common(command, suffix, "Built", True)
 
-    def _list_constraints(self):
+    def _list_built_constraints(self):
         """
         Lists constraints names on the search table
         """
@@ -2395,7 +2395,7 @@ class PostgresTable(PostgresBase):
         Note:
          - not necessarily all built
          - not necessarily a supset of all the built constraints.
-        For the current built constraints on the search table, see _list_constraints
+        For the current built constraints on the search table, see _list_built_constraints
         """
         selecter = SQL("SELECT constraint_name, type, columns, check_func FROM meta_constraints WHERE table_name = %s")
         cur = self._execute(selecter, [self.search_table], silent=True)

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -818,7 +818,7 @@ class PostgresBase(object):
                 # drop the suffix
                 original_name = original_name[:len(source)]
 
-            assert original_name + source = name
+            assert original_name + source == name
 
             target_name = original_name + target
             try:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1937,6 +1937,7 @@ class PostgresTable(PostgresBase):
                     message = "Index with name {} already exists".format(name)
                     if warning_only:
                         print(message)
+                        continue
                     else:
                         raise ValueError(message)
                 creator = self._create_index_statement(name,

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -539,7 +539,7 @@ class PostgresBase(object):
                             "It has been renamed to {} ".format(deprecated_name) +
                             "and it can be deleted " +
                             "with the following SQL command:\n" +
-                            self.cursor().mogrify(command))
+                            self._db.cursor().mogrify(command))
 
     def _check_restricted_suffix(self, name, kind="Index", skip_dep=False):
         """

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -4750,13 +4750,13 @@ class PostgresStatsTable(PostgresBase):
                 logging.warning(
                         "You are about to add {:d} rows ".format(len(to_add)) +
                         "all with values = {} into ".format(jallcols) +
-                        "the counts table {}. ".format(self.counts + suffix)
+                        "the counts table {}. ".format(self.counts + suffix) +
                         "This might decrease the counts table performance" +
                         "significantly!"
                         )
                 ok = raw_input(
                         "Are you sure you want to add {:d}".format(len(to_add)) +
-                        "rows to {}? (y/N) ".format(self.counts + suffix)
+                        "rows to {}? (y/N) ".format(self.counts + suffix))
                 if not (ok and ok[0] in ['y','Y']):
                     logging.warning("Aborting insertion")
                     return False

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -863,7 +863,7 @@ class PostgresBase(object):
                                                      Identifier(c_target)))
                     done.add(c_target)
 
-                for index in self._list_constraints(tablename_new):
+                for index in self._list_indexes(tablename_new):
                     if index in done:
                         continue
                     i_target = target_name(index, tablename_new, "Index")

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2049,10 +2049,7 @@ class PostgresTable(PostgresBase):
         else:
             analyzer = SQL("EXPLAIN ANALYZE {0}").format(selecter)
         cur = self._db.cursor()
-        print cur.mogrify(selecter, values)
         cur = self._execute(analyzer, values, silent=True)
-        for line in cur:
-            print line[0]
 
     def _list_built_indexes(self):
         """
@@ -3947,7 +3944,6 @@ class PostgresStatsTable(PostgresBase):
         - ``split_list`` -- whether entries of lists should be counted once for each entry.
         - ``threshold_inequality`` -- if true, then any lower threshold will still count for having stats.
         """
-        print  (jcols, ccols, cvals, threshold, split_list, threshold_inequality)
         if split_list:
             values = [jcols, "split_total"]
         else:
@@ -3966,9 +3962,6 @@ class PostgresStatsTable(PostgresBase):
         selecter = SQL("SELECT 1 FROM {0} WHERE cols = %s AND stat = %s AND {1} AND {2} AND {3}")
         selecter = selecter.format(Identifier(self.stats), SQL(ccols), SQL(cvals), SQL(threshold))
         cur = self._execute(selecter, values)
-        print cur.rowcount
-        print cur.mogrify(selecter, values)
-        return cur.rowcount > 0
 
     def quick_count(self, query, split_list=False, suffix=''):
         """

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -436,14 +436,14 @@ class PostgresBase(object):
     def _table_exists(self, tablename):
         cur = self._execute(SQL("SELECT 1 from pg_tables where tablename=%s"),
                             [tablename], silent=True)
-        return cur.fetchone()[0] is not None
+        return cur.fetchone() is not None
 
     def _index_exists(self, indexname, tablename=None):
         if tablename:
             cur = self._execute(
                     SQL("SELECT 1 FROM pg_indexes WHERE indexname = %s AND tablename = %s"),
                     [indexname, tablename],  silent=True)
-            return cur.fetchone()[0] is not None
+            return cur.fetchone() is not None
         else:
             cur = self._execute(SQL("SELECT tablename FROM pg_indexes WHERE indexname=%s"),
                     [indexname],  silent=True)
@@ -454,6 +454,8 @@ class PostgresBase(object):
                 return table[0]
 
     def _relation_exists(self, name):
+        # if the relation does not exist, returns a NULL value
+        # otherwise, the name of the relation
         cur = self._execute(SQL("SELECT to_regclass(%s)"), [name], silent=True)
         return cur.fetchone()[0] is not None
 

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2877,9 +2877,6 @@ class PostgresTable(PostgresBase):
                 self.conn.rollback()
                 raise RuntimeError("Different number of rows in searchfile and extrafile")
 
-            if countsfile is not None:
-                self.stats._copy_extra_counts_to_tmp()
-
             ## a workaround while resort is disabled
             self.restore_pkeys(suffix=suffix)
             #if self._id_ordered and resort:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -4747,7 +4747,7 @@ class PostgresStatsTable(PostgresBase):
             inserter = SQL("INSERT INTO {0} (cols, values, count, split, extra) VALUES %s")
             if split_list:
                 to_add = [(Json(c), Json(v), ct, True, False) for ((c, v), ct) in to_add.items()]
-            cur = self._execute(inserter.format(Identifier(self.counts + suffix)), to_add, values_list=True)
+            self._execute(inserter.format(Identifier(self.counts + suffix)), to_add, values_list=True)
             if len(to_add) > 10000:
                 logging.warning(
                         "{:d} rows were just inserted to".format(len(to_add)) +

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1926,7 +1926,7 @@ class PostgresTable(PostgresBase):
         creator = SQL("CREATE INDEX {0} ON {1} USING %s ({2}){3}"%(type))
         return creator.format(Identifier(name), Identifier(table), columns, storage_params)
 
-    def create_counts_indexes(self, suffix=""):
+    def create_counts_indexes(self, suffix="", warning_only=False):
         tablename = self.search_table + "_counts"
         storage_params = {}
         with DelayCommit(self, silence=True):
@@ -1934,8 +1934,11 @@ class PostgresTable(PostgresBase):
                 now = time.time()
                 name = index["name"].format(tablename) + suffix
                 if self._index_exists(name):
-                    raise ValueError(
-                            "Index with name {} already exists".format(name))
+                    message = "Index with name {} already exists".format(name)
+                    if warning_only:
+                        print(message)
+                    else:
+                        raise ValueError(message)
                 creator = self._create_index_statement(name,
                                                        tablename,
                                                        index["type"],

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1943,7 +1943,7 @@ class PostgresTable(PostgresBase):
                                                        tablename,
                                                        index["type"],
                                                        index["columns"],
-                                                       None,
+                                                       [[]] * len(index["columns"]),
                                                        storage_params)
                 self._execute(creator, storage_params.values())
                 print "Index {} created in {:.3f} secs".format(name, time.time() - now)

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -31,7 +31,7 @@ from glob import glob
 import csv
 import sys
 
-from psycopg2 import connect, DatabaseError, InterfaceError, ProgrammingError, NotSupportedError
+from psycopg2 import connect, DatabaseError, InterfaceError, OperationalError, ProgrammingError, NotSupportedError
 from psycopg2.sql import SQL, Identifier, Placeholder, Literal, Composable
 from psycopg2.extras import execute_values
 from psycopg2.extensions import cursor as pg_cursor
@@ -380,7 +380,7 @@ class PostgresBase(object):
             else:
                 try:
                     cur.execute(query, values)
-                except (ProgrammingError, NotSupportedError) as e:
+                except (OperationalError, ProgrammingError, NotSupportedError) as e:
                     try:
                         context = ' happens while executing {}'.format(cur.mogrify(query, values))
                     except Exception:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -3962,6 +3962,7 @@ class PostgresStatsTable(PostgresBase):
         selecter = SQL("SELECT 1 FROM {0} WHERE cols = %s AND stat = %s AND {1} AND {2} AND {3}")
         selecter = selecter.format(Identifier(self.stats), SQL(ccols), SQL(cvals), SQL(threshold))
         cur = self._execute(selecter, values)
+        return cur.rowcount > 0
 
     def quick_count(self, query, split_list=False, suffix=''):
         """

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -4747,13 +4747,13 @@ class PostgresStatsTable(PostgresBase):
             cur = self._execute(inserter.format(Identifier(self.counts + suffix)), to_add, values_list=True)
             if len(to_add) > 10000:
                 logging.warning(
-                        "{:d} rows, ".format(len(to_add)) +
-                        "with with cols = {}, were added ".format(jallcols) +
-                        "into {}.".format(self.counts + suffix) +
+                        "{:d} rows were just inserted to".format(len(to_add)) +
+                        " into {}, ".format(self.counts + suffix) +
+                        "all with with cols = {}. ".format(jallcols) +
                         "This might decrease the counts table performance" +
                         "significantly! Consider clearing all the stats " +
-                        "db.{}_clear_stats_counts()".format(self.search_table) +
-                        " and rebuilding them more carefully."
+                        "db.{}.stats._clear_stats_counts()".format(self.search_table) +
+                        " and rebuilding the stats more carefully."
                         )
         self.logger.info("Added stats in %.3f secs"%(time.time() - now))
         return True

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -168,11 +168,11 @@ _counts_types =  dict(zip(_counts_cols,
     ("jsonb", "jsonb", "bigint", "boolean", "boolean")))
 _counts_jsonb_idx = jsonb_idx(_counts_cols, _counts_types)
 _counts_indexes = [{"name": "{}_cols_vals_split",
-                  "columns": [('cols', 'values', 'split')],
-                  "type": "btree"},
-                 {"name": "{}_cols_split",
-                  "columns": [('cols', 'split')],
-                  "type": "btree"}]
+                   "columns": ('cols', 'values', 'split'),
+                   "type": "btree"},
+                   {"name": "{}_cols_split",
+                    "columns": ('cols', 'split'),
+                    "type": "btree"}]
 
 
 _stats_cols = ("cols", "stat", "value", "constraint_cols", "constraint_values", "threshold")
@@ -1928,7 +1928,6 @@ class PostgresTable(PostgresBase):
 
     def create_counts_indexes(self, suffix=""):
         tablename = self.search_table + "_counts"
-        name = "{}_cols_vals_split".format(tablename) + suffix
         storage_params = {}
         with DelayCommit(self, silence=True):
             for index in _counts_indexes:
@@ -2816,7 +2815,8 @@ class PostgresTable(PostgresBase):
             counts_indexes = []
             for table in tables:
                 if table.endswith("_counts"):
-                    counts_indexes.append("{}_counts_cols_vals_split".format(table))
+                    counts_indexes = [index["name"].format(table)
+                                            for index in _counts_indexes]
             indexes += counts_indexes
             constraints = self.list_constraints().keys()
             self._swap(tables, indexes, constraints, '', '_old' + str(backup_number))

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2115,13 +2115,13 @@ class PostgresTable(PostgresBase):
                     else:
                         raise ValueError(message)
                 creator = self._create_index_statement(name,
-                                                       tablename,
+                                                       tablename + suffix,
                                                        index["type"],
                                                        index["columns"],
                                                        [[]] * len(index["columns"]),
                                                        storage_params)
                 self._execute(creator, storage_params.values())
-                print "Index {} created in {:.3f} secs".format(index["name"].format(tablename), time.time() - now)
+                print "Index {} created in {:.3f} secs".format(index["name"].format(self.search_table), time.time() - now)
 
 
 

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2049,7 +2049,10 @@ class PostgresTable(PostgresBase):
         else:
             analyzer = SQL("EXPLAIN ANALYZE {0}").format(selecter)
         cur = self._db.cursor()
+        print cur.mogrify(selecter, values)
         cur = self._execute(analyzer, values, silent=True)
+        for line in cur:
+             print line[0]
 
     def _list_built_indexes(self):
         """

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -840,7 +840,7 @@ class PostgresBase(object):
                 tablename_new = table + target
                 self._execute(rename_table.format(Identifier(tablename_old), Identifier(tablename_new)))
 
-                done = {} # done constraints/indexes
+                done = set({}) # done constraints/indexes
                 # We threat pkey separately
                 pkey_old = table + source + "_pkey"
                 pkey_new = table + target + "_pkey"

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -509,9 +509,9 @@ class PostgresBase(object):
             tablename = self._constraint_exists(name + suffix)
             if tablename:
                 kind = "Constraint"
-                begin_renamer = SQL("ALTER TABLE {0} RENAME CONSTRAINT").format(tablename)
+                begin_renamer = SQL("ALTER TABLE {0} RENAME CONSTRAINT").format(Identifier(tablename))
                 end_renamer = SQL("{0} TO {1}")
-                begin_command = SQL("ALTER TABLE {0}").format(tablename)
+                begin_command = SQL("ALTER TABLE {0}").format(Identifier(tablename))
                 end_command = SQL("DROP CONSTRAINT {0}")
             elif self._index_exists(name + suffix):
                 kind = "Index"

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -3153,7 +3153,7 @@ class PostgresTable(PostgresBase):
                 self.log_db_change("reload", counts=(countsfile is not None), stats=(statsfile is not None))
             print "Reloaded %s in %.3f secs" % (self.search_table, time.time() - now_overall)
 
-    def reload_final_swap(self, tables=None, metafile=None, indexed=True, commit=True):
+    def reload_final_swap(self, tables=None, metafile=None, commit=True):
         """
         Renames the _tmp versions of `tables` to the live versions.
         and updates the corresponding meta_tables row if `metafile` is provided
@@ -3162,7 +3162,6 @@ class PostgresTable(PostgresBase):
 
         - ``tables`` -- list of strings (optional), of the tables to renamed. If None is provided, renames all the tables ending in `_tmp`
         - ``metafile`` -- a string (optional), giving a file containing the meta information for the table.
-        - ``indexed`` -- boolean, whether the temporary table has indexes and constraints on it.
         """
         with DelayCommit(self, commit, silence=True):
             if tables is None:
@@ -5946,7 +5945,7 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
             for table, filedata, included in file_list:
                 if table in failures:
                     continue
-                table.reload_final_swap(tables=included, metafile=filedata[-1], reindex=reindex)
+                table.reload_final_swap(tables=included, metafile=filedata[-1])
 
         if failures:
             print "Reloaded %s"%(", ".join(tablenames))

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2121,7 +2121,7 @@ class PostgresTable(PostgresBase):
                                                        [[]] * len(index["columns"]),
                                                        storage_params)
                 self._execute(creator, storage_params.values())
-                print "Index {} created in {:.3f} secs".format(name, time.time() - now)
+                print "Index {} created in {:.3f} secs".format(index["name"].format(tablename), time.time() - now)
 
 
 

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -36,7 +36,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'formatters', 'proportioners', 'totaler', 'StatsDisplay',
            'Configuration',
            'names_and_urls', 'name_and_object_from_url',
-           'datetime_to_timestamp_in_ms', 'timestamp_in_ms_to_datetime']
+           'datetime_to_timestamp_in_ms', 'timestamp_in_ms_to_datetime',
+           'reraise']
 
 from flask import (request, make_response, flash, url_for,
                    render_template, send_file)
@@ -75,3 +76,4 @@ from .downloader import Downloader
 from .display_stats import formatters, proportioners, totaler, StatsDisplay
 from .config import Configuration
 from .names_and_urls import names_and_urls, name_and_object_from_url
+from .reraise import reraise

--- a/lmfdb/utils/reraise.py
+++ b/lmfdb/utils/reraise.py
@@ -1,0 +1,18 @@
+import sys
+
+# Reraise an exception, possibly with a different message, type, or traceback.
+if sys.version_info.major < 3:  # Python 2?
+    # Using exec avoids a SyntaxError in Python 3.
+    exec("""def reraise(exc_type, exc_value, exc_traceback=None):
+            # Reraise an exception, possibly with a different message, type, or traceback.
+                raise exc_type, exc_value, exc_traceback""")
+else:
+    def reraise(exc_type, exc_value, exc_traceback=None):
+        """
+        Reraise an exception, possibly with a different message, type, or traceback.
+        """
+        if exc_value is None:
+            exc_value = exc_type()
+        if exc_value.__traceback__ is not exc_traceback:
+            raise exc_value.with_traceback(exc_traceback)
+        raise exc_value

--- a/lmfdb/verify/mf_newforms.py
+++ b/lmfdb/verify/mf_newforms.py
@@ -128,7 +128,8 @@ class mf_newforms(MfChecker):
         nfyes = {'nf_label':{'exists':True}}
         selfdual = {'nf_label':{'exists':True}, 'is_self_dual':True}
         return (self.check_crosstable_count('nf_fields', 1, 'nf_label', 'label', constraint=nfyes) +
-                self.check_crosstable('nf_fields_new', 'field_poly', 'nf_label', 'coeffs', 'label', constraint=nfyes) +
+                # since coeffs is still jsonb, we must use coeffs_array
+                self.check_crosstable('nf_fields', 'field_poly', 'nf_label', 'coeffs_array', 'label', constraint=nfyes) +
                 self.check_crosstable('nf_fields', 0, 'nf_label', 'r2', 'label', constraint=selfdual) +
                 self.check_crosstable_dotprod('nf_fields', 'field_disc', 'nf_label', ['disc_sign', 'disc_abs'], 'label', constraint=nfyes))
 


### PR DESCRIPTION
- We no longer use to_regclass, to test if a relation exists, as it behaves in a weird fashion with upper case names.
- The bug above was creating name clashing of the indexes on reload, when these had upper case characters
- We now avoid name clashing when restoring or renaming indexes, by renaming them
eg
```
WARNING:LMFDB@2019-05-16 19:04:22,895: Index with name bmf_forms_field_label_level_label_CM_bc_tmp already exists. It has been renamed to bmf_forms_field_label_level_label_CM_bc_dep0_tmp and it can be deleted with the following SQL command:
DROP INDEX "bmf_forms_field_label_level_label_CM_bc_dep0_tmp" 
```
- Added indexes on the counts tables on reload, and thus resolves #3054
- Added a warning message when more than 10k rows are inserted into the counts tables, eg
```
WARNING:LMFDB@2019-05-17 10:26:18,285: 45083 rows, with with cols = '["degree", "class_number"]', were added into nf_fields_counts.This might decrease the counts table performance significantly! Consider clearing all the stats db.nf_fields_clear_stats_counts() and rebuilding them more carefully.
```
as we saw in #3093

- Better error message when a SQL command fails