### PR TITLE
Polishing Galois group pages

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -86,7 +86,7 @@ def index():
     if len(request.args) != 0:
         return galois_group_search(request.args)
     info = {'count': 50}
-    info['degree_list'] = range(16)[2:]
+    info['degree_list'] = range(48)[2:]
     return render_template("gg-index.html", title="Galois Groups", bread=bread, info=info, credit=GG_credit, learnmore=learnmore_list())
 
 # For the search order-parsing

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -10,32 +10,41 @@
 
 
 <p>
-Browse by {{KNOWL('gg.degree', title='degree')}} $n$ :
+Browse by {{KNOWL('gg.degree', title='degree')}} $n$:
 {% for n in info.degree_list: %}
-   <a href="?n={{n}}">{{n}}</a>
+   <a href="?n={{n}}">{{n}}</a>{% if not loop.last %},{% endif %}
 {% endfor %}
 </p>
 
 <p>
 Browse by type:
-<a href="?parity=-1">Odd</a>
-<a href="?parity=1">Even</a>
-<a href="?cyc=True">Cyclic</a>
-<a href="?cyc=False">Non-cyclic</a>
-<a href="?solv=True">Solvable</a>
-<a href="?solv=False">Non-solvable</a>
-<a href="?prim=True">Primitive</a>
+<a href="?parity=-1">Odd</a>,
+<a href="?parity=1">Even</a>,
+<a href="?cyc=True">Cyclic</a>,
+<a href="?cyc=False">Non-cyclic</a>,
+<a href="?solv=True">Solvable</a>,
+<a href="?solv=False">Non-solvable</a>,
+<a href="?prim=True">Primitive</a>,
 <a href="?prim=False">Imprimitive</a>
 
 <p>
 Browse by abstract group:
-<a href="?gapid=[6,1]">$S_3$</a>
-<a href="?gapid=[8,3]">$D_4$</a>
-<a href="?gapid=[12,3]">$A_4$</a>
-<a href="?gapid=[24,12]">$S_4$</a>
-<a href="?gapid=[60,5]">$A_5$</a>
-<a href="?gapid=[120,34]">$S_5$</a>
-<a href="?gapid=[168,42]">$\GL(3,2)$</a>
+<a href="?gapid=[6,1]">$S_3$</a>,
+<a href="?gapid=[8,3]">$D_4$</a>,
+<a href="?gapid=[12,3]">$A_4$</a>,
+<a href="?gapid=[24,12]">$S_4$</a>,
+<a href="?gapid=[60,5]">$A_5$</a>,
+<a href="?gapid=[120,34]">$S_5$</a>,
+<a href="?gapid=[168,42]">$\GL(3,2)$</a>,
+<a href="?gapid=[360,118]">$A_6$</a>,
+<a href="?gapid=[504,156]">$\PSL(2,8)$</a>,
+<a href="?gapid=[660,13]">$\PSL(2,11)$</a>,
+<a href="?gapid=[1092,25]">$\PSL(2,13)$</a>,
+<a href="?solv=False&order=5616">$\PSL(3,3)$</a>,
+<a href="?solv=False&t=323%2C6815&order=6048">$\PSU(3,3)$</a>,
+<a href="?solv=False&t=993%2C12781%2C14345%2C666&order=25920">$\PSp(4,3)$</a>,
+<a href="?solv=False&n=11..22&order=7920">$M_{11}$</a>,
+<a href="?solv=False&n=12&order=95040">$M_{12}$</a>
 <p>
 
 <p>
@@ -105,7 +114,7 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
           </tr>
           <tr>
             <td>
-              {{KNOWL('gg.tnumber',title='$t$-number')}} 
+              {{KNOWL('gg.tnumber',title='$T$-number')}} 
             </td><td><input type="text" name="t" value="" placeholder="3" size=10></td>
 	    <td>
 	      <span class="formexample">e.g. 3 or 4,6 or 2..5 or 4,6..8</span>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -55,19 +55,23 @@ table.ntdata a {
 
 <tr>
 <td align=left> 
-{{KNOWL('gg.degree',title='Degree')}} <td align=left> <input type='text' name='n' size="5" value="{{info.n}}">
-</td>
+{{KNOWL('gg.degree',title='Degree')}} 
 
 <td align=left> 
-{{KNOWL('gg.tnumber',title='$t$-number')}} 
-<td align=left> <input type="text" name="t" size="5" value="{{info.t}}" ></td>
+{{KNOWL('gg.tnumber',title='$T$-number')}} 
 
 <td align=left> 
 {{KNOWL('group.order',title='Order')}} 
-<td align=left> <input type="text" name="order" size="5" value="{{info.order}}" ></td>
+
 <td align=left> 
 {{KNOWL('group.small_group_label',title='GAP id')}} 
-<td align=left><input type="text" name="gapid" size="5" value="{{info.gapid}}" ></td>
+
+<tr>
+<td align=left> <input type='text' name='n' size="5" placeholder="6" value="{{info.n}}">
+<td align=left> <input type="text" name="t" size="5" placeholder="2" value="{{info.t}}" ></td>
+<td align=left> <input type="text" name="order" size="5" placeholder="12" value="{{info.order}}" ></td>
+
+<td align=left><input type="text" name="gapid" size="5" placeholder="[6,3]" value="{{info.gapid}}" ></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Addressing issues brought up at the workshop.  All changes are on the index page or search results page for Galois groups.

In the browse section, separate items (like degrees) by commas
Add more interesting groups in the groups to browse by
The convention is that groups are nTt, to t = T-number (lower case for the value, but uppercase for the term T-number)

Also laid out research fields on the search results page in newer format and added placeholder entries.