### PR TITLE
Add two more group families to the latex aliases. 

### DIFF
--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -75,6 +75,8 @@ katexOpts = {
   "\\PGL": '{\\textrm{PGL}}',
   "\\Sp": '{\\textrm{Sp}}',
   "\\GSp": '{\\textrm{GSp}}',
+  "\\PSp": '{\\textrm{PSp}}',
+  "\\PSU": '{\\textrm{PSU}}',
   "\\Gal": '{\\mathop{\\rm Gal}}',
   "\\Aut": '{\\mathop{\\rm Aut}}',
   "\\Sym": '{\\mathop{\\rm Sym}}',


### PR DESCRIPTION
In the pretty names for transitive groups, PSp now appears a few times, e.g., 27T993, and PSU appears in 36T6815.  With this, all simple groups appearing in the transitive group tables will have pretty names.