### PR TITLE
Artin efficiency

### DIFF
--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -885,14 +885,8 @@ class NumberFieldGaloisGroup(object):
         try:
             return self._residue_field_degrees(p)
         except AttributeError:
-            # Try to make WebNumberField, but only helps if the field is in our database
-            wnf = self.wnf()
-            if wnf._data is None:
-                from lmfdb.number_fields.number_field import sage_residue_field_degrees_function
-                fn_with_pari_output = sage_residue_field_degrees_function(self.nfinit())
-            else:
-                from lmfdb.number_fields.number_field import residue_field_degrees_function
-                fn_with_pari_output = residue_field_degrees_function(wnf)
+            from lmfdb.number_fields.number_field import residue_field_degrees_function
+            fn_with_pari_output = residue_field_degrees_function(self.nfinit())
             self._residue_field_degrees = lambda p: map(Integer, fn_with_pari_output(p))
             # This function is better, becuase its output has entries in Integer
             return self._residue_field_degrees(p)

--- a/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
+++ b/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
@@ -31,6 +31,7 @@
     {% endif %}
    <div>
     Roots:
+     <center>
       <table>
         {% for root in object.number_field_galois_group().computation_roots()%}
         <tr>
@@ -39,6 +40,7 @@
           <td>${{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td>
         {% endfor %}
       </table>
+     </center>
    </div>
     
     <h3>Generators of the action on the roots 

--- a/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
+++ b/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
@@ -31,24 +31,15 @@
     {% endif %}
    <div>
     Roots:
-    {#
-    <center>
-      <table class="ntdata">
-      <tbody>
+      <table>
         {% for root in object.number_field_galois_group().computation_roots()%}
-          <tr> <td>$r_{{loop.index}}$</td><td>${{root.latex(letter="a")}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td></tr>
+        <tr>
+          <td> $r_{ {{loop.index}} }$</td>
+          <td> $=$ </td>
+          <td>${{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td>
         {% endfor %}
-        
-      </tbody>
       </table>
-      </center>
-      #}
-      \[ \begin{aligned}
-        {% for root in object.number_field_galois_group().computation_roots()%}
-          r_{ {{loop.index}} } &= {{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right) \\
-        {% endfor %}
-        \end{aligned}\]
-    </div>
+   </div>
     
     <h3>Generators of the action on the roots 
     {% if object.number_field_galois_group().degree() < 4  %}

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -40,13 +40,7 @@
     {% endif %}
    <div>
     Roots:
-      {#
-      \[ \begin{aligned}
-        {% for root in object.number_field_galois_group().computation_roots()%}
-          r_{ {{loop.index}} } &= {{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right) \\
-        {% endfor %}
-        \end{aligned}\]
-      #}
+      <center>
       <table>
         {% for root in object.number_field_galois_group().computation_roots()%}
         <tr>
@@ -55,6 +49,7 @@
           <td>${{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td>
         {% endfor %}
         </table>
+      </center>
     </div>
     
     <h3>Generators of the action on the roots 

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -40,18 +40,6 @@
     {% endif %}
    <div>
     Roots:
-    {#
-    <center>
-      <table class="ntdata">
-      <tbody>
-        {% for root in object.number_field_galois_group().computation_roots()%}
-          <tr> <td>$r_{{loop.index}}$</td><td>${{root.latex(letter="a")}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td></tr>
-        {% endfor %}
-        
-      </tbody>
-      </table>
-      </center>
-      #}
       {#
       \[ \begin{aligned}
         {% for root in object.number_field_galois_group().computation_roots()%}

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -52,11 +52,21 @@
       </table>
       </center>
       #}
+      {#
       \[ \begin{aligned}
         {% for root in object.number_field_galois_group().computation_roots()%}
           r_{ {{loop.index}} } &= {{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right) \\
         {% endfor %}
         \end{aligned}\]
+      #}
+      <table>
+        {% for root in object.number_field_galois_group().computation_roots()%}
+        <tr>
+          <td> $r_{ {{loop.index}} }$</td>
+          <td> $=$ </td>
+          <td>${{root}} +O\left({{object.number_field_galois_group().residue_characteristic()}}^{ {{object.number_field_galois_group().computation_precision()}} }\right)$</td>
+        {% endfor %}
+        </table>
     </div>
     
     <h3>Generators of the action on the roots 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -475,8 +475,8 @@ def render_field_webpage(args):
     if nf.degree() > 1:
         gpK = nf.gpK()
         rootof1coeff = gpK.nfrootsof1()
-        rootofunityorder = int(rootof1coeff[1])
-        rootof1coeff = rootof1coeff[2]
+        rootofunityorder = int(rootof1coeff[0])
+        rootof1coeff = rootof1coeff[1]
         rootofunity = web_latex(Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))) 
         rootofunity += ' (order $%d$)' % rootofunityorder
     else:
@@ -586,7 +586,7 @@ def render_field_webpage(args):
     try:
         info["tim_number_field"] = NumberFieldGaloisGroup(nf._data['coeffs'])
         arts = [z.label() for z in info["tim_number_field"].artin_representations()]
-        print arts
+        #print arts
         for ar in arts:
             info['friends'].append(('Artin representation '+str(ar), 
                 url_for("artin_representations.render_artin_representation_webpage", label=ar)))
@@ -761,40 +761,25 @@ def number_field_search(info, query):
     info['gg_display'] = group_pretty_and_nTj
 
 def residue_field_degrees_function(nf):
-    """ Given a WebNumberField, returns a function that has
+    """ Given the result of pari(nfinit(...)), returns a function that has
             input: a prime p
             output: the residue field degrees at the prime p
     """
-    k1 = nf.gpK()
     D = nf.disc()
-    return main_work(k1,D,'pari')
 
-def sage_residue_field_degrees_function(nf):
-    """ Version of above which takes a sage number field
-        Used by Artin representation code when the Artin field is not
-        in the database.
-        Changing it to take a pari number field
-    """
-    D = nf.disc()
-    return main_work(nf,D,'sage')
-
-def main_work(k1, D, typ):
-    # Difference for sage vs pari array indexing
-    ind = 3 if typ == 'sage' else 4
     def decomposition(p):
         if not ZZ(p).divides(D):
-            dec = k1.idealprimedec(p)
-            dec = [z[ind] for z in dec]
-            return dec
+            return [z[3] for z in nf.idealprimedec(p)]
         else:
             raise ValueError("Expecting a prime not dividing D")
+
     return decomposition
 
 # Compute Frobenius cycle types, returns string nicely presenting this
 
 
 def frobs(nf):
-    frob_at_p = residue_field_degrees_function(nf)
+    frob_at_p = residue_field_degrees_function(nf.gpK())
     D = nf.disc()
     ans = []
     seeram = False
@@ -849,10 +834,6 @@ def nf_download(**args):
 
 def nf_data(**args):
     label = args['nf']
-    print ""
-    print ""
-    print label
-    print ""
     nf = WebNumberField(label)
     data = '/* Data is in the following format\n'
     data += '   Note, if the class group has not been computed, it, the class number, the fundamental units, regulator and whether grh was assumed are all 0.\n'

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -773,9 +773,10 @@ def sage_residue_field_degrees_function(nf):
     """ Version of above which takes a sage number field
         Used by Artin representation code when the Artin field is not
         in the database.
+        Changing it to take a pari number field
     """
     D = nf.disc()
-    return main_work(pari(nf),D,'sage')
+    return main_work(nf,D,'sage')
 
 def main_work(k1, D, typ):
     # Difference for sage vs pari array indexing

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -5,7 +5,7 @@ import os, yaml
 from flask import url_for
 from sage.all import (
     gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap, RealField,
-    AbelianGroup, QQ, gp, NumberField, PolynomialRing, latex, pari, cached_function)
+    AbelianGroup, QQ, NumberField, PolynomialRing, latex, pari, cached_function)
 
 from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,
@@ -613,7 +613,7 @@ class WebNumberField:
             Qx = PolynomialRing(QQ,'x')
             # while [1] is a perfectly good basis for Z, gp seems to want []
             basis = [Qx(el.replace('a','x')) for el in self.zk()] if self.degree() > 1 else []
-            k1 = gp( "nfinit([%s,%s])" % (str(self.poly()),str(basis)) )
+            k1 = pari( "nfinit([%s,%s])" % (str(self.poly()),str(basis)) )
             self._data['gpK'] = k1
         return self._data['gpK']
 

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -76,7 +76,7 @@
             </span>
 -->
           <div class="undertopright">
-            <a href="{{ url_for('contact') }}" target=_blank">Feedback</a>
+            <a href="{{ url_for('contact') }}" target="_blank">Feedback</a>
               &middot;
             <a href="#" id="menutoggle">
             {%- if g.show_menu -%}


### PR DESCRIPTION
There were several places where Artin representations would compute the discriminant of the underlying number field which can hang inside sage as it tries to factor a big polynomial discriminant.  This removes all that problem.  In some places, we don't need the discriminant and can easily make a list of "bad" (i.e. ramified) primes or "hard" primes from data in the database.  Otherwise, we call nfinit from pari inside sage with a list of hard primes and pari will not need to factor the polynomial discriminant.

There was then a place where we did something like this, once with pari(...) and once with gp(...).  The results differ in how sage sees the indexing of list entries.  Now we just use pari(...) which simplified some code.

An example where the above problem happens is

  http://beta.lmfdb.org/ArtinRepresentation/2.2777e2.24t138.2c1

which times out (I think it would take a minimum of several days to succeed), but 

  http://beta.lmfdb.org/ArtinRepresentation/2.2777e2.24t138.2c1

will load.  (Note, this page also suffers from katex won't typeset long strings, but that's another fish to fry.)
