### PR TITLE
Add home page for Galois orbit of Artin representations

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -17,6 +17,7 @@ from lmfdb.artin_representations import artin_representations_page
 from lmfdb.artin_representations.math_classes import ArtinRepresentation
 
 LABEL_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+c\d+$')
+ORBIT_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+$')
 
 
 # Utility for permutations
@@ -45,6 +46,13 @@ def make_cond_key(D):
     if D1<1: D1=ZZ(1)
     D1 = int(D1.log(10))
     return '%04d%s'%(D1,str(D))
+
+def parse_artin_orbit_label(label):
+    label = clean_input(label)
+    if ORBIT_RE.match(label):
+        return label
+    else:
+        raise ValueError
 
 def parse_artin_label(label):
     label = clean_input(label)
@@ -133,23 +141,41 @@ def render_artin_representation_webpage(label):
     clean_label = clean_input(label)
     if clean_label != label:
         return redirect(url_for('.render_artin_representation_webpage', label=clean_label), 301)
-    try:
-        the_rep = ArtinRepresentation(label)
-    except:
+    # We could have a single representation or a Galois orbit
+    case = 'rep' if ('c' in clean_label) else 'orbit'
+    # Do this twice to customize error messages
+    if case == 'rep':
         try:
-            newlabel = parse_artin_label(label)
-            flash_error("Artin representation %s is not in database", newlabel)
-            return redirect(url_for(".index"))
-        except ValueError:
-            flash_error("%s is not in a valid form for an Artin representation label", label)
-            return redirect(url_for(".index"))
+            the_rep = ArtinRepresentation(label)
+        except:
+            try:
+                newlabel = parse_artin_label(label)
+                flash_error("Artin representation %s is not in database", newlabel)
+                return redirect(url_for(".index"))
+            except ValueError:
+                flash_error("%s is not in a valid form for an Artin representation label", label)
+                return redirect(url_for(".index"))
+    else: # it is an orbit
+        try:
+            the_rep = ArtinRepresentation(label+'c1')
+        except:
+            try:
+                newlabel = parse_artin_orbit_label(label)
+                flash_error("Galois orbit of Artin representations %s is not in database", newlabel)
+                return redirect(url_for(".index"))
+            except ValueError:
+                flash_error("%s is not in a valid form for the label of a Galois orbit of Artin representations", label)
+                return redirect(url_for(".index"))
+        # in this case we want all characters
+        num_conj = the_rep.galois_conjugacy_size()
+        allchars = [ ArtinRepresentation(label+'c'+str(j)).character_formatted() for j in range(1,num_conj+1)]
 
-    extra_data = {} # for testing?
-    extra_data['galois_knowl'] = group_display_knowl(5,3) # for testing?
     #artin_logger.info("Found %s" % (the_rep._data))
 
-
-    title = "Artin Representation %s" % label
+    if case=='rep':
+        title = "Artin representation %s" % label
+    else:
+        title = "Galois orbit of Artin representations %s" % label
     the_nf = the_rep.number_field_galois_group()
     if the_rep.sign() == 0:
         processed_root_number = "not computed"
@@ -158,49 +184,61 @@ def render_artin_representation_webpage(label):
     properties = [("Label", label),
                   ("Dimension", str(the_rep.dimension())),
                   ("Group", the_rep.group()),
-                  ("Conductor", "$" + the_rep.factored_conductor_latex() + "$"),
-                  #("Bad primes", str(the_rep.bad_primes())),
-                  ("Root number", processed_root_number),
-                  ("Frobenius-Schur indicator", str(the_rep.indicator()))
-                  ]
+                  ("Conductor", "$" + the_rep.factored_conductor_latex() + "$")]
+    if case == 'rep':
+        properties.append( ("Root number", processed_root_number) )
+    properties.append( ("Frobenius-Schur indicator", str(the_rep.indicator())) )
 
     friends = []
     nf_url = the_nf.url_for()
     if nf_url:
         friends.append(("Artin Field", nf_url))
-    cc = the_rep.central_character()
-    if cc is not None:
-        if the_rep.dimension()==1:
-            if cc.order == 2:
-                cc_name = cc.symbol
+    if case == 'rep':
+        cc = the_rep.central_character()
+        if cc is not None:
+            if the_rep.dimension()==1:
+                if cc.order == 2:
+                    cc_name = cc.symbol
+                else:
+                    cc_name = cc.texname
+                friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
             else:
-                cc_name = cc.texname
-            friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
-        else:
-            detrep = the_rep.central_character_as_artin_rep()
-            friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
-    add_lfunction_friends(friends,label)
+                detrep = the_rep.central_character_as_artin_rep()
+                friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
+        add_lfunction_friends(friends,label)
 
-    # once the L-functions are in the database, the link can always be shown
-    #if the_rep.dimension() <= 6:
-    if the_rep.dimension() == 1:
-        # Zeta is loaded differently
-        if cc.modulus == 1 and cc.number == 1:
-            friends.append(("L-function", url_for("l_functions.l_function_dirichlet_page", modulus=cc.modulus, number=cc.number)))
-        else:
-            # looking for Lhash dirichlet_L_modulus.number
-            mylhash = 'dirichlet_L_%d.%d'%(cc.modulus,cc.number)
-            lres = db.lfunc_instances.lucky({'Lhash': mylhash})
-            if lres is not None:
+        # once the L-functions are in the database, the link can always be shown
+        #if the_rep.dimension() <= 6:
+        if the_rep.dimension() == 1:
+            # Zeta is loaded differently
+            if cc.modulus == 1 and cc.number == 1:
                 friends.append(("L-function", url_for("l_functions.l_function_dirichlet_page", modulus=cc.modulus, number=cc.number)))
+            else:
+                # looking for Lhash dirichlet_L_modulus.number
+                mylhash = 'dirichlet_L_%d.%d'%(cc.modulus,cc.number)
+                lres = db.lfunc_instances.lucky({'Lhash': mylhash})
+                if lres is not None:
+                    friends.append(("L-function", url_for("l_functions.l_function_dirichlet_page", modulus=cc.modulus, number=cc.number)))
 
-    # Dimension > 1
-    elif int(the_rep.conductor())**the_rep.dimension() <= 729000000000000:
-        friends.append(("L-function", url_for("l_functions.l_function_artin_page",
-                                          label=the_rep.label())))
-    info={}
+        # Dimension > 1
+        elif int(the_rep.conductor())**the_rep.dimension() <= 729000000000000:
+            friends.append(("L-function", url_for("l_functions.l_function_artin_page",
+                                              label=the_rep.label())))
+        orblabel = re.sub(r'c\d+$', '', label)
+        friends.append(("Galois orbit "+orblabel,
+            url_for(".render_artin_representation_webpage", label=orblabel)))
+    else:
+        for j in range(1,1+the_rep.galois_conjugacy_size()):
+            newlabel = label+'c'+str(j)
+            friends.append(("Artin representation "+newlabel,
+                url_for(".render_artin_representation_webpage", label=newlabel)))
 
-    return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, cycle_string=cycle_string, properties2=properties, extra_data=extra_data, info=info, learnmore=learnmore_list())
+    info={} # for testing
+
+    if case == 'rep':
+        return render_template("artin-representation-show.html", credit=tim_credit, support=support_credit, title=title, bread=bread, friends=friends, object=the_rep, cycle_string=cycle_string, properties2=properties, info=info, learnmore=learnmore_list())
+    # else we have an orbit
+    return render_template("artin-representation-galois-orbit.html", credit=tim_credit, support=support_credit, title=title, bread=bread, allchars=allchars, friends=friends, object=the_rep, cycle_string=cycle_string, properties2=properties, info=info, learnmore=learnmore_list())
 
 @artin_representations_page.route("/random")
 def random_representation():

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -12,7 +12,6 @@ from lmfdb.utils import (
     parse_primes, parse_restricted, parse_element_of, parse_galgrp,
     parse_ints, parse_container, parse_bool, clean_input, flash_error,
     search_wrap)
-from lmfdb.galois_groups.transitive_group import group_display_knowl
 from lmfdb.artin_representations import artin_representations_page
 from lmfdb.artin_representations.math_classes import ArtinRepresentation
 

--- a/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
+++ b/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
@@ -1,0 +1,116 @@
+{% extends "homepage.html" %}
+
+{% block content %}
+
+    <h2> Basic invariants</h2>
+    <table>
+        <tr><td>{{ KNOWL('artin.dimension', title='Dimension') }}:<td>${{ object.dimension() }}$ </tr>
+        <tr><td>{{ KNOWL('artin.gg_quotient', title='Group') }}:<td>{{ object.pretty_galois_knowl() | safe }}</td>
+        <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>${{ object.conductor_equation() }} $</tr>
+        <tr><td> {{ KNOWL('artin.number_field', title='Artin number field') }}: <td>Splitting field of
+                $f={{ object.number_field_galois_group().polynomial_latex()}}$ over $\Q$</tr>
+        <tr><td> Size of {{ KNOWL('artin.galois_orbit', title='Galois orbit') }}: <td> {{object.galois_conjugacy_size()}}
+        <tr><td> Smallest {{ KNOWL('artin.permutation_container', title='containing permutation representation') }}: <td> {{object.smallest_gal_t_format()|safe}}
+        <tr><td> {{ KNOWL('artin.parity', title='Parity') }}:<td> {{ object.parity()}} </tr>
+    </table>
+
+
+    
+    <h2> Galois action </h2>
+     
+    <h3>Roots of defining polynomial</h3>
+    {% if object.number_field_galois_group().computation_minimal_polynomial()|length > 2 %}
+    <div>
+    The roots of $f$ are computed in an extension of $\Q_{ {{object.number_field_galois_group().residue_characteristic()}} }$ to precision {{object.number_field_galois_group().computation_precision()}}.
+    </div>
+    <div>
+    Minimal polynomial of a generator $a$ of $K$ over $\mathbb{Q}_{ {{object.number_field_galois_group().residue_characteristic()}} }$: ${{object.number_field_galois_group().computation_minimal_polynomial_latex()}}$
+    </div>
+    {% else %}
+    The roots of $f$ are computed in $\Q_{ {{object.number_field_galois_group().residue_characteristic()}} }$ to precision {{object.number_field_galois_group().computation_precision()}}.
+    {% endif %}
+   <div>
+    Roots:
+    {#
+    <center>
+      <table class="ntdata">
+      <tbody>
+        {% for root in object.number_field_galois_group().computation_roots()%}
+          <tr> <td>$r_{{loop.index}}$</td><td>${{root.latex(letter="a")}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td></tr>
+        {% endfor %}
+        
+      </tbody>
+      </table>
+      </center>
+      #}
+      \[ \begin{aligned}
+        {% for root in object.number_field_galois_group().computation_roots()%}
+          r_{ {{loop.index}} } &= {{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right) \\
+        {% endfor %}
+        \end{aligned}\]
+    </div>
+    
+    <h3>Generators of the action on the roots 
+    {% if object.number_field_galois_group().degree() < 4  %}
+        ${% for i in range(1, object.number_field_galois_group().degree()+1) %}
+             r_{ {{i}} }{% if not loop.last %},  {% endif %}
+        {% endfor %}$
+    {% else %}
+        $r_1, \ldots, r_{ {{object.number_field_galois_group().degree()}} }$
+    {% endif %}
+</h3>
+    <div>
+    <center>
+    <table class="ntdata">
+        <thead>
+          <tr><td>Cycle notation</td>
+          </tr>
+        </thead>
+      <tbody>
+        {% for gen in object.number_field_galois_group().G_gens()%}
+        <tr> <td><center>${{cycle_string(gen)}}$</center></td></tr>
+        {% endfor %}
+      </tbody>
+      </table>
+    </center>
+    </div>
+    
+    <h3> Character values on conjugacy classes</h3>
+    <div> 
+      <center><table class="ntdata">
+      <thead><tr><td>Size</td><td>Order</td><td>Action on
+    {% if object.number_field_galois_group().degree() < 4  %}
+        ${% for i in range(1, object.number_field_galois_group().degree()+1) %}
+             r_{ {{i}} }{% if not loop.last %},  {% endif %}
+        {% endfor %}$
+    {% else %}
+        $r_1, \ldots, r_{ {{object.number_field_galois_group().degree()}} }$
+    {% endif %}</td><td colspan="{{object.galois_conjugacy_size()}}" align="center">Character values</td></tr>
+        <tr><td></td><td></td><td></td>
+        {% for blah in allchars %}
+        <td align="center">$c{{loop.index}}$</td>
+        {% endfor %}
+        </tr></thead>
+
+      <tbody>
+        {% for gen in object.number_field_galois_group().conjugacy_classes()%}
+        {% set outer_loop = loop.index %}
+            <tr {% if loop.index == object.number_field_galois_group().index_complex_conjugation()%}class="bluehighlight"{%endif%}> 
+                <td align="center">${{gen.size()}}$</td>
+                <td align="center">${{gen.order()}}$</td>
+                <td align="center">${{cycle_string(gen.representative())}}$</td>
+                {% for cvalue in allchars %}
+                    <td align="center">${{ cvalue[outer_loop - 1]}}$</td>
+                {% endfor %}
+                </tr>
+        {% endfor %}
+      </tbody>
+      </table>
+      </center>
+       The blue line marks the conjugacy class containing complex conjugation.
+    </div>
+ <div>
+   
+{% endblock %}
+
+


### PR DESCRIPTION
This adds a home page for a Galois orbit of Artin representations.  It is mainly a target for friend links.  For now, to get to it, start on an Artin representation home page and it is a friend.