### PR TITLE
HGM search buttons

### DIFF
--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -7,7 +7,6 @@
     tr.topline td, tr.topline th { border-top: 2px solid black; }
 </style>
 
-
 <div>
 A cusp-index of degree $d$ is a weakly increasing 
 list of positive integers $[u_1,\dots,u_k]$ with $\sum_{i=1}^k \phi(u_i) = d$. 
@@ -214,23 +213,23 @@ Enter values into one or more boxes to restrict the list of families returned.
 <table border=0 cellpadding=5>
 <tr>
 <td align=left> {{KNOWL('hgm.degree', title="Degree")}}
-  <td><input type='text' name='degree' size=10 example='4'> 
+  <td><input type='text' name='degree' size=10 example='4' class='family'> 
 <span class="formexample"> e.g. 4</span></td>
 <td align=left> {{KNOWL('hgm.weight', title="Weight")}}
-<td><input type='text' name='weight' size=10 example='3'> 
+<td><input type='text' name='weight' size=10 example='3' class='family'> 
   <span class="formexample"> e.g. 3 </span></td>
 
 
 <tr>
 <td align=left > {{KNOWL('hgm.familyhodgevector', title="Family Hodge vector")}}
-  <td><input type='text' name='famhodge' size=10 example='[1,1,1,1]'> 
+  <td><input type='text' name='famhodge' size=10 example='[1,1,1,1]' class='family'> 
 <span class="formexample"> e.g. [1,1,1,1]</span></td>
 
 <td align=left>{{KNOWL('hgm.defining_parameters', '$A$')}}
-  <td><input type='text' name='A' size=10 example='[3,2,2]'> 
+  <td><input type='text' name='A' size=10 example='[3,2,2]' class='family'> 
 <span class="formexample"> e.g. [3,2,2]</span></td>
 <td align=left>{{KNOWL('hgm.defining_parameters', '$B$')}}
-  <td><input type='text' name='B' size=10 example='[6,4]'> 
+  <td><input type='text' name='B' size=10 example='[6,4]' class='family'> 
 <span class="formexample"> e.g. [6,4] </span></td>
 
 <tr>
@@ -243,19 +242,19 @@ Enter values into one or more boxes to restrict the list of families returned.
       <option value="7">7</option>
     </select>
   <td align=left>{{KNOWL('hgm.defining_parameter_ppart','$A_p$')}}
-  <td><input type='text' name='Ap' size=10 example='[2,2,1,1]'>
+  <td><input type='text' name='Ap' size=10 example='[2,2,1,1]' class='family'>
       <span class="formexample"> e.g. [2,2,1,1]</span></td>
   <td align=left>{{KNOWL('hgm.defining_parameter_ppart','$B_p$')}}
-  <td><input type='text' name='Bp' size=10 example='[2,2,1,1]'>
+  <td><input type='text' name='Bp' size=10 example='[2,2,1,1]' class='family'>
       <span class="formexample"> e.g. [2,2,1,1]</span></td>
 </tr> <tr>
   <td></td>
   <td></td>
   <td align=left>{{KNOWL('hgm.defining_parameter_primetoppart','$A^\perp_p$')}}
-  <td><input type='text' name='Apperp' size=10 example='[2,2,1,1]'>
+  <td><input type='text' name='Apperp' size=10 example='[2,2,1,1]' class='family'>
       <span class="formexample"> e.g. [2,2,1,1]</span></td>
   <td align=left>{{KNOWL('hgm.defining_parameter_primetoppart','$B^\perp_p$')}}
-  <td><input type='text' name='Bpperp' size=10 example='[2,2,1,1]'>
+  <td><input type='text' name='Bpperp' size=10 example='[2,2,1,1]' class='family'>
       <span class="formexample"> e.g. [2,2,1,1]</span></td>
 </tr> <tr>
 </table>
@@ -308,9 +307,20 @@ list of corresponding hypergeometric motives.
           </tr>
   </table>
         <button type="submit" name="Submit" value="Search">Search for motives</button>
-        <button type="submit" name="Submit Family" value="Search Family">Search for families</button>
+        <button type="submit" id="family" name="Submit Family" value="Search Family">Search for families</button>
       </form>
 
+
+{# If the user hits enter while in a family input box, trigger
+   family search instead of motive search #}
+
+<script type="text/javascript">
+  $(".family").keyup(function(e) {
+      if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {
+          $("#family").click();
+      }
+});
+</script>
 
 
 


### PR DESCRIPTION
On the index page for HGMs, one can search for either families or for individual motives.  It was suggested that a user might edit the input box for families and then just hit return expecting the search result to be families, but they get search results for individual HGMs.  This changes that.

If you hit enter while the mouse is in an input box for families, you get a families search.  If you hit enter when the mouse is in an input box for individual motives, you get a individual motive search.  If you click a button, you get the result of whichever button you click on.