### PR TITLE
Add 1-dim Artin rep as link for Dirichlet characters

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -168,19 +168,18 @@ def render_artin_representation_webpage(label):
     nf_url = the_nf.url_for()
     if nf_url:
         friends.append(("Artin Field", nf_url))
-    if the_rep.determinant() is None:
-        cc = the_rep.central_character()
-        if cc is not None:
-            if the_rep.dimension()==1:
-                if cc.order == 2:
-                    cc_name = cc.symbol
-                else:
-                    cc_name = cc.texname
-                friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
+    cc = the_rep.determinant()
+    if cc is not None:
+        if the_rep.dimension()==1:
+            if cc.order == 2:
+                cc_name = cc.symbol
             else:
-                detrep = the_rep.central_character_as_artin_rep()
-                friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
-        add_lfunction_friends(friends,label)
+                cc_name = cc.texname
+            friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
+        else:
+            detrep = ArtinRepresentation(cc)
+            friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
+    add_lfunction_friends(friends,label)
 
     # once the L-functions are in the database, the link can always be shown
     #if the_rep.dimension() <= 6:

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -168,18 +168,19 @@ def render_artin_representation_webpage(label):
     nf_url = the_nf.url_for()
     if nf_url:
         friends.append(("Artin Field", nf_url))
-    cc = the_rep.central_character()
-    if cc is not None:
-        if the_rep.dimension()==1:
-            if cc.order == 2:
-                cc_name = cc.symbol
+    if the_rep.determinant() is None:
+        cc = the_rep.central_character()
+        if cc is not None:
+            if the_rep.dimension()==1:
+                if cc.order == 2:
+                    cc_name = cc.symbol
+                else:
+                    cc_name = cc.texname
+                friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
             else:
-                cc_name = cc.texname
-            friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
-        else:
-            detrep = the_rep.central_character_as_artin_rep()
-            friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
-    add_lfunction_friends(friends,label)
+                detrep = the_rep.central_character_as_artin_rep()
+                friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
+        add_lfunction_friends(friends,label)
 
     # once the L-functions are in the database, the link can always be shown
     #if the_rep.dimension() <= 6:

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -125,13 +125,23 @@ class ArtinRepresentation(object):
     def NFGal(self):
         return  map(int, self._data["NFGal"]);
 
+    # If the dimension is 1, we want the result as a webcharacter
+    # Otherwise, we want the label of it as an Artin rep.
+    # Mostly, this is pulled from the database, but we can fall back
+    # and compute it ourselves
     def determinant(self):
         if len(self._data['Dets'])>0:
             parts = self.label().split("c")
-            thischar = str(self._data['Dets'][int(parts[1])-1])
-            wc = WebSmallDirichletCharacter(modulus=wc[0], number=wc[1])
-        # If we don't have it, return None and the code will compute it
-        return None
+            thischar = str( self._data['Dets'][int(parts[1])-1] )
+            if self.dimension()==1:
+                wc = thischar.split(r'.')
+                self._data['central_character'] = WebSmallDirichletCharacter(modulus=wc[0], number=wc[1])
+                return self._data['central_character']
+            return(thischar)
+        # Not in the database
+        if self.dimension()==1:
+            return self.central_character()
+        return self.central_character_as_artin_rep()
 
     def conductor_equation(self):
         # Returns things of the type "1", "7", "49 = 7^{2}"

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -141,7 +141,7 @@ class ArtinRepresentation(object):
         # Not in the database
         if self.dimension()==1:
             return self.central_character()
-        return self.central_character_as_artin_rep()
+        return self.central_character_as_artin_rep().label()
 
     def conductor_equation(self):
         # Returns things of the type "1", "7", "49 = 7^{2}"

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -125,6 +125,14 @@ class ArtinRepresentation(object):
     def NFGal(self):
         return  map(int, self._data["NFGal"]);
 
+    def determinant(self):
+        if len(self._data['Dets'])>0:
+            parts = self.label().split("c")
+            thischar = str(self._data['Dets'][int(parts[1])-1])
+            wc = WebSmallDirichletCharacter(modulus=wc[0], number=wc[1])
+        # If we don't have it, return None and the code will compute it
+        return None
+
     def conductor_equation(self):
         # Returns things of the type "1", "7", "49 = 7^{2}"
         factors = self.factored_conductor()

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -778,7 +778,7 @@ class WebChar(WebCharObject):
 
         f = []
         cglink = url_character(type=self.type,number_field=self.nflabel,modulus=self.modlabel)
-        f.append( ("Character Group", cglink) )
+        f.append( ("Character group", cglink) )
         if self.nflabel:
             f.append( ('Number Field', '/NumberField/' + self.nflabel) )
         if self.type == 'Dirichlet' and self.chi.is_primitive() and self.conductor < 10000:
@@ -1140,7 +1140,7 @@ class WebDBDirichletCharacter(WebChar, WebDBDirichlet):
 
         friendlist = []
         cglink = url_character(type=self.type, modulus=self.modulus)
-        friendlist.append( ("Character Group", cglink) )
+        friendlist.append( ("Character group", cglink) )
         if self.type == "Dirichlet" and self.isprimitive == "Yes":
             url = url_character(
                 type=self.type,
@@ -1158,6 +1158,14 @@ class WebDBDirichletCharacter(WebChar, WebDBDirichlet):
             )
         if len(self.vflabel) > 0:
             friendlist.append( ("Value Field", '/NumberField/' + self.vflabel) )
+        label = "%s.%s"%(self.modulus, self.number)
+        myrep = db.artin_reps.lucky({'Dets': {'$contains': label}})
+        if not myrep is None:
+            j=myrep['Dets'].index(label)
+            artlabel = myrep['Baselabel']+'c'+str(j+1)
+            friendlist.append(('Artin representation '+artlabel,
+                url_for('artin_representations.render_artin_representation_webpage', label=artlabel)))
+
         return friendlist
 
     def symbol_numerator(self):


### PR DESCRIPTION
This finishes issue #1994 -- for a Dirichlet character home page, if we have the corresponding 1-dimensional Artin representation, we add it as a friend.

This relies on pre-computing the corresponding dirichlet characters and storing them in the database.  At the moment, not all data has been computed, but that causes no harm.  If someone hit a Dirichlet character where we had not done the precomputation on the Artin side, then it is not found and there is no link, but that is the current situation.

This also uses the precomputed central characters for the display of a page if they are found in the database.