### PR TITLE
typo in api example

### DIFF
--- a/lmfdb/api/templates/api.html
+++ b/lmfdb/api/templates/api.html
@@ -74,7 +74,7 @@ where the prefix "-" indicates to sort in descending order.
     #}
     <li>
     To see those elliptic curves, where the field <code>torsion_structure</code> is the list  [2,2], encoded as a list of integers:
-    <a href='{{ url_for(".api_query", table="ec_curves", torsion_structure="ls2;2", _delim=";")}}'>?torsion_structure=ls2;2&amp;_delim=;</a>.
+    <a href='{{ url_for(".api_query", table="ec_curves", torsion_structure="li2;2", _delim=";")}}'>?torsion_structure=li2;2&amp;_delim=;</a>.
     </li>
     <!--
     <li>To only retrieve the fields <code>authors</code> and <code>last_author</code> of the knowl documents,


### PR DESCRIPTION
Given that torsion is a list of integers, we should use `li` not `ls`