### PR TITLE
Fix bug in _parse_projection

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1202,7 +1202,7 @@ class PostgresTable(PostgresBase):
                     search_cols.append(col)
                 projection.pop(col, None)
             for col in self._extra_cols:
-                if (col in projvals) == including:
+                if (col in projection) == including:
                     extra_cols.append(col)
                 projection.pop(col, None)
             if projection: # there were more columns requested


### PR DESCRIPTION
@JohnCremona found an issue with using dictionaries to specify a projection when you include columns from an extras table.  This PR fixes the issue (it was just a typo in a variable name).

To test, the following should now work, producing a list of dictionaries with both `conductor` and `iwdata` included.
```
NN = [c for c in curves.search(projection={'conductor':True,'iwdata':True}, limit=100)]
```