### PR TITLE
Fix part of issue 3283.

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -14,10 +14,10 @@
 <tr>
 <td align=left>{{ KNOWL('ec.q.conductor', title='Conductor') }}</td>
 <td align=left>{{ KNOWL('ec.q.j_invariant', title='j-invariant') }}</td>
-<td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} </td>
 <td align=left>{{ KNOWL('ec.rank', title='Rank') }}</td>
 <td align=left>{{ KNOWL('ec.torsion_order', title='Torsion order') }}</td>
 <td align=left>{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</td>
+<td align=left>{{ KNOWL('ec.complex_multiplication',title="CM") }} </td>
 </tr>
 
 <tr>


### PR DESCRIPTION
This addresses the second problem mentioned in issue #3283 where giving the conductor and rank causes the search to fail.  The problem was just that input boxes and labels were not aligned properly.