### PR TITLE
Hgm bracket changes

### DIFF
--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -281,7 +281,8 @@ def hgm_search(info, query):
     queryab = {}
     for param in ['A', 'B', 'A2', 'B2', 'A3', 'B3', 'A5', 'B5', 'A7', 'B7',
                   'Au2', 'Bu2', 'Au3', 'Bu3', 'Au5', 'Bu5', 'Au7', 'Bu7']:
-        parse_bracketed_posints(info, queryab, param, split=False,
+        parse_bracketed_posints(info, queryab, param, split=True, 
+                                keepbrackets=True,
                                 listprocess=lambda a: sorted(a, reverse=True))
     # Combine the parts of the query if there are A,B parts
     if queryab:
@@ -293,7 +294,7 @@ def hgm_search(info, query):
     # generic, irreducible not in DB yet
     parse_ints(info, query, 'degree')
     parse_ints(info, query, 'weight')
-    parse_bracketed_posints(info, query, 'famhodge', 'family Hodge vector',split=False)
+    parse_bracketed_posints(info, query, 'famhodge', 'family Hodge vector',split=True)
     parse_restricted(info, query, 'sign', allowed=['+1',1,-1], process=int)
     # Make a version to search reversed way
     if not family_search:

--- a/lmfdb/hypergm/templates/hgm-search.html
+++ b/lmfdb/hypergm/templates/hgm-search.html
@@ -136,15 +136,15 @@ $t$</td><td align=left> <input type="text" name="t" size="3" value="{{info.t}}" 
     </a> 
 {% endif %}
 </td>
-<td>$[{{hgm.A}}]$</td>
-<td>$[{{hgm.B}}]$</td>
+<td>${{hgm.A}}$</td>
+<td>${{hgm.B}}$</td>
 {% if not info.family %}
     <td>${{info.display_t(hgm.t)}}$</td>
     <td>${{info.factorint(hgm.cond)}}$</td>
 {% endif %}
 <td>${{hgm.degree}}$</td>
 <td>${{hgm.weight}}$</td>
-<td>$[{{hgm.famhodge}}]$</td>
+<td>${{hgm.famhodge}}$</td>
 </tr>
 
 {% endfor %}

--- a/lmfdb/hypergm/templates/hgm-show-family.html
+++ b/lmfdb/hypergm/templates/hgm-show-family.html
@@ -18,7 +18,7 @@
       <tr><td>{{KNOWL('hgm.degree', title="Degree")}}:<td>${{info.degree}}$
       <tr><td>{{KNOWL('hgm.weight', title="Weight")}}:<td>${{info.weight}}$
       <tr><td>{{KNOWL('hgm.type', title="Type")}}:<td>{{info.type}}
-      <tr><td>{{KNOWL('mot.hodgevector', title="Hodge vector")}}:<td>$[{{info.hodge}}]$
+      <tr><td>{{KNOWL('mot.hodgevector', title="Hodge vector")}}:<td>${{info.hodge}}$
       <tr><td>{{KNOWL('hgm.imprimitivity_index', title="Imprimitivity index")}}:<td>${{info.imprim}}$
       <tr><td>{{KNOWL('hgm.determinant', title="Motive determinant character")}}:<td>${{info.det}}$
       <tr><td>{{KNOWL('hgm.bezout_matrix', title="Bezout matrix")}}:<td>${{info.bezoutmat}}$

--- a/lmfdb/hypergm/templates/hgm-show-motive.html
+++ b/lmfdb/hypergm/templates/hgm-show-motive.html
@@ -7,8 +7,8 @@
 <p>
   <p>
     <table>
-      <tr><td> $A$: <td> $[{{ info.A }}]$ </td></tr>
-      <tr><td> $B$: <td> $[{{ info.B }}]$ </td></tr>
+      <tr><td> $A$: <td> ${{ info.A }}$ </td></tr>
+      <tr><td> $B$: <td> ${{ info.B }}$ </td></tr>
       <tr><td> $t$: <td> ${{ info.t }}$ </td></tr>
     </table>
 </p>

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -455,7 +455,7 @@ def parse_primes(inp, query, qfield, mode=None, radical=None):
     _parse_subset(primes, query, qfield, mode, radical, prod)
 
 @search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
-def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, check_divisibility=None, keepbrackets=False, extractor=None):
+def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, listprocess=None, check_divisibility=None, keepbrackets=False, extractor=None):
     if (not BRACKETED_POSINT_RE.match(inp) or
         (maxlength is not None and inp.count(',') > maxlength - 1) or
         (exactlength is not None and inp.count(',') != exactlength - 1) or
@@ -498,6 +498,8 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
                     raise ValueError("Each entry must divide the next, such as [2,4].")
         if process is not None:
             L = [process(a) for a in L]
+        if listprocess is not None:
+            L = listprocess(L)
         if extractor is not None:
             for qf, v in zip(qfield, extractor(L)):
                 if qf in query and query[qf] != v:


### PR DESCRIPTION
There were artifacts of the change over to postgres where lists of integers previously stored as strings such as '2,1' are now stored as jsonb [2,1].  This led to double brackets being displayed and problems parsing search boxes.  This fixes those issues.  This applies to A, B, and hodge vectors on pages for individual motives, for families, and for search result pages.