### PR TITLE
EC/Q: trivial change in advance of a data upload for torsion growth data

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -471,8 +471,10 @@ class WebEC(object):
         for F, T in tor_gro.items():
             tg1 = {}
             tg1['bc'] = "Not in database"
-            if ":" in F:
-                F = F.replace(":",".")
+            # mongo did not allow "." in a dict key so we changed (e.g.) '3.1.44.1' to '3:1:44:1'
+            # Here we change it back (but this code also works in case the fields already use ".")
+            F = F.replace(":",".")
+            if "." in F:
                 field_data = nf_display_knowl(F, field_pretty(F))
                 deg = int(F.split(".")[0])
                 bcc = [x for x,y in zip(bcs, bcfs) if y==F]


### PR DESCRIPTION
This is rather trivial, only changing 2 lines.

There is a column 'tor_gro' in ec_curves which is a dict whose keys are either field labels or strings representing comma-separated ints defining a polynomial and hence a number field.  With mongo such strings used as keys were not allowed to contain dots (".") as field labels do, so field labels were stored with "." replaced by ":", and (in one of the lines being changed here) we changed back whle preparing an elliptic curve's web page for display.

I am working on uploading a lot more torsion growth data (as provided by Enrique Gonzalez Jimenez and Filip Naijman) giving all possible torsion growth in number fields of degree up to 23 (only conductors up to 400000 so far).  I would prefer to use normal field labels now.  With the proposed code change, old format data still works (see http://localhost:37777/EllipticCurve/Q/196080/x/1) but so will the new.

If someone knows that dicts in postgresql have any restrictions on what strings may be used as keys, please say.

This PR is independent of any others by me.