### PR TITLE
Galois show bounds

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -186,7 +186,8 @@ def render_group_webpage(args):
                                                       int(data['gapid']),
                                                       str([int(data['order']), int(data['gapid'])]))
         data['otherreps'] = wgg.otherrep_list()
-        ae = wgg.arith_equivalent()
+        ae = data['arith_equiv']
+        del data['arith_equiv']
         if ae>0:
             if ae>1:
                 data['arith_equiv'] = r'A number field with this Galois group has %d <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'% ae

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -194,8 +194,6 @@ def render_group_webpage(args):
                 data['arith_equiv'] = r'A number field with this Galois group has exactly one <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> field.'
         elif ae > -1:
             data['arith_equiv'] = r'A number field with this Galois group has no <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'
-        if len(data['otherreps']) == 0:
-            data['otherreps']="There is no other low degree representation."
         intreps = list(db.gps_gmodules.search({'n': n, 't': t}))
         if len(intreps) > 0:
             data['int_rep_classes'] = [str(z[0]) for z in intreps[0]['gens']]

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -141,8 +141,7 @@ def yesno(val):
 
 
 def render_group_webpage(args):
-    data = None
-    info = {}
+    data = {}
     if 'label' in args:
         label = clean_input(args['label'])
         label = label.replace('t', 'T')
@@ -156,6 +155,7 @@ def render_group_webpage(args):
         data['label_raw'] = label.lower()
         title = 'Galois Group: ' + label
         wgg = WebGaloisGroup.from_nt(data['n'], data['t'])
+        data['wgg'] = wgg
         n = data['n']
         t = data['t']
         data['yesno'] = yesno
@@ -192,7 +192,7 @@ def render_group_webpage(args):
                 data['arith_equiv'] = r'A number field with this Galois group has %d <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'% ae
             else:
                 data['arith_equiv'] = r'A number field with this Galois group has exactly one <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> field.'
-        else:
+        elif ae > -1:
             data['arith_equiv'] = r'A number field with this Galois group has no <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'
         if len(data['otherreps']) == 0:
             data['otherreps']="There is no other low degree representation."
@@ -228,13 +228,12 @@ def render_group_webpage(args):
         pretty = group_display_pretty(n,t)
         if len(pretty)>0:
             prop2.extend([('Group:', pretty)])
-            info['pretty_name'] = pretty
+            data['pretty_name'] = pretty
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
-        info.update(data)
 
         bread = get_bread([(label, ' ')])
-        return render_template("gg-show-group.html", credit=GG_credit, title=title, bread=bread, info=info, properties2=prop2, friends=friends, KNOWL_ID="gg.%s"%info['label_raw'], learnmore=learnmore_list())
+        return render_template("gg-show-group.html", credit=GG_credit, title=title, bread=bread, info=data, properties2=prop2, friends=friends, KNOWL_ID="gg.%s"%data['label_raw'], learnmore=learnmore_list())
 
 
 def search_input_error(info, bread):

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -187,7 +187,6 @@ def render_group_webpage(args):
                                                       str([int(data['order']), int(data['gapid'])]))
         data['otherreps'] = wgg.otherrep_list()
         ae = data['arith_equiv']
-        del data['arith_equiv']
         if ae>0:
             if ae>1:
                 data['arith_equiv'] = r'A number field with this Galois group has %d <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'% ae
@@ -195,6 +194,8 @@ def render_group_webpage(args):
                 data['arith_equiv'] = r'A number field with this Galois group has exactly one <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> field.'
         elif ae > -1:
             data['arith_equiv'] = r'A number field with this Galois group has no <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields.'
+        else:
+            data['arith_equiv'] = r'Data on whether or not a number field with this Galois group has <a knowl="nf.arithmetically_equivalent", title="arithmetically equivalent">arithmetically equivalent</a> fields has not been computed.'
         intreps = list(db.gps_gmodules.search({'n': n, 't': t}))
         if len(intreps) > 0:
             data['int_rep_classes'] = [str(z[0]) for z in intreps[0]['gens']]

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -170,7 +170,7 @@ table.ntdata a {
 {% if info.show_subs %}
 <td >{{ wgg.subfields() | safe }}</td>
 {% endif %}
-<td >{{wgg.otherrep_list()|safe}}</td>
+<td >{{wgg.otherrep_list(givebound=False)|safe}}</td>
 </tr>
 
 {% endfor %}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -22,9 +22,15 @@ table.reptable td, table.reptable th {
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>
       <tr><td>{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
-      <tr><td>{{KNOWL('gg.resolvents', 'Low degree resolvents')}}:<td>&nbsp;&nbsp;<td>{{info.resolve|safe}}</tr>
     </table>
   </p>
+
+  <p><h2>{{KNOWL('gg.resolvents', 'Low degree resolvents')}}</h2>
+  <blockquote>
+  {{info.resolve|safe}}
+
+<p> Resolvents shown for degrees $\leq {{info.wgg.quotient_bound()}}$
+  </blockquote>
 
   <p><h2>{{ KNOWL('gg.subfields', title='Subfields') }}</h2>
    <p>
@@ -37,6 +43,7 @@ table.reptable td, table.reptable th {
    <p>
    <blockquote>
     {{info.otherreps|safe}}
+    <p> Other representations shown for degrees $\leq {{info.wgg.sibling_bound()}}$
    </blockquote>
    {% if info.arith_equiv %}
      <blockquote>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -44,11 +44,9 @@ table.reptable td, table.reptable th {
    <blockquote>
     {{info.otherreps|safe}}
    </blockquote>
-   {% if info.arith_equiv is defined %}
-     <blockquote>
-        {{info.arith_equiv|safe}}
-     </blockquote>
-   {% endif %}
+   <blockquote>
+      {{info.arith_equiv|safe}}
+   </blockquote>
    </p>
 
   <p><h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy Classes') }}</h2>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -43,9 +43,8 @@ table.reptable td, table.reptable th {
    <p>
    <blockquote>
     {{info.otherreps|safe}}
-    <p> Other representations shown for degrees $\leq {{info.wgg.sibling_bound()}}$
    </blockquote>
-   {% if info.arith_equiv %}
+   {% if info.arith_equiv is defined %}
      <blockquote>
         {{info.arith_equiv|safe}}
      </blockquote>

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -123,8 +123,15 @@ class WebGaloisGroup:
             return self._data['pretty']
         return self._data['name']
 
-    def otherrep_list(self):
-        return(list_with_mult(self._data['siblings'], names=False))
+    def otherrep_list(self, givebound=True):
+        sibs = self._data['siblings']
+        pharse = "with degree $\leq %d$"% self.sibling_bound()
+        if len(sibs)==0 and givebound:
+            return "There are no siblings "+pharse
+        li = list_with_mult(sibs, names=False)
+        if givebound:
+            li += '<p>Siblings are shown '+pharse
+        return li
 
     def subfields(self):
         return(list_with_mult(self._data['subfields']))

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -169,6 +169,11 @@ class WebGaloisGroup:
         self._data['conjclasses'] = ans
         return(ans)
 
+    def sibling_bound(self):
+        return self._data['bound_siblings']
+
+    def quotient_bound(self):
+        return self._data['bound_quotients']
 
 
 ############  Misc Functions

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -470,11 +470,12 @@ def resolve_display(resolves):
     for j in resolves:
         if j[0] != old_deg:
             if old_deg < 0:
-                ans += '<table>'
+                ans += '<table><tr><th>'
+                ans += '|G/N|<th>Galois groups for stem field(s)'
             else:
                 ans += '</td></tr>'
             old_deg = j[0]
-            ans += '<tr><td>' + str(j[0]) + ': </td><td>'
+            ans += '<tr><td align="right">' + str(j[0]) + ':&nbsp; </td><td>'
         else:
             ans += ', '
         k = j[1]

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -253,12 +253,15 @@ def galois_module_knowl(n, t, index):
 
 
 def cclasses_display_knowl(n, t, name=None):
+    ncc = WebGaloisGroup.from_nt(n,t).num_conjclasses()
     if not name:
-        name = 'Conjugacy class representatives for '
+        name = 'The %d conjugacy class representatives for '% ncc
+        if n==1 and t==1:
+            name = 'The conjugacy class representative for '
         name += group_display_short(n, t)
-    if WebGaloisGroup.from_nt(n,t).num_conjclasses() < 50:
+    if ncc < 50:
         return '<a title = "' + name + ' [gg.conjugacy_classes.data]" knowl="gg.conjugacy_classes.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + name + '</a>'
-    return name + ' is not computed'
+    return name + ' are not computed'
 
 
 def character_table_display_knowl(n, t, name=None):


### PR DESCRIPTION
As we expand the range of data on Galois groups, we cannot always compute things to the same extent.  On a page such as 

  http://127.0.0.1:37777/GaloisGroup/24T18003

we explicitly say below the resolvents and below the siblings the extent to which we have computed each of these.  For resolvents, there are now also column headers to clarify what one is looking at, and the knowl for the header "Low degree resolvents" tries to explain things more fully.

We also have entries where we have not (yet) been able to compute arithmetically equivalent fields (i.e., H such that (G,G_1, H) is a Gassmann triple with G_1 the stabilizer of 1).  If we haven't computed it we give a message saying that, as on

  http://127.0.0.1:37777/GaloisGroup/28T86

