### PR TITLE
Fixing yaml.load commands

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -622,7 +622,7 @@ class ECNF(object):
         # read in code.yaml from current directory:
 
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
+        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
 
         # Fill in placeholders for this specific curve:
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -504,7 +504,7 @@ class WebEC(object):
         # read in code.yaml from current directory:
 
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")))
+        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
 
         # Fill in placeholders for this specific curve:
 

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -837,7 +837,7 @@ def how_computed_page():
 
 
 _curdir = os.path.dirname(os.path.abspath(__file__))
-code_list = yaml.load(open(os.path.join(_curdir, "code.yaml")))
+code_list = yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
 
 
 same_for_all = ['signature', 'genus']

--- a/lmfdb/homepage/boxes.py
+++ b/lmfdb/homepage/boxes.py
@@ -18,7 +18,7 @@ def load_boxes():
     boxes = []
     _curdir = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(_curdir, "index_boxes.yaml")) as boxfile:
-        listboxes = yaml.load_all(boxfile)
+        listboxes = yaml.load_all(boxfile, Loader=yaml.FullLoader)
         for b in listboxes:
             B = Box(b['title'])
             B.content = b['content']

--- a/lmfdb/homepage/sidebar.py
+++ b/lmfdb/homepage/sidebar.py
@@ -49,7 +49,7 @@ class SideBar(object):
     """
     def __init__(self):
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self.toc_dic =  yaml.load(open(os.path.join(_curdir, "sidebar.yaml")))
+        self.toc_dic =  yaml.load(open(os.path.join(_curdir, "sidebar.yaml")), Loader=yaml.FullLoader)
         self.main_headings = self.toc_dic.keys()
         self.main_headings.sort()
         heading = lambda k: linked_name(self.toc_dic[k]['heading'],'heading')

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -885,7 +885,7 @@ class WebNumberField:
     def make_code_snippets(self):
          # read in code.yaml from numberfields directory:
         _curdir = os.path.dirname(os.path.abspath(__file__))
-        self.code = yaml.load(open(os.path.join(_curdir, "code.yaml")))
+        self.code = yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
         self.code['show'] = {'sage':'','pari':'', 'magma':''} # use default show names
 
         # Fill in placeholders for this specific field:


### PR DESCRIPTION
The commands work, but a change in the yaml library makes the old calls deprecated and trigger warning messages.  This adjusts the commands (per the yaml directions) and now there are no warnings.