### PR TITLE
If the conductor of an L-function is 1, don't show its conductor as 1=1

### DIFF
--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -125,7 +125,7 @@ class Lfunction(object):
 
         info['degree'] = int(self.degree)
         info['conductor'] = self.level
-        if not is_prime(int(self.level)):
+        if not is_prime(int(self.level)) and int(self.level)!=1:
             if self.level >= 10**8:
                 info['conductor'] = latex(self.level_factored)
             else:


### PR DESCRIPTION
This fixes issue #3006.  Just go to the page for the Riemann zeta-function.  The conductor is no longer shown as 1=1.  