### PR TITLE
Add random objects to browse for HGMs

### DIFF
--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -459,6 +459,17 @@ def show_slopes(sl):
         return "None"
     return(sl)
 
+@hypergm_page.route("/random_family")
+def random_family():
+    label = db.hgm_families.random()
+    return redirect(url_for(".by_family_label", label= label))
+
+@hypergm_page.route("/random_motive")
+def random_motive():
+    label = db.hgm_motives.random()
+    s = label.split('_t')
+    return redirect(url_for(".by_label", label= s[0], t='t'+s[1]))
+
 @hypergm_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of Hypergeometric Motive Data over $\Q$'

--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -177,6 +177,12 @@ Families above are separated by type -- those with odd weight and
 even degree are symplectic, otherwise they are orthogonal.  Boxes
 are blank for combinations of weight and degree which cannot occur.
 
+<p>
+A <a href={{url_for('.random_family')}}>random family of hypergeometric motives</a> from the database.
+</p>
+<p>
+A <a href={{url_for('.random_motive')}}>random hypergeometric motive</a> from the database.
+</p>
 
 
     <h2>Find a specific HGM</h2>


### PR DESCRIPTION
On the index page for HGMs in the browse area, there are now lines for getting a random family and a random motive.