### PR TITLE
Add update_from_file method to db object

### DIFF
--- a/Postgres_FAQ.md
+++ b/Postgres_FAQ.md
@@ -297,7 +297,10 @@ Note that you need editor priviledges to add, delete or modify data.
 
 1. How do I update data?
 
-   There are a number of methods for updating data.  One option is
+   There are a number of methods for updating data.  We present them
+   in rough order of ease of use, and roughly reverse order in terms of speed.
+
+   The first option is
    `upsert`, which takes a query and dictionary containing values to
    be set and updates a single row satisfying the query.  If no row
    satisfies the query, a new row will be added.  If multiple rows
@@ -326,7 +329,25 @@ Note that you need editor priviledges to add, delete or modify data.
    sage: db.test_table.rewrite(func, {'discriminant':{'$le':25}})
    ```
 
-   Under the hood, this function uses the `reload` method, which is
+   Sometimes the new data cannot be derived from existing data.  In this case
+   the `update_from_file` function can be used, which allows you to specify
+   new values for any subset of columns and of rows.  For example:
+
+   ```python
+   sage: db.test_table.update_from_file("test.txt", label_col="label", sep=":")
+   ```
+
+   Example contents of `test.txt`:
+
+   ```
+   label:discriminant:bar
+   text:numeric:text
+
+   1.12.A:33:hello
+   2.30.A:90:world
+   ```
+
+   Under the hood, the `rewrite` function uses `reload`, which is
    also available for use directly.  It takes as input files
    containing the desired data for the table (for basic usage, you can
    just give one file; others are available if your table has an
@@ -345,14 +366,15 @@ Note that you need editor priviledges to add, delete or modify data.
    3    20      3.20.B  [2,5]
    ```
 
-   The `reload` method is the fastest option, but requires you to
+   The `reload` method supports arbitrary changes to the data, but requires you to
    produce an appropriate file.
 
 1. What if I change my mind and want to revert to the old version of a table, from before a reload?
 
    You can use the `reload_revert` method to switch back to the old
    version.  Note that this will also work for the `rewrite` method,
-   since it relies on `reload`.  If you want to undo a `reload_all`,
+   since it relies on `reload`, and for the `update_from_file` method
+   (unless `inplace=True` was used).  If you want to undo a `reload_all`,
    see the `reload_all_revert` method on `db`.
 
    There is no built-in way to undo direct additions to tables via


### PR DESCRIPTION
The current methods for updating a table don't handle the case of updating a single column for every row very well: `upsert` is slow when run on many rows, `update` can't handle data that varies by row, `rewrite` requires that the new values be computable from existing ones, and using a raw `reload` is cumbersome.

This PR adds a new method that allows a developer to provide a file of the same format used in `copy_from` and `reload`: a header and then one line per record in the table to be updated.  Unlike those methods, only columns being change need to be included: other data will remain unchanged.  By default, the change is made to a copy of the table so that it can be undone using `reload_revert`; an `inplace` keyword is also available which may be useful for large tables like L-functions.