### PR TITLE
Update the sort orders for searches in HGCWA

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -15,7 +15,7 @@ text-align:right;
   <p>
     Currently the database contains all groups $G$ acting as automorphisms of
     curves $X/\C$ of genus {{info.stats.genus.min}} to
-    {{info.stats.genus.max}} such that $X/G$ has genus 0. There are {{info.stats.refined_passports.distinct}}
+    {{info.stats.genus.max}} such that $X/G$ has genus 0, as well as genus 2 through 4  with quotient genus greater than 0. There are {{info.stats.refined_passports.distinct}}
     distinct {{KNOWL('curve.highergenus.aut.refinedpassport',title='refined passports')}} in the database. The number of distinct
     {{KNOWL('curve.highergenus.aut.generatingvector',title='generating vectors')}} is {{info.stats.generating_vectors.distinct}}.
     Here are some <a href="{{url_for('.statistics')}}">further statistics</a>.

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -103,93 +103,26 @@
 
 
   
-<!--<tr>
-<td align=left>
-{{KNOWL('ag.curve.genus',title='Genus')}}:</td><td align=left> <input type='text' name='genus' size="5" value="{{info.genus}}">
-</td>
-<td align=left>
-{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}:
-<td align=left> <input type="text" name="signature" size="15" value="{{info.signature}}" >
-</tr>
-<tr align=left>
-<td align=left>
-{{KNOWL('group.order',title='Group order(s)')}}:
-<td align=left> <input type="text" name="group_order" size="15" value="{{info.group_order}}" >
-<td align=left>
-{{KNOWL('group.small_group_label',title="Group identifier")}}:
-<td align=left> <input type="text" name="group" size="8" value="{{info.group}}" >
-</td>
-</tr>
-<tr><td>
-{{KNOWL('ag.hyperelliptic_curve',title='Hyperelliptic curve(s)')}}:
-</td>
-  <td> <select id='inc_hyper' name='inc_hyper'>
-{% if info.inc_hyper == "only" %}
-           <option value="include">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only" selected="yes">only</option>
-{% else %}
-{% if info.inc_hyper == "exclude" %}
-           <option value="include">include</option>
-           <option value="exclude" selected="yes">exclude</option>
-           <option value="only">only</option>
-{% else %}
-           <option value="include" selected="yes">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only">only</option>
-{% endif %}
-{% endif %}
-</td>
-<td >
-{{KNOWL('ag.cyclic_trigonal',title='Cyclic trigonal curve(s)')}}:
-</td>
-  <td> <select id='inc_cyc_trig' name='inc_cyc_trig'>
-{% if info.inc_cyc_trig == "only" %}
-           <option value="include">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only" selected="yes">only</option>
-{% else %}
-{% if info.inc_cyc_trig == "exclude" %}
-           <option value="include">include</option>
-           <option value="exclude" selected="yes">exclude</option>
-           <option value="only">only</option>
-{% else %}
-           <option value="include" selected="yes">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only">only</option>
-{% endif %}
-{% endif %}
-</td>
-<td>
-{{KNOWL('curve.highergenus.aut.full',title="Full automorphism group")}}:
-</td>
-  <td> <select id='inc_full' name='inc_full'>
-{% if info.inc_full == "only" %}
-           <option value="include">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only" selected="yes">only</option>
-{% else %}
-{% if info.inc_full == "exclude" %}
-           <option value="include">include</option>
-           <option value="exclude" selected="yes">exclude</option>
-           <option value="only">only</option>
-{% else %}
-           <option value="include" selected="yes">include</option>
-           <option value="exclude">exclude</option>
-           <option value="only">only</option>
-{% endif %}
-{% endif %}
-</td>
-</tr>
+
+
 <tr>
- <td align=left>
-{{KNOWL('curve.highergenus.aut.dimension',title='Dimension of the family')}}:
-<td align=left> <input type="text" name="dim" size="5" value="{{info.dim}}" > </td>
-<td align='left' colspan='4'>Maximum number of families to display: <input type='text' id='count' name='count' value="{{info.count}}" size='10'>
-</td>
-</tr> -->
-
-
+   <td>
+     {{KNOWL('curve.highergenus.aut.sort_order',title='Sort order')}}:
+   </td>
+   <td>
+     <select name="sort_order">
+         <option value="genus"{% if info.sort_order == "genus" %} selected {% endif %}>genus</option>
+         <option value="g0"{% if info.sort_order == "g0" %} selected {% endif %}>quotient genus</option>
+	   <option value="group_order"{% if info.sort_order == "group_order" %} selected{% endif %}>group order</option>
+         <option value="dim"{% if info.sort_order == "dim" %} selected {% endif %}>dimension</option>
+	 <option value="descgenus"{% if info.sort_order == "descgenus" %} selected {% endif %}>genus descending</option>
+	         <option value="descg0"{% if info.sort_order == "descg0" %} selected {% endif %}>quotient genus descending</option>
+	   <option value="descgroup_order"{% if info.sort_order == "descgroup_order" %} selected {% endif %}>group order descending</option>
+         <option value="descdim"{% if info.sort_order == "descdim" %} selected {% endif %}>dimension descending</option>
+               
+     </select>
+   </td>
+ </tr>
 
 
 <tr>
@@ -219,8 +152,9 @@ Download displayed results for
 
   <th>{{KNOWL('dq.curve.highergenus.aut.label',title='Refined Passport Label')}}</th>
   <th>{{KNOWL('ag.curve.genus',title='Genus')}}</th>
-  <th>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension')}}</th>
   <th>{{KNOWL('group.small_group_label',title='Group')}}</th>
+  <th>{{KNOWL('group.order',title='Group Order')}}</th>
+    <th>{{KNOWL('curve.highergenus.aut.dimension',title='Dimension')}}</th>
   <th>{{KNOWL('curve.highergenus.aut.signature',title='Signature')}}</th>
 </tr>
 </thead>
@@ -231,9 +165,10 @@ Download displayed results for
 
   <td align='left'><a href="/HigherGenus/C/Aut/{{field.passport_label}}">{{field.passport_label}}</a></td>
     <td>{{field.genus}}</td>
-  <td>{{field.dim}}</td>
-  <td>{{field.group}}</td>
-   <td>${{info.sign_display(field.signature)}}$</td>
+  <td>${{info.group_display(field.group)}}$</td>
+  <td>{{field.group_order}}</td>
+    <td>{{field.dim}}</td>
+  <td>${{info.sign_display(field.signature)}}$</td>
 
 
 </tr>


### PR DESCRIPTION
For these first three, you can experiment with search order using this search:
/HigherGenus/C/Aut/?start=0&paging=0&genus=3-5&g0=0-1&group_order=2-6&count=91
* Designated a fixed sort order for search results.
* Created drop down menu to give options for search result priority (completing #3109 for HGCWA)
* Made groups pretty print on search instead of just gap/magma number, and rearranged order of columns in search a bit



Three small unrelated fixes:
* Got rid of "name" in parse calls (see PR #3130 comments)
* Fixed incorrect "friends" loop  (see PR #3130 comments)
* top matter on index page: /HigherGenus/C/Aut/   For the moment I just hard coded in max and min of higher quotient genus data, because redoing the statistics on HGCWA is upcoming, and so this will just be a temporary fix.)

I think this pull request should get merged before #3130, otherwise I think Edgar's "cleanup" will be overwritten with this pull.