### PR TITLE
Make character notation in sidebar consistent

### DIFF
--- a/lmfdb/homepage/sidebar.py
+++ b/lmfdb/homepage/sidebar.py
@@ -25,9 +25,9 @@ def linked_name(item, level=""):
             this_entry = '&nbsp;'
         if 'status' in item and item['status'] == 'future':
             this_entry = ''.join(['<div class="future">',this_entry,'</div>'])
-	if 'status' in item and item['status'] == 'beta':
+    if 'status' in item and item['status'] == 'beta':
             this_entry = ''.join(['<div class="beta">',this_entry,'</div>'])
-        return this_entry
+    return this_entry
 
 # The unique instance of the class SideBar:
 

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -211,10 +211,14 @@
       url_for: "representations"
    parts:
     - title: "Characters:"
-      url_for: "characters.render_characterNavigation"
+      status: beta
       part2:
+         - title: Dirichlet Characters
+           url_for:  "characters.render_Dirichletwebpage"
+           status: notonbeta
          - title: Dirichlet
            url_for:  "characters.render_Dirichletwebpage"
+           status: beta
          - title: Hecke
            url_for:  "characters.render_Heckewebpage"
            status: future

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -176,7 +176,10 @@
   {%- if entry.part2 -%}
     <td scope="col" width="40%">
     {%- for pt2 in entry.part2 -%}
-      {%- if BETA or not pt2.status -%}
+      {%- if BETA and pt2.status == "notonbeta" -%}
+      {%- elif not BETA and pt2.status == "notonbeta" -%}
+          <span class="subtitle">{{ pt2.url | safe }}</span>
+      {%- elif BETA or not pt2.status -%}
           <span class="subtitle">{{ pt2.url | safe }}</span>
       {%- endif -%}
       {%- if pt2.part3 -%}


### PR DESCRIPTION
In #3207, Edgar pointed out that the way we notate Dirichlet and Artin
representations in the sidebar was inconsistent between beta and main.
This makes them consistent: on main, that section appears like

```
Representations:
  Dirichlet Characters
  Artin
```

and on beta, that section appears like

```
Representations:
  Characters:
    Dirichlet
    Hecke
  Galois:
    Artin
    mod l
```