### PR TITLE
EC/Q: improved display of optimality and Manin constant data 

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -270,11 +270,20 @@ def elliptic_curve_search(info, query):
         mode = 'append'
     parse_primes(info, query, 'nonsurj_primes', name='non-maximal primes',
                  qfield='nonmax_primes',mode=mode, radical='nonmax_rad')
+    # The button which used to be labelled Optimal only no/yes"
+    # (default no) has been renamed "Curves per isogeny class all/one"
+    # (default one) but the only change in behavious is that we no
+    # longer treat class 990h (where the optial curve is #3 not #1) as
+    # special: the "one" option just restricts to curves whose
+    # 'number' is 1.
     if 'optimal' in info and info['optimal'] == 'on':
+        query.update({'number':1})
+
+        # Old behaviour was as follows:
         # For all isogeny classes except 990h the optimal curve is number 1, while for class 990h it is number 3.
         # So setting query['number'] = 1 is nearly correct, but fails on 990h3.
         # Instead, we use this more complicated query:
-        query.update({"$or":[{'iso':'990h', 'number':3}, {'iso':{'$ne':'990h'},'number':1}]})
+        # query.update({"$or":[{'iso':'990h', 'number':3}, {'iso':{'$ne':'990h'},'number':1}]})
 
     info['curve_url_LMFDB'] = lambda dbc: url_for(".by_triple_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1], number=dbc['lmfdb_number'])
     info['iso_url_LMFDB'] = lambda dbc: url_for(".by_double_iso_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1])

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -60,12 +60,16 @@ class ECisog_class(object):
         self.curves = [db.ec_curves.lucky({'iso':self.iso, number_key: i+1})
                           for i in range(ncurves)]
 
-        # Set optimality flags.  The optimal curve is number 1 except
-        # in one case which is labeled differently in the Cremona tables
-        self.optimality_known = (self.ncurves==1) or (self.conductor<OPTIMALITY_BOUND)
+        # Set optimality flags.  The optimal curve is conditionally
+        # number 1 except in one case which is labeled differently in
+        # the Cremona tables.  We know which curve is optimal iff the
+        # optimality code for curve #1 is 1 (except for class 990h).
+        self.optimality_known = (self.optimality==1) or (self.iso=='990h')
         self.optimality_bound = OPTIMALITY_BOUND
+        self.optimal_label = self.label if self.label_type == 'Cremona' else self.lmfdb_label
         for c in self.curves:
-            c['optimal'] = (c['number']==(3 if self.iso == '990h' else 1))
+            c['optimal'] = (c['optimality']!=0)
+            c['optimality_known'] = (c['optimality']<2)
             c['ai'] = c['ainvs']
             c['curve_url_lmfdb'] = url_for(".by_triple_label", conductor=N, iso_label=iso, number=c['lmfdb_number'])
             c['curve_url_cremona'] = url_for(".by_ec_label", label=c['label'])

--- a/lmfdb/elliptic_curves/t
+++ b/lmfdb/elliptic_curves/t
@@ -1,0 +1,26 @@
+Class of size 2, either curve may be optimal:
+
+http://localhost:37777/EllipticCurve/Q/300006b1/
+http://localhost:37777/EllipticCurve/Q/300006b2/
+
+3 curves in class, any of the first 3 may be optimal, the 4th is not.
+All Manin constants are conditional on the first curve being optimal:
+
+http://localhost:37777/EllipticCurve/Q/499992a1/
+http://localhost:37777/EllipticCurve/Q/499992a2/
+http://localhost:37777/EllipticCurve/Q/499992a3/
+http://localhost:37777/EllipticCurve/Q/499992a4/
+
+2 curves in class, N>260000 but we know which is optimal:
+
+http://localhost:37777/EllipticCurve/Q/300003a1/
+http://localhost:37777/EllipticCurve/Q/300003a2/
+
+2 curves in class, the second has Manin constant 2:
+
+http://localhost:37777/EllipticCurve/Q/104393a1/
+http://localhost:37777/EllipticCurve/Q/104393a2/
+
+The rogue class 990 where curve 99h3 is optial (LMFDB class label 990.i with 990.i3 optimal):
+
+http://localhost:37777/EllipticCurve/Q/990h/

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -301,16 +301,28 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.q.optimal', title='\( \Gamma_0(N) \)-optimal') }}:</td>
         <td>
-	  {% if data.data.Gamma0optimal %}yes{% else %}no{% endif %}{% if not data.data.optimality_known %}<sup>*</sup>{% endif %}
+	  {% if data.data.optimality_code==1 %}yes{% elif data.data.optimality_code==0 %}no{% else %}unknown<sup>*</sup> (one of {{ data.data.optimality_code }} curves in this isogeny class which might be optimal){% endif %}
         </td>
         </tr>
         <tr>
         <td>{{ KNOWL('ec.q.manin_constant', title='Manin constant') }}:</td>
-	<td>{% if data.data.Gamma0optimal %}1{% else %}not computed{% endif %}</td>
+	<td>{{ data.data.manin_constant }} {% if not data.data.manin_known %} (conditional<sup>*</sup>){% endif %}</td>
         </tr>
 	</table>
 
-	{% if not data.data.optimality_known %}<sup>*</sup>optimality has not been proved rigorously in all cases for conductors over {{ data.data.optimality_bound }}, but the Manin constant is correct where given{% endif %}
+	{% if not data.data.optimality_known or not data.data.manin_known %}
+	<sup>*</sup>
+
+	{% if not data.data.optimality_known %} The optimal curve in
+	each isogeny class has not been determined in all cases for
+	conductors over {{ data.data.optimality_bound }}.{% endif %}
+
+	{% if not data.data.manin_known %}
+	The Manin constant is correct provided that {% if
+	data.data.number ==1 %} this curve {% else %} curve {{
+	data.data.optimal_label }} {% endif %} is optimal.{% endif %}
+
+	{% endif %}
 	</p>
 
 	{#

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -149,15 +149,15 @@ Please enter a value or leave blank:
           <td>
           <span class="formexample"> e.g. 4 </span>
           </td>
-          <td>{{ KNOWL('ec.q.optimal',title="Optimal only") }}</td>
+          <td>{{ KNOWL('ec.isogeny_class',title="Curves per isogeny class") }}</td>
           <td>
              <select name='optimal', style="width: 155px">
     {% if optimal=='on' %}
-               <option value="">No</option>
-               <option value="on" selected="yes">Yes</option>
+               <option value="">all</option>
+               <option value="on" selected="yes">one</option>
     {% else %}
-               <option value="">No</option>
-               <option value="on">Yes</option>
+               <option value="">all</option>
+               <option value="on">one</option>
     {% endif %}
              </select>
           </td>

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -44,7 +44,12 @@ text-align: center;
 {% endfor %}
 </table>
 
-{% if not info.optimality_known %}<sup>*</sup>optimality has not been proved rigorously for conductors over {{ info.optimality_bound }}{% endif %}
+{% if not info.optimality_known %}<sup>*</sup>optimality has not been
+proved rigorously for conductors over {{ info.optimality_bound }}.  In
+this case the optimal curve is certainly one of the {{
+info.curves[0].optimality }} curves highlighted, and conditionally
+curve {{info.optimal_label}}.{% endif %}
+
 <h2>{{KNOWL('ec.rank', title='Rank')}}</h2>
 {{ place_code('rank') }}
 <p>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -52,7 +52,7 @@
 <td align=left>{{ KNOWL('ec.q.analytic_sha_order', title='Analytic order of &#1064;') }}</td>
 <td align=left>{{ KNOWL('ec.isogeny', title='Cyclic isogeny degree') }}</td>
 <td align=left>{{KNOWL('ec.maximal_galois_rep', title='Maximal primes')}}</td>
-<td align=left>{{ KNOWL('ec.q.optimal', title='Optimal only') }}</td>
+<td align=left>{{ KNOWL('ec.isogeny_class', title='Curves per isogeny class') }}</td>
 <td align=left colspan=2>{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}
 </td>
 </tr>
@@ -65,11 +65,11 @@
 <td align=left>
 <select name='optimal', style='width: 155px'>
 {% if info.optimal=='on' %}
-  <option value="">No</option>
-  <option selected value="on">Yes</option>
+  <option value="">all</option>
+  <option selected value="on">one</option>
 {% else %}
-  <option value="">No</option>
-  <option value="on">Yes</option>
+  <option value="">all</option>
+  <option value="on">one</option>
 {% endif %}
 </select>
 </td>

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -99,4 +99,4 @@ class HomePageTest(LmfdbTest):
                         '[1, -1, 0, -1575, 751869]')
 
         self.check_args("EllipticCurve/Q/?conductor=990&surj_quantifier=include&optimal=on",
-                        '990h3')
+                        '990h1')

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -14,7 +14,7 @@ from sage.all import EllipticCurve, latex, ZZ, QQ, prod, Factorization, PowerSer
 
 ROUSE_URL_PREFIX = "http://users.wfu.edu/rouseja/2adic/" # Needs to be changed whenever J. Rouse and D. Zureick-Brown move their data
 
-OPTIMALITY_BOUND = 260000 # optimality of curve no. 1 in class only proved in all cases for conductor less than this
+OPTIMALITY_BOUND = 270000 # optimality of curve no. 1 in class (except class 990h) only proved in all cases for conductor less than this
 
 cremona_label_regex = re.compile(r'(\d+)([a-z]+)(\d*)')
 lmfdb_label_regex = re.compile(r'(\d+)\.([a-z]+)(\d*)')
@@ -212,7 +212,6 @@ class WebEC(object):
             data['an'] = r['anlist']
             data['ap'] = r['aplist']
 
-        print(data['minq_label'])
         minq_N, minq_iso, minq_number = split_lmfdb_label(data['minq_label'])
 
         data['disc_factor'] = latex(Dfac)

--- a/scripts/elliptic_curves/hash.m
+++ b/scripts/elliptic_curves/hash.m
@@ -1,0 +1,1 @@
+/scratch/home/jcremona/CMFs/magma/hash.m

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -576,27 +576,25 @@ def opt_man(line):
 
     Input line fields:
 
-    label opt mc
+    N iso num ainvs opt mc
 
-    where label = full curve label, opt = (0 if not optimal, 1 if
-    optimal, n>1 if one of n possibly optimal curves in the isogeny
-    class), and mc = Manin constant *conditional* on curve #1 in the
-    lcass being the optimal one.
+    where opt = (0 if not optimal, 1 if optimal, n>1 if one of n
+    possibly optimal curves in the isogeny class), and mc = Manin
+    constant *conditional* on curve #1 in the lcass being the optimal
+    one.
 
     Sample input lines with comments added:
 
-    250002e1 1 1 # optimal, mc=1
-    250002f1 1 1 # optimal, mc=1
-    250002f2 0 1 # not optimal, mc=1
-    250002g1 3 1 #
-    250002g2 3 1 # 3 possible optimal curves in class g, mc=1 for all whichever is optimal
-    250002g3 3 1 #
-    250002g4 0 1 # not optimal, mc=1
-    250002h1 1 1 # optimal, mc=1
-    250002i1 2 1 #
-    250002i2 2 1 # 2 possible optimal curves in class i, mc=1 for all whichever is optimal
+    11 a 1 [0,-1,1,-10,-20] 1 1       # optimal, mc=1
+    11 a 2 [0,-1,1,-7820,-263580] 0 1 # not optimal, mc=1
+    11 a 3 [0,-1,1,0,0] 0 5           # not optimal, mc=5
+    499992 a 1 [0,-1,0,4481,148204] 3 1       # one of 3 possible optimal curves in class g, mc=1 for all whichever is optimal
+    499992 a 2 [0,-1,0,-29964,1526004] 3 1    # one of 3 possible optimal curves in class g, mc=1 for all whichever is optimal
+    499992 a 3 [0,-1,0,-446624,115024188] 3 1 # one of 3 possible optimal curves in class g, mc=1 for all whichever is optimal
+    499992 a 4 [0,-1,0,-164424,-24344100] 0 1 # not optimal, mc=1
     """
-    label, opt, mc = split(line)
+    N, iso, num, ainvs, opt, mc = split(line)
+    label = N+iso+num
     opt = int(opt)
     mc = int(mc)
     return label, {
@@ -700,7 +698,7 @@ def upload_to_db(base_path, min_N, max_N, insert=True, mode='test'):
     galreps_filename = 'galrep/galrep.%s-%s' % (min_N, max_N)
     twoadic_filename = '2adic/2adic.%s-%s' % (min_N, max_N)
     allisog_filename = 'allisog/allisog.%s-%s' % (min_N, max_N)
-    opt_man_filename = 'opt_man.%s-%s' % (min_N, max_N)
+    opt_man_filename = 'opt_man/opt_man.%s-%s' % (min_N, max_N)
     file_list = [allbsd_filename, allgens_filename, intpts_filename, alldegphi_filename, alllabels_filename, galreps_filename,twoadic_filename,allisog_filename,opt_man_filename]
     #    file_list = [twoadic_filename]
     #    file_list = [allgens_filename]
@@ -1210,20 +1208,12 @@ def add_an(e, verbose=False):
 
 def read_opt_man_data():
     opt_man_dict = {}
-    for N in range(25):
-        fname = "/scratch/home/jcremona/ecdata/tmanin.{}0000-{}9999".format(N,N)
+    for N in range(50):
+        fname = "/scratch/home/jcremona/ecdata/opt_man/opt_man.{}0000-{}9999".format(N,N)
         print("Reading from {}".format(fname))
         for line in open(fname):
-            N, iso, num, ai, mc = line.split()
+            N, iso, num, ainvs, opt, mc = line.split()
             label = N+iso+num
-            mc = int(mc)
-            opt = 1 if num=='1' else 0
-            opt_man_dict[label] = {'optimality': opt, 'manin_constant': mc}
-    for N in range(25,41):
-        fname = "/scratch/home/jcremona/ecdata/opt_man.{}0000-{}9999".format(N,N)
-        print("Reading from {}".format(fname))
-        for line in open(fname):
-            label, opt, mc = line.split()
             mc = int(mc)
             opt = int(opt)
             opt_man_dict[label] = {'optimality': opt, 'manin_constant': mc}


### PR DESCRIPTION
After new data upload, we can now display better information about optimality and Manin constants for elliptic curves over Q.  See Issue #3181 .

Cases to look at:

Class of size 2, either curve may be optimal:

http://localhost:37777/EllipticCurve/Q/300006b1/
http://localhost:37777/EllipticCurve/Q/300006b2/

3 curves in class, any of the first 3 may be optimal, the 4th is not.
All Manin constants are conditional on the first curve being optimal:

http://localhost:37777/EllipticCurve/Q/499992a1/
http://localhost:37777/EllipticCurve/Q/499992a2/
http://localhost:37777/EllipticCurve/Q/499992a3/
http://localhost:37777/EllipticCurve/Q/499992a4/

2 curves in class, N>260000 but we know which is optimal:

http://localhost:37777/EllipticCurve/Q/300003a1/
http://localhost:37777/EllipticCurve/Q/300003a2/

2 curves in class, the second has Manin constant 2:

http://localhost:37777/EllipticCurve/Q/104393a1/
http://localhost:37777/EllipticCurve/Q/104393a2/

The rogue class 990 where curve 99h3 is optial (LMFDB class label 990.i with 990.i3 optimal):

http://localhost:37777/EllipticCurve/Q/990h/

NB When I was testing this using test.sh I sometimes saw failures in the test of random curves suggesting that the 'min_quad_twist' column is sometimes invalid (it is a dictionary and the key 'label' is invalid).  I still would like this PR to be reviewed for its logic and how the display looks, but I also try to track down the data issue -- which has nothing to do with this PR.

Also, ignore the script code change.

