### PR TITLE
fixing upsert, when used for insertion

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2823,7 +2823,8 @@ class PostgresTable(PostgresBase):
                     self._execute(updater, dvalues)
                 if not self._out_of_order and any(key in self._sort_keys for key in data):
                     self._break_order()
-            else: # insertion
+
+            else:  # insertion
                 if "id" in data or "id" in query:
                     raise ValueError("Cannot specify an id for insertion")
                 new_row = True
@@ -2838,8 +2839,8 @@ class PostgresTable(PostgresBase):
                 if self.extra_table is not None:
                     extras_data["id"] = self.max_id() + 1
                 for table, dat in cases:
-                    inserter = SQL("INSERT INTO {0} ({1}) VALUES ({2})")
-                    inserter.format(Identifier(table),
+                    inserter = SQL("INSERT INTO {0} ({1}) VALUES ({2})").format(
+                                    Identifier(table),
                                     SQL(", ").join(map(Identifier, dat.keys())),
                                     SQL(", ").join(Placeholder() * len(dat)))
                     self._execute(inserter, self._parse_values(dat))

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2779,7 +2779,7 @@ class PostgresTable(PostgresBase):
             if col != "id" and col not in self._search_cols:
                 raise ValueError("%s is not a column of %s"%(col, self.search_table))
         if self.extra_table is None:
-            search_data = data
+            search_data = dict(data)
             for col in data:
                 if col not in self._search_cols:
                     raise ValueError("%s is not a column of %s"%(col, self.search_table))


### PR DESCRIPTION
This resolves #3136 and fixes another minor bug where the data object submitted for upsert could be unintentionally modified by the upsert call.

you can try it out
```
db.create_table_like('test_inv_tables', 'inv_tables')

import json

rec_find = json.loads('{"db_id":14, "name":"fields_human"}')
rec_set = json.loads('{"nice_name":"fields_human", "NOTES":null, "INFO":null}')
print db.test_inv_tables.upsert(rec_find, rec_set)
db.drop_table('test_inv_tables')
```
