### PR TITLE
Nitpick: spaces of modular forms include Eisenstein series and old forms

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -100,10 +100,10 @@ class CmfTest(LmfdbTest):
                 page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%s" % elt, follow_redirects=True)
                 assert elt in page.data
                 # redirect to the same page
-                assert "Space of Cuspidal Newforms of " in page.data
+                assert "Space of Modular Forms of " in page.data
                 page = self.tc.get("/ModularForm/GL2/Q/holomorphic/%s" % elt, follow_redirects=True)
                 assert elt in page.data
-                assert "Space of Cuspidal Newforms of " in page.data
+                assert "Space of Modular Forms of " in page.data
 
     def test_tracehash(self):
         for t, l in [[1329751273693490116,'7.3.b.a'],[1294334189658968734, '4.5.b.a'],[0,'not found']]:

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -276,7 +276,7 @@ class WebNewformSpace(object):
             character_str = r"Character {level}.{orbit_label}".format(level=self.level, orbit_label=self.char_orbit_label)
             # character_str = r"Character \(\chi_{{{level}}}({conrey}, \cdot)\)".format(level=self.level, conrey=self.conrey_indexes[0])
             self.dim_str = r"\(%s\)"%(self.dim)
-        self.title = r"Space of Cuspidal Newforms of Level %s, Weight %s, and %s"%(self.level, self.weight, character_str)
+        self.title = r"Space of Modular Forms of Level %s, Weight %s, and %s"%(self.level, self.weight, character_str)
         gamma1_link = '/ModularForm/GL2/Q/holomorphic/%d/%d' % (self.level, self.weight)
         self.friends = [('Newspace %d.%d' % (self.level, self.weight), gamma1_link)]
 
@@ -421,7 +421,7 @@ class WebGamma1Space(object):
             ('Trace form to text', url_for('cmf.download_traces', label=self.label)),
             ('All stored data to text', url_for('cmf.download_full_space', label=self.label))
         ]
-        self.title = r"Space of Cuspidal Newforms of Level %s and Weight %s"%(self.level, self.weight)
+        self.title = r"Space of Modular Forms of Level %s and Weight %s"%(self.level, self.weight)
         self.friends = []
 
     @staticmethod


### PR DESCRIPTION
so they shouldn't be called "Space of Newforms" in the title.