### PR TITLE
Change display of class group for number fields

### DIFF
--- a/lmfdb/number_fields/templates/nf-index.html
+++ b/lmfdb/number_fields/templates/nf-index.html
@@ -101,7 +101,7 @@ A <a href={{url_for('.random_nfglobal')}}>random global number field</a> from th
   <td><input type='text' name='class_number' size=10 example='5'>
 <span class="formexample"> e.g. 5</span></td>
 <td>
-<td align=left>{{KNOWL('nf.ideal_class_group', title = 'Class group strucutre')}}
+<td align=left>{{KNOWL('nf.ideal_class_group', title = 'Class group structure')}}
   <td><input type='text' name='class_group' size=10 example='[2,4]'>
 <span class="formexample"> e.g. [ ], [3], or [2,4]</span></td>
 </tr>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -5,7 +5,7 @@ import os, yaml
 from flask import url_for
 from sage.all import (
     gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap, RealField,
-    AbelianGroup, QQ, NumberField, PolynomialRing, latex, pari, cached_function)
+    QQ, NumberField, PolynomialRing, latex, pari, cached_function)
 
 from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -682,7 +682,6 @@ class WebNumberField:
         cg_list = self._data['class_group']
         if cg_list == []:
             return 'Trivial'
-        #return cg_list
         return '$%s$'%str(cg_list)
 
     def class_group_invariants_raw(self):
@@ -693,7 +692,11 @@ class WebNumberField:
     def class_group(self):
         if self.haskey('class_group'):
             cg_list = self._data['class_group']
-            return str(AbelianGroup(cg_list)) + ', order ' + self.class_number_latex()
+            if cg_list == []:
+                return 'Trivial group, which has order $1$'
+            cg_list = [r'C_{%s}'% z for z in cg_list]
+            cg_string = r'\times '.join(cg_list)
+            return '$%s$, which has order %s'%(cg_string, self.class_number_latex())
         return na_text()
 
     def class_number(self):


### PR DESCRIPTION
The way we display the class group of a number field has been bugging me for many years.  This gives it a standard typeset display.  It uses C_n for cyclic groups since it is a notation used elsewhere in the LMFDB, and the group is multiplicative, so it seems better than Z/nZ here.

Here are three variations:
One non-trivial factor
http://127.0.0.1:37777/NumberField/2.0.55.1
http://www.lmfdb.org/NumberField/2.0.55.1

Several factors
http://127.0.0.1:37777/NumberField/2.0.1140.1
http://www.lmfdb.org/NumberField/2.0.1140.1

Trivial group
http://127.0.0.1:37777/NumberField/25.1.87484106193162239109441451974421849.1
http://www.lmfdb.org/NumberField/25.1.87484106193162239109441451974421849.1

The last one also has the grh information, which is independent of this (it gets added elsewhere in the code)