### PR TITLE
correct list of isogeny degrees on ec/Q home pages

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -249,7 +249,10 @@ class WebEC(object):
 
         cond, iso, num = split_lmfdb_label(self.lmfdb_label)
         self.one_deg = ZZ(self.class_deg).is_prime()
-        isodegs = [str(d) for d in self.isogeny_degrees if d>1]
+        # NB self.isogeny_degrees is currently incorrect (as of
+        # 2019-06-13) but we can get the degrees from the correct row
+        # of the isogeny matrix
+        isodegs = [str(d) for d in sorted(list(set(self.isogeny_matrix[self.lmfdb_number-1]))) if d>1]
         if len(isodegs)<3:
             data['isogeny_degrees'] = " and ".join(isodegs)
         else:


### PR DESCRIPTION
See #3155.   Previously the list of isogeny degrees shown on a curve's home page was sometimes incorrect, having been taken from the wrong row of the isogeny matrix.  This was caused by having different numbersing of curves in the isogeny class for Cremona labels and LMFDB labels.
Compare http://beta.lmfdb.org/EllipticCurve/Q/15/a/5 which incorrectly says that the curve has 16-isogenies, with http://localhost:37777/EllipticCurve/Q/15/a/5 which correctly says that the degrees are at most 4.  This curve is '15a1' and to justify the above statement:
sage: E = EllipticCurve('15a1'); E.ainvs()
(1, 1, 1, -10, -10)
sage: [E.isogeny_degree(E2) for E2 in E.isogeny_class()]
[1, 2, 2, 2, 4, 4, 4, 4]

NB We will also have to change the isogeny_degrees column in db.ec_curves, as this fix does not correct searching by isogeny degrees (this curve is still found by searching for isogeny degree 16), but half a loaf is better than none.