### PR TITLE
Search again

### DIFF
--- a/lmfdb/abvar/fq/templates/abvarfq-search-results.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-search-results.html
@@ -11,8 +11,7 @@
 <h2> Refine search </h2>
 
 <form id='re-search' onsubmit="cleanSubmit(this.id)">
-    <input type="hidden" name="start" value="{{info.start}}"/>
-    <input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
     <table border="0">
 
@@ -120,7 +119,7 @@
 
         <tr>
             <td class="button">
-                <button type='submit' value='refine'>Search again</button>
+                <button type='submit' value='refine' onclick='resetStart()'>Search again</button>
             </td> </tr>
     </table>
 

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -3,7 +3,7 @@
 {# Refine search page #}
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
+  {% include 'hidden_search_inputs.html' %}
   <table>
     <tr>
       <td>{{ KNOWL('artin.dimension',title="Dimension") }}
@@ -36,7 +36,7 @@
     <tr>
       <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value="{{info.count}}" size=10></td>
   <tr>
-    <td class="button"><button type='submit' value='Search'>Search again</button></td>
+    <td class="button"><button type='submit' value='Search' onclick='resetStart()'>Search again</button></td>
   </table>
 </form>
 

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -6,37 +6,39 @@
   {% include 'hidden_search_inputs.html' %}
   <table>
     <tr>
-      <td>{{ KNOWL('artin.dimension',title="Dimension") }}
-      <td>{{ KNOWL('artin.conductor',title = "Conductor") }}
-      <td>{{ KNOWL('artin.gg_quotient',title="Group") }}
-      <td>{{ KNOWL('artin.root_number',title="Root number") }}
-      <td>{{ KNOWL('artin.parity',title="Parity") }}
+      <td>{{ KNOWL('artin.dimension',title="Dimension") }}</td>
+      <td>{{ KNOWL('artin.conductor',title = "Conductor") }}</td>
+      <td>{{ KNOWL('artin.gg_quotient',title="Group") }}</td>
+      <td>{{ KNOWL('artin.root_number',title="Root number") }}</td>
+      <td>{{ KNOWL('artin.parity',title="Parity") }}</td>
 
     <tr>
-      <td><input type='text' name='dimension' value="{{info.dimension}}" size=15/>
-      <td><input type='text' name='conductor' value="{{info.conductor}}" size=15/>
-      <td><input type='text' name='group' value="{{info.group}}" size=15>
-      <td><input type='text' name='root_number' value = "{{info.root_number}}" size=15/>
+      <td><input type='text' name='dimension' value="{{info.dimension}}" size=15/></td>
+      <td><input type='text' name='conductor' value="{{info.conductor}}" size=15/></td>
+      <td><input type='text' name='group' value="{{info.group}}" size=15></td>
+      <td><input type='text' name='root_number' value = "{{info.root_number}}" size=15/></td>
       <td><select name='Is_Even' width="105" style="width: 105px">
         <option value=''>All</option>
         <option value='True' {{ "selected" if info.Is_Even == 'True'}} >Even</option>
         <option value='False' {{ "selected" if info.Is_Even == 'False'}} >Odd</option>
-        </select>
+      </select></td>
+    </tr>
 
     <tr>
-      <td>{{ KNOWL('artin.permutation_container',title="Smallest permutation container") }}
-      <td>{{KNOWL('artin.ramified_primes', 'Ramified primes')}}
-      <td>{{KNOWL('artin.unramified_primes', 'Unramified primes')}}
-      <td>{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}
+      <td>{{ KNOWL('artin.permutation_container',title="Smallest permutation container") }}</td>
+      <td>{{KNOWL('artin.ramified_primes', 'Ramified primes')}}</td>
+      <td>{{KNOWL('artin.unramified_primes', 'Unramified primes')}}</td>
+      <td>{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}</td>
+    </tr>
     <tr>
-      <td><input type='text' name='container' value="{{info.container}}" size=15>
-      <td><input type='text' name='ramified' value="{{info.ramified}}" size=15/>
-      <td><input type='text' name='unramified' value = "{{info.unramified}}" size=15/>
+      <td><input type='text' name='container' value="{{info.container}}" size=15></td>
+      <td><input type='text' name='ramified' value="{{info.ramified}}" size=15/></td>
+      <td><input type='text' name='unramified' value = "{{info.unramified}}" size=15/></td>
       <td><input type='text' name='frobenius_schur_indicator' value = "{{info.frobenius_schur_indicator}}" size=15/></td>
-    <tr>
-      <td align=left colspan=4>Maximum number of Artin representations to display <input type='text' name='count' value="{{info.count}}" size=10></td>
+    </tr>
   <tr>
     <td class="button"><button type='submit' value='Search' onclick='resetStart()'>Search again</button></td>
+  </tr>
   </table>
 </form>
 

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1759,7 +1759,7 @@ class PostgresTable(PostgresBase):
                 self._search_iterator(res, search_cols, extra_cols, projection)
                 )
         if info is not None:
-            if offset >= nres:
+            if offset >= nres > 0:
                 # We're passing in an info dictionary, so this is a front end query,
                 # and the user has requested a start location larger than the number
                 # of results.  We adjust the results to be the last page instead.

--- a/lmfdb/belyi/templates/belyi_search_results.html
+++ b/lmfdb/belyi/templates/belyi_search_results.html
@@ -4,8 +4,7 @@
 <h2>Refine search </h2>
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table>
   <td>{{ KNOWL('belyi.degree', title='degree') }}</td>
@@ -38,7 +37,7 @@
   </tr>
 
 <tr style="height:50px">
-<td class="button"><button type='submit' value='refine' style="width: 110px">Search again</button></td>
+<td class="button"><button type='submit' value='refine' style="width: 110px" onclick='resetStart()'>Search again</button></td>
 <td align=left colspan="7">
 <input type="hidden" name="query" value="{{info.query}}"/>
 Download all search results for&nbsp;

--- a/lmfdb/bianchi_modular_forms/templates/bmf-search_results.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-search_results.html
@@ -4,8 +4,7 @@
 <h2> Further refine search </h2>
 
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table>
 <tr>
 <td>Field</td>
@@ -64,7 +63,7 @@
 <tr>
 <td>Maximum number</td>
 <td><input type='text' name='count' value={{info.count}} size=10></td>
-<td colspan=3><button type='submit' value='Search'>Search</button></td>
+<td colspan=3><button type='submit' value='Search' onclick='resetStart()'>Search</button></td>
 </tr>
 </table>
 </form>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -4,8 +4,7 @@
 <h2>Refine search</h2>
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table border="0">
 <tr>
@@ -39,7 +38,7 @@
 <td colspan=2 align=left>maximum results to display</td>
 <td align=left> <input type='text' name='limit'size=6 value="{{args.limit}}"> </td></tr>
 <tr>
-<td class="button"><button type='submit' width="170" style="width: 170px" name='refine' value='1'>Search again</button>
+<td class="button"><button type='submit' width="170" style="width: 170px" name='refine' value='1' onclick='resetStart()'>Search again</button>
 </td> </tr>
 </table>
 

--- a/lmfdb/classical_modular_forms/templates/cmf_refine_search.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_refine_search.html
@@ -22,9 +22,7 @@ function set_buckets(col_selecter, bucket_id) {
 {% endif %}
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
-<input type="hidden" name="hst" value="{{info.search_type}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table>
   <tr>

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -11,8 +11,7 @@
 <h2> Refine search </h2>
 
 <form id='re-search' onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table border="0">
 
@@ -110,7 +109,7 @@
 
 <tr>
 <td class="button">
-<button type='submit' value='refine'>Search again</button>
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td> </tr>
 </table>
 

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -8,7 +8,7 @@
 <h2> Further refine search </h2>
 
 <form id='re-search' onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0" cellpadding="5">
 
 <tr>
@@ -88,15 +88,7 @@
 </td>
 </tr>
 
-<tr>
-<td align=left colspan=2>Maximum number of curves to display
-</td>
-<td align=left><input type='text' name='count' value={{info.count}} size=10>
-</td>
-<td>&nbsp;
-</td>
-</tr>
-<tr><td class="button"><button type='submit' value='refine'>Search again</button></td></tr>
+<tr><td class="button"><button type='submit' value='refine' onclick='resetStart()'>Search again</button></td></tr>
 </table>
 </form>
 

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -10,7 +10,7 @@ table.ntdata a {
 </style>
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
           <tr>
@@ -71,12 +71,8 @@ table.ntdata a {
 </tr>
 
 <tr>
-<td align='left' colspan='8'>Maximum number of groups to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-</td>
-</tr>
-<tr>
 <td align=left colspan="2"> 
-<button type='submit' value='refine'>Search again</button>
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td></tr>
 </table>
 </form>

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.tests import LmfdbTest
 
 
@@ -7,11 +7,11 @@ class GalGpTest(LmfdbTest):
     # All tests should pass
     #
     def test_search_deg(self):
-        L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=7&t=&count=50')
+        L = self.tc.get('/GaloisGroup/?start=0&parity=0&cyc=0&solv=0&prim=0&n=7&t=&count=50')
         assert 'all 7 matches' in L.data
 
     def test_search_t_solv_prim(self):
-        L = self.tc.get('/GaloisGroup/?start=0&paging=0&parity=-1&cyc=0&solv=1&prim=-1&n=&t=18&count=50')
+        L = self.tc.get('/GaloisGroup/?start=0&parity=-1&cyc=0&solv=1&prim=-1&n=&t=18&count=50')
         assert '14T18' in L.data
         assert '294' in L.data # order of 21T18
 
@@ -20,7 +20,7 @@ class GalGpTest(LmfdbTest):
         assert '22528' in L.data # order of 22T29
 
     def test_search_range(self):
-        L = self.tc.get('GaloisGroup/?start=0&paging=0&parity=0&cyc=0&solv=0&prim=0&n=8-11&t=3-5&count=50')
+        L = self.tc.get('GaloisGroup/?start=0&parity=0&cyc=0&solv=0&prim=0&n=8-11&t=3-5&count=50')
         assert '8T3' in L.data
         assert '660' in L.data # order of 11T5
 

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -4,8 +4,7 @@
 <h2>Refine search </h2>
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table>
 <tr>
@@ -80,7 +79,7 @@
 
 <tr>
 
-<td class="button"><button type='submit' value='refine' style='min-width: 110px'>Search again</button></td>
+<td class="button"><button type='submit' value='refine' style='min-width: 110px' onclick='resetStart()'>Search again</button></td>
 
 <td><select name='geom_aut_grp_id' style="width: 110px">
     <option ></option>

--- a/lmfdb/hecke_algebras/templates/hecke_algebras-search.html
+++ b/lmfdb/hecke_algebras/templates/hecke_algebras-search.html
@@ -3,7 +3,7 @@
 
 <h2> Further refine search </h2>
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 <tr>
 <td align=left>{{ KNOWL('cmf.level', title='Level') }}</td>
@@ -30,9 +30,7 @@
 
 <tr>&nbsp;</tr>
 <tr>
-<td align=left colspan=2>Maximum number of Hecke Algebras to display</td>
-<td align=left><input type='text' name='count' size=10 value={{info.count}}></td>
-<td><button type='submit' size=10  value='refine'>Search again</button></td>
+<td><button type='submit' size=10  value='refine' onclick='resetStart()'>Search again</button></td>
 </tr>
 </table>
 </form>

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-search.html
@@ -5,8 +5,7 @@
 {% include "hgcwa-clean-submit.html" %}
 
 <form id="re-search" onsubmit="cleanSubmitHGCWA(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
@@ -97,8 +96,6 @@
         {% endif %}
         {% endif %}
         </td>
-<td align='left' colspan='4'>Maximum number of families to display: <input type='text' id='count' name='count' value="{{info.count}}" size='10'>
-</td>
 </tr>
 
 
@@ -127,7 +124,7 @@
 
 <tr>
   <td>
-<button type='submit' value='refine'>Search again</button>
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td>
 </tr>
 

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
@@ -4,7 +4,7 @@
 <h2> Further refine search </h2>
 
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table border="0">
 
@@ -65,11 +65,7 @@
 </td>
 </tr>
 <tr>
-<td>Maximum number</td>
-<td><input type='text' name='count' size=10 value={{info.count}}></td>
-</tr>
-<tr>
-<td class="button"><button type='submit' value='Search'>Search again</button>
+<td class="button"><button type='submit' value='Search' onclick='resetStart()'>Search again</button>
 </td>
 </tr>
 </table>

--- a/lmfdb/hypergm/templates/hgm-search.html
+++ b/lmfdb/hypergm/templates/hgm-search.html
@@ -3,100 +3,88 @@
 {% block content %}
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
-<td align=left> 
-{{KNOWL('hgm.degree',title='degree')}}</td><td align=left> <input type='text' name='degree' size="8" value="{{info.degree}}" example='4'>
-</td>
+<td align=left> {{KNOWL('hgm.degree',title='degree')}}</td>
+<td align=left> <input type='text' name='degree' size="8" value="{{info.degree}}" example='4'></td>
 <td> {{KNOWL('hgm.weight', title="weight")}} </td>
 <td><input type='text' name='weight' size="8" example='3' value="{{info.weight}}"> </td>
-<td align=left> 
-$A$:
-<td align=left> <input type="text" name="A" size="8" value="{{info.A}}" example='[3,2,2]'>
-
-<td align=left>  $B$ 
-<td align=left> <input type="text" name="B" size="8" value="{{info.B}}" example='[6,4]'>
-<td align=left> {{KNOWL('hgm.familyhodgevector', title="family Hodge vector")}}
-  <td align=left><input type='text' name='famhodge' size="8" value="{{info.famhodge}}" example='[1,1,1,1]'>
+<td align=left> $A$:</td>
+<td align=left> <input type="text" name="A" size="8" value="{{info.A}}" example='[3,2,2]'></td>
+<td align=left>  $B$</td>
+<td align=left> <input type="text" name="B" size="8" value="{{info.B}}" example='[6,4]'></td>
+<td align=left> {{KNOWL('hgm.familyhodgevector', title="family Hodge vector")}}</td>
+<td align=left><input type='text' name='famhodge' size="8" value="{{info.famhodge}}" example='[1,1,1,1]'></td>
+</tr>
 
 <tr>
-<td align=left><a title="A2">A<sub>2</sub></a>
-  <td><input type='text' name='A2' size="8" value="{{info.A2}}" example='[1,1,1,1]'>
-<td align=left><a title="A3">A<sub>3</sub></a>
-  <td><input type='text' name='A3' size="8" value="{{info.A3}}" example='[1,1,1,1]'>
-<td align=left><a title="A5">A<sub>5</sub></a>
-  <td><input type='text' name='A5' size="8" value="{{info.A5}}" example='[1,1,1,1]'>
-<td align=left><a title="A7">A<sub>7</sub></a>
-  <td><input type='text' name='A7' size="8" value="{{info.A7}}" example='[1,1,1,1]'>
+<td align=left><a title="A2">A<sub>2</sub></a></td>
+<td><input type='text' name='A2' size="8" value="{{info.A2}}" example='[1,1,1,1]'></td>
+<td align=left><a title="A3">A<sub>3</sub></a></td>
+<td><input type='text' name='A3' size="8" value="{{info.A3}}" example='[1,1,1,1]'></td>
+<td align=left><a title="A5">A<sub>5</sub></a></td>
+<td><input type='text' name='A5' size="8" value="{{info.A5}}" example='[1,1,1,1]'></td>
+<td align=left><a title="A7">A<sub>7</sub></a></td>
+<td><input type='text' name='A7' size="8" value="{{info.A7}}" example='[1,1,1,1]'></td>
 
 
 {% if not info.family %}
-<td align=left> {{KNOWL('mot.hodgevector', title="Hodge vector")}}
-  <td align=left><input type='text' name='hodge' size="8" value="{{info.hodge}}" example='[1,1,1,1]'>
+<td align=left> {{KNOWL('mot.hodgevector', title="Hodge vector")}}</td>
+<td align=left><input type='text' name='hodge' size="8" value="{{info.hodge}}" example='[1,1,1,1]'></td>
 {% endif %}
+</tr>
 
 <tr>
-<td align=left><a title="B2">
-B<sub>2</sub></a> 
-<td><input type='text' name='B2' size="8" value="{{info.B2}}" example='[1,1,1,1]'>
-<td align=left><a title="B3">
-B<sub>3</sub></a> 
-<td><input type='text' name='B3' size="8" value="{{info.B3}}" example='[1,1,1,1]'>
-<td align=left><a title="B5">
-B<sub>5</sub></a> 
-<td><input type='text' name='B5' size="8" value="{{info.B5}}" example='[1,1,1,1]'>
-<td align=left><a title="B7">
-B<sub>7</sub></a>
-<td><input type='text' name='B7' size="8" value="{{info.B7}}" example='[1,1,1,1]'>
+<td align=left><a title="B2">B<sub>2</sub></a></td>
+<td><input type='text' name='B2' size="8" value="{{info.B2}}" example='[1,1,1,1]'></td>
+<td align=left><a title="B3">B<sub>3</sub></a></td>
+<td><input type='text' name='B3' size="8" value="{{info.B3}}" example='[1,1,1,1]'></td>
+<td align=left><a title="B5">B<sub>5</sub></a></td>
+<td><input type='text' name='B5' size="8" value="{{info.B5}}" example='[1,1,1,1]'></td>
+<td align=left><a title="B7">B<sub>7</sub></a></td>
+<td><input type='text' name='B7' size="8" value="{{info.B7}}" example='[1,1,1,1]'></td>
+</tr>
 
 {% if not info.family %}
 <tr>
-<td align=left> {{KNOWL('hgm.conductor', title="conductor")}}
-  <td><input type='text' name='conductor' size=10 value="{{info.conductor}}" example='2^13 3^7'>
+<td align=left> {{KNOWL('hgm.conductor', title="conductor")}}</td>
+<td><input type='text' name='conductor' size=10 value="{{info.conductor}}" example='2^13 3^7'></td>
 
-  <td align=left> 
-$t$</td><td align=left> <input type="text" name="t" size="3" value="{{info.t}}" example='3/2'></td>
+<td align=left>$t$</td>
+<td align=left> <input type="text" name="t" size="3" value="{{info.t}}" example='3/2'></td>
 
-  <td align=left> 
-    $\epsilon$
-  <td align=left> 
-    <input type="text" name="sign" size="3" value="{{info.sign}}" example='-1'>
+<td align=left> $\epsilon$</td>
+<td align=left> <input type="text" name="sign" size="3" value="{{info.sign}}" example='-1'></td>
+</tr>
 {% endif %}
 
 <tr>
-<td align=left><a title="Au2">A<sup>2</sup></a>
-  <td><input type='text' name='Au2' size="8" value="{{info.Au2}}" example='[1,1,1,1]'>
-<td align=left><a title="Au3">A<sup>3</sup></a>
-  <td><input type='text' name='Au3' size="8" value="{{info.Au3}}" example='[1,1,1,1]'>
-<td align=left><a title="Au5">A<sup>5</sup></a>
-  <td><input type='text' name='Au5' size="8" value="{{info.Au5}}" example='[1,1,1,1]'>
-<td align=left><a title="Au7">A<sup>7</sup></a>
-  <td><input type='text' name='Au7' size="8" value="{{info.Au7}}" example='[1,1,1,1]'>
+<td align=left><a title="Au2">A<sup>2</sup></a></td>
+<td><input type='text' name='Au2' size="8" value="{{info.Au2}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Au3">A<sup>3</sup></a></td>
+<td><input type='text' name='Au3' size="8" value="{{info.Au3}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Au5">A<sup>5</sup></a></td>
+<td><input type='text' name='Au5' size="8" value="{{info.Au5}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Au7">A<sup>7</sup></a></td>
+<td><input type='text' name='Au7' size="8" value="{{info.Au7}}" example='[1,1,1,1]'></td>
+</tr>
 
 <tr>
-<td align=left><a title="Bu2">B<sup>2</sup></a>
-  <td><input type='text' name='Bu2' size="8" value="{{info.Bu2}}" example='[1,1,1,1]'>
-<td align=left><a title="Bu3">B<sup>3</sup></a>
-  <td><input type='text' name='Bu3' size="8" value="{{info.Bu3}}" example='[1,1,1,1]'>
-<td align=left><a title="Bu5">B<sup>5</sup></a>
-  <td><input type='text' name='Bu5' size="8" value="{{info.Bu5}}" example='[1,1,1,1]'>
-<td align=left><a title="Bu7">B<sup>7</sup></a>
-  <td><input type='text' name='Bu7' size="8" value="{{info.Bu7}}" example='[1,1,1,1]'>
-
-
-<tr>
-{% if not info.family %}
-  <td align='left' colspan='4'>Maximum number of motives to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-{% else %}
-  <td align='left' colspan='4'>Maximum number of families to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-{% endif %}
+<td align=left><a title="Bu2">B<sup>2</sup></a></td>
+<td><input type='text' name='Bu2' size="8" value="{{info.Bu2}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Bu3">B<sup>3</sup></a></td>
+<td><input type='text' name='Bu3' size="8" value="{{info.Bu3}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Bu5">B<sup>5</sup></a></td>
+<td><input type='text' name='Bu5' size="8" value="{{info.Bu5}}" example='[1,1,1,1]'></td>
+<td align=left><a title="Bu7">B<sup>7</sup></a></td>
+<td><input type='text' name='Bu7' size="8" value="{{info.Bu7}}" example='[1,1,1,1]'></td>
+</tr>
 
 <tr>
 <td align=left colspan="2"> 
-<button type='submit' value='refine'>Search again</button>
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td></tr>
 </table>
 {% if info.family %}

--- a/lmfdb/lattice/templates/lattice-search.html
+++ b/lmfdb/lattice/templates/lattice-search.html
@@ -3,7 +3,7 @@
 
 <h2> Further refine search </h2>
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
@@ -34,11 +34,7 @@
 
 <tr>&nbsp;</tr>
 <tr>
-<td align=left colspan=2>Maximum number of integral lattices to display</td>
-<td align=left><input type='text' name='count' value={{info.count}} size=10></td>
-</tr>
-<tr>
-<td class="button"><button type='submit' size=10  value='refine'>Search again</button></td>
+<td class="button"><button type='submit' size=10  value='refine' onclick='resetStart()'>Search again</button></td>
 </tr>
 </table>
 </form>

--- a/lmfdb/local_fields/templates/lf-search.html
+++ b/lmfdb/local_fields/templates/lf-search.html
@@ -3,41 +3,31 @@
 {% block content %}
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
-<td align=left> 
-{{KNOWL('lf.degree',title='Degree')}}:</td><td align=left> <input type='text' name='n' size=3 value="{{info.n}}">
-<td align=left> 
-{{KNOWL('lf.discriminant_exponent',title='Discriminant exponent')}} $c$:
-<td align=left> <input type="text" name="c" size="3" value="{{info.c}}" >
-
-<td align=left> 
-{{KNOWL('nf.galois_group',title='Galois group')}}:
-<td align=left> <input type="text" name="gal" size="8" value="{{info.gal}}" >
+<td align=left>{{KNOWL('lf.degree',title='Degree')}}:</td>
+<td align=left> <input type='text' name='n' size=3 value="{{info.n}}"></td>
+<td align=left> {{KNOWL('lf.discriminant_exponent',title='Discriminant exponent')}} $c$:</td>
+<td align=left> <input type="text" name="c" size="3" value="{{info.c}}" ></td>
+<td align=left> {{KNOWL('nf.galois_group',title='Galois group')}}:</td>
+<td align=left> <input type="text" name="gal" size="8" value="{{info.gal}}" ></td>
+</tr>
 
 <tr>
-<td align=left> 
-Prime $p$:</td><td align=left> <input type="text" name="p" size="3" value="{{info.p}}" ></td>
-</td>
-<td align=left> 
-{{KNOWL('lf.ramification_index',title='Ramification index')}} $e$:
-<td align=left> 
-<input type="text" name="e" size="3" value="{{info.e}}" >
+<td align=left> Prime $p$:</td>
+<td align=left> <input type="text" name="p" size="3" value="{{info.p}}" ></td>
+<td align=left> {{KNOWL('lf.ramification_index',title='Ramification index')}} $e$:</td>
+<td align=left> <input type="text" name="e" size="3" value="{{info.e}}" ></td>
 
-<td align=left>
-  {{KNOWL('lf.top_slope',title='Top slope')}}:
-<td align=left> 
-<input type="text" name="topslope" size="8" value="{{info.topslope}}">
-
+<td align=left> {{KNOWL('lf.top_slope',title='Top slope')}}:</td>
+<td align=left> <input type="text" name="topslope" size="8" value="{{info.topslope}}"></td>
+</tr>
 
 <tr>
-<td align='left' colspan='4'>Maximum number of fields to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-
-<tr>
-<td align=left colspan="2"> 
-<button type='submit' value='refine'>Search again</button>
+<td align=left colspan="2">
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td></tr>
 </table>
 </form>

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.tests import LmfdbTest
 
 class LocalFieldTest(LmfdbTest):
@@ -6,7 +6,7 @@ class LocalFieldTest(LmfdbTest):
     # All tests should pass
     #
     def test_search_ramif_cl_deg(self):
-		L = self.tc.get('/LocalNumberField/?start=0&paging=0&n=8&c=24&gal=8T5&p=2&e=8&count=20')
+		L = self.tc.get('/LocalNumberField/?n=8&c=24&gal=8T5&p=2&e=8&count=20')
 		assert '4 matches' in L.data
 
     def test_search_top_slope(self):

--- a/lmfdb/modlmf/templates/modlmf-search.html
+++ b/lmfdb/modlmf/templates/modlmf-search.html
@@ -3,7 +3,7 @@
 
 <h2> Further refine search </h2>
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
@@ -39,7 +39,7 @@
 </td><td><button type='button' id='more_modp_button'>more</button>
 </td></tr>
 <tr>
-<td class="button"><button type='submit' size=10  value='refine'>Search again</button>
+<td class="button"><button type='submit' size=10  value='refine' onclick='resetStart()'>Search again</button>
  </td>
 </tr>
 

--- a/lmfdb/motives/templates/motive-search.html
+++ b/lmfdb/motives/templates/motive-search.html
@@ -3,41 +3,29 @@
 {% block content %}
 
 <form id="re-search">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="paging" value="0"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
-<td align=left> 
-{{KNOWL('lf.degree',title='Degree')}}:</td><td align=left> <input type='text' name='n' size=3 value="{{info.n}}">
-</td>
-<td align=left> 
-{{KNOWL('lf.discriminant_exponent',title='Discriminant exponent')}} $c$:
-<td align=left> <input type="text" name="c" size="3" value="{{info.c}}" >
+<td align=left> {{KNOWL('lf.degree',title='Degree')}}:</td>
+<td align=left> <input type='text' name='n' size=3 value="{{info.n}}"></td>
+<td align=left> {{KNOWL('lf.discriminant_exponent',title='Discriminant exponent')}} $c$:</td>
+<td align=left> <input type="text" name="c" size="3" value="{{info.c}}" ></td>
 
-<td align=left> 
-{{KNOWL('nf.galois_group',title='Galois group')}}:
-<td align=left> <input type="text" name="gal" size="8" value="{{info.gal}}" >
-
-</tr>
-<tr>
-<td align=left> 
-Prime $p$:</td><td align=left> <input type="text" name="p" size="3" value="{{info.p}}" ></td>
-</td>
-<td align=left> 
-{{KNOWL('lf.ramification_index',title='Ramification index')}} $e$:
-<td align=left> 
-<input type="text" name="e" size="3" value="{{info.e}}" >
+<td align=left> {{KNOWL('nf.galois_group',title='Galois group')}}:</td>
+<td align=left> <input type="text" name="gal" size="8" value="{{info.gal}}" ></td>
 </tr>
 
 <tr>
-<td align='left' colspan='4'>Maximum number of fields to display: <input type='text' name='count' value="{{info.count}}" size='10'>
-</td>
+<td align=left> Prime $p$:</td>
+<td align=left> <input type="text" name="p" size="3" value="{{info.p}}" ></td>
+<td align=left> {{KNOWL('lf.ramification_index',title='Ramification index')}} $e$:</td>
+<td align=left> <input type="text" name="e" size="3" value="{{info.e}}" ></td>
 </tr>
 
 <tr>
-<td align=left colspan="2"> 
-<button type='submit' value='refine'>Search again</button>
+<td align=left colspan="2">
+<button type='submit' value='refine' onclick='resetStart()'>Search again</button>
 </td></tr>
 </table>
 </form>

--- a/lmfdb/number_fields/templates/nf-search.html
+++ b/lmfdb/number_fields/templates/nf-search.html
@@ -5,8 +5,7 @@
 <h2> Further refine search </h2>
 
 <form id="re-search" onsubmit="cleanSubmit(this.id)">
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
@@ -66,7 +65,7 @@
 #}
 
 <tr> 
-<td class="button" align=left><button type='submit' value='refine'>Search again</button></td> 
+<td class="button" align=left><button type='submit' value='refine' onclick='resetStart()'>Search again</button></td> 
 </tr>
 </table>
 </form>

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from lmfdb.tests import LmfdbTest
 
 class NumberFieldTest(LmfdbTest):
@@ -22,7 +22,7 @@ class NumberFieldTest(LmfdbTest):
         assert '16T1535' in L.data
 
     def test_search_ramif_cl_deg(self):
-        L = self.tc.get('/NumberField/?start=0&paging=0&degree=5&signature=&galois_group=&class_number=&class_group=[2%2C2]&ur_primes=7&discriminant=&ram_quantifier=some&ram_primes=2%2C3%2C5&count=20')
+        L = self.tc.get('/NumberField/?degree=5&signature=&galois_group=&class_number=&class_group=[2%2C2]&ur_primes=7&discriminant=&ram_quantifier=some&ram_primes=2%2C3%2C5&count=20')
         assert '5.1.27000000000.8' in L.data
 
     def test_abelian_conductor(self):
@@ -46,7 +46,7 @@ class NumberFieldTest(LmfdbTest):
         assert '41' in L.data # minpoly
 
     def test_search_disc(self):
-        L = self.tc.get('/NumberField/?start=&paging=0&degree=&signature=&galois_group=&class_number=&class_group=&ur_primes=&discriminant=1988-2014&ram_quantifier=all&ram_primes=&count=')
+        L = self.tc.get('/NumberField/?degree=&signature=&galois_group=&class_number=&class_group=&ur_primes=&discriminant=1988-2014&ram_quantifier=all&ram_primes=&count=')
         assert '401' in L.data # factor of one of the discriminants
 
     def test_url_label(self):

--- a/lmfdb/rep_galois_modl/templates/rep_galois_modl-search.html
+++ b/lmfdb/rep_galois_modl/templates/rep_galois_modl-search.html
@@ -3,7 +3,7 @@
 
 <h2> Further refine search </h2>
 <form id='re-search'>
-<input type="hidden" name="start" value="{{info.start}}"/>
+{% include 'hidden_search_inputs.html' %}
 <table border="0">
 
 <tr>
@@ -34,9 +34,7 @@
 
 <tr>&nbsp;</tr>
 <tr>
-<td align=left colspan=2>Maximum number of integral rep_galois_modls to display</td>
-<td align=left><input type='text' name='count' value={{info.count}} size=10></td>
-<td><button type='submit' size=10  value='refine'>Search again</button></td>
+<td><button type='submit' size=10  value='refine' onclick='resetStart()'>Search again</button></td>
 </tr>
 </table>
 </form>

--- a/lmfdb/sato_tate_groups/templates/st_results.html
+++ b/lmfdb/sato_tate_groups/templates/st_results.html
@@ -4,8 +4,7 @@
 <h2>Refine search </h2>
 
 <form id='re-search' onsubmit='cleanSubmit(this.id)'>
-<input type="hidden" name="start" value="{{info.start}}"/>
-<input type="hidden" name="count" value="{{info.count}}"/>
+{% include 'hidden_search_inputs.html' %}
 
 <table>
 <td>{{ KNOWL('st_group.weight', title='weight') }}</td>
@@ -43,7 +42,7 @@
 </tr>
 
 <tr>
-<td class="button"><button type='submit' name='refine' value='1' style="width: 110px">Search again</button></td>
+<td class="button"><button type='submit' name='refine' value='1' style="width: 110px" onclick='resetStart()'>Search again</button></td>
 </tr>
 
 </table>

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -335,21 +335,15 @@ function decrease_start_by_count_and_submit_form(form_id) {
   startelem = $('input[name=start]');
   count = parseInt($('input[name=count]').val());
   newstart = parseInt(startelem.val())-count;
-  if(newstart<0) 
+  if(newstart<0)
     newstart = 0;
   startelem.val(newstart);
-  pagingelem = $('input[name=paging]');
-  if (typeof pagingelem != 'undefined')
-    pagingelem.val(1);
   $('form[id='+form_id+']').submit()
 };
 function increase_start_by_count_and_submit_form(form_id) {
   startelem = $('input[name=start]');
   count = parseInt($('input[name=count]').val());
   startelem.val(parseInt(startelem.val())+count);
-  pagingelem = $('input[name=paging]');
-  if (typeof pagingelem != 'undefined')
-    pagingelem.val(1);
   $('form[id='+form_id+']').submit()
 };
 

--- a/lmfdb/templates/hidden_search_inputs.html
+++ b/lmfdb/templates/hidden_search_inputs.html
@@ -1,4 +1,3 @@
 <input type="hidden" name="start" value="{{info.start}}"/>
 <input type="hidden" name="count" value="{{info.count}}"/>
-<input type="hidden" name="prevnext" value=""/>
 <input type="hidden" name="hst" value="{{info.search_type}}"/>

--- a/lmfdb/templates/hidden_search_inputs.html
+++ b/lmfdb/templates/hidden_search_inputs.html
@@ -1,0 +1,4 @@
+<input type="hidden" name="start" value="{{info.start}}"/>
+<input type="hidden" name="count" value="{{info.count}}"/>
+<input type="hidden" name="prevnext" value=""/>
+<input type="hidden" name="hst" value="{{info.search_type}}"/>

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -890,10 +890,4 @@ def parse_start(info, default=0):
             start += (1 - (start + 1) / count) * count
     except (KeyError, ValueError):
         start = default
-    try:
-        paging = int(info['paging'])
-        if paging == 0:
-            start = 0
-    except (KeyError, ValueError, TypeError):
-        pass
     return start


### PR DESCRIPTION
This PR makes a number of changes related to search results pages.

* It addresses #2771 by removing input boxes for changing the number of results per page (on results pages).
* It addresses #2641 by setting `start=0` whenever the Search Again button is pressed (actually, it's set to the empty string so that it's removed by the cleaner)
* It changes the behavior when a large value of start is entered into the URL: now the last page will be shown instead of an empty list of results.  To observe this behavior, go to a search result page and add `&start=1000000000`
* It encapsulates the hidden input boxes into a separate template so that they can be adjusted in the future.
* It cleans up malformatted HTML on various search result pages.
* It removes a `paging` mechanism that wasn't functional.