### PR TITLE
Fixes for #2792 and #3132

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -31,7 +31,7 @@ from glob import glob
 import csv
 import sys
 
-from psycopg2 import connect, DatabaseError, InterfaceError, OperationalError, ProgrammingError, NotSupportedError
+from psycopg2 import connect, DatabaseError, InterfaceError, OperationalError, ProgrammingError, NotSupportedError, DataError
 from psycopg2.sql import SQL, Identifier, Placeholder, Literal, Composable
 from psycopg2.extras import execute_values
 from psycopg2.extensions import cursor as pg_cursor
@@ -380,7 +380,7 @@ class PostgresBase(object):
             else:
                 try:
                     cur.execute(query, values)
-                except (OperationalError, ProgrammingError, NotSupportedError) as e:
+                except (OperationalError, ProgrammingError, NotSupportedError, DataError) as e:
                     try:
                         context = ' happens while executing {}'.format(cur.mogrify(query, values))
                     except Exception:

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -28,7 +28,7 @@ from lmfdb.utils import to_dict, code_snippet_knowl
 import markdown
 from lmfdb.knowledge import logger
 from lmfdb.utils import datetime_to_timestamp_in_ms,\
-                        timestamp_in_ms_to_datetime
+                        timestamp_in_ms_to_datetime, flash_error
 
 #ejust for those, who still use an older markdown
 try:
@@ -757,8 +757,8 @@ def render_knowl(ID, footer=None, kwargs=None,
 
 @knowledge_page.route("/", methods=['GET', 'POST'])
 def index():
+    from psycopg2 import DataError
     cur_cat = request.args.get("category", "")
-
 
     filtermode = request.args.get("filtered")
     from knowl import knowl_status_code, knowl_type_code
@@ -780,7 +780,14 @@ def index():
     search = request.args.get("search", "")
     regex = (request.args.get("regex", "") == "on")
     keywords = search if regex else search.lower()
-    knowls = knowldb.search(category=cur_cat, filters=filters, types=types, keywords=keywords, regex=regex)
+    try:
+        knowls = knowldb.search(category=cur_cat, filters=filters, types=types, keywords=keywords, regex=regex)
+    except DataError as e:
+        knowls = {}
+        if regex and "invalid regular expression" in str(e):
+	    flash_error("The string %s is not a valid regular expression", keywords)
+        else:
+            flash_error("Unexpected error %s occured during knowl search", str(e))
 
     def first_char(k):
         t = k['title']

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -195,7 +195,7 @@ def ref_to_link(txt):
                 ans += ", "
             ans += this_link
 
-    return '[' + ans + ']' + " " + everythingelse
+    return '[' + ans + ']'  + everythingelse
 
 def md_latex_accents(text):
     """


### PR DESCRIPTION
Resolves #2792 by removing the trailing space when \cite is used in a knowl, compare

http://www.lmfdb.org/knowledge/show/rcs.source.nf
http://127.0.0.1:37777/knowledge/show/rcs.source.nf

Resolves #3132 by displaying a more useful error message when an invalid regular expression is specified in a knowl serach, compare

www.lmfdb.org/knowledge/?search=*%5C.cmf&regex=on
http://127.0.0.1:37777/knowledge/?search=*%5C.cmf&regex=on

Well-formed regular expressions still work as they should

http://127.0.0.1:37777/knowledge/?search=.*%5C.cmf&regex=on

This PR supersedes #3135.
