### PR TITLE
bfH to bbH

### DIFF
--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -62,7 +62,7 @@ class Genus2Test(LmfdbTest):
         # Square over a quadratic extension that is CM over one extension and
         # multiplication by a quaternion algebra ramifying at infinity over another
         assert 'square of' in L.data and '2.2.8.1-64.1-a3'\
-            in L.data and r'\mathbf{H}' in L.data and '(CM)' in L.data
+            in L.data and r'\mathbb{H}' in L.data and '(CM)' in L.data
 
     def test_by_url_isogeny_class_discriminant(self):
         L = self.tc.get('/Genus2Curve/Q/15360/f/983040/')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -76,7 +76,7 @@ def factorsRR_raw_to_pretty(factorsRR):
     elif factorsRR == ['CC', 'CC']:
         return r'\C \times \C'
     elif factorsRR == ['HH']:
-        return r'\mathbf{H}'
+        return r'\mathbb{H}'
     elif factorsRR == ['M_2(RR)']:
         return r'\mathrm{M}_2 (\R)'
     elif factorsRR == ['M_2(CC)']:


### PR DESCRIPTION
We use blackboard bold for RR, and CC; we should do the same for HH, the next term in the sequence.  :)