### PR TITLE
Change back artin rep tables

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -84,7 +84,7 @@ def artin_representation_jump(info):
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)
 
 @search_wrap(template="artin-representation-search.html",
-             table=db.artin_reps_new,
+             table=db.artin_reps,
              title='Artin Representation Search Results',
              err_title='Artin Representation Search Error',
              per_page=50,
@@ -204,7 +204,7 @@ def render_artin_representation_webpage(label):
 
 @artin_representations_page.route("/random")
 def random_representation():
-    rep = db.artin_reps_new.random(projection=2)
+    rep = db.artin_reps.random(projection=2)
     num = random.randrange(len(rep['GaloisConjugates']))
     label = rep['Baselabel']+"c"+str(num+1)
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -91,7 +91,7 @@ class ArtinRepresentation(object):
                 label = "%sc%s"%(str(x[0]),str(x[1]))
             else:
                 raise ValueError("Invalid number of positional arguments")
-            self._data = db.artin_reps_new.lucky({'Baselabel':str(base)})
+            self._data = db.artin_reps.lucky({'Baselabel':str(base)})
             conjs = self._data["GaloisConjugates"]
             conj = [xx for xx in conjs if xx['GalOrbIndex'] == conjindex]
             self._data['label'] = label
@@ -99,12 +99,12 @@ class ArtinRepresentation(object):
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_reps_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_reps.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
         # What about label?
-        return cls(data=db.artin_reps_new.lucky(*args, **kwds))
+        return cls(data=db.artin_reps.lucky(*args, **kwds))
 
     @classmethod
     def find_one_in_galorbit(cls, baselabel):
@@ -623,18 +623,18 @@ class NumberFieldGaloisGroup(object):
             else:
                 coeffs = x[0]
             coeffs = [int(c) for c in coeffs]
-            self._data = db.artin_field_data_new.lucky({'Polynomial':coeffs})
+            self._data = db.artin_field_data.lucky({'Polynomial':coeffs})
             if self._data is None:
                 # This should probably be a ValueError, but we use an AttributeError for backward compatibility
                 raise AttributeError("No Galois group data for polynonial %s"%(coeffs))
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_field_data_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_field_data.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
-        result = db.artin_field_data_new.lucky(*args, **kwds)
+        result = db.artin_field_data.lucky(*args, **kwds)
         if result is not None:
             return cls(data=result)
 

--- a/scripts/artin_representations/import_art_nf.py
+++ b/scripts/artin_representations/import_art_nf.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/sage -python
 
 # This version writes the data to a file, deletes all records from the database,
-# then reloads from the files.
+# then reloads from the files. 
 
 
 import sys, os


### PR DESCRIPTION
There are two database tables for artin reps.  Currently, we are using temporarily named tables on both beta and the main site.  This changes the names back to artin_reps and artin_field_data.

The first step should be to copy these two tables to the cloud.  The code on the cloud does not access them, so no harm should come of it.

Then this can be merged.  The only changes are the table names are changed.

Once this code goes to the cloud version, the tables artin_reps_new and artin_field_data_new can be deleted.