### PR TITLE
EC/Q code updates

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -2,7 +2,7 @@
 from flask import url_for
 from lmfdb.utils import web_latex, encode_plot
 from lmfdb.elliptic_curves import ec_logger
-from lmfdb.elliptic_curves.web_ec import split_lmfdb_label, split_cremona_label
+from lmfdb.elliptic_curves.web_ec import split_lmfdb_label, split_cremona_label, OPTIMALITY_BOUND
 from lmfdb import db
 
 from sage.all import latex, matrix, PowerSeriesRing, QQ
@@ -62,7 +62,8 @@ class ECisog_class(object):
 
         # Set optimality flags.  The optimal curve is number 1 except
         # in one case which is labeled differently in the Cremona tables
-        self.optimality_known = (self.ncurves==1) or (self.conductor<60000)
+        self.optimality_known = (self.ncurves==1) or (self.conductor<OPTIMALITY_BOUND)
+        self.optimality_bound = OPTIMALITY_BOUND
         for c in self.curves:
             c['optimal'] = (c['number']==(3 if self.iso == '990h' else 1))
             c['ai'] = c['ainvs']

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -310,7 +310,7 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 	</table>
 
-	{% if not data.data.optimality_known %}<sup>*</sup>optimality has not been proved rigorously in all cases for conductors over 60000, but the Manin constant is correct where given{% endif %}
+	{% if not data.data.optimality_known %}<sup>*</sup>optimality has not been proved rigorously in all cases for conductors over {{ data.data.optimality_bound }}, but the Manin constant is correct where given{% endif %}
 	</p>
 
 	{#

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -44,7 +44,7 @@ text-align: center;
 {% endfor %}
 </table>
 
-{% if not info.optimality_known %}<sup>*</sup>optimality has not been proved rigorously for conductors over 60000{% endif %}
+{% if not info.optimality_known %}<sup>*</sup>optimality has not been proved rigorously for conductors over {{ info.optimality_bound }}{% endif %}
 <h2>{{KNOWL('ec.rank', title='Rank')}}</h2>
 {{ place_code('rank') }}
 <p>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -301,11 +301,19 @@ class WebEC(object):
         else:
             self.class_url = url_for(".by_double_iso_label", conductor=N, iso_label=iso)
             self.class_name = self.lmfdb_iso
+
         self.friends = [
             ('Isogeny class ' + self.class_name, self.class_url),
             ('Minimal quadratic twist %s %s' % (data['minq_info'], data['minq_label']), url_for(".by_triple_label", conductor=minq_N, iso_label=minq_iso, number=minq_number)),
-            ('All twists ', url_for(".rational_elliptic_curves", jinv=self.jinv)),
-            ('L-function', url_for("l_functions.l_function_ec_page", conductor_label = N, isogeny_class_label = iso))]
+            ('All twists ', url_for(".rational_elliptic_curves", jinv=self.jinv))]
+
+        lfun_url = url_for("l_functions.l_function_ec_page", conductor_label = N, isogeny_class_label = iso)
+        origin_url = lfun_url.lstrip('/L/').rstrip('/')
+
+        if db.lfunc_instances.exists({'url':origin_url}):
+            self.friends += [('L-function', lfun_url)]
+        else:
+            self.friends += [('L-function not available', "")]
 
         if not self.cm:
             if N<=300:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -448,7 +448,7 @@ class WebEC(object):
 
     def make_torsion_growth(self):
         try:
-            tor_gro = self.get(tor_gro)
+            tor_gro = self.tor_gro
         except AttributeError: # for curves with norsion growth data
             tor_gro = None
         if tor_gro is None:

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -100,7 +100,7 @@ The documents in the mongo collection 'curves' in the database 'elliptic_curves'
    - 'degree': (int) degree of modular parametrization, e.g. 1984
    - 'nonmax_primes': (list of ints) primes p for which the
       mod p Galois representation is not maximal, e.g. [5]
-   - 'nonmax_radd': (int) product of nonmax_primes
+   - 'nonmax_rad': (int) product of nonmax_primes
    - 'modp_images': (list of strings) Sutherland codes for the
       images of the mod p Galois representations for the primes in
       'nonmax_primes' e.g. ['5B']
@@ -1008,34 +1008,32 @@ def update_int_pts(filename, test=True, verbose=0, basepath=None):
 def swap2curves(iso, n1=1, n2=2, test=True):
     """Swaps the Cremona number part of the Cremona labels of two curves in isogeny class iso.
 
+    Here iso is the Cremona label of an isogeny class (no dot, no
+    final number).
+
     Example: swap2curves('235470bb') will swap curves '235470bb1' and
     '235470bb2'.  The only columns affected are 'label' and 'number'.
     This uses the fact that the columns 'lmfdb_label' (and
     'lmfdb_number') are unchanged.
+
     """
-    c1 = curves.lucky({'label':iso+str(n1)})
-    c2 = curves.lucky({'label':iso+str(n2)})
-    c1_lmfdb_label = c1['lmfdb_label']
-    c2_lmfdb_label = c2['lmfdb_label']
+    c1_old_label = iso+str(n1)
+    c2_old_label = iso+str(n2)
+    c1_lmfdb_label = curves.lucky({'label':c1_old_label}, projection='lmfdb_label')
+    c2_lmfdb_label = curves.lucky({'label':c2_old_label}, projection='lmfdb_label')
     print("Retrieved curves with LMFDB labels {} and {}".format(c1_lmfdb_label, c2_lmfdb_label))
-    print("Old (Cremona) labels for these: {} and {}".format(c1['label'], c2['label']))
-    c1_new_label = c2['label']
-    c2_new_label = c1['label']
-    c1_new_number = c2['number']
-    c2_new_number = c1['number']
-    c1['label'] = c1_new_label
-    c2['label'] = c2_new_label
-    c1['number'] = c1_new_number
-    c2['number'] = c2_new_number
-    print("New (Cremona) labels for these: {} and {}".format(c1_new_label, c2_new_label))
+    print("Old (Cremona) labels for these: {} and {}".format(c1_old_label, c2_old_label))
+    c1_new_data = {'label': c2_old_label, 'number': n2}
+    c2_new_data = {'label': c1_old_label, 'number': n1}
+    print("New (Cremona) labels for these: {} and {}".format(c2_old_label, c1_old_label))
 
     # Now do the updates:
-    
+
+    print("Changing data for {} using {}".format(c1_lmfdb_label, c1_new_data))
+    print("Changing data for {} using {}".format(c2_lmfdb_label, c2_new_data))
     if not test:
-        print("Replacing {}".format(c1['lmfdb_label']))
-        curves.upsert({'lmfdb_label':c1['lmfdb_label']},c1)
-        print("Replacing {}".format(c2['lmfdb_label']))
-        curves.upsert({'lmfdb_label':c2['lmfdb_label']},c2)
+        curves.upsert({'lmfdb_label':c1_lmfdb_label},c1_new_data)
+        curves.upsert({'lmfdb_label':c2_lmfdb_label},c2_new_data)
+        print("changes made")
     else:
         print("Taking no further action")
-        


### PR DESCRIPTION
Fairly minor updates in preparation for some data uploading.

   1. columns 'anlist' and 'aplist' now exist for all curves, not just #1 in each class, so in elliptic_curve/web_ec.py we do not need to fetch them separately for other curves.  For safety until new data is pushed to production the old behaviour is still there if needed.
   2. Optimality has now been proved for curve #1 in each class of conductor<250000 (was 60000).  All occurrences of 60000 have been replaced by a macro now set to 250000 for ease of later upgrading.
   3. No error is triggered for curves with no torsion growth data (which exists for N<400000 but not yet for the new data about to be uploaded).

Test by looking at curve and class pages for 60000<N<250000, e.g. http://localhost:37777/EllipticCurve/Q/100016p/  and any curve in that class (section Modular Invariants).

(+ some script updates not affecting the website)