### PR TITLE
mf.siegel.degree -> mf.siegel

### DIFF
--- a/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_index.html
+++ b/lmfdb/siegel_modular_forms/templates/ModularForm_GSp4_Q_index.html
@@ -2,11 +2,11 @@
 {% block content %}
 <p>
   The database contains examples of scalar and vector
-  valued {{KNOWL('mf.siegel.degree',title='Siegel modular forms')}}, as well as
+  valued {{KNOWL('mf.siegel',title='Siegel modular forms')}}, as well as
   dimension formulas for spaces of Siegel modular forms.  The examples
   that are not {{KNOWL('mf.siegeil.lift',title='lifts')}} represent most of
   the known examples that have appeared in the literature.
-</p> 
+</p>
 
 <h2>Browse spaces</h2>
 <p>


### PR DESCRIPTION
Fixing the wrong knowl on the browse page for Siegel modular forms.