### PR TITLE
font-family: KaTeX_Math; for dirichletseries

### DIFF
--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1190,6 +1190,7 @@ div.limit-height {
 /*  font-size: 75%;
 */
   font-style: italic;
+  font-family: KaTeX_Math;
 }
 
 /*** Tables for the Siegel corner ***/


### PR DESCRIPTION
With this, the fonts on exponent on the RHS of a Dirichlet series match the font on the LHS.  
e.g.: http://localhost:37777/L/Riemann/
This resolves #1918.