### PR TITLE
Split ors

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1867,7 +1867,10 @@ class PostgresTable(PostgresBase):
                         nres = min(total, self._count_cutoff)
 
         if not split_ors: # also handle the case len(queries) == 1
-            prelimit = max(limit, self._count_cutoff - offset) if nres is None else limit
+            if nres is None or limit is None:
+                prelimit = limit
+            else:
+                prelimit = max(limit, self._count_cutoff - offset)
             cur = run_one_query(query, prelimit, offset)
             if limit is None:
                 if info is not None:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1867,7 +1867,7 @@ class PostgresTable(PostgresBase):
                         nres = min(total, self._count_cutoff)
 
         if not split_ors: # also handle the case len(queries) == 1
-            if nres is None or limit is None:
+            if nres is not None or limit is None:
                 prelimit = limit
             else:
                 prelimit = max(limit, self._count_cutoff - offset)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -725,6 +725,7 @@ def number_field_jump(info):
              shortcuts={'natural':number_field_jump,
                         #'algebra':number_field_algebra,
                         'download':download_search},
+             split_ors=['galois_group'],
              bread=lambda:[('Global Number Fields', url_for(".number_field_render_webpage")),
                            ('Search Results', '.')],
              learnmore=learnmore_list)


### PR DESCRIPTION
Add the ability to split the `$or` clause of a query into multiple queries which are then combined and sorted in Python.  This speeds up searches for Galois groups because it causes Postgres to use the correct indexes.