### PR TITLE
Hide nearby object boxes (issue #2095)

### DIFF
--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -495,7 +495,7 @@ def initLfunction(L, args, request):
     info['learnmore'] = learnmore_list(request.path)
 
     (info['zeroslink'], info['plotlink']) = set_zeroslink_and_plotlink(L, args)
-    info['navi']= set_navi(L)
+    # info['navi']= set_navi(L)
 
     return info
 

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -262,19 +262,17 @@ def render_one_maass_waveform_wp(info, prec=9):
         info["friends"] = [("L-function", Llink)]
 
     # Navigation to previous and next form
-    next_form_id = info['MF'].next_maassform_id()
-    if next_form_id:
-        next_data = ('next', r"$f_{\text next}$", url_for('mwf.render_one_maass_waveform',
-                                                                maass_id = next_form_id) )
-    else:
-        next_data = ('','','')
-    prev_form_id = info['MF'].prev_maassform_id()
-    if prev_form_id:
-        prev_data = ('previous', r"$f_{\text prev}$", url_for('mwf.render_one_maass_waveform',
-                                                                maass_id = prev_form_id) )
-    else:
-        prev_data = ('','','')
-
+    # next_form_id = info['MF'].next_maassform_id()
+    # if next_form_id:
+    #    next_data = ('next', r"$f_{\text next}$", url_for('mwf.render_one_maass_waveform', maass_id = next_form_id) )
+    # else:
+    #    next_data = ('','','')
+    # prev_form_id = info['MF'].prev_maassform_id()
+    # if prev_form_id:
+    #    prev_data = ('previous', r"$f_{\text prev}$", url_for('mwf.render_one_maass_waveform', maass_id = prev_form_id) )
+    # else:
+    #    prev_data = ('','','')
+    
     # info['navi'] = ( prev_data, next_data )
 
     info["downloads"] = [ ('All stored data of the form',

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -275,7 +275,7 @@ def render_one_maass_waveform_wp(info, prec=9):
     else:
         prev_data = ('','','')
 
-    info['navi'] = ( prev_data, next_data )
+    # info['navi'] = ( prev_data, next_data )
 
     info["downloads"] = [ ('All stored data of the form',
                            url_for('mwf.render_one_maass_waveform', maass_id=maass_id,


### PR DESCRIPTION
This PR addresses #2095 by hiding the nearby object boxes on the few pages that use them.  Compare:

http://www.lmfdb.org/L/Character/Dirichlet/27/5/
http://127.0.0.1:37777/L/Character/Dirichlet/27/5/

http://www.lmfdb.org/ModularForm/GL2/Q/Maass/4f5558f688aece2646000023
http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/4f5558f688aece2646000023

http://www.lmfdb.org/L/ModularForm/GL2/Q/Maass/4f5558f688aece2646000023
http://127.0.0.1:37777/L/ModularForm/GL2/Q/Maass/4f5558f688aece2646000023
