### PR TITLE
Add default value of p for search

### DIFF
--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -300,10 +300,8 @@ def hgm_search(info, query):
         query['__table__'] = db.hgm_families
 
     queryab = {}
-    p = info['p']
+    p = info.get('p','2')
     for param in ['A', 'B']:
-#    , 'A2', 'B2', 'A3', 'B3', 'A5', 'B5', 'A7', 'B7',
-#                  'Au2', 'Bu2', 'Au3', 'Bu3', 'Au5', 'Bu5', 'Au7', 'Bu7']:
         parse_bracketed_posints(info, queryab, param, split=True, 
                                 keepbrackets=True,
                                 listprocess=lambda a: sorted(a, reverse=True))

--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -237,7 +237,7 @@ Enter values into one or more boxes to restrict the list of families returned.
   <td>Prime $p$
   <td>
     <select name="p">
-      <option value="2">2</option>
+      <option value="">2</option>
       <option value="3">3</option>
       <option value="5">5</option>
       <option value="7">7</option>

--- a/lmfdb/hypergm/templates/hgm-search.html
+++ b/lmfdb/hypergm/templates/hgm-search.html
@@ -49,10 +49,10 @@
 <td align=left>{{KNOWL('hgm.defining_parameter_primetoppart','$B^\perp_p$')}}
 </tr><tr>
 <td><select name="p">
-  <option "2" {{ "selected" if info.p == '2'}}>2</option>
-  <option "3" {{ "selected" if info.p == '3'}}>3</option>
-  <option "5" {{ "selected" if info.p == '5'}}>5</option>
-  <option "7" {{ "selected" if info.p == '7'}}>7</option>
+  <option value="" {{ "selected" if info.p == '2'}}>2</option>
+  <option value="3" {{ "selected" if info.p == '3'}}>3</option>
+  <option value="5" {{ "selected" if info.p == '5'}}>5</option>
+  <option value="7" {{ "selected" if info.p == '7'}}>7</option>
   </select>
 </td>
 <td><input type='text' name='Ap' size="8" value="{{info.Ap}}" example='[1,1,1,1]'></td>


### PR DESCRIPTION
This fixes a bug -- on the index page for HGM's,  if you click on a value in the table for families it gives an error.  This stems from a recent change where a prime p is expected as part of any search.  This pull request fixes that bug by making 2 the default prime.