### PR TITLE
isogeny degree -> cyclic isogeny degree

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -150,7 +150,7 @@ Please enter a value or leave blank:
           <span class="formexample"> e.g. 4 </span>
           </td>
           <td>
-          {{ KNOWL('ec.isogeny',title="isogeny degree") }}
+          cyclic {{ KNOWL('ec.isogeny',title="isogeny degree") }}
           </td>
           <td>
           <input type='text' name='isodeg' example="16" size=10 />

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -51,7 +51,7 @@
 </tr>
 
 <tr>
-<td align=left>{{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
+<td align=left>cyclic {{ KNOWL('ec.isogeny', title='isogeny degree') }}</td>
 <td align=left>{{KNOWL('ec.maximal_galois_rep', title='maximal primes')}}
 </td>
 <td align=left colspan=2>{{KNOWL('ec.maximal_galois_rep', title='non-maximal primes')}}


### PR DESCRIPTION
Changing the caption of `isogeny degree` to `cyclic isogeny degree`, where the knowl stays only on the last 2 words.
The knowl now also mentions what we mean by cyclic.
