### PR TITLE
Fixing computations for bigger bigger groups

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -17,7 +17,7 @@ from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
 from .transitive_group import (
     group_display_pretty, small_group_display_knowl, galois_module_knowl_guts,
-    subfield_display, resolve_display, generators, chartable,
+    subfield_display, resolve_display, chartable,
     group_alias_table, WebGaloisGroup)
 
 # Test to see if this gap installation knows about transitive groups
@@ -168,17 +168,17 @@ def render_group_webpage(args):
         if ZZ(order).is_prime():
             data['ordermsg'] = "$%s$ (is prime)" % order
         pgroup = len(ZZ(order).prime_factors()) < 2
-        cclasses = wgg.conjclasses()
-        if ZZ(order) < ZZ(10000000) and len(cclasses) < 21:
+        if wgg.num_conjclasses() < 50:
+            data['cclasses'] = wgg.conjclasses()
+        if ZZ(order) < ZZ(10000000) and wgg.num_conjclasses() < 21:
             ctable = chartable(n, t)
         else:
             ctable = 'Data not available'
-        data['gens'] = generators(n, t)
+        data['gens'] = wgg.generator_string()
         if n == 1 and t == 1:
             data['gens'] = 'None needed'
         data['chartable'] = ctable
         data['parity'] = "$%s$" % data['parity']
-        data['cclasses'] = wgg.conjclasses()
         data['subinfo'] = subfield_display(n, data['subfields'])
         data['resolve'] = resolve_display(data['quotients'])
         if data['gapid'] == 0:

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -10,7 +10,7 @@ from sage.all import ZZ, latex, gap
 from lmfdb import db
 from lmfdb.app import app
 from lmfdb.utils import (
-    list_to_latex_matrix, flash_error,
+    list_to_latex_matrix, flash_error, comma,
     clean_input, prep_ranges, parse_bool, parse_ints, parse_bracketed_posints, parse_restricted,
     search_wrap)
 from lmfdb.number_fields.web_number_field import modules2string
@@ -171,13 +171,11 @@ def render_group_webpage(args):
         if wgg.num_conjclasses() < 50:
             data['cclasses'] = wgg.conjclasses()
         if ZZ(order) < ZZ(10000000) and wgg.num_conjclasses() < 21:
-            ctable = chartable(n, t)
-        else:
-            ctable = 'Data not available'
+            data['chartable'] = chartable(n, t)
         data['gens'] = wgg.generator_string()
         if n == 1 and t == 1:
             data['gens'] = 'None needed'
-        data['chartable'] = ctable
+        data['num_cc'] = comma(wgg.num_conjclasses())
         data['parity'] = "$%s$" % data['parity']
         data['subinfo'] = subfield_display(n, data['subfields'])
         data['resolve'] = resolve_display(data['quotients'])

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -48,6 +48,7 @@ table.reptable td, table.reptable th {
   <p><h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy Classes') }}</h2>
    <p>
 
+      {% if info.cclasses is defined %}
    <table class="ntdata">
       <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
       <tbody>
@@ -60,6 +61,9 @@ table.reptable td, table.reptable th {
         {% endfor %}
       </tbody>
       </table>
+      {% else %}
+        Data not computed.
+      {% endif %}
 
 
    </p>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -62,7 +62,8 @@ table.reptable td, table.reptable th {
       </tbody>
       </table>
       {% else %}
-        Data not computed.
+        There are {{ info.num_cc }} conjugacy classes of elements.
+        Data not shown.
       {% endif %}
 
 
@@ -80,9 +81,15 @@ table.reptable td, table.reptable th {
     </table>
 
     <table>
-      <tr><td>Character table:<td>&nbsp;&nbsp;<td><pre>
+      <tr><td>Character table:
+      {% if info.chartable is defined %}
+      <td>&nbsp;&nbsp;<td>
+      <pre>
 {{info.chartable}}
-</pre></td></tr>
+</pre>
+      {% else %}
+      Data not available.
+      {% endif %}
     </table> </div> </p>
 {% if info.int_reps %}
 <p><h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -66,6 +66,10 @@ def list_with_mult(lis, names=True):
             ans += "<span style='font-size: small'> x %d</span>"% k[1]
     return ans
 
+# Given [[1,2,4],[3,5]] give the string '(1,2,4)(3,5)'
+def cyclestrings(perm):
+    a = ['('+','.join([str(u) for u in v])+')' for v in perm]
+    return ''.join(a)
 
 ############  Galois group object
 
@@ -111,6 +115,9 @@ class WebGaloisGroup:
     def order(self):
         return int(self._data['order'])
 
+    def gens(self):
+        return(self._data['gens'])
+
     def display_short(self):
         if self._data.get('pretty',None) is not None:
             return self._data['pretty']
@@ -122,12 +129,23 @@ class WebGaloisGroup:
     def subfields(self):
         return(list_with_mult(self._data['subfields']))
 
+    def generator_string(self):
+        if str(self.n()) == "1":
+            return "None needed"
+        gens = self.gens()
+        gens = [cyclestrings(g) for g in gens]
+        gens = ', '.join(gens)
+        return gens
+
     def gapgroupnt(self):
         if int(self.n()) == 1:
             G = gap.SmallGroup(1, 1)
         else:
-            G = gap.TransitiveGroup(self.n(), self.t())
+            G = gap('Group(['+self.generator_string()+'])')
         return G
+
+    def num_conjclasses(self):
+        return self._data['num_conj_classes']
 
     def conjclasses(self):
         if 'conjclasses' in self._data:
@@ -157,21 +175,6 @@ class WebGaloisGroup:
 
 def base_label(n, t):
     return str(n) + "T" + str(t)
-
-# When labeling other rep'ns, we go successively through characters
-# This can exhaust the alphabet.  So, c could be a longer string!
-
-
-def nextchr(c):
-    s = ord('a') - 1  # really 96
-    l = [ZZ(ord(j) - s) for j in list(c)]
-    l.reverse()
-    tot = ZZ(l, 27) + 1
-    newl = tot.digits(27)
-    newl.reverse()
-    newl = map(lambda x: x + 1 if x == 0 else x, newl)
-    return ''.join([chr(j + s) for j in newl])
-
 
 def trylink(n, t):
     label = base_label(n, t)
@@ -241,7 +244,9 @@ def cclasses_display_knowl(n, t, name=None):
     if not name:
         name = 'Conjugacy class representatives for '
         name += group_display_short(n, t)
-    return '<a title = "' + name + ' [gg.conjugacy_classes.data]" knowl="gg.conjugacy_classes.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
+    if WebGaloisGroup.from_nt(n,t).num_conjclasses() < 50:
+        return '<a title = "' + name + ' [gg.conjugacy_classes.data]" knowl="gg.conjugacy_classes.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
+    return name + 'is not computed'
 
 
 def character_table_display_knowl(n, t, name=None):
@@ -249,8 +254,7 @@ def character_table_display_knowl(n, t, name=None):
         name = 'Character table for '
         name += group_display_short(n, t)
     group = WebGaloisGroup.from_nt(n, t)
-    cclasses = group.conjclasses()
-    if ZZ(group.order()) < ZZ(10000000) and len(cclasses) < 21:
+    if ZZ(group.order()) < ZZ(10000000) and group.num_conjclasses() < 21:
         return '<a title = "' + name + ' [gg.character_table.data]" knowl="gg.character_table.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
     return name + ' is not computed'
 
@@ -318,7 +322,7 @@ def galois_group_data(n, t):
     inf += '%s</div>'%(group['name'])
 
     rest = '<div><h3>Generators</h3><blockquote>'
-    rest += generators(n, t)
+    rest += WebGaloisGroup.from_nt(n,t).generator_string()
     rest += '</blockquote></div>'
 
     rest += '<div><h3>Subfields</h3><blockquote>'
@@ -484,12 +488,14 @@ def group_display_inertia(code):
 
 def cclasses(n, t):
     group = WebGaloisGroup.from_nt(n,t)
-    cc = group.conjclasses()
+    if group.num_conjclasses() >= 50:
+        return 'Data not computed'
     html = """<div>
             <table class="ntdata">
             <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
             <tbody>
          """
+    cc = group.conjclasses()
     for c in cc:
         html += '<tr><td>' + str(c[3]) + '</td>'
         html += '<td>' + str(c[2]) + '</td>'
@@ -508,19 +514,6 @@ def chartable(n, t):
     ctable = re.sub("^.*\n", '', ctable)
     ctable = re.sub("^.*\n", '', ctable)
     return ctable
-
-
-def generators(n, t):
-    if str(n) == "1":
-        return "None needed"
-    else:
-        G = gap.TransitiveGroup(n, t)
-    gens = G.SmallGeneratingSet()
-    gens = str(gens)
-    gens = re.sub("[\[\]]", '', gens)
-    gens = gens.replace(' ', '')
-    gens = gens.replace('),', '), ')
-    return gens
 
 
 def group_alias_table():

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -246,7 +246,7 @@ def cclasses_display_knowl(n, t, name=None):
         name += group_display_short(n, t)
     if WebGaloisGroup.from_nt(n,t).num_conjclasses() < 50:
         return '<a title = "' + name + ' [gg.conjugacy_classes.data]" knowl="gg.conjugacy_classes.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
-    return name + 'is not computed'
+    return name + ' is not computed'
 
 
 def character_table_display_knowl(n, t, name=None):

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -17,7 +17,8 @@ class DynamicKnowlTest(LmfdbTest):
 
     def test_character_table_knowl(self):
         L = self.tc.get('/knowledge/show/gg.character_table.data?n=5&t=5', follow_redirects=True)
-        assert '6  . -2  .  .  .  1' in L.data
+        # character table order can vary, so use trivial character
+        assert '1  1  1  1  1  1  1' in L.data
 
     def test_small_group_knowl(self):
         L = self.tc.get('/knowledge/show/group.small.data?gapid=2.1', follow_redirects=True)

--- a/scripts/galois_groups/import_gg_data.py
+++ b/scripts/galois_groups/import_gg_data.py
@@ -40,6 +40,8 @@ def dosubs(ent):
     diflis.sort()
     ans = [[j[0], [j[1], j[2]], lis2.count(j)] for j in diflis]
     ent['quotients'] = ans
+    ent['bound_quotients'] = 47
+    ent['bound_siblings'] = 47
     del ent['resolve']
 
     return(ent)


### PR DESCRIPTION
Some Galois group pages were not working now that the range of degrees has been extended.

For some computations, we would create the transitive group in gap, but we are now beyond gap's knowledge.  So, we have precomputed generators for the groups and stored them in the database.  This means we don't have to compute them on they fly, and they can be used to initialize the group in gap.  For example,

  http://127.0.0.1:37777/GaloisGroup/47T6

gives a server error on beta, but now loads.

This group has over 100,000 conjugacy classes.  So, with this change, we do not try to compute/display conjugacy classes if there are more than 49 of them.

On a page like

  http://127.0.0.1:37777/NumberField/22.0.3388109619085565148335762714038503428163.1

the knowl for conjugacy classes and the character table is now just a "not computed" message.

On a page like
  http://127.0.0.1:37777/NumberField/7.3.2007889.2
the knowls for conjugacy classes and character table work as before (because the number of classes is manageable).