### PR TITLE
Fix yaml warning

### DIFF
--- a/lmfdb/homepage/__init__.py
+++ b/lmfdb/homepage/__init__.py
@@ -10,7 +10,7 @@ from .sidebar import get_sidebar
 # reading and sorting list of contributors once at startup
 _curdir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(_curdir, "..", "..", "CONTRIBUTORS.yaml")) as contrib_file:
-    contribs = yaml.load_all(contrib_file)
+    contribs = yaml.load_all(contrib_file, Loader=yaml.FullLoader)
     contribs = sorted(contribs, key = lambda x : x['name'].split()[-1])
 
 __all__ = ['load_boxes', 'contribs', 'get_sidebar']


### PR DESCRIPTION
When you start up the lmfdb, or import db in a sage session, you get a warning about loading yaml files.  This just adds the information to that call as prescribed by https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
and the warning goes away.