### PR TITLE
Download ModSym even when no Hecke cutter

### DIFF
--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -621,7 +621,7 @@ class CMF_download(Downloader):
 
         out += self._magma_MakeCharacters(newform, hecke_nf) + newlines
 
-        if newform.hecke_cutters:
+        if newform.hecke_cutters <> None:
             out += self._magma_MakeNewformModSym(newform, hecke_nf) + newlines
         if newform.has_exact_qexp:
             # to return errors

--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -621,7 +621,7 @@ class CMF_download(Downloader):
 
         out += self._magma_MakeCharacters(newform, hecke_nf) + newlines
 
-        if newform.hecke_cutters <> None and newform.weight > 1:
+        if newform.hecke_cutters is not None and newform.weight > 1:
             out += self._magma_MakeNewformModSym(newform, hecke_nf) + newlines
         if newform.has_exact_qexp:
             # to return errors

--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -621,7 +621,7 @@ class CMF_download(Downloader):
 
         out += self._magma_MakeCharacters(newform, hecke_nf) + newlines
 
-        if newform.hecke_cutters <> None:
+        if newform.hecke_cutters <> None and newform.weight > 1:
             out += self._magma_MakeNewformModSym(newform, hecke_nf) + newlines
         if newform.has_exact_qexp:
             # to return errors


### PR DESCRIPTION
For example, http://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/24/2/f/a/