### PR TITLE
Fixing a number of issues on hgcwa

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/code.yaml
+++ b/lmfdb/higher_genus_w_automorphisms/code.yaml
@@ -131,7 +131,7 @@ gen_vect_label:
 
 
 add_to_total_basic:
-   gap:  "Add( data, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list, genus:=genus, dimension:=dim, r:=r, g0:=g0,  passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic) ); "
+   gap:  "Add( data, rec( group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=perm_list, genus:=genus, dimension:=dim, r:=r, g0:=g0,  passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic, is_cyclic_trigonal:=is_cyclic_trigonal) ); "
    magma: "Append(~data, rec<RecFormat | group:=G, gp_id:=gp_id, signature:=signature, gen_vectors:=gen_vectors_as_perm, conj_classes:=cc, genus:=genus, dimension:=dim, r:=r, g0:=g0, passport_label:= passport_label,gen_vect_label:=gen_vect_label, is_hyperelliptic:=is_hyperelliptic,is_cyclic_trigonal:=is_cyclic_trigonal >);"
 
 

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -508,7 +508,7 @@ def render_passport(args):
         prop2 = [
             ('Genus', '\(%d\)' % g),
             ('Quotient Genus', '\(%d\)' % g0),
-            ('Small Group', '\(%s\)' %  pretty_group),
+            ('Group', '\(%s\)' %  pretty_group),
             ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature']))),
             ('Generating Vectors','\(%d\)' % numb)
         ]

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This Blueprint is about Higher Genus Curves
-# Authors: Jen Paulhus, Lex Martin, David Neill Asanza
+# Authors: Jen Paulhus, Lex Martin, David Neill Asanza, Nhi Ngo, Albert Ford
 # (initial code copied from John Jones Local Fields)
 
 import ast, os, re, StringIO, yaml
@@ -19,7 +19,7 @@ from lmfdb.higher_genus_w_automorphisms.hgcwa_stats import HGCWAstats
 
 
 # Determining what kind of label
-family_label_regex = re.compile(r'(\d+)\.(\d+-\d+)\.(\d+\.\d+-[^\.]*$)')
+family_label_regex = re.compile(r'(\d+)\.(\d+-\d+)\.(\d+\.\d+-?[^\.]*$)')
 passport_label_regex = re.compile(r'((\d+)\.(\d+-\d+)\.(\d+\.\d+.*))\.(\d+)')
 cc_label_regex = re.compile(r'((\d+)\.(\d+-\d+)\.(\d+)\.(\d+.*))\.(\d+)')
 
@@ -56,15 +56,19 @@ def tfTOyn(bool):
 
 def sign_display(L):
     sizeL = len(L)
-    signL = "[ " + str(L[0]) + "; "
-    for i in range(1,sizeL-1):
-        signL= signL + str(L[i]) + ", "
-
-    signL=signL + str(L[sizeL-1]) + " ]"
+    if sizeL == 1:
+        signL = "[ " + str(L[0]) + "; -]"
+    else:
+        signL = "[ " + str(L[0]) + "; "
+        for i in range(1,sizeL-1):
+            signL= signL + str(L[i]) + ", "
+        signL=signL + str(L[sizeL-1]) + " ]"    
     return signL
 
 def cc_display(L):
     sizeL = len(L)
+    if sizeL == 0:
+        return
     if sizeL == 1:
         return str(L[0])
     stg = str(L[0])+ ", "
@@ -90,12 +94,14 @@ def sort_sign(L):
     return [L[0]] +L1
 
 def label_to_breadcrumbs(L):
-    newsig = '['
-    for i in range(0,len(L)):
+    newsig = '['+L[0]
+    for i in range(1,len(L)):
         if (L[i] == '-'):
             newsig += ","
         elif (L[i] == '.'):
             newsig += ';'
+        elif (L[i] == '0'):  # The case where there is no ramification gives a 0 in signature
+            newsig += '-'
         else:
             newsig += L[i]
 
@@ -353,6 +359,7 @@ def higher_genus_w_automorphisms_search(info, query):
         if query.get('signature'):
             query['signature'] = info['signature'] = str(sort_sign(ast.literal_eval(query['signature']))).replace(' ','')
     parse_gap_id(info,query,'group',name='Group',qfield='group')
+    parse_ints(info,query,'g0',name='Quotient Genus')
     parse_ints(info,query,'genus',name='Genus')
     parse_ints(info,query,'dim',name='Dimension of the family')
     parse_ints(info,query,'group_order', name='Group orders')
@@ -387,6 +394,7 @@ def render_family(args):
             return redirect(url_for(".index"))
         data=dataz[0]
         g = data['genus']
+        g0=data['g0']
         GG = ast.literal_eval(data['group'])
         gn = GG[0]
         gt = GG[1]
@@ -403,6 +411,7 @@ def render_family(args):
 
         prop2 = [
             ('Genus', '\(%d\)' % g),
+             ('Quotient Genus', '\(%d\)' %  g0),
             ('Group', '\(%s\)' %  pretty_group),
             ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature'])))
         ]
@@ -471,6 +480,7 @@ def render_passport(args):
             return redirect(url_for(".index"))
         data=dataz[0]
         g = data['genus']
+        g0=data['g0']
         GG = ast.literal_eval(data['group'])
         gn = GG[0]
         gt = GG[1]
@@ -497,6 +507,7 @@ def render_passport(args):
 
         prop2 = [
             ('Genus', '\(%d\)' % g),
+            ('Quotient Genus', '\(%d\)' % g0),
             ('Small Group', '\(%s\)' %  pretty_group),
             ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature']))),
             ('Generating Vectors','\(%d\)' % numb)
@@ -507,7 +518,8 @@ def render_passport(args):
                      'group': pretty_group,
                      'gpid': smallgroup,
                      'numb':numb,
-                     'disp_numb':min(numb,numgenvecs)
+                     'disp_numb':min(numb,numgenvecs),
+                     'g0': data ['g0']
                    })
 
         if spname:
@@ -533,11 +545,19 @@ def render_passport(args):
                 x3=' '
 
             x4=[]
-            for perm in dat['gen_vectors']:
-                cycperm=Permutation(perm).cycle_string()
+            if dat['g0'] == 0:
+                for perm in dat['gen_vectors']:
+                    cycperm=Permutation(perm).cycle_string()
+                    x4.append(sep.join(split_perm(cycperm)))
 
-                x4.append(sep.join(split_perm(cycperm)))
-
+            elif dat['g0'] > 0:
+                for perm in dat['gen_vectors']:
+                    cycperm =Permutation(perm).cycle_string()
+                    #if display_perm == '()':
+                    if cycperm == '()':
+                        x4.append('Id(G)')
+                    else:
+                        x4.append(sep.join(split_perm(cycperm)))
             Ldata.append([x1,x2,x3,x4])
 
 
@@ -752,7 +772,7 @@ def hgcwa_code_download(**args):
     nhypcycstr += code_list['add_to_total_basic'][lang] + '\n'
 
     start = time.time()
-    lines = [(startstr + (signHfmt if dataz.get('signH') is not None else stdfmt).format(**dataz) + ((hypfmt.format(**dataz) if dataz['hyperelliptic'] else cyctrigfmt.format(**dataz) if dataz['cyclic_trigonal'] else nhypcycstr) if dataz.get('hyperelliptic') else '')) for dataz in data]
+    lines = [(startstr + (signHfmt if 'signH' in dataz else (stdfmt + (hypfmt if (dataz.get('hyperelliptic') and dataz['hyperelliptic']) else cyctrigfmt if (dataz.get('cyclic_trigonal') and dataz['cyclic_trigonal']) else nhypcycstr)))).format(**dataz) for dataz in data]
     code += '\n'.join(lines)
     print "%s seconds for %d bytes" %(time.time() - start,len(code))
     strIO = StringIO.StringIO()
@@ -762,8 +782,6 @@ def hgcwa_code_download(**args):
 
 
 
-
-#JEN TEST FUNCTION
 @higher_genus_w_automorphisms_page.route("/download/<download_type>")
 #def hgcwa_code_download_search(**args):
 def hgcwa_code_download_search(res,download_type):
@@ -831,7 +849,7 @@ def hgcwa_code_download_search(res,download_type):
             nhypcycstr += code_list['add_to_total_basic'][lang] + '\n'
     
             start = time.time()
-            lines = [(startstr + (signHfmt if 'signH' in dataz else stdfmt).format(**dataz) + ((hypfmt.format(**dataz) if dataz['hyperelliptic'] else cyctrigfmt.format(**dataz) if dataz['cyclic_trigonal'] else nhypcycstr) if 'hyperelliptic' in dataz else '')) for dataz in data]
+            lines = [(startstr + (signHfmt if 'signH' in dataz else (stdfmt + (hypfmt if (dataz.get('hyperelliptic') and dataz['hyperelliptic']) else cyctrigfmt if (dataz.get('cyclic_trigonal') and dataz['cyclic_trigonal']) else nhypcycstr)))).format(**dataz) for dataz in data]
             code += '\n'.join(lines)
 
 

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -75,6 +75,16 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
           </tr>
 
 
+ <tr align=left>
+            <td align=right>
+             {{KNOWL('curve.highergenus.aut.quotientgenus',title='Quotient Genus')}}:
+            </td><td><input type="integer" name="g0" value=""
+      placeholder="0"></td>
+      <td>
+	<span class="formexample">e.g. 4, or a range like 3..5</span>
+      </td>
+          </tr>
+	  
 	  <tr>
             <td align=right>
               {{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
@@ -152,4 +162,5 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
       </form>
 
 
-{% endblock %}
+      {% endblock %}
+      

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -10,26 +10,24 @@
 <table border="0">
 
 <tr>
-<td align=left>
-{{KNOWL('ag.curve.genus',title='Genus')}}:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
-</td>
+  <td align=left>{{KNOWL('ag.curve.genus',title='Genus')}}:</td>
+  <td align=left><input type='text' name="genus" size="5" value="{{info.genus}}"></td>
+  <td align=left>{{KNOWL('curve.highergenus.aut.quotientgenus',title='Quotient Genus')}}:</td>
+  <td align=left><input type="text" name="g0" size="5" value="{{info.g0}}"></td>
+</tr>
 
-<td align=left>
-{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
-<td align=left> <input type="text" name="signature" size="15" value="{{info.signature}}" >
-
+<tr>
+  <td align=left>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:</td>
+  <td align=left><input type="text" name="dim" size="5" value="{{info.dim}}"></td>
+  <td align=left>{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:</td>
+  <td align=left><input type="text" name="signature" size="15" value="{{info.signature}}"></td>
 </tr>
 
 <tr align=left>
-
-<td align=left>
-{{KNOWL('group.order',title='Group order(s)')}}:
-<td align=left> <input type="text" name="group_order" size="15" value="{{info.group_order}}" >
-<td align=left>
-{{KNOWL('group.small_group_label',title="Group identifier")}}:
-<td align=left> <input type="text" name="group" size="8" value="{{info.group}}" >
-</td>
-
+  <td align=left>{{KNOWL('group.order',title='Group order(s)')}}:</td>
+  <td align=left><input type="text" name="group_order" size="15" value="{{info.group_order}}"></td>
+  <td align=left>{{KNOWL('group.small_group_label',title="Group identifier")}}:</td>
+  <td align=left><input type="text" name="group" size="8" value="{{info.group}}"></td>
 </tr>
 
 <tr><td>
@@ -75,12 +73,96 @@
 {% endif %}
 {% endif %}
 </td>
+</tr>
+
+<tr>
+    <td>
+        {{KNOWL('curve.highergenus.aut.full',title="Full automorphism group")}}:
+        </td>
+        
+          <td> <select id='inc_full' name='inc_full'>
+        {% if info.inc_full == "only" %}
+                   <option value="include">include</option>
+                   <option value="exclude">exclude</option>
+                   <option value="only" selected="yes">only</option>
+        {% else %}
+        {% if info.inc_full == "exclude" %}
+                   <option value="include">include</option>
+                   <option value="exclude" selected="yes">exclude</option>
+                   <option value="only">only</option>
+        {% else %}
+                   <option value="include" selected="yes">include</option>
+                   <option value="exclude">exclude</option>
+                   <option value="only">only</option>
+        {% endif %}
+        {% endif %}
+        </td>
+<td align='left' colspan='4'>Maximum number of families to display: <input type='text' id='count' name='count' value="{{info.count}}" size='10'>
+</td>
+</tr>
 
 
+  
+<!--<tr>
+<td align=left>
+{{KNOWL('ag.curve.genus',title='Genus')}}:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
+</td>
+<td align=left>
+{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
+<td align=left> <input type="text" name="signature" size="15" value="{{info.signature}}" >
+</tr>
+<tr align=left>
+<td align=left>
+{{KNOWL('group.order',title='Group order(s)')}}:
+<td align=left> <input type="text" name="group_order" size="15" value="{{info.group_order}}" >
+<td align=left>
+{{KNOWL('group.small_group_label',title="Group identifier")}}:
+<td align=left> <input type="text" name="group" size="8" value="{{info.group}}" >
+</td>
+</tr>
+<tr><td>
+{{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curve(s)')}}:
+</td>
+  <td> <select id='inc_hyper' name='inc_hyper'>
+{% if info.inc_hyper == "only" %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% else %}
+{% if info.inc_hyper == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% endif %}
+{% endif %}
+</td>
+<td >
+{{KNOWL('ag.cyclic_trigonal',title='Cyclic trigonal curve(s)')}}:
+</td>
+  <td> <select id='inc_cyc_trig' name='inc_cyc_trig'>
+{% if info.inc_cyc_trig == "only" %}
+           <option value="include">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only" selected="yes">only</option>
+{% else %}
+{% if info.inc_cyc_trig == "exclude" %}
+           <option value="include">include</option>
+           <option value="exclude" selected="yes">exclude</option>
+           <option value="only">only</option>
+{% else %}
+           <option value="include" selected="yes">include</option>
+           <option value="exclude">exclude</option>
+           <option value="only">only</option>
+{% endif %}
+{% endif %}
+</td>
 <td>
 {{KNOWL('curve.highergenus.aut.full',title="Full automorphism group")}}:
 </td>
-
   <td> <select id='inc_full' name='inc_full'>
 {% if info.inc_full == "only" %}
            <option value="include">include</option>
@@ -98,20 +180,17 @@
 {% endif %}
 {% endif %}
 </td>
-
-
 </tr>
-
 <tr>
-
  <td align=left>
 {{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
 <td align=left> <input type="text" name="dim" size="5" value="{{info.dim}}" > </td>
-
-
 <td align='left' colspan='4'>Maximum number of families to display: <input type='text' id='count' name='count' value="{{info.count}}" size='10'>
 </td>
-</tr>
+</tr> -->
+
+
+
 
 <tr>
   <td>
@@ -175,4 +254,5 @@ Download displayed results for
 {% endif %}
 {% include 'debug_info.html' %}
 
-{% endblock %}
+  {% endblock %}
+  

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-family.html
@@ -7,13 +7,13 @@
 
 
 
-<p><h2> Family Information</h2>
+<h2> Family Information</h2>
 
   <table>
       <tr><td> {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>
       <tr><td>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family:')}}</td><td> {{info.dim}} </td></tr>
     </table>
-</p>
+
 
 
 <h2>Cover</h2><table>
@@ -23,15 +23,13 @@
       </table> 
 
 
-<p> <h2>Group </h2>
+<h2>Group </h2>
   <table>
    {% if info.specialname %}
    <tr><td>{{KNOWL('group.small_group_label',title='Name')}}:</td> <td>${{info.group}}$</td></tr>
    {% endif %}
      <tr><td>{{KNOWL('group.small_group_label',title='Identifier')}}:</td><td>{{info.gpid}}</td></tr>
     </table>
-
-</p>
 
 
 <p> <h2> Conjugacy Class(es) of {{KNOWL('curve.highergenus.aut.refinedpassport',title='Refined Passports')}} </h2>
@@ -57,3 +55,4 @@
 
   
 {% endblock %}
+

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -8,7 +8,8 @@
 <h2> Family Information</h2>
 
   <table>
-      <tr><td>  {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>
+    <tr><td>  {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>
+     <tr><td>  {{KNOWL('ag.curve.genus',title='Quotient Genus')}}:  </td><td> {{ info.g0 }} </td></tr>
    {% if info.specialname %}
    <tr><td>{{KNOWL('group.small_group_label',title='Group name')}}:</td> <td>${{info.group}}$</td></tr>
    {% endif %}
@@ -19,8 +20,6 @@
   <table>
     <tr><td>{{KNOWL('curve.highergenus.aut.conjugacyclasses', title="Conjugacy classes")}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
   </table> {% endif %}
-<!--      <tr><td>{{KNOWL('curve.highergenus.aut.conjugacyclasses', title="Conjugacy classes")}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>-->
- 
 
 
 <p>  {% if info.fullauto  %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -1,12 +1,11 @@
 {% extends "homepage.html" %}
 
-<!-- in templates -->
 
 {% block content %}
 
 
 
-<p><h2> Family Information</h2>
+<h2> Family Information</h2>
 
   <table>
       <tr><td>  {{KNOWL('ag.curve.genus',title='Genus')}}:  </td><td> {{ info.genus }} </td></tr>
@@ -15,8 +14,13 @@
    {% endif %}
   <tr><td>{{KNOWL('group.small_group_label',title='Group identifier')}}:</td> <td>{{info.gpid}}</td></tr>
   <tr><td>{{KNOWL('curve.highergenus.aut.signature', title='Signature')}}:</td> <td>${{info.sign}}$</td></tr>
-  <tr><td>{{KNOWL('curve.highergenus.aut.conjugacyclasses', title="Conjugacy classes")}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
-  </table></p>
+  </table>
+    {% if info.passport_cc %}
+  <table>
+    <tr><td>{{KNOWL('curve.highergenus.aut.conjugacyclasses', title="Conjugacy classes")}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>
+  </table> {% endif %}
+<!--      <tr><td>{{KNOWL('curve.highergenus.aut.conjugacyclasses', title="Conjugacy classes")}} for this {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passport')}}: </td><td>{{info.passport_cc}}</td></tr>-->
+ 
 
 
 <p>  {% if info.fullauto  %}
@@ -32,8 +36,8 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
  {% endif %}
 
 
-
-  <p><h2>Other Data</h2>
+{% if info.other_data  %}
+<h2>Other Data</h2>
     <table>
        <!-- <tr><td>Dimension of the corresponding {{KNOWL('ag.shimura_variety',title='Shimura variety')}}:</td><td>{{ info.Ndim}}</td></tr>-->
       {% if info.ishyp %}
@@ -47,8 +51,8 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
        <tr><td>{{KNOWL('ag.cyclic_trigonal',title='Trigonal automorphism')}}:</td> <td>{{info.cinv}}</td></tr>
        {% endif %}  {% endif %}
     </table>
+{% endif %}
 
-  </p>
 
   <p>
     {% if info.eqns %}

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -50,3 +50,16 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
         assert 'Distribution of groups in curves of genus 5' in L.data
 
         
+    def test_quo_genus_gt_0(self):
+        L = self.tc.get('/HigherGenus/C/Aut/3.2-1.2.0.1')
+        assert '[2;-]' in L.data
+
+    def test_quo_genus_search(self):
+        L = self.tc.get('/HigherGenus/C/Aut/?genus=3&g0=1..3')
+        assert 'displaying all 10 matches' in L.data
+
+    def idG_showing(self):
+        L = self.tc.get('/HigherGenus/C/Aut/2.2-1.1.2-2.1')
+        assert 'Id(G)' in L.data
+
+        


### PR DESCRIPTION
Ok, let's try this again.   This is a clean pull request to replace #3126.  I replicated my original pull request comments at the bottom here, after the second page break.  And I addressed the issues Drew brought up in that pull request (comments after first page break below).  In particular, I have made changes to the database which should be transferred to production at some point.  Finally, I will add information to the completeness knowl about quotient genus >0 data once this pull request is ready to go (I don't want people searching for g0>0 until this pull request is available).

--------------------------------------------
**Drew's comments**

(1) Searching on group order 2 gives different results than searching on group [2,1], compare:

http://localhost:37777/HigherGenus/C/Aut/?group_order=2
http://localhost:37777/HigherGenus/C/Aut/?start=0&paging=0&group=%5B2%2C1%5D

**Fixed in the data.**

(2) There is a problem in how group order searches are being processed. The value entered into the group order field on the main browse page is not present on the search results page, compare:

http://localhost:37777/HigherGenus/C/Aut/?group_order=2
http://beta.lmfdb.org/HigherGenus/C/Aut/?group_order=2

also, if you enter the group order on the search results page (rather than from the main browse page) it does not work correctly, compare

http://localhost:37777/HigherGenus/C/Aut/?start=0&paging=0&groupsize=2
http://beta.lmfdb.org/HigherGenus/C/Aut/?start=0&paging=0&group_order=2

**Fixed.**

Would it make sense to create a completely new branch that contains only the changes intended for this PR?

**Done here.**

(3) I don't understand why the search results for quotient genus 2:

http://localhost:37777/HigherGenus/C/Aut/?g0=2
include the signature [1;2,2,2]. 

**This was a typo in the data that is now fixed.  The signature of that entry should be [2;2,2] so the search was doing the correct thing, the signature was just not displaying correctly.**

I also think the signature knowl should reference the quotient genus knowl.

**Done.  Although the nom de plume I'm using to create group knowls written by Tim D.  shows up as the last person to edit it, since I forgot to switch accounts before editing!**

(4) Just a small suggestion for improvement: it seems like the quotient genus would be a natural thing to add to the properties box and the list of invariants on the home page of the passport.

**Done.**

(5) I think it would be a good idea to add some additional tests to test_hwcga.py that specifically check the problems that this PR is intended to fix so that they don't recur, and to check that the new quotient genus search/display works as desired.

**I added a few more slightly generic ones.  If anyone has suggestions for other tests to run, I'm all ears.**


------------------------------------
**The original pull request comments.**

This code fixes a number of small issues on the higher genus data pages.

I have updated the hgcwa_passports table in a few places to fix some small errors with the data, so that will need to be updated on the production version eventually. This fixed, for example, issue Issue #3108 as you can see if you run the search on beta now:
http://beta.lmfdb.org/HigherGenus/C/Aut/?start=0&paging=0&genus=3&signature=%5B1%3B2%5D

The primary issue is that some data I thought did not make the switch to Postgres last August actually did make it. This "new" data is for quotient genus >0 (only for genus of the original curve up to 4 for the moment) and this data required a series of small changes. But the pages for that data were works in progress back then, and so aren't displaying correctly on lmfdb.org. This pull request fixes them. It might be worth considering these as "new" pages even though there are only a handful of entries currently in the database which display this way (instead of just as a pull request fixing errors). If you search for quotient genus >0 you will find one of the "new" pages.

We've fixed some pages returned errors:
http://www.lmfdb.org/HigherGenus/C/Aut/3.2-1.2.0.1
(See #3111 too)

Or a page like the following which had () instead of Id(G) for the identity element of the group.
http://www.lmfdb.org/HigherGenus/C/Aut/2.2-1.1.2-2.1

We also made searching by quotient genus a part of the main search functionality

Magma and Gap downloads had some issues on the page and I fixed most of them (except see #2577)

Notice that [2;2] now correctly shows as [2;-] which fixes #3110
http://localhost:37777/HigherGenus/C/Aut/?start=0&paging=0&genus=3&signature=%5B2%5D&count=200

Also in #3110 they ask about genus 7, but I only have data for genus 4 and quotient genus >0 in the database yet---Note the completeness knowl specifically says only quotient genus =0 but I will change that to include the quotient genus >0 once this pull request is accepted. I don't want to add higher genus data until I am sure these pages are stable. Similarly I will need to update a couple knowls like signature and generating vectors to explain the quotient genus >0.

There was an error if you searched for certain labels. It was a small regex error.

Sort order like #3109 is coming soon...