### PR TITLE
EC/Q fix two minor labelling issues

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -436,7 +436,7 @@ def render_curve_webpage_by_label(label):
                          bread=data.bread, title=data.title,
                          friends=data.friends,
                          downloads=data.downloads,
-                         KNOWL_ID="ec.q.%s"%label,
+                         KNOWL_ID="ec.q.%s"%lmfdb_label,
                          BACKUP_KNOWL_ID="ec.q.%s"%data.lmfdb_iso,
                          learnmore=learnmore_list())
     ec_logger.debug("Total walltime: %ss"%(time.time() - t0))

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -526,12 +526,12 @@ No Iwasawa invariant data is available for this curve.
 This curve has non-trivial cyclic isogenies of degree \(d\) for \(d=\)
 {{ data.data.isogeny_degrees}}.
 <br>
-Its isogeny class <a href={{ data.class_url }}>{{data.lmfdb_iso}}</a>
+Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
 consists of {{data.class_size}} curves linked by isogenies of
 {% if data.one_deg %}degree{% else %}degrees dividing{% endif %}
  {{data.class_deg}}.
 {% else %}
-This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_url }}>{{data.lmfdb_iso}}</a>
+This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
     consists of this curve only.
 </p>
 {% endif %}


### PR DESCRIPTION
This fixes issue #3163 by correctly setting KNOWL_ID (top knowls for elliptic curves use the lmfdb labels).

Also  another small thing:  compare http://www.lmfdb.org/EllipticCurve/Q/106b1/ where (near the bottom) the isogeny class is referred to as 106.a instead of 106b, with http://localhost:37777/EllipticCurve/Q/106b1/
