### PR TITLE
Fix parsing of field nicknames and allow plus for cyclotomic ones

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -169,6 +169,7 @@ cyclolookup[4] = '2.0.4.1'
 for n, label in cyclolookup.items():
     if n % 2 == 1:
         cyclolookup[2*n] = label
+
 rcyclolookup = {n:label for label,n in rcycloinfo.items()}
 for n in [1,3,4]:
     rcyclolookup[n] = '1.1.1.1'


### PR DESCRIPTION
This fixes the bug noticed by @JohnCremona, that entering a field nickname like Qzeta15+ in the nickname/label box for global number fields triggers a server error.  The reason is that the code would try ZZ(15+) and only catch value errors, and this is a different type of error.  There are several changes.

We parse the user input more carefully before calling ZZ.  Now we only take ZZ on a string of digits in this function.

We lowercase the user input, so QSqrt5 will work, as will qzeta15.

We also allow a "+" or "plus" after a zeta value, so Qzeta15+ and qzeta39plus also both work.

Finally, we look things up with the dictionaries which are already built in web_numberfield instead of relying on the fields we want to have index 1 for their respective discriminants.