### PR TITLE
Restore fundamental units

### DIFF
--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -83,22 +83,22 @@ table.ntdata a {
           {{ place_code('unit_group') }}
 
           <table>
-            <tr><td>Rank:<td>&nbsp;&nbsp;<td>${{info.unit_rank}}$
+            <tr><td>{{ KNOWL('nf.rank', title='Rank')}}:<td>&nbsp;&nbsp;<td>${{info.unit_rank}}$
             <td>{{ place_code('unit_rank') }}</tr>
             <tr><td>Torsion generator:<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
             <td>{{ place_code('unit_torsion_gen') }}</tr>
 {% if info.unit_rank==1 %}
-            <tr><td>Fundamental unit:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
+            <tr><td>{{ KNOWL('nf.fundamental_units', title='Fundamental unit') }}:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
                 {{ info.grh_label|safe }}
               <td>{{ place_code('fundamental_units') }}
             </tr>
             {% endif %}
             {% if info.unit_rank>1 %}
-            <tr><td>Fundamental units:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
+            <tr><td>{{ KNOWL('nf.fundamental_units', title='Fundamental units') }}:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}
                 {{ info.grh_label|safe }}
             <td>{{ place_code('fundamental_units') }}</tr>
             {% endif %}
-            <tr><td>Regulator:<td>&nbsp;&nbsp;<td>{{info.regulator}}
+            <tr><td>{{ KNOWL('nf.regulator', title='Regulator') }}:<td>&nbsp;&nbsp;<td>{{info.regulator}}
           {{ info.grh_label|safe }}
             <td>{{ place_code('regulator') }}
            </tr>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -85,7 +85,7 @@ table.ntdata a {
           <table>
             <tr><td>{{ KNOWL('nf.rank', title='Rank')}}:<td>&nbsp;&nbsp;<td>${{info.unit_rank}}$
             <td>{{ place_code('unit_rank') }}</tr>
-            <tr><td>Torsion generator:<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
+            <tr><td>{{ KNOWL('nf.torsion', title='Torsion generator':<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
             <td>{{ place_code('unit_torsion_gen') }}</tr>
 {% if info.unit_rank==1 %}
             <tr><td>{{ KNOWL('nf.fundamental_units', title='Fundamental unit') }}:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -85,7 +85,7 @@ table.ntdata a {
           <table>
             <tr><td>{{ KNOWL('nf.rank', title='Rank')}}:<td>&nbsp;&nbsp;<td>${{info.unit_rank}}$
             <td>{{ place_code('unit_rank') }}</tr>
-            <tr><td>{{ KNOWL('nf.torsion', title='Torsion generator':<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
+            <tr><td>{{ KNOWL('nf.torsion', title='Torsion generator') }}:<td>&nbsp;&nbsp;<td>{{info.root_of_unity}}
             <td>{{ place_code('unit_torsion_gen') }}</tr>
 {% if info.unit_rank==1 %}
             <tr><td>{{ KNOWL('nf.fundamental_units', title='Fundamental unit') }}:<td>&nbsp;&nbsp;<td>{{info.fund_units|safe}}

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -103,3 +103,9 @@ class NumberFieldTest(LmfdbTest):
 
         L = self.tc.get('/NumberField/?start=0&degree=7&signature=%5B3%2C2%5D&count=100', follow_redirects=True)
         assert '7.3.1420409.1' in L.data
+
+    def test_fundamental_units(self):
+        L = self.tc.get('NumberField/2.2.10069.1/')
+        assert '43388173' in L.data
+        L = self.tc.get('NumberField/3.3.10004569.1')
+        assert '22153437467081345' in L.data

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -105,7 +105,7 @@ class NumberFieldTest(LmfdbTest):
         assert '7.3.1420409.1' in L.data
 
     def test_fundamental_units(self):
-        L = self.tc.get('NumberField/2.2.10069.1/')
+        L = self.tc.get('NumberField/2.2.10069.1')
         assert '43388173' in L.data
         L = self.tc.get('NumberField/3.3.10004569.1')
         assert '22153437467081345' in L.data

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -645,6 +645,7 @@ class WebNumberField:
         units = self.units()
         if len(units) > 500:
             return "Units are too long to display, but can be downloaded with other data for this field from 'Stored data to gp' link to the right"
+        return units
 
     def units(self):  # fundamental units
         res = None


### PR DESCRIPTION
This PR fixes a recently introduced bug that was preventing fundamental units from being displayed on number field home pages due to a missing return statement in the recently added units_safe function.  

Before: http://www.lmfdb.org/NumberField/3.3.10004569.1
After: http://127.0.0.1:37777/NumberField/3.3.10004569.1

This PR also includes a test for fundamental units that will catch this kind of error in the future.

