### PR TITLE
Fix sibling count

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -407,11 +407,12 @@ class WebNumberField:
             for s in sibcnts:
                 repcounts[s[0][0]] += s[1]
             gc = 0
-            if galord<24:
+            if galord<48:
                 del repcounts[galord]
                 if self.degree() < galord:
                     gc = 1 
-            repcounts[self.degree()] -= numae
+            if numae>0:
+                repcounts[self.degree()] -= numae
             if repcounts[self.degree()] == 0:
                 del repcounts[self.degree()]
             self._data['repdata'] = [repcounts, numae, gc]


### PR DESCRIPTION
This bug is currently only visible for one field:

  http://127.0.0.1:37777/NumberField/40.4.818380493827663732613543259594667183634328825351814767249590812771172429611764531578535936000000000000000000000000.1
vs
http://beta.lmfdb.org/NumberField/40.4.818380493827663732613543259594667183634328825351814767249590812771172429611764531578535936000000000000000000000000.1

The one on beta has a section indicating that the S_40 field has a degree 40 sibling.  It doesn't.  Ultimately, it is because for larger degree transitive groups, we put -1 for the count of arithmetically equivalent fields if we don't know it (yet).