### PR TITLE
Remove nbsp's that were making firefox insert erroneous newlines and …

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -193,14 +193,14 @@ function show_qexp(qstyle) {
     <table class="qexp-table">
       <tr>
         <td class="fdef">\(f(q)\)</td>
-        <td class="op">&nbsp;\(=\)&nbsp;</td>
+        <td class="op">\(=\)</td>
         <td class="output smalloutput">{{ newform.q_expansion(prec_max=10) | safe }}</td>
         <td class="output mediumoutput nodisplay">{{ newform.q_expansion(prec_max=100) | safe }}</td>
       </tr>
       {% if newform.dim > 1 %}
       <tr>
         <td class="topspace fdef">\(\operatorname{Tr}(f)(q)\)</td>
-        <td class="op topspace">&nbsp;\(=\)&nbsp;</td>
+        <td class="op topspace">\(=\)</td>
         <td class="output topspace smalloutput">{{ newform.trace_expansion(prec_max=10) | safe }}</td>
         <td class="output topspace mediumoutput nodisplay">{{ newform.trace_expansion(prec_max=100) | safe }}</td>
       </tr>


### PR DESCRIPTION
…messing up alignment fixes #2840 see that ticket for details