### PR TITLE
Pretty Galois groups

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -16,7 +16,7 @@ from lmfdb.utils import (
 from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
 from .transitive_group import (
-    group_display_pretty, small_group_display_knowl, galois_module_knowl_guts,
+    small_group_display_knowl, galois_module_knowl_guts,
     subfield_display, resolve_display, chartable,
     group_alias_table, WebGaloisGroup)
 
@@ -130,7 +130,7 @@ def galois_group_search(info, query):
 
     degree_str = prep_ranges(info.get('n'))
     info['show_subs'] = degree_str is None or (LIST_RE.match(degree_str) and includes_composite(degree_str))
-    info['group_display'] = group_display_pretty
+    info['group_display'] = group_display_short
     info['yesno'] = yesno
     info['wgg'] = WebGaloisGroup.from_data
 
@@ -225,7 +225,7 @@ def render_group_webpage(args):
             ('Primitive', yesno(data['prim'])),
             ('$p$-group', yesno(pgroup)),
         ]
-        pretty = group_display_pretty(n,t)
+        pretty = group_display_short(n,t, emptyifnotpretty=True)
         if len(pretty)>0:
             prop2.extend([('Group:', pretty)])
             data['pretty_name'] = pretty

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -16,7 +16,7 @@ from lmfdb.utils import (
 from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
 from .transitive_group import (
-    small_group_display_knowl, galois_module_knowl_guts,
+    small_group_display_knowl, galois_module_knowl_guts, group_display_short,
     subfield_display, resolve_display, chartable,
     group_alias_table, WebGaloisGroup)
 

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -68,25 +68,25 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
               </tr>
               <tr>
                 <td> <select name='parity'>
-                   <option value='Any'>All</option>
+                   <option value=''>All</option>
                    <option value='-1'>Odd</option>
                    <option value='1'>Even</option>
                   </select>
                 </td>
                 <td> <select name='cyc'>
-                   <option value='Any'>All</option>
+                   <option value=''>All</option>
                    <option value='True'>Yes</option>
                    <option value='False'>No</option>
                   </select>
                 </td>
                 <td> <select name='solv'>
-                   <option value='Any'>All</option>
+                   <option value=''>All</option>
                    <option value='True'>Yes</option>
                    <option value='False'>No</option>
                   </select>
                 </td>
                 <td> <select name='prim'>
-                   <option value='Any'>All</option>
+                   <option value=''>All</option>
                    <option value='True'>Yes</option>
                    <option value='False'>No</option>
                   </select>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -24,67 +24,27 @@ table.ntdata a {
               </tr>
               <tr>
                 <td> <select name='parity'>
- {% if info.parity=='1' %}
-                   <option value='Any'>All</option>
-                   <option value='-1'>Odd</option>
-                   <option selected='yes' value='1'>Even</option>
- {% elif info.parity=='-1' %}
-                   <option value='Any'>All</option>
-                   <option selected='yes' value='-1'>Odd</option>
-                   <option value='1'>Even</option>
- {% else %}
-                   <option selected='yes' value='Any'>All</option>
-                   <option value='-1'>Odd</option>
-                   <option value='1'>Even</option>
- {% endif %}
+                   <option value='' {{ "selected" if info.parity != '1' and info.parity != '-1' }} >All</option>
+                   <option value='-1' {{ "selected" if info.parity == '-1' }}>Odd</option>
+                   <option value='1'{{ "selected" if info.parity == '1' }}>Even</option>
                   </select>
                 </td>
                 <td> <select name='cyc'>
- {% if info.cyc=='True' %}
-                   <option value='Any'>All</option>
-                   <option selected='yes' value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% elif info.cyc=='False' %}
-                   <option value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option selected='yes' value='False'>No</option>
- {% else %}
-                   <option selected='yes' value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% endif %}
+                   <option value='' {{ "selected" if info.cyc != 'True' and info.cyc != 'False' }}>All</option>
+                   <option value='True' {{ "selected" if info.cyc == 'True' }}>Yes</option>
+                   <option value='False' {{ "selected" if info.cyc == 'False' }}>No</option>
                   </select>
                 </td>
                 <td> <select name='solv'>
- {% if info.solv=='True' %}
-                   <option value='Any'>All</option>
-                   <option selected='yes' value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% elif info.solv=='False' %}
-                   <option value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option selected='yes' value='False'>No</option>
- {% else %}
-                   <option selected='yes' value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% endif %}
+                   <option value='' {{ "selected" if info.solv != 'True' and info.solv != 'False' }}>All</option>
+                   <option value='True' {{ "selected" if info.solv == 'True' }}>Yes</option>
+                   <option value='False' {{ "selected" if info.solv == 'False' }}>No</option>
                   </select>
                 </td>
                 <td> <select name='prim'>
- {% if info.prim=='True' %}
-                   <option value='Any'>All</option>
-                   <option selected='yes' value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% elif info.prim=='False' %}
-                   <option value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option selected='yes' value='False'>No</option>
- {% else %}
-                   <option selected='yes' value='Any'>All</option>
-                   <option value='True'>Yes</option>
-                   <option value='False'>No</option>
- {% endif %}
+                   <option value='' {{ "selected" if info.prim != 'True' and info.prim != 'False' }}>All</option>
+                   <option value='True' {{ "selected" if info.prim == 'True' }}>Yes</option>
+                   <option value='False' {{ "selected" if info.prim == 'False' }}>No</option>
                   </select>
                 </td>
               </tr>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -17,7 +17,9 @@ table.reptable td, table.reptable th {
       {% if info.pretty_name %}
       <tr><td>{{KNOWL('gg.simple_name', title='Group')}} :<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
       {% endif %}
+      {% if info.n < 16 %}
       <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}} :<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
+      {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -112,19 +112,24 @@ class WebGaloisGroup:
           return self._data['arith_equiv']
         return 0
 
+    def gapid(self):
+        return int(self._data['gapid'])
+
     def order(self):
         return int(self._data['order'])
 
     def gens(self):
         return(self._data['gens'])
 
-    def display_short(self):
+    def display_short(self, emptyifnotpretty=False):
         if self._data.get('pretty',None) is not None:
             return self._data['pretty']
-        gapid = "%d.%d"%(group['order'],group['gapid'])
+        gapid = "%d.%d"%(self.order(),self.gapid())
         gapgroup = db.gps_small.lookup(gapid)
         if gapgroup and 'pretty' in gapgroup:
-            return gapgroup['pretty']
+            return "$%s$" % gapgroup['pretty']
+        if emptyifnotpretty:
+            return ""
         return self._data['name']
 
     def otherrep_list(self, givebound=True):
@@ -200,40 +205,26 @@ def trylink(n, t):
     return '%dT%d' % (n, t)
 
 
-def group_display_short(n, t):
-    return WebGaloisGroup.from_nt(n,t).display_short()
-    #label = base_label(n, t)
-    #group = db.gps_transitive.lookup(label)
-    #if group is not None and group.get('pretty',None) is not None:
-    #    return group['pretty']
-    #return "%dT%d"%(n,t)
-
-# Returns the empty string if there is no pretty name
-def group_display_pretty(n, t):
-    return WebGaloisGroup.from_nt(n,t).display_short()
-
-    label = base_label(n, t)
-    group = db.gps_transitive.lookup(label)
-    if group.get('pretty', None) is not None:
-        return group['pretty']
-    return ""
+def group_display_short(n, t, emptyifnotpretty=False):
+    return WebGaloisGroup.from_nt(n,t).display_short(emptyifnotpretty)
 
 def group_pretty_and_nTj(n, t, useknowls=False):
     label = base_label(n, t)
     string = label
     group = db.gps_transitive.lookup(label)
+    group_obj = WebGaloisGroup.from_data(group)
     if useknowls and group is not None:
         ntj = '<a title = "' + label + ' [nf.galois_group.data]" knowl="nf.galois_group.data" kwargs="n=' + str(n) + '&t=' + str(t) + '">' + label + '</a>'
     else:
         ntj = label
-    if group is not None and group.get('pretty',None) is not None:
-        pretty = group['pretty']
+    pretty = group_obj.display_short(True) if group else ''
+    if pretty != '':
         # modify if we use knowls and have the gap id
         if useknowls:
             gapid = "%d.%d"%(group['order'],group['gapid'])
             gapgroup = db.gps_small.lookup(gapid)
             if gapgroup is not None:
-                pretty = small_group_display_knowl(group['order'], group['gapid'], name=group['pretty'])
+                pretty = small_group_display_knowl(group['order'], group['gapid'], name='$'+gapgroup['pretty']+'$')
         string = pretty + ' (as ' + ntj + ')'
     else:
         string = ntj

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -121,6 +121,10 @@ class WebGaloisGroup:
     def display_short(self):
         if self._data.get('pretty',None) is not None:
             return self._data['pretty']
+        gapid = "%d.%d"%(group['order'],group['gapid'])
+        gapgroup = db.gps_small.lookup(gapid)
+        if gapgroup and 'pretty' in gapgroup:
+            return gapgroup['pretty']
         return self._data['name']
 
     def otherrep_list(self, givebound=True):
@@ -197,14 +201,17 @@ def trylink(n, t):
 
 
 def group_display_short(n, t):
-    label = base_label(n, t)
-    group = db.gps_transitive.lookup(label)
-    if group is not None and group.get('pretty',None) is not None:
-        return group['pretty']
-    return "%dT%d"%(n,t)
+    return WebGaloisGroup.from_nt(n,t).display_short()
+    #label = base_label(n, t)
+    #group = db.gps_transitive.lookup(label)
+    #if group is not None and group.get('pretty',None) is not None:
+    #    return group['pretty']
+    #return "%dT%d"%(n,t)
 
 # Returns the empty string if there is no pretty name
 def group_display_pretty(n, t):
+    return WebGaloisGroup.from_nt(n,t).display_short()
+
     label = base_label(n, t)
     group = db.gps_transitive.lookup(label)
     if group.get('pretty', None) is not None:
@@ -582,7 +589,7 @@ def complete_group_codes(codes):
 aliases = {}
 
 # Do all cyclic groups as once
-for j in range(1,24):
+for j in range(1,48):
     aliases['C'+str(j)] = [(j,1)]
 
 aliases['S1'] = [(1, 1)]

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -332,9 +332,10 @@ def galois_group_data(n, t):
         inf += ", primitive"
     else:
         inf += ", imprimitive"
-    inf += '<div>'
-    inf += '<a title="%s [gg.conway_name]" knowl="gg.conway_name" kwarts="n=%s&t=%s">%s</a>: '%('CHM label',str(n),str(t),'CHM label')
-    inf += '%s</div>'%(group['name'])
+    if n < 16:
+        inf += '<div>'
+        inf += '<a title="%s [gg.conway_name]" knowl="gg.conway_name" kwarts="n=%s&t=%s">%s</a>: '%('CHM label',str(n),str(t),'CHM label')
+        inf += '%s</div>'%(group['name'])
 
     rest = '<div><h3>Generators</h3><blockquote>'
     rest += WebGaloisGroup.from_nt(n,t).generator_string()


### PR DESCRIPTION
The main change is when trying to display a nice name for a Galois group, if we don't have one stored, we check the small groups database in case the group is there too.  A good example to see the difference is

  http://beta.lmfdb.org/GaloisGroup/?n=32
  http://127.0.0.1:37777/GaloisGroup/?n=32

and look at the column for name.  There are none on beta, but there are with these changes.

There is also a little cleanup of code, eliminating a near redundant function; simplified template for 'select's, and adjusted so that cleaning the url works better (on beta, search for degree 32 and look at the url compared with after this change).