### PR TITLE
503 alternatives warwick -> beta

### DIFF
--- a/lmfdb/templates/503.html
+++ b/lmfdb/templates/503.html
@@ -3,12 +3,13 @@
 
 <h3>The LMFDB is currently unavailable.</h3>
 <p>
-{% if 'warwick' in request.url_root  or 'beta' in request.url_root %}
-You can visit our main site at
+You can visit our
+{% if 'beta' in request.url_root %}
+main site at
 <a href="http://www.lmfdb.org">www.lmfdb.org</a>.
 {% else %}
-You can visit our alternate site at
-<a href="http://lmfdb.warwick.ac.uk">lmfdb.warwick.ac.uk</a>.
+beta site at
+<a href="http://beta.lmfdb.org">beta.lmfdb.org</a>.
 {% endif %}
 </p>
 <p>


### PR DESCRIPTION
I replaced `lmfdb.warwick.ac.uk` with `beta.lmfdb.org`.
Feel free to edit the text.

