### PR TITLE
Fix issue 3234 - NF search fails on range starting with 0

### DIFF
--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -318,7 +318,8 @@ def parse_element_of(inp, query, qfield, split_interval=False, parse_singleton=i
 # Parses signed ints as an int and a sign the fields these are stored are passed in as qfield = (sign_field, abs_field)
 @search_parser(clean_info=True, prep_ranges=True) # see SearchParser.__call__ for actual arguments when calling
 def parse_signed_ints(inp, query, qfield, parse_one=None):
-    if parse_one is None: parse_one = lambda x: (int(x.sign()), int(x.abs()))
+    if parse_one is None: 
+        parse_one = lambda x: (int(x.sign()), int(x.abs())) if x != 0 else (1,0)
     sign_field, abs_field = qfield
     if SIGNED_LIST_RE.match(inp):
         parsed = parse_range3(inp, split0 = True)


### PR DESCRIPTION
To test, search for quadratic fields with discriminant range 0..30, and variations of that.  Currently it produces no results, but with this change, it gives the same result as 1..30, as it should.

The source was that the sign of the sage integer 0 is 0, so we work around that.