### PR TITLE
Flasherror

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import ast, re, StringIO, time
+import ast
+import re
+import StringIO
+import time
 
 from flask import render_template, url_for, request, redirect, send_file
-from markupsafe import Markup
 from collections import defaultdict
 from sage.rings.all import PolynomialRing, ZZ
 

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -2,7 +2,7 @@
 
 import ast, re, StringIO, time
 
-from flask import flash, render_template, url_for, request, redirect, send_file
+from flask import render_template, url_for, request, redirect, send_file
 from markupsafe import Markup
 from collections import defaultdict
 from sage.rings.all import PolynomialRing, ZZ
@@ -11,7 +11,7 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from lmfdb.utils import (
-    to_dict,
+    to_dict, flash_error,
     parse_ints, parse_string_start, parse_nf_string, parse_galgrp,
     parse_subset, parse_submultiset, parse_bool, parse_bool_unknown,
     search_wrap)
@@ -85,16 +85,16 @@ def abelian_varieties_by_gq(g, q):
 
 @abvarfq_page.route("/<int:g>/<int:q>/<iso>")
 def abelian_varieties_by_gqi(g, q, iso):
-    label = abvar_label(g,q,iso)
+    label = abvar_label(g, q, iso)
     try:
         validate_label(label)
     except ValueError as err:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label: %s." % (label, str(err))), "error")
+        flash_error("%s is not a valid label: %s.", label, str(err))
         return search_input_error()
     try:
         cl = AbvarFq_isoclass.by_label(label)
     except ValueError as err:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not in the database." % (label)), "error")
+        flash_error("%s is not in the database.", label, "error")
         return search_input_error()
     bread = get_bread((str(g), url_for(".abelian_varieties_by_g", g=g)),
                       (str(q), url_for(".abelian_varieties_by_gq", g=g, q=q)),
@@ -205,7 +205,7 @@ def abelian_variety_browse(**args):
     gs = av_stats.gs
     try:
         if ',' in info['table_dimension_range']:
-            flash(Markup("Error: You cannot use commas in the table ranges."), "error")
+            flash_error("You cannot use commas in the table ranges.")
             raise ValueError
         parse_ints(info,table_params,'table_dimension_range',qfield='g')
     except (ValueError, AttributeError, TypeError):
@@ -221,7 +221,7 @@ def abelian_variety_browse(**args):
     qs = av_stats.qs
     try:
         if ',' in info['table_field_range']:
-            flash(Markup("Error: You cannot use commas in the table ranges."), "error")
+            flash_error("You cannot use commas in the table ranges.")
             raise ValueError
         parse_ints(info,table_params,'table_field_range',qfield='q')
     except (ValueError, AttributeError, TypeError):
@@ -262,44 +262,48 @@ def by_label(label):
     try:
         validate_label(label)
     except ValueError as err:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label: %s." % (label, str(err))), "error")
+        flash_error("%s is not a valid label: %s.", label, str(err))
         return redirect(url_for(".abelian_varieties"))
     g, q, iso = split_label(label)
-    return redirect(url_for(".abelian_varieties_by_gqi", g = g, q = q, iso = iso))
+    return redirect(url_for(".abelian_varieties_by_gqi", g=g, q=q, iso=iso))
 
 @abvarfq_page.route("/random")
 def random_class():
     label = db.av_fqisog.random()
     g, q, iso = split_label(label)
-    return redirect(url_for(".abelian_varieties_by_gqi", g = g, q = q, iso = iso))
+    return redirect(url_for(".abelian_varieties_by_gqi", g=g, q=q, iso=iso))
 
 @abvarfq_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of the Weil Polynomial Data'
     bread = get_bread(('Completeness', '.'))
     return render_template("single.html", kid='dq.av.fq.extent',
-                           credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+                           credit=abvarfq_credit, title=t, bread=bread,
+                           learnmore=learnmore_list_remove('Completeness'))
 
 @abvarfq_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of the Weil Polynomial Data'
     bread = get_bread(('Reliability', '.'))
     return render_template("single.html", kid='dq.av.fq.reliability',
-                           credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+                           credit=abvarfq_credit, title=t, bread=bread,
+                           learnmore=learnmore_list_remove('Reliability'))
 
 @abvarfq_page.route("/Source")
 def how_computed_page():
     t = 'Source of the Weil Polynomial Data'
     bread = get_bread(('Source', '.'))
     return render_template("single.html", kid='dq.av.fq.source',
-                           credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+                           credit=abvarfq_credit, title=t, bread=bread,
+                           learnmore=learnmore_list_remove('Source'))
 
 @abvarfq_page.route("/Labels")
 def labels_page():
     t = 'Labels for Isogeny Classes of Abelian Varieties'
     bread = get_bread(('Labels', '.'))
     return render_template("single.html", kid='av.fq.lmfdb_label',
-                           credit=abvarfq_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Labels'))
+                           credit=abvarfq_credit, title=t, bread=bread,
+                           learnmore=learnmore_list_remove('Labels'))
 
 lmfdb_label_regex = re.compile(r'(\d+)\.(\d+)\.([a-z_]+)')
 

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -96,7 +96,7 @@ def abelian_varieties_by_gqi(g, q, iso):
     try:
         cl = AbvarFq_isoclass.by_label(label)
     except ValueError as err:
-        flash_error("%s is not in the database.", label, "error")
+        flash_error("%s is not in the database.", label)
         return search_input_error()
     bread = get_bread((str(g), url_for(".abelian_varieties_by_g", g=g)),
                       (str(q), url_for(".abelian_varieties_by_gq", g=g, q=q)),

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -494,6 +494,13 @@ def humans_txt():
 
 @app.context_processor
 def add_colors():
+    # FIXME:
+    # - the template should use global variable g.color
+    # - try to get the color from
+    #       - the cookie
+    #       - from the config file
+    # - remove cookie at logout (see line 307 of users/main)
+    # - add cookie at login or when a color change happens (see line 175 of users/main)
     from lmfdb.utils.color import all_color_schemes
     color = request.args.get('color')
     if color and color.isdigit():

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -45,7 +45,7 @@ def parse_artin_label(label):
     if LABEL_RE.match(label):
         return label
     else:
-        raise ValueError("input %s is not in a valid form for an Artin representation label, such as 9.2e12_587e3.10t32.1c1")
+        raise ValueError
 
 def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
@@ -72,8 +72,8 @@ def artin_representation_jump(info):
     label = info['natural']
     try:
         label = parse_artin_label(label)
-    except ValueError as err:
-        flash_error("%s" % (err),label)
+    except ValueError:
+        flash_error("%s is not in a valid form for an Artin representation label", label)
         return redirect(url_for(".index"))
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)
 
@@ -130,11 +130,11 @@ def render_artin_representation_webpage(label):
         the_rep = ArtinRepresentation(label)
     except:
         try:
-            newlabel=parse_artin_label(label)
+            newlabel = parse_artin_label(label)
             flash_error("Artin representation %s is not in database", newlabel)
             return redirect(url_for(".index"))
-        except ValueError as err:
-            flash_error("%s" % (err), label)
+        except ValueError:
+            flash_error("%s is not in a valid form for an Artin representation label", label)
             return redirect(url_for(".index"))
 
     extra_data = {} # for testing?

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -234,8 +234,7 @@ def belyi_jump(info):
         if re.match(r'^\d+T\d+-\[\d+,\d+,\d+\]-\d+-\d+-\d+-g\d+$', jump):
             return redirect(url_for_belyi_passport_label(jump), 301)
         else:
-            errmsg = "%s is not a valid Belyi map or passport label"
-    flash_error (errmsg, jump)
+            flash_error("%s is not a valid Belyi map or passport label", jump)
     return redirect(url_for(".index"))
 
 class Belyi_download(Downloader):

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -2,13 +2,13 @@
 
 import re
 
-from flask import render_template, url_for, request, redirect, flash
+from flask import render_template, url_for, request, redirect
 from markupsafe import Markup
 from sage.all import latex
 
 from lmfdb import db
 from lmfdb.utils import (
-    to_dict, web_latex_ideal_fact,
+    to_dict, web_latex_ideal_fact, flash_error,
     nf_string_to_label, parse_nf_string, parse_noop, parse_start, parse_count, parse_ints,
     teXify_pol, search_wrap)
 from lmfdb.number_fields.web_number_field import field_pretty, WebNumberField, nf_display_knowl
@@ -340,10 +340,13 @@ def bianchi_modular_form_by_label(lab):
         lab = res['label']
 
     if res is None:
-        flash(Markup("No Bianchi modular form in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No Bianchi modular form in the database has label or name %s", lab)
         return redirect(url_for(".index"))
     else:
-        return redirect(url_for(".render_bmf_webpage", field_label = res['field_label'], level_label = res['level_label'], label_suffix = res['label_suffix']))
+        return redirect(url_for(".render_bmf_webpage",
+                        field_label=res['field_label'],
+                        level_label=res['level_label'],
+                        label_suffix=res['label_suffix']))
 
 @bmf_page.route("/Source")
 def how_computed_page():

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -3,7 +3,6 @@
 import re
 
 from flask import render_template, url_for, request, redirect
-from markupsafe import Markup
 from sage.all import latex
 
 from lmfdb import db

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -10,8 +10,8 @@ try:
     from dirichlet_conrey import DirichletGroup_conrey
 except:
     logger.critical("dirichlet_conrey.pyx cython file is not available ...")
-from flask import flash
 from markupsafe import Markup
+from lmfdb.utils import flash_error
 
 # utility functions #
 
@@ -39,8 +39,8 @@ def parse_interval(arg, name):
         s = arg[1:-1].split('..')
         a,b = (int(s[0]), int(s[1]))
     if a <= 0 or b < a:
-        flash(Markup("Error:  <span style='color:black'>%s</span> is not a valid value for %s. It should be a positive integer (e.g. 7) or a nonempty range of positive integers (e.g. 1-10 or 1..10)"%(arg,name)), "error")
-        raise ValueError("invalid "+name)
+        flash_error("%s is not a valid value for %s. It should be a positive integer (e.g. 7) or a nonempty range of positive integers (e.g. 1-10 or 1..10)", arg, name)
+        raise ValueError("invalid " + name)
     return a,b
 
 def parse_limit (arg):
@@ -51,7 +51,7 @@ def parse_limit (arg):
     if re.match('^[0-9]+$', arg):
         limit = int(arg)
     if limit > 100:
-        flash(Markup("Error:  <span style='color:black'>%s</span> is not a valid limit on the number of results to display.  It should be a positive integer no greater than 100."%arg), "error")
+        flash_error("%s is not a valid limit on the number of results to display.  It should be a positive integer no greater than 100.", arg)
         raise ValueError("limit")
     return limit
 
@@ -189,17 +189,17 @@ class CharacterSearch:
         self.primitive = query.get('primitive')
         self.limit = parse_limit(query.get('limit'))
         if self.parity and not self.parity in ['Odd','Even']:
-            flash(Markup("Error:  <span style='color:black'>%s</span> is not a valid value for parity.  It must be 'Odd', 'Even', or 'All'"),"error")
+            flash_error("%s is not a valid value for parity.  It must be 'Odd', 'Even', or 'All'")
             raise ValueError('parity')
         if self.primitive and not self.primitive in ['Yes','No']:
-            flash(Markup("Error:  <span style='color:black'>%s</span> is not a valid value for primitive.  It must be 'Yes', 'No', or 'All'"),"error")
+            flash_error("%s is not a valid value for primitive.  It must be 'Yes', 'No', or 'All'")
             raise ValueError('primitive')
         self.mmin, self.mmax = parse_interval(self.modulus,'modulus') if self.modulus else (1, 9999)
         if self.mmax > 9999:
-            flash(Markup("Error: Searching is limited to charactors of modulus less than $10^5$"),"error")
+            flash_error("Searching is limited to charactors of modulus less than $10^5$")
             raise ValueError('modulus')
         if self.order and self.mmin > 999:
-            flash(Markup("Error: For order searching the minimum modulus needs to be less than $10^3$"),"error")
+            flash_error("For order searching the minimum modulus needs to be less than $10^3$")
             raise ValueError('modulus')
 
         self.cmin, self.cmax = parse_interval(self.conductor, 'conductor') if self.conductor else (1, self.mmax)

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -188,14 +188,14 @@ class CharacterSearch:
         self.primitive = query.get('primitive')
         self.limit = parse_limit(query.get('limit'))
         if self.parity and not self.parity in ['Odd','Even']:
-            flash_error("%s is not a valid value for parity.  It must be 'Odd', 'Even', or 'All'")
+            flash_error("%s is not a valid value for parity.  It must be 'Odd', 'Even', or 'All'", self.parity)
             raise ValueError('parity')
         if self.primitive and not self.primitive in ['Yes','No']:
-            flash_error("%s is not a valid value for primitive.  It must be 'Yes', 'No', or 'All'")
+            flash_error("%s is not a valid value for primitive.  It must be 'Yes', 'No', or 'All'", self.primitive)
             raise ValueError('primitive')
         self.mmin, self.mmax = parse_interval(self.modulus,'modulus') if self.modulus else (1, 9999)
         if self.mmax > 9999:
-            flash_error("Searching is limited to charactors of modulus less than $10^5$")
+            flash_error("Searching is limited to characters of modulus less than $10^5$")
             raise ValueError('modulus')
         if self.order and self.mmin > 999:
             flash_error("For order searching the minimum modulus needs to be less than $10^3$")

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -10,7 +10,6 @@ try:
     from dirichlet_conrey import DirichletGroup_conrey
 except:
     logger.critical("dirichlet_conrey.pyx cython file is not available ...")
-from markupsafe import Markup
 from lmfdb.utils import flash_error
 
 # utility functions #

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -188,10 +188,10 @@ class CharacterSearch:
         self.primitive = query.get('primitive')
         self.limit = parse_limit(query.get('limit'))
         if self.parity and not self.parity in ['Odd','Even']:
-            flash_error("%s is not a valid value for parity.  It must be 'Odd', 'Even', or 'All'", self.parity)
+            flash_error("%s is not a valid value for parity.  It must be 'Odd' or 'Even'", self.parity)
             raise ValueError('parity')
         if self.primitive and not self.primitive in ['Yes','No']:
-            flash_error("%s is not a valid value for primitive.  It must be 'Yes', 'No', or 'All'", self.primitive)
+            flash_error("%s is not a valid value for primitive.  It must be 'Yes' or 'No'", self.primitive)
             raise ValueError('primitive')
         self.mmin, self.mmax = parse_interval(self.modulus,'modulus') if self.modulus else (1, 9999)
         if self.mmax > 9999:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -343,7 +343,7 @@ def random_Dirichletwebpage():
 @characters_page.route("/calc-<calc>/Dirichlet/<int:modulus>/<int:number>")
 def dc_calc(calc, modulus, number):
     val = request.args.get("val", [])
-    args = {'type':'Dirichlet', 'modulus':modulus, 'number':number}
+    args = {'type': 'Dirichlet', 'modulus': modulus, 'number': number}
     if not val:
         return flask.abort(404)
     try:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -115,8 +115,6 @@ def render_DirichletNavigation():
 
         flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", label)
         return render_template('CharacterNavigate.html', **info)
-        #FIXME, delete line below?
-        #return redirect(url_for(".render_Dirichletwebpage"), 301)
 
     if args:
         # if user clicked refine search, reset start to 0
@@ -237,10 +235,10 @@ def render_Dirichletwebpage(modulus=None, number=None):
     except ValueError:
         modulus = 0
     if modulus <= 0:
-        flash_error ("%s is not a valid modulus for a Dirichlet character.  It should be a positive integer.", args['modulus'])
+        flash_error("%s is not a valid modulus for a Dirichlet character. It should be a positive integer.", args['modulus'])
         return redirect(url_for(".render_Dirichletwebpage"))
     if modulus > 10**20:
-        flash_error ("specified modulus %s is too large, it should be less than $10^{20}$.", modulus)
+        flash_error("specified modulus %s is too large, it should be less than $10^{20}$.", modulus)
         return redirect(url_for(".render_Dirichletwebpage"))
 
 
@@ -266,7 +264,7 @@ def render_Dirichletwebpage(modulus=None, number=None):
 
     number = label_to_number(modulus, number)
     if number == 0:
-        flash_error("the value %s is invalid.  It should be a positive integer coprime to and no greater than the modulus %s.", args['number'],args['modulus'])
+        flash_error("the value %s is invalid. It should be a positive integer coprime to and no greater than the modulus %s.", args['number'], args['modulus'])
         return redirect(url_for(".render_Dirichletwebpage"))
     args['number'] = number
     webchar = make_webchar(args)

--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -229,7 +229,7 @@ class CMF_download(Downloader):
             count = db.mf_newforms.count(query)
         limit = 1000
         if count > limit:
-            flash_error("We limit downloads of traces to %d forms", limit)
+            flash_error("We limit downloads of traces to %s forms", limit)
             return redirect(url_for('.index'))
         if spaces:
             res = list(db.mf_newspaces.search(query, projection=['label', 'traces']))

--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -229,8 +229,7 @@ class CMF_download(Downloader):
             count = db.mf_newforms.count(query)
         limit = 1000
         if count > limit:
-            msg = "We limit downloads of traces to %d forms" % limit
-            flash_error(msg)
+            flash_error("We limit downloads of traces to %d forms", limit)
             return redirect(url_for('.index'))
         if spaces:
             res = list(db.mf_newspaces.search(query, projection=['label', 'traces']))

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -215,7 +215,7 @@ def index():
         elif search_type == 'SpaceDimensions':
             bad_keys = [key for key in newform_only_fields if key in info]
             if bad_keys:
-                flash_error("%s invalid for searching spaces" % (", ".join(bad_keys)))
+                flash_error("%s invalid for searching spaces", ", ".join(bad_keys))
             return dimension_space_search(info)
         elif search_type == 'Traces':
             return trace_search(info)
@@ -533,7 +533,7 @@ def jump_box(info):
             return redirect(url_for_label(jump), 301)
         except ValueError:
             errmsg = "%s is not a valid newform or space label"
-    flash_error (errmsg, jump)
+    flash_error(errmsg, jump)
     return redirect(url_for(".index"))
 
 
@@ -710,9 +710,9 @@ def newform_parse(info, query):
 def newspace_parse(info, query):
     for key, display in newform_only_fields.items():
         if key in info:
-            msg = "%s not valid when searching for spaces" % display
-            flash_error(msg)
-            raise ValueError(msg)
+            msg = "%s not valid when searching for spaces"
+            flash_error(msg, display)
+            raise ValueError(msg  % display)
     if 'dim' not in info and 'hst' not in info:
         # When coming from browse page, add dim condition to only show non-empty spaces
         info['dim'] = '1-'

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 import re
 
-from flask import render_template, url_for, redirect, abort, request, flash
+from flask import render_template, url_for, redirect, abort, request
 from markupsafe import Markup
 from sage.all import ZZ, next_prime, cartesian_product_iterator,\
                      cached_function, prime_range, prod
@@ -335,7 +335,7 @@ def render_newform_webpage(label):
     errs.extend(parse_prec(info))
     newform.setup_cc_data(info)
     if errs:
-        flash(Markup("<br>".join(errs)), "error")
+        flash_error("%s", "<br>".join(errs))
     return render_template("cmf_newform.html",
                            info=info,
                            newform=newform,
@@ -367,7 +367,7 @@ def render_embedded_newform_webpage(newform_label, embedding_label):
     errs = parse_prec(info)
     newform.setup_cc_data(info)
     if errs:
-        flash(Markup("<br>".join(errs)), "error")
+        flash_error("%s", "<br>".join(errs))
     return render_template("cmf_embedded_newform.html",
                            info=info,
                            newform=newform,

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import re
 
 from flask import render_template, url_for, redirect, abort, request
-from markupsafe import Markup
 from sage.all import ZZ, next_prime, cartesian_product_iterator,\
                      cached_function, prime_range, prod
 from sage.databases.cremona import class_to_int, cremona_letter_code

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -677,7 +677,7 @@ class CmfTest(LmfdbTest):
             assert elt in page.data
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+2000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
-        assert 'Error: We limit downloads of traces to 1000 forms' in page.data
+        assert 'Error: We limit downloads of traces to' in page.data
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+30000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
         assert '863.2.c' in page.data
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -113,7 +113,7 @@ def conductor_label_norm(lab):
     if re.match(r'\d+.\d+',s):
         return s.split('.')[0]
     else:
-        flash_error("%s is not a valid conductor label. It must be of the form N.m or [N,c,d]" % lab)
+        flash_error("%s is not a valid conductor label. It must be of the form N.m or [N,c,d]", lab)
         raise ValueError
 
 def get_nf_info(lab):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -6,15 +6,15 @@ import ast, re, StringIO, time
 from operator import mul
 from urllib import quote, unquote
 
-from flask import render_template, request, url_for, redirect, flash, send_file, make_response
-from markupsafe import Markup
+from flask import render_template, request, url_for, redirect, send_file, make_response
 
 from lmfdb import db
 from lmfdb.backend.encoding import Json
 from lmfdb.app import app
 from lmfdb.utils import (
-    to_dict,
-    parse_ints, parse_noop, nf_string_to_label, parse_nf_string, parse_nf_elt, parse_bracketed_posints,
+    to_dict, flash_error,
+    parse_ints, parse_noop, nf_string_to_label,
+    parse_nf_string, parse_nf_elt, parse_bracketed_posints,
     search_wrap)
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberField
@@ -23,13 +23,20 @@ from lmfdb.ecnf.ecnf_stats import ECNF_stats
 from lmfdb.ecnf.WebEllipticCurve import ECNF, web_ainvs, convert_IQF_label
 from lmfdb.ecnf.isog_class import ECNF_isoclass
 
+
 def split_full_label(lab):
     r""" Split a full curve label into 4 components
     (field_label,conductor_label,isoclass_label,curve_number)
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form (number field label) - (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 2.2.5.1-31.1-a1" % lab), "error")
+        flash_error("%s is not a valid"
+                    "elliptic curve label. It must be of the form"
+                    "(number field label) - "
+                    "(conductor label) - "
+                    "(isogeny class label) - "
+                    "(curve identifier) "
+                    "separated by dashes, such as 2.2.5.1-31.1-a1", lab)
         raise ValueError
     field_label = data[0]
     conductor_label = data[1]
@@ -38,7 +45,11 @@ def split_full_label(lab):
         isoclass_label = re.search("(CM)?[a-zA-Z]+", data[2]).group()
         curve_number = re.search("\d+", data[2]).group()  # (a string)
     except AttributeError:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1" % lab), "error")
+        flash_error("%s is not a valid"
+                    "elliptic curve label. "
+                    "The last part must contain both an isogeny class label "
+                    "(a sequence of letters), "
+                    "followed by a curve id (an integer), such as a1",  lab)
         raise ValueError
     return (field_label, conductor_label, isoclass_label, curve_number)
 
@@ -49,7 +60,12 @@ def split_short_label(lab):
     """
     data = lab.split("-")
     if len(data) != 2:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. It must be of the form (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 31.1-a1" % lab), "error")
+        flash_error("%s is not a valid "
+                    "elliptic curve label. It must be of the form "
+                    "(conductor label) - "
+                    "(isogeny class label) - "
+                    "(curve identifier) separated by dashes, "
+                    "such as 31.1-a1", lab)
         raise ValueError
     conductor_label = data[0]
     try:
@@ -57,7 +73,10 @@ def split_short_label(lab):
         isoclass_label = re.search("[a-zA-Z]+", data[1]).group()
         curve_number = re.search("\d+", data[1]).group()  # (a string)
     except AttributeError:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1" % lab), "error")
+        flash_error("%s is not a valid "
+                    "elliptic curve label. The last part must contain both an "
+                    "isogeny class label (a sequence of letters), followed by "
+                    "a curve id (an integer), such as a1", lab)
         raise ValueError
     return (conductor_label, isoclass_label, curve_number)
 
@@ -68,7 +87,7 @@ def split_class_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid isogeny class label. It must be of the form (number field label) - (conductor label) - (isogeny class label) (separated by dashes), such as 2.2.5.1-31.1-a" % lab), "error")
+        flash_error("%s is not a valid isogeny class label. It must be of the form (number field label) - (conductor label) - (isogeny class label) (separated by dashes), such as 2.2.5.1-31.1-a", lab)
         raise ValueError
     field_label = data[0]
     conductor_label = data[1]
@@ -82,7 +101,7 @@ def split_short_class_label(lab):
     """
     data = lab.split("-")
     if len(data) != 2:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid isogeny class label. It must be of the form (conductor label) - (isogeny class label) (separated by dashes), such as 31.1-a" % lab), "error")
+        flash_error("%s is not a valid isogeny class label. It must be of the form (conductor label) - (isogeny class label) (separated by dashes), such as 31.1-a", lab)
         raise ValueError
     conductor_label = data[0]
     isoclass_label = data[1]
@@ -94,7 +113,7 @@ def conductor_label_norm(lab):
     if re.match(r'\d+.\d+',s):
         return s.split('.')[0]
     else:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid conductor label. It must be of the form N.m or [N,c,d]" % lab), "error")
+        flash_error("%s is not a valid conductor label. It must be of the form N.m or [N,c,d]" % lab)
         raise ValueError
 
 def get_nf_info(lab):
@@ -103,7 +122,7 @@ def get_nf_info(lab):
         label = nf_string_to_label(lab)
         pretty = field_pretty (label)
     except ValueError as err:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid number field. %s" % (lab,err)), "error")
+        flash_error("%s is not a valid number field. %s", lab,err)
         raise ValueError
     return label, pretty
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -30,13 +30,7 @@ def split_full_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash_error("%s is not a valid"
-                    "elliptic curve label. It must be of the form"
-                    "(number field label) - "
-                    "(conductor label) - "
-                    "(isogeny class label) - "
-                    "(curve identifier) "
-                    "separated by dashes, such as 2.2.5.1-31.1-a1", lab)
+        flash_error("%s is not a valid elliptic curve label. It must be of the form (number field label) - (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 2.2.5.1-31.1-a1", lab)
         raise ValueError
     field_label = data[0]
     conductor_label = data[1]
@@ -45,11 +39,7 @@ def split_full_label(lab):
         isoclass_label = re.search("(CM)?[a-zA-Z]+", data[2]).group()
         curve_number = re.search("\d+", data[2]).group()  # (a string)
     except AttributeError:
-        flash_error("%s is not a valid"
-                    "elliptic curve label. "
-                    "The last part must contain both an isogeny class label "
-                    "(a sequence of letters), "
-                    "followed by a curve id (an integer), such as a1",  lab)
+        flash_error("%s is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1",  lab)
         raise ValueError
     return (field_label, conductor_label, isoclass_label, curve_number)
 
@@ -60,12 +50,7 @@ def split_short_label(lab):
     """
     data = lab.split("-")
     if len(data) != 2:
-        flash_error("%s is not a valid "
-                    "elliptic curve label. It must be of the form "
-                    "(conductor label) - "
-                    "(isogeny class label) - "
-                    "(curve identifier) separated by dashes, "
-                    "such as 31.1-a1", lab)
+        flash_error("%s is not a valid elliptic curve label. It must be of the form (conductor label) - (isogeny class label) - (curve identifier) separated by dashes, such as 31.1-a1", lab)
         raise ValueError
     conductor_label = data[0]
     try:
@@ -73,10 +58,7 @@ def split_short_label(lab):
         isoclass_label = re.search("[a-zA-Z]+", data[1]).group()
         curve_number = re.search("\d+", data[1]).group()  # (a string)
     except AttributeError:
-        flash_error("%s is not a valid "
-                    "elliptic curve label. The last part must contain both an "
-                    "isogeny class label (a sequence of letters), followed by "
-                    "a curve id (an integer), such as a1", lab)
+        flash_error("%s is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1", lab)
         raise ValueError
     return (conductor_label, isoclass_label, curve_number)
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -87,9 +87,17 @@ def rational_elliptic_curves(err_args=None):
     t = 'Elliptic Curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
     if err_args.get("err_msg"):
-        flash_error(err_args.pop("err_msg"),err_args.pop("label"))
+        # this comes from elliptic_curve_jump_error
+        flash_error(err_args.pop("err_msg"), err_args.pop("label"))
         return redirect(url_for(".rational_elliptic_curves"))
-    return render_template("ec-index.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list(), calling_function = "ec.rational_elliptic_curves", **err_args)
+    return render_template("ec-index.html",
+                           info=info,
+                           credit=ec_credit(),
+                           title=t,
+                           bread=bread,
+                           learnmore=learnmore_list(),
+                           calling_function="ec.rational_elliptic_curves",
+                           **err_args)
 
 @ec_page.route("/random")
 def random_curve():
@@ -142,8 +150,6 @@ def elliptic_curve_jump_error(label, args, wellformed_label=False, cremona_label
     err_args['label'] = label
     if wellformed_label:
         err_args['err_msg'] = "No curve or isogeny class in the database has label %s"
-    # elif cremona_label:
-    #     err_args['err_msg'] = "To search for a Cremona label use 'Cremona:%s'"
     elif missing_curve:
         err_args['err_msg'] = "The elliptic curve %s is not in the database"
     elif not label:

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -148,9 +148,9 @@ def render_group_webpage(args):
         data = db.gps_transitive.lookup(label)
         if data is None:
             if re.match(r'^\d+T\d+$', label):
-                flash_error("Group <span style='color:black'>%s</span> was not found in the database.", label)
+                flash_error("Group %s was not found in the database.", label)
             else:
-                flash_error("<span style='color:black'>%s</span> is not a valid label for a Galois group.", label)
+                flash_error("%s is not a valid label for a Galois group.", label)
             return redirect(url_for(".index"))
         data['label_raw'] = label.lower()
         title = 'Galois Group: ' + label

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -237,7 +237,7 @@ def genus2_jump(info):
                     errmsg = "hash %s not found"
             else:
                 errmsg = "%s is not a valid genus 2 curve or isogeny class label"
-    flash_error (errmsg, jump)
+        flash_error(errmsg, jump)
     return redirect(url_for(".index"))
 
 class G2C_download(Downloader):

--- a/lmfdb/hecke_algebras/main.py
+++ b/lmfdb/hecke_algebras/main.py
@@ -2,12 +2,11 @@
 
 import ast, re, StringIO, time
 
-from flask import render_template, request, url_for, redirect, make_response, flash,  send_file
-from markupsafe import Markup
+from flask import render_template, request, url_for, redirect, make_response,  send_file
 from sage.all import latex, matrix, sqrt, sage_eval, prime_range
 
 from lmfdb import db
-from lmfdb.utils import parse_ints, clean_input, search_wrap
+from lmfdb.utils import parse_ints, clean_input, search_wrap, flash_error
 from lmfdb.hecke_algebras import hecke_algebras_page
 from lmfdb.hecke_algebras.hecke_algebras_stats import hecke_algebras_summary
 
@@ -73,9 +72,9 @@ def hecke_algebras_by_label(lab):
     if db.hecke_algebras.exists({'label':lab}):
         return render_hecke_algebras_webpage(label=lab)
     if hecke_algebras_label_regex.match(lab):
-        flash(Markup("The Hecke Algebra <span style='color:black'>%s</span> is not recorded in the database or the label is invalid" % lab), "error")
+        flash_error("The Hecke Algebra %s is not recorded in the database or the label is invalid", lab)
     else:
-        flash(Markup("No Hecke Algebras in the database has label <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No Hecke Algebras in the database has label %s", lab)
     return redirect(url_for(".hecke_algebras_render_webpage"))
 
 def hecke_algebras_by_orbit_label(lab):
@@ -84,9 +83,9 @@ def hecke_algebras_by_orbit_label(lab):
         ol=sp[0]+'.'+sp[1]+'.'+sp[2]
         return render_hecke_algebras_webpage(label=ol)
     if hecke_algebras_orbit_label_regex.match(lab):
-        flash(Markup("The Hecke Algebra orbit <span style='color:black'>%s</span> is not recorded in the database or the label is invalid" % lab), "error")
+        flash_error("The Hecke Algebra orbit %s is not recorded in the database or the label is invalid", lab)
     else:
-        flash(Markup("No Hecke Algebras orbit in the database has label <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No Hecke Algebras orbit in the database has label %s", lab)
     return redirect(url_for(".hecke_algebras_render_webpage"))
 
 def download_search(info):
@@ -159,10 +158,10 @@ def hecke_algebras_search(info, query):
         parse_ints(info, query, field, name)
     if info.get('ell'):
         if int(info.get('ell'))>13:
-            flash(Markup("No data for primes or integers greater than $13$ is available"), "error")
+            flash_error("No data for primes or integers greater than $13$ is available")
             return redirect(url_for(".hecke_algebras_render_webpage"))
         elif int(info.get('ell')) not in [2,3,5,7,11,13]:
-            flash(Markup("No data for integers which are not primes"), "error")
+            flash_error("No data for integers which are not primes")
             return redirect(url_for(".hecke_algebras_render_webpage"))
     if info.get('orbit_label'):
         check=[int(i) for i in info['orbit_label'].split(".")]
@@ -172,14 +171,14 @@ def hecke_algebras_search(info, query):
                     if info.get(field):
                         int(info.get(field))
             except ValueError:
-                flash(Markup("Orbit label <span style='color:black'>%s</span> and input Level or Weight are not compatible" %(info.get('orbit_label'))),"error")
+                flash_error("Orbit label %s and input Level or Weight are not compatible", info.get('orbit_label'))
                 return redirect(url_for(".hecke_algebras_render_webpage"))
             if int(info.get('level'))!=check[0]:
-                flash(Markup("Orbit label <span style='color:black'>%s</span> and Level <span style='color:black'>%s</span> are not compatible inputs" %(info.get('orbit_label'), info.get('level'))),"error")
+                flash_error("Orbit label %s and Level %s are not compatible inputs" %(info.get('orbit_label'), info.get('level'))
                 return redirect(url_for(".hecke_algebras_render_webpage"))
         if 'weight' in info and info.get('weight'):
             if int(info.get('weight'))!=check[1]:
-                flash(Markup("Orbit label <span style='color:black'>%s</span> and Weight <span style='color:black'>%s</span> are not compatible inputs" %(info.get('orbit_label'), info.get('weight'))), "error")
+                flash_error("Orbit label %s and Weight %s are not compatible inputs", info.get('orbit_label'), info.get('weight'))
                 return redirect(url_for(".hecke_algebras_render_webpage"))
         if 'ell' in info and info.get('ell'):
             return render_hecke_algebras_webpage_l_adic(orbit_label=info.get('orbit_label'), prime=info.get('ell'))
@@ -209,7 +208,7 @@ def render_hecke_algebras_webpage(**args):
     if data is None:
         t = "Hecke Algebras Search Error"
         bread = [('HeckeAlgebra', url_for(".hecke_algebras_render_webpage"))]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label for a Hecke Algebras in the database." % (lab)),"error")
+        flash_error("%s is not a valid label for a Hecke Algebras in the database.", lab)
         return render_template("hecke_algebras-error.html", title=t, properties=[], bread=bread, learnmore=learnmore_list())
     info = {}
     info.update(data)
@@ -294,7 +293,7 @@ def render_hecke_algebras_webpage_l_adic(**args):
     if data is None:
         t = "Hecke Algebras Search Error"
         bread = [('HeckeAlgebra', url_for(".hecke_algebras_render_webpage"))]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label for the &#x2113;-adic information for an Hecke Algebra orbit in the database." % (lab)),"error")
+        flash_error("%s is not a valid label for the &#x2113;-adic information for an Hecke Algebra orbit in the database.", lab)
         return render_template("hecke_algebras-error.html", title=t, properties=[], bread=bread, learnmore=learnmore_list())
     info = {}
     info.update(data)

--- a/lmfdb/hecke_algebras/main.py
+++ b/lmfdb/hecke_algebras/main.py
@@ -174,7 +174,7 @@ def hecke_algebras_search(info, query):
                 flash_error("Orbit label %s and input Level or Weight are not compatible", info.get('orbit_label'))
                 return redirect(url_for(".hecke_algebras_render_webpage"))
             if int(info.get('level'))!=check[0]:
-                flash_error("Orbit label %s and Level %s are not compatible inputs" %(info.get('orbit_label'), info.get('level'))
+                flash_error("Orbit label %s and Level %s are not compatible inputs", info.get('orbit_label'), info.get('level'))
                 return redirect(url_for(".hecke_algebras_render_webpage"))
         if 'weight' in info and info.get('weight'):
             if int(info.get('weight'))!=check[1]:

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from flask import render_template, url_for, request, redirect, make_response, flash
-from markupsafe import Markup
+from flask import render_template, url_for, request, redirect, make_response
 
 from lmfdb import db
 from lmfdb.utils import (
-    web_latex_split_on_pm,
+    web_latex_split_on_pm, flash_error,
     parse_nf_string, parse_ints, parse_hmf_weight,
     teXify_pol, add_space_if_positive,
     search_wrap)
@@ -68,7 +67,7 @@ def split_full_label(lab):
     """
     data = lab.split("-")
     if len(data) != 3:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a" % lab), "error")
+        flash_error("%s is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a", lab)
         raise ValueError
     field_label = data[0]
     level_label = data[1]
@@ -82,7 +81,7 @@ def hilbert_modular_form_by_label(lab):
         res = lab
         lab = res['label']
     if res is None:
-        flash(Markup("No Hilbert modular form in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No Hilbert modular form in the database has label or name %s", lab)
         return redirect(url_for(".hilbert_modular_form_render_webpage"))
     else:
         return redirect(url_for(".render_hmf_webpage", field_label=split_full_label(lab)[0], label=lab))
@@ -283,7 +282,7 @@ def render_hmf_webpage(**args):
         label = str(args['label'])
         data = get_hmf(label)
     if data is None:
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a" % args['label']), "error")
+        flash_error("%s is not a valid Hilbert modular form label. It must be of the form (number field label) - (level label) - (orbit label) separated by dashes, such as 2.2.5.1-31.1-a", args['label'])
         return search_input_error()
     info = {}
     try:

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from flask import abort, flash, jsonify, make_response,\
                   redirect, render_template, render_template_string,\
                   request, url_for
+from markupsafe import Markup
 from flask_login import login_required, current_user
 from knowl import Knowl, knowldb, knowl_title, knowl_exists
 from lmfdb.users import admin_required, knowl_reviewer_required
@@ -49,9 +50,9 @@ def allowed_id(ID):
         for c in "[],T":
             ID = ID.replace(c,'')
     if not allowed_knowl_id.match(ID):
-        flash("""Oops, knowl id '%s' is not allowed.
+        flash_error("""Oops, knowl id '%s' is not allowed.
                   It must consist of lowercase characters,
-                  no spaces, numbers or '.', '_' and '-'.""" % ID, "error")
+                  no spaces, numbers or '.', '_' and '-'.""", ID)
         return False
     return True
 
@@ -324,7 +325,7 @@ def edit(ID):
     author = knowl._last_author
     # Existing comments can only be edited by admins and the author
     if knowl.type == -2 and author and not (current_user.is_admin() or current_user.get_id() == author):
-        flash("You can only edit your own comments", "error")
+        flash_error("You can only edit your own comments")
         return redirect(url_for(".show", ID=knowl.source))
 
     lock = None
@@ -404,9 +405,9 @@ def remove_author(ID):
     k = Knowl(ID)
     uid = current_user.get_id()
     if uid not in k.authors:
-        flash("You are not an author on %s"%(k.id), "error")
+        flash_error("You are not an author on %s", k.id)
     elif len(k.authors) == 1:
-        flash("You cannot remove yourself unless there are other authors", "error")
+        flash_error("You cannot remove yourself unless there are other authors")
     else:
         knowldb.remove_author(ID, uid)
     return redirect(url_for(".show", ID=ID))
@@ -464,7 +465,7 @@ def comment_history(limit=25):
 def delete(ID):
     k = Knowl(ID)
     k.delete()
-    flash("Knowl %s has been deleted." % ID)
+    flash(Markup("Knowl %s has been deleted." % ID))
     return redirect(url_for(".index"))
 
 
@@ -473,7 +474,7 @@ def delete(ID):
 def resurrect(ID):
     k = Knowl(ID)
     k.resurrect()
-    flash("Knowl %s has been resurrected." % ID)
+    flash(Markup("Knowl %s has been resurrected." % ID))
     return redirect(url_for(".show", ID=ID))
 
 @knowledge_page.route("/review/<ID>/<int:timestamp>")
@@ -482,7 +483,7 @@ def review(ID, timestamp):
     timestamp = timestamp_in_ms_to_datetime(timestamp)
     k = Knowl(ID, timestamp=timestamp)
     k.review(who=current_user.get_id())
-    flash("Knowl %s has been positively reviewed." % ID)
+    flash(Markup("Knowl %s has been positively reviewed." % ID))
     return redirect(url_for(".show", ID=ID))
 
 @knowledge_page.route("/demote/<ID>/<int:timestamp>")
@@ -491,7 +492,7 @@ def demote(ID, timestamp):
     timestamp = timestamp_in_ms_to_datetime(timestamp)
     k = Knowl(ID, timestamp=timestamp)
     k.review(who=current_user.get_id(), set_beta=True)
-    flash("Knowl %s has been returned to beta." % ID)
+    flash(Markup("Knowl %s has been returned to beta." % ID))
     return redirect(url_for(".show", ID=ID))
 
 @knowledge_page.route("/review_recent/<int:days>/")
@@ -554,7 +555,7 @@ def delete_comment(ID):
             raise ValueError
         comment.delete()
     except ValueError:
-        flash("Only admins and the original author can delete comments", "error")
+        flash_error("Only admins and the original author can delete comments")
     return redirect(url_for(".show", ID=comment.source))
 
 @knowledge_page.route("/edit", methods=["POST"])
@@ -579,12 +580,12 @@ def save_form():
     if FINISH_RENAME:
         k = Knowl(ID)
         k.actually_rename()
-        flash("Renaming complete; the history of %s has been merged into %s" % (ID, k.source_name))
+        flash(Markup("Renaming complete; the history of %s has been merged into %s" % (ID, k.source_name)))
         return redirect(url_for(".show", ID=k.source_name))
     elif UNDO_RENAME:
         k = Knowl(ID)
         k.undo_rename()
-        flash("Renaming undone; the history of %s has been merged back into %s" % (k.source_name, ID))
+        flash(Markup("Renaming undone; the history of %s has been merged back into %s" % (k.source_name, ID)))
         return redirect(url_for(".show", ID=ID))
     NEWID = request.form.get('krename', '').strip()
     k = Knowl(ID, saving=True, renaming=bool(NEWID))
@@ -595,7 +596,7 @@ def save_form():
         if not k.content and not k.title and k.exists(allow_deleted=True):
             # Creating a new knowl with the same id as one that had previously been deleted
             k.resurrect()
-            flash("Knowl successfully created.  Note that a knowl with this id existed previously but was deleted; its history has been restored.")
+            flash(Markup("Knowl successfully created.  Note that a knowl with this id existed previously but was deleted; its history has been restored."))
         k.title = new_title
         k.content = new_content
         k.timestamp = datetime.now()
@@ -603,7 +604,7 @@ def save_form():
         k.save(who=who)
     if NEWID:
         if not current_user.is_admin():
-            flash("You do not have permissions to rename knowl", "error")
+            flash_error("You do not have permissions to rename knowl")
         elif not allowed_id(NEWID):
             pass
         else:
@@ -611,18 +612,18 @@ def save_form():
                 if k.sed_safety == 0:
                     time.sleep(0.01)
                     k.actually_rename(NEWID)
-                    flash("Knowl renamed to {0} successfully.".format(NEWID))
+                    flash(Markup("Knowl renamed to {0} successfully.".format(NEWID)))
                 else:
                     k.start_rename(NEWID, who)
             except ValueError as err:
-                flash(str(err), "error")
+                flash_error(str(err), "error")
             else:
                 if k.sed_safety == 1:
-                    flash("Knowl rename process started. You can change code references using".format(NEWID))
-                    flash("git grep -l '{0}' | xargs sed -i '' -e 's/{0}/{1}/g' (Mac)".format(ID, NEWID))
-                    flash("git grep -l '{0}' | xargs sed -i 's/{0}/{1}/g' (Linux)".format(ID, NEWID))
+                    flash(Markup("Knowl rename process started. You can change code references using".format(NEWID)))
+                    flash(Markup("git grep -l '{0}' | xargs sed -i '' -e 's/{0}/{1}/g' (Mac)".format(ID, NEWID)))
+                    flash(Markup("git grep -l '{0}' | xargs sed -i 's/{0}/{1}/g' (Linux)".format(ID, NEWID)))
                 elif k.sed_safety == -1:
-                    flash("Knowl rename process started.  This knowl appears in the code (see references below), but cannot trivially be replaced with grep/sed".format(NEWID))
+                    flash(Markup("Knowl rename process started.  This knowl appears in the code (see references below), but cannot trivially be replaced with grep/sed".format(NEWID)))
                 ID = NEWID
     if k.type == -2:
         return redirect(url_for(".show", ID=k.source))

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 import ast, re, StringIO, time
 
-from flask import render_template, request, url_for, redirect, make_response, flash, send_file
-from markupsafe import Markup
+from flask import render_template, request, url_for, redirect, make_response, send_file
 from sage.all import ZZ, QQ, PolynomialRing, latex, matrix, PowerSeriesRing, sqrt
 
 from lmfdb.utils import (
-    web_latex_split_on_pm,
+    web_latex_split_on_pm, flash_error,
     parse_ints, parse_list, parse_count, parse_start, clean_input,
     search_wrap)
 from lmfdb.lattice import lattice_page
@@ -107,9 +106,9 @@ def lattice_by_label_or_name(lab):
         if label is not None:
             return redirect(url_for(".render_lattice_webpage", label=label))
     if lattice_label_regex.match(lab):
-        flash(Markup("The integral lattice <span style='color:black'>%s</span> is not recorded in the database or the label is invalid" % lab), "error")
+        flash_error("The integral lattice %s is not recorded in the database or the label is invalid", lab)
     else:
-        flash(Markup("No integral lattice in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No integral lattice in the database has label or name %s", lab)
     return redirect(url_for(".lattice_render_webpage"))
 
 #download
@@ -193,7 +192,7 @@ def lattice_search(info, query):
     # Check if length of gram is triangular
     gram = info.get('gram')
     if gram and not (9 + 8*ZZ(gram.count(','))).is_square():
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3]." % (gram)),"error")
+        flash_error("%s is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3].", gram)
         raise ValueError
     parse_list(info, query, 'gram', process=vect_to_sym)
 
@@ -208,7 +207,7 @@ def render_lattice_webpage(**args):
     if f is None:
         t = "Integral Lattices Search Error"
         bread = [('Lattices', url_for(".lattice_render_webpage"))]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label or name for an integral lattice in the database." % (lab)),"error")
+        flash_error("%s is not a valid label or name for an integral lattice in the database.", lab)
         return render_template("lattice-error.html", title=t, properties=[], bread=bread, learnmore=learnmore_list())
     info = {}
     info.update(f)

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -174,9 +174,9 @@ def render_field_webpage(args):
         data = db.lf_fields.lookup(label)
         if data is None:
             if re.match(r'^\d+\.\d+\.\d+\.\d+$', label):
-                flash_error("Field <span style='color:black'>%s</span> was not found in the database.", label)
+                flash_error("Field %s was not found in the database.", label)
             else:
-                flash_error("<span style='color:black'>%s</span> is not a valid label for a local number field.", label)
+                flash_error("%s is not a valid label for a local number field.", label)
             return redirect(url_for(".index"))
         title = 'Local Number Field ' + prettyname(data)
         polynomial = coeff_to_poly(data['coeffs'])

--- a/lmfdb/modlmf/main.py
+++ b/lmfdb/modlmf/main.py
@@ -2,12 +2,11 @@
 
 import ast, re, StringIO, time
 
-from flask import render_template, request, url_for, make_response, redirect, flash, send_file
-from markupsafe import Markup
+from flask import render_template, request, url_for, make_response, redirect, send_file
 from sage.all import QQ, PolynomialRing, PowerSeriesRing, conway_polynomial, prime_range, latex
 
 from lmfdb import db
-from lmfdb.utils import web_latex_split_on_pm, parse_ints, search_wrap
+from lmfdb.utils import web_latex_split_on_pm, parse_ints, search_wrap, flash_error
 from lmfdb.modlmf import modlmf_page
 from lmfdb.modlmf.modlmf_stats import get_stats
 
@@ -87,9 +86,9 @@ def modlmf_by_label(lab):
     if db.modlmf_forms.exists({'label': lab}):
         return render_modlmf_webpage(label=lab)
     if modlmf_label_regex.match(lab):
-        flash(Markup("The mod &#x2113; modular form <span style='color:black'>%s</span> is not recorded in the database or the label is invalid" % lab), "error")
+        flash_error("The mod &#x2113; modular form %s is not recorded in the database or the label is invalid", lab)
     else:
-        flash(Markup("No mod &#x2113; modular form in the database has label <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No mod &#x2113; modular form in the database has label %s", lab)
     return redirect(url_for(".modlmf_render_webpage"))
 
 #download
@@ -151,7 +150,7 @@ def render_modlmf_webpage(**args):
     if data is None:
         t = "Mod &#x2113; Modular Form Search Error"
         bread = [('mod &#x2113; Modular Forms', url_for(".modlmf_render_webpage"))]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label for a mod &#x2113; modular form in the database." % (lab)),"error")
+        flash_error("%s is not a valid label for a mod &#x2113; modular form in the database.", lab)
         return render_template("modlmf-error.html", title=t, properties=[], bread=bread, learnmore=learnmore_list())
     info = {}
     info.update(data)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -619,7 +619,7 @@ def by_label(label):
             return redirect(url_for(".by_label", label=nflabel), 301)
         return render_field_webpage({'label': nflabel})
     except ValueError as err:
-        flash_error("<span style='color:black'>%s</span> is not a valid input for a <span style='color:black'>label</span>.  "+ str(err), label)
+        flash_error("%s is not a valid input for a <span style='color:black'>label</span>.  %s", label, str(err))
         return redirect(url_for(".number_field_render_webpage"))
 
 # input is a sage int

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -619,7 +619,7 @@ def by_label(label):
             return redirect(url_for(".by_label", label=nflabel), 301)
         return render_field_webpage({'label': nflabel})
     except ValueError as err:
-        flash_error("<span style='color:black'>%s</span> us not a valid input for a <span style='color:black'>label</span>.  "+ str(err), label)
+        flash_error("<span style='color:black'>%s</span> is not a valid input for a <span style='color:black'>label</span>.  "+ str(err), label)
         return redirect(url_for(".number_field_render_webpage"))
 
 # input is a sage int

--- a/lmfdb/permutations/main.py
+++ b/lmfdb/permutations/main.py
@@ -6,6 +6,7 @@ import flask
 from flask import render_template, request, url_for, redirect
 from lmfdb.permutations import permutations_page, logger
 from sage.all import Permutation, Integer
+from lmfdb.utils import flash_error
 
 def get_bread(breads=[]):
     bc = [("Permutations", url_for(".index"))]
@@ -42,7 +43,7 @@ def show():
         p = Permutation(data)
     except (TypeError, ValueError):
         logger.info("Impossible to create a permutation from input.")
-        flask.flash("Ooops, impossible to create a permutation from given input!", "error")
+        flash_error("Ooops, impossible to create a permutation from given input!")
         return flask.redirect(url_for(".index"))
     return render_template("permutations.html", permutation=p,
             rankbread=get_bread())

--- a/lmfdb/rep_galois_modl/main.py
+++ b/lmfdb/rep_galois_modl/main.py
@@ -2,12 +2,11 @@
 
 import ast, re, StringIO, time
 
-from flask import flash, make_response, send_file, request, render_template, redirect, url_for
-from markupsafe import Markup
+from flask import make_response, send_file, request, render_template, redirect, url_for
 from sage.all import ZZ, conway_polynomial
 
 from lmfdb import db
-from lmfdb.utils import parse_ints, parse_list, search_wrap
+from lmfdb.utils import flash_error, parse_ints, parse_list, search_wrap
 #should these functions be defined in lattices or somewhere else?
 from lmfdb.lattice.main import vect_to_sym, vect_to_matrix
 from lmfdb.rep_galois_modl import rep_galois_modl_page #, rep_galois_modl_logger
@@ -86,9 +85,9 @@ def rep_galois_modl_by_label_or_name(lab):
     if db.modlgal_reps.exists({'$or':[{'label': lab}, {'name': lab}]}):
         return render_rep_galois_modl_webpage(label=lab)
     if rep_galois_modl_label_regex.match(lab):
-        flash(Markup("The integral rep_galois_modl <span style='color:black'>%s</span> is not recorded in the database or the label is invalid" % lab), "error")
+        flash_error("The integral rep_galois_modl %s is not recorded in the database or the label is invalid", lab)
     else:
-        flash(Markup("No integral rep_galois_modl in the database has label or name <span style='color:black'>%s</span>" % lab), "error")
+        flash_error("No integral rep_galois_modl in the database has label or name %s", lab)
     return redirect(url_for(".rep_galois_modl_render_webpage"))
 
 #download
@@ -146,7 +145,7 @@ def rep_galois_modl_search(info, query):
     # Check if length of gram is triangular
     gram = info.get('gram')
     if gram and not (9 + 8*ZZ(gram.count(','))).is_square():
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3]." % (gram)),"error")
+        flash_error("%s is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3].", % gram)
         raise ValueError
     parse_list(info, query, 'gram', process=vect_to_sym)
 
@@ -159,7 +158,7 @@ def render_rep_galois_modl_webpage(**args):
     if data is None:
         t = "Mod &#x2113; Galois representations Search Error"
         bread = [('Representations', "/Representation"),("mod &#x2113;", url_for(".rep_galois_modl_render_webpage"))]
-        flash(Markup("Error: <span style='color:black'>%s</span> is not a valid label for a mod &#x2113; Galois representation in the database." % (lab)),"error")
+        flash_error("%s is not a valid label for a mod &#x2113; Galois representation in the database.", lab)
         return render_template("rep_galois_modl-error.html", title=t, properties=[], bread=bread, learnmore=learnmore_list())
     info = {}
     info.update(data)

--- a/lmfdb/rep_galois_modl/main.py
+++ b/lmfdb/rep_galois_modl/main.py
@@ -145,7 +145,7 @@ def rep_galois_modl_search(info, query):
     # Check if length of gram is triangular
     gram = info.get('gram')
     if gram and not (9 + 8*ZZ(gram.count(','))).is_square():
-        flash_error("%s is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3].", % gram)
+        flash_error("%s is not a valid input for Gram matrix.  It must be a list of integer vectors of triangular length, such as [1,2,3].",  gram)
         raise ValueError
     parse_list(info, query, 'gram', process=vect_to_sym)
 

--- a/lmfdb/siegel_modular_forms/dimensions.py
+++ b/lmfdb/siegel_modular_forms/dimensions.py
@@ -136,7 +136,7 @@ def dimension_Sp4Z_2(wt_range):
       <li><span class="emph">Cusp</span>: The subspace of cusp forms.</li>
     </ul>
     """
-    return _dimension_Gamma_2(wt_range, 2, group = 'Sp4(Z)')
+    return _dimension_Gamma_2(wt_range, 2, group='Sp4(Z)')
 
 def dimension_table_Sp4Z_j(wt_range, j_range):
     result = {}
@@ -145,11 +145,11 @@ def dimension_table_Sp4Z_j(wt_range, j_range):
     for j in j_range:
         if is_odd(j):
             for wt in wt_range:
-                result[wt][j]=0
+                result[wt][j] = 0
         else:
-            _,olddim= dimension_Sp4Z_j(wt_range, j)
+            _, olddim = dimension_Sp4Z_j(wt_range, j)
             for wt in wt_range:
-                result[wt][j]=olddim[wt]['Total']
+                result[wt][j] = olddim[wt]['Total']
     return result
 
 def dimension_Sp4Z_j(wt_range, j):
@@ -159,8 +159,8 @@ def dimension_Sp4Z_j(wt_range, j):
       <li><span class="emph">Non cusp</span>: The subspace of non cusp forms.</li>
       <li><span class="emph">Cusp</span>: The subspace of cusp forms.</li>
     </ul>
-    """    
-    return _dimension_Gamma_2(wt_range, j, group = 'Sp4(Z)')
+    """
+    return _dimension_Gamma_2(wt_range, j, group='Sp4(Z)')
 
 
 

--- a/lmfdb/siegel_modular_forms/dimensions.py
+++ b/lmfdb/siegel_modular_forms/dimensions.py
@@ -5,9 +5,8 @@
 #
 # Author: Nils Skoruppa <nils.skoruppa@gmail.com>
 
-from flask import flash
-from markupsafe import Markup
 from sage.all import is_odd, is_even, ZZ, QQ, FunctionField, PowerSeriesRing
+from lmfdb.utils import flash_error
 
 from lmfdb import db
 from lmfdb.utils import parse_ints_to_list_flash
@@ -32,19 +31,19 @@ def parse_dim_args(dim_args, default_dim_args):
     args={}
     if 'k' in res:
         if res['k'][-1] > MAXWT:
-            flash(Markup("Error: <span style='color:black'>$k$</span> cannot exceed <span style='color:black'>%s</span>." % MAXWT), "error")
+            flash_error("<span style='color:black'>$k$</span> cannot exceed %s.",  MAXWT)
             raise ValueError("dim_args")
         if len(res['k']) > MAXWTRANGE:
-            flash(Markup("Error: range for <span style='color:black'>$k$</span> cannot include more than %s</span> values." % MAXWTRANGE), "error")
+            flash_error("range for <span style='color:black'>$k$</span> cannot include more than %s values.", MAXWTRANGE)
             raise ValueError("dim_args")
         args = {'k_range':res['k']}
     if 'j' in res:
         if res['j'][-1] > MAXJ:
-            flash(Markup("Error: <span style='color:black'>$j$</span> cannot exceed <span style='color:black'>%s</span>." % MAXJ), "error")
+            flash_error("<span style='color:black'>$j$</span> cannot exceed %s.", MAXJ)
             raise ValueError("dim_args")
         args['j_range'] = [j for j in res['j'] if j%2 == 0]
         if not args['j_range']:
-            flash(Markup("Error: <span style='color:black'>$j$</span> should be a nonnegative even integer."), "error")
+            flash_error("<span style='color:black'>$j$</span> should be a nonnegative even integer.")
             raise ValueError("dim_args")
     return args
 

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -4,8 +4,7 @@
 
 import StringIO
 
-from flask import render_template, url_for, request, send_file, flash, redirect
-from markupsafe import Markup
+from flask import render_template, url_for, request, send_file, redirect
 from sage.all import latex, Set
 
 from lmfdb import db

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -23,7 +23,7 @@ import sample
 ###############################################################################
 
 def find_samples(family, weight):
-    slist = db.smf_samples.search({'collection':{'$contains':[family]}, 'weight':int(weight)},'name')
+    slist = db.smf_samples.search({'collection': {'$contains': [family]}, 'weight': int(weight)}, 'name')
     ret = []
     for name in slist:
         url = url_for(".by_label", label=family+"."+name)

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -71,7 +71,7 @@ def by_label(label):
             if len(sam) > 0:
                 bread.append(('$'+family.latex_name+'$', url_for('.by_label',label=slabel[0])))
                 return render_sample_page(family, sam[0], request.args, bread)
-    flash_error ("No siegel modular form data for %s was found in the database.", label)
+    flash_error("No Siegel modular form data for %s was found in the database.", label)
     return redirect(url_for(".index"))
 
 @smf_page.route('/Sp4Z_j/<int:k>/<int:j>')
@@ -124,7 +124,7 @@ def Sp4Z_j():
     bread = [("Modular Forms", url_for('modular_forms')),
              ('Siegel Modular Forms', url_for('.index')),
              ('$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$', '')]
-    info={'args':request.args}
+    info={'args': request.args}
     try:
         dim_args = dimensions.parse_dim_args(request.args, {'k':'10-20','j':'0-30'})
     except ValueError:
@@ -135,7 +135,7 @@ def Sp4Z_j():
         try:
             info['table'] = dimensions.dimension_table_Sp4Z_j(dim_args['k_range'], dim_args['j_range'])
         except NotImplementedError as err:
-            flash(Markup(err), "error")
+            flash_error(err)
             info['error'] = True
     return render_template('ModularForm_GSp4_Q_Sp4Zj.html',
                            title='$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$',
@@ -177,7 +177,7 @@ def build_dimension_table(info, fam, args):
                         raise NotImplementedError("Please specify a single value of <span style='color:black'>$j$</span> rather than a range of values.")
                     kwargs[arg] = dim_args['j_range'][0]
         except NotImplementedError as err:
-            flash(Markup(err), "error")
+            flash_error(err)
             info['error'] = True
         if not info.get('error'):
             info['kwargs'] = kwargs
@@ -185,8 +185,8 @@ def build_dimension_table(info, fam, args):
                 headers, table = fam.dimension(**kwargs)
                 info['headers'] = headers
                 info['table'] = table
-            except (ValueError,NotImplementedError) as err:
-                flash(Markup(err), "error")
+            except (ValueError, NotImplementedError) as err:
+                flash_error(err)
                 info['error'] = True
     return
 
@@ -256,10 +256,10 @@ def render_sample_page(family, sam, args, bread):
         if label:
             info['field_label'] = label
             info['field_url'] = url_for('number_fields.by_label', label=label)
-            info['field_href'] = '<a href="%s">%s</a>'%(info['field_url'], field_pretty(label))
-    
+            info['field_href'] = '<a href="%s">%s</a>' % (info['field_url'], field_pretty(label))
+
     bread.append((info['name'], ''))
-    title='Siegel Modular Forms Sample ' + info['full_name']
+    title = 'Siegel Modular Forms Sample ' + info['full_name']
     properties = [('Space', info['space_href']),
                   ('Name', info['name']),
                   ('Type', '<br>'.join(info['type'].split(','))),

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -175,7 +175,7 @@ def login(**kwargs):
         logger.info("login: '%s' - '%s'" % (user.get_id(), user.name))
         # FIXME add color cookie, see change_colors
         return flask.redirect(next or url_for(".info"))
-    flask.flash(Markup("Oops! Wrong username or password."), "error")
+    flash_error("Oops! Wrong username or password.")
     return flask.redirect(url_for(".info"))
 
 

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -10,6 +10,8 @@ from lmfdb.logger import make_logger
 from flask import render_template, request, Blueprint, url_for, make_response
 from flask_login import login_required, login_user, current_user, logout_user, LoginManager, __version__ as FLASK_LOGIN_VERSION
 from distutils.version import StrictVersion
+from lmfdb.utils import flash_error
+from markupsafe import Markup
 
 from lmfdb import db
 assert db
@@ -69,7 +71,7 @@ def ctx_proc_userdata():
 
         userdata['user_is_admin'] = current_user.is_admin()
         userdata['user_can_review_knowls'] = current_user.is_knowl_reviewer()
-        userdata['get_username'] = get_username # this is a function
+        userdata['get_username'] = get_username  # this is a function
     return userdata
 
 # blueprint specific definition of the body_class variable
@@ -115,8 +117,10 @@ def list():
 def change_colors(scheme):
     userid = current_user.get_id()
     userdb.change_colors(userid, scheme)
-    flask.flash("Color scheme successfully changed")
-    return flask.redirect(url_for(".info"))
+    flask.flash(Markup("Color scheme successfully changed"))
+    response = make_response(flask.redirect(url_for(".info")))
+    response.set_cookie('color', str(scheme))
+    return response
 
 @login_page.route("/myself")
 def info():
@@ -127,7 +131,7 @@ def info():
     info['next'] = request.referrer
     from lmfdb.utils.color import all_color_schemes
     return render_template("user-info.html",
-                           all_colors = all_color_schemes.values(),
+                           all_colors=all_color_schemes.values(),
                            info=info, title="Userinfo",
                            bread=base_bread() + [("Myself", url_for(".info"))])
 
@@ -140,7 +144,7 @@ def set_info():
     for k, v in request.form.iteritems():
         setattr(current_user, k, v)
     current_user.save()
-    flask.flash("Thank you for updating your details!")
+    flask.flash(Markup("Thank you for updating your details!"))
     return flask.redirect(url_for(".info"))
 
 
@@ -159,7 +163,7 @@ def profile(userid):
 @login_page.route("/login", methods=["POST"])
 def login(**kwargs):
     # login and validate the user …
-    # remember = True sets a cookie to remmeber the user
+    # remember = True sets a cookie to remember the user
     name = request.form["name"]
     password = request.form["password"]
     next = request.form["next"]
@@ -167,10 +171,11 @@ def login(**kwargs):
     user = LmfdbUser(name)
     if user and user.authenticate(password):
         login_user(user, remember=remember)
-        flask.flash("Hello %s, your login was successful!" % user.name)
+        flask.flash(Markup("Hello %s, your login was successful!" % user.name))
         logger.info("login: '%s' - '%s'" % (user.get_id(), user.name))
+        # FIXME add color cookie, see change_colors
         return flask.redirect(next or url_for(".info"))
-    flask.flash("Oops! Wrong username or password.", "error")
+    flask.flash(Markup("Oops! Wrong username or password."), "error")
     return flask.redirect(url_for(".info"))
 
 
@@ -245,26 +250,26 @@ def register_token(token):
     elif request.method == 'POST':
         name = request.form['name']
         if not allowed_usernames.match(name):
-            flask.flash("""Oops, usename '%s' is not allowed.
+            flash_error("""Oops, usename '%s' is not allowed.
                   It must consist of lower/uppercase characters,
-                  no spaces, numbers or '.', '_' and '-'.""" % name, "error")
+                  no spaces, numbers or '.', '_' and '-'.""", name)
             return flask.redirect(url_for(".register_new"))
 
         pw1 = request.form['password1']
         pw2 = request.form['password2']
         if pw1 != pw2:
-            flask.flash("Oops, passwords do not match!", "error")
+            flash_error("Oops, passwords do not match!")
             return flask.redirect(url_for(".register_new"))
 
-        if len(pw1) <= 3:
-            flask.flash("Oops, password too short. Minimum 4 characters please!", "error")
+        if len(pw1) < 8:
+            flash_error("Oops, password too short. Minimum 8 characters please!")
             return flask.redirect(url_for(".register_new"))
 
         full_name = request.form['full_name']
         #next = request.form["next"]
 
         if userdb.user_exists(name):
-            flask.flash("Sorry, user ID '%s' already exists!" % name, "error")
+            flash_error("Sorry, user ID '%s' already exists!", name)
             return flask.redirect(url_for(".register_new"))
 
         newuser = userdb.new_user(name, pwd=pw1,  full_name=full_name)
@@ -272,7 +277,7 @@ def register_token(token):
         #newuser.full_name = full_name
         #newuser.save()
         login_user(newuser, remember=True)
-        flask.flash("Hello %s! Congratulations, you are a new user!" % newuser.name)
+        flask.flash(Markup("Hello %s! Congratulations, you are a new user!" % newuser.name))
         logger.debug("removed login token '%s'" % token)
         logger.info("new user: '%s' - '%s'" % (newuser.get_id(), newuser.name))
         return flask.redirect(url_for(".info"))
@@ -284,25 +289,26 @@ def change_password():
     uid = current_user.get_id()
     pw_old = request.form['oldpwd']
     if not current_user.authenticate(pw_old):
-        flask.flash("Ooops, old password is wrong!", "error")
+        flash_error("Ooops, old password is wrong!")
         return flask.redirect(url_for(".info"))
 
     pw1 = request.form['password1']
     pw2 = request.form['password2']
     if pw1 != pw2:
-        flask.flash("Oops, new passwords do not match!", "error")
+        flash_error("Oops, new passwords do not match!")
         return flask.redirect(url_for(".info"))
 
     userdb.change_password(uid, pw1)
-    flask.flash("Your password has been changed.")
+    flask.flash(Markup("Your password has been changed."))
     return flask.redirect(url_for(".info"))
 
 
 @login_page.route("/logout")
 @login_required
 def logout():
+    # FIXME delete color cookie
     logout_user()
-    flask.flash("You are logged out now. Have a nice day!")
+    flask.flash(Markup("You are logged out now. Have a nice day!"))
     return flask.redirect(request.args.get("next") or request.referrer or url_for('.info'))
 
 

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -5,7 +5,7 @@
 import re
 from collections import defaultdict, Counter
 
-from flask import flash
+from lmfdb.utils.utilities import flash_error
 from markupsafe import Markup
 from sage.all import ZZ, QQ, prod, euler_phi, CyclotomicField, PolynomialRing
 from sage.misc.decorators import decorator_keywords
@@ -69,7 +69,7 @@ class SearchParser(object):
             if self.clean_info:
                 info[field] = inp
         except (ValueError, AttributeError, TypeError) as err:
-            flash(Markup("Error: <span style='color:black'>%s</span> is not a valid input for <span style='color:black'>%s</span>. %s" % (inp, name, str(err))), "error")
+            flash_error("<span style='color:black'>%s</span> is not a valid input for <span style='color:black'>%s</span>. %s", inp, name, str(err))
             info['err'] = ''
             raise
 
@@ -123,8 +123,7 @@ def parse_ints_to_list_flash(arg,name):
     try:
         return parse_ints_to_list(arg)
     except ValueError:
-        errmsg = "Error: <span style='color:black'>%s</span> is not a valid input for <span style='color:black'>%s</span>." % (arg,name)
-        flash(Markup(errmsg+"  It needs to be an integer (such as 25), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121)."), "error")
+        flash_error("Error: <span style='color:black'>%s</span> is not a valid input for <span style='color:black'>%s</span>. It needs to be an integer (such as 25), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).", arg, name)
         raise
 
 @search_parser # see SearchParser.__call__ for actual arguments when calling

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -6,7 +6,6 @@ import re
 from collections import defaultdict, Counter
 
 from lmfdb.utils.utilities import flash_error
-from markupsafe import Markup
 from sage.all import ZZ, QQ, prod, euler_phi, CyclotomicField, PolynomialRing
 from sage.misc.decorators import decorator_keywords
 


### PR DESCRIPTION
This addresses #3140.

Is a bit a hard to be sure that #3140 has been resolved, but here are some checks one can do:
- see that there is no single line of the shape `flash(...., 'error')` 
```
$ git grep flash | grep 'error' | grep -v flash_error
lmfdb/characters/ListCharacters.py:    """ parses a user specified interval of positive integers (or a single integer), flashes errors and raises exceptions """
lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py:        # This isn't the right place to do input validation, but it is easier to flash errors here (this is a hack to address issue #1820)
lmfdb/siegel_modular_forms/siegel_modular_form.py:        # error message is flashed in parse_dim_args
lmfdb/siegel_modular_forms/siegel_modular_form.py:        # error message is flashed in parse_dim_args
lmfdb/templates/style.css:#flashes p.error {
lmfdb/utils/utilities.py:    flash(Markup("Error: %s"%(errmsg%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args)))),"error")
```


- see that there are only two lines which use flash and formatting with '%'
```
$git grep flash | grep '%[^s]' | grep -v 'flash(Markup'
lmfdb/sato_tate_groups/main.py:            flash_error('The search query took longer than expected! Please help us improve by reporting this error  <a href="%s" target=_blank>here</a>.' % ctx['feedbackpage'])
lmfdb/templates/homepage.html:    {% with msgs = get_flashed_messages(with_categories=true) -%}
lmfdb/utils/search_wrapper.py:            flash_error('The search query took longer than expected! Please help us improve by reporting this error  <a href="%s" target=_blank>here</a>.' % ctx['feedbackpage'])
```

- Everything of the shape `flash*(' is either 'flash(Markup' or using 'flash_error'
```
$git grep 'flash.*(' | grep -v flash_error | grep -v 'flash(Markup'
lmfdb/inventory_app/templates/edit_show_list.html:    var callback = function(){ flashName(element);}
lmfdb/inventory_app/templates/edit_show_list.html:function flashName(item){
lmfdb/inventory_app/templates/edit_show_list.html://    var callback = function(){ flashName(element);}
lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py:        # This isn't the right place to do input validation, but it is easier to flash errors here (this is a hack to address issue #1820)
lmfdb/sato_tate_groups/main.py:            weight_list = parse_ints_to_list_flash(info.get('weight'),'weight')
lmfdb/sato_tate_groups/main.py:            degree_list = parse_ints_to_list_flash(info.get('degree'),'degree')
lmfdb/sato_tate_groups/main.py:            components_list = parse_ints_to_list_flash(info.get('components'), 'components')
lmfdb/siegel_modular_forms/dimensions.py:            res[v] = parse_ints_to_list_flash(arg, "$"+v+"$")
lmfdb/siegel_modular_forms/siegel_modular_form.py:        evs_to_show = parse_ints_to_list_flash(args.get('ev_index'), 'list of $l$')
lmfdb/siegel_modular_forms/siegel_modular_form.py:        fcs_to_show = parse_ints_to_list_flash(args.get('fc_det'), 'list of $\\det(F)$')
lmfdb/templates/homepage.html:    {% with msgs = get_flashed_messages(with_categories=true) -%}
lmfdb/utils/search_parsing.py:def parse_ints_to_list_flash(arg,name):
```

- for last, one should look at every `flash(Markup` and be sure that they make sense
```
git grep 'flash(Markup'
lmfdb/knowledge/main.py:    flash(Markup("Knowl %s has been deleted." % ID))
lmfdb/knowledge/main.py:    flash(Markup("Knowl %s has been resurrected." % ID))
lmfdb/knowledge/main.py:    flash(Markup("Knowl %s has been positively reviewed." % ID))
lmfdb/knowledge/main.py:    flash(Markup("Knowl %s has been returned to beta." % ID))
lmfdb/knowledge/main.py:        flash(Markup("Renaming complete; the history of %s has been merged into %s" % (ID, k.source_name)))
lmfdb/knowledge/main.py:        flash(Markup("Renaming undone; the history of %s has been merged back into %s" % (k.source_name, ID)))
lmfdb/knowledge/main.py:            flash(Markup("Knowl successfully created.  Note that a knowl with this id existed previously but was deleted; its history has been restored."))
lmfdb/knowledge/main.py:                    flash(Markup("Knowl renamed to {0} successfully.".format(NEWID)))
lmfdb/knowledge/main.py:                    flash(Markup("Knowl rename process started. You can change code references using".format(NEWID)))
lmfdb/knowledge/main.py:                    flash(Markup("git grep -l '{0}' | xargs sed -i '' -e 's/{0}/{1}/g' (Mac)".format(ID, NEWID)))
lmfdb/knowledge/main.py:                    flash(Markup("git grep -l '{0}' | xargs sed -i 's/{0}/{1}/g' (Linux)".format(ID, NEWID)))
lmfdb/knowledge/main.py:                    flash(Markup("Knowl rename process started.  This knowl appears in the code (see references below), but cannot trivially be replaced with grep/sed".format(NEWID)))
lmfdb/users/main.py:    flask.flash(Markup("Color scheme successfully changed"))
lmfdb/users/main.py:    flask.flash(Markup("Thank you for updating your details!"))
lmfdb/users/main.py:        flask.flash(Markup("Hello %s, your login was successful!" % user.name))
lmfdb/users/main.py:        flask.flash(Markup("Hello %s! Congratulations, you are a new user!" % newuser.name))
lmfdb/users/main.py:    flask.flash(Markup("Your password has been changed."))
lmfdb/users/main.py:    flask.flash(Markup("You are logged out now. Have a nice day!"))
lmfdb/utils/utilities.py:    flash(Markup("Error: %s"%(errmsg%tuple(map(lambda x: "<span style='color:black'>%s</span>"%x, args)))),"error")
```