### PR TITLE
Fix local field knowls

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -73,7 +73,7 @@ def local_field_data(label):
     ans += 'Extension of $\Q_{%s}$ defined by %s<br>'%(str(f['p']),web_latex(coeff_to_poly(f['coeffs'])))
     gt = f['gal']
     gn = f['n']
-    ans += 'Degree: %s<br>' % str(gt)
+    ans += 'Degree: %s<br>' % str(gn)
     ans += 'Ramification index $e$: %s<br>' % str(f['e'])
     ans += 'Residue field degree $f$: %s<br>' % str(f['f'])
     ans += 'Discriminant ideal:  $(p^{%s})$ <br>' % str(f['c'])


### PR DESCRIPTION
In the knowl for a local field, one of the pieces of data is the degree.  Currently, it shows the T-number of the Galois group and this fixes it so it shows the degree.  As an example:

  http://127.0.0.1:37777/LocalNumberField/2.8.8.7
  http://www.lmfdb.org/LocalNumberField/2.8.8.7

Look in the intermediate fields section for local field knowls, and then inside a knowl, for the line which gives the degree