### PR TITLE
Allow user to download data from a number field page in a usable form.

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -641,6 +641,11 @@ class WebNumberField:
             return 1
         return na_text()
 
+    def units_safe(self):  # fundamental units, if they are not too long
+        units = self.units()
+        if len(units) > 500:
+            return "Units are too long to display, but can be downloaded with other data for this field from 'Stored data to gp' link to the right"
+
     def units(self):  # fundamental units
         res = None
         if self.haskey('units'):


### PR DESCRIPTION
This fixes issue #3201 by not showing the fundamental units if they are too long.  Part of this is to offer the user the opportunity to download the data in a usable form.  This provides that in gp format.  Currently, we leave it to the user to do whatever modifications they need for some other systems.

This also fixes the following bug.  For a number field, such as the one listed in issue #3201, the links to download code for various systems did not work (and this fixes those links).