### PR TITLE
typo in _check_index_name

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2159,7 +2159,7 @@ class PostgresTable(PostgresBase):
             raise ValueError("""kind={} is not "Index" or "Constraint" """)
 
         selecter = SQL("SELECT 1 FROM {} WHERE {} = %s AND table_name = %s")
-        cur = self._execute(selecter.format(map(Identifier, [meta, meta_name])),
+        cur = self._execute(selecter.format(*map(Identifier, [meta, meta_name])),
                             [name, self.search_table])
         if cur.rowcount > 0:
             raise ValueError("{} name {} is invalid, ".format(kind, name) +


### PR DESCRIPTION
There was a malformed query in `_check_index_name`, it boils down to 
```
>>> "{} {}".format(['a','b'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: tuple index out of range
```
vs
```
>>> "{} {}".format(*['a','b'])
'a b'
```