### PR TITLE
Nilpotency

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -232,7 +232,8 @@ def render_group_webpage(args):
             data['pretty_name'] = pretty
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
-        if data['nilpotency'] < 0:
+        data['nilpotency'] = '$%s$' % data['nilpotency']
+        if data['nilpotency'] == '$-1$':
             data['nilpotency'] += ' (not nilpotent)'
 
         bread = get_bread([(label, ' ')])

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+#i -*- coding: utf-8 -*-
 # This Blueprint is about Galois Groups
 # Author: John Jones
 
@@ -232,6 +232,8 @@ def render_group_webpage(args):
             data['pretty_name'] = pretty
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
+        if data['nilpotency'] < 0:
+            data['nilpotency'] += ' (not nilpotent)'
 
         bread = get_bread([(label, ' ')])
         return render_template("gg-show-group.html", credit=GG_credit, title=title, bread=bread, info=data, properties2=prop2, friends=friends, KNOWL_ID="gg.%s"%data['label_raw'], learnmore=learnmore_list())

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -121,6 +121,7 @@ def galois_group_search(info, query):
     parse_ints(info,query,'n','degree')
     parse_ints(info,query,'t')
     parse_ints(info,query,'order')
+    parse_ints(info,query,'nilpotency')
     parse_bracketed_posints(info, query, qfield='gapidfull', split=False, exactlength=2, keepbrackets=True, name='GAP id', field='gapid')
     for param in ('cyc', 'solv', 'prim'):
         parse_bool(info, query, param, process=int, blank=['0','Any'])

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -138,6 +138,15 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 	    </td>
           </tr>
 
+          <tr>
+            <td>
+              {{KNOWL('group.nilpotent',title='Nilpotency class')}} 
+            </td><td><input type="text" name="nilpotency" value="" placeholder="1..100" size=10></td>
+	    <td>
+	      <span class="formexample">e.g. -1, or 1..3</span>
+	    </td>
+          </tr>
+
 
           <tr>
           <td> Results to display </td>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -66,12 +66,16 @@ table.ntdata a {
 <td align=left> 
 {{KNOWL('group.small_group_label',title='GAP id')}} 
 
+<td align=left> 
+{{KNOWL('group.nilpotent',title='Nilpotency')}} 
+
 <tr>
 <td align=left> <input type='text' name='n' size="5" placeholder="6" value="{{info.n}}">
 <td align=left> <input type="text" name="t" size="5" placeholder="2" value="{{info.t}}" ></td>
 <td align=left> <input type="text" name="order" size="5" placeholder="12" value="{{info.order}}" ></td>
 
 <td align=left><input type="text" name="gapid" size="5" placeholder="[6,3]" value="{{info.gapid}}" ></td>
+<td align=left><input type="text" name="nilpotency" size="5" placeholder="1..100" value="{{info.nilpotency}}" ></td>
 </tr>
 
 <tr>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -22,6 +22,7 @@ table.reptable td, table.reptable th {
       {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
+      <tr><td>{{KNOWL('gg.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotentcy}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>
       <tr><td>{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
     </table>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -22,7 +22,7 @@ table.reptable td, table.reptable th {
       {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
-      <tr><td>{{KNOWL('gg.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotentcy}}</tr>
+      <tr><td>{{KNOWL('gg.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>
       <tr><td>{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
     </table>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -22,7 +22,7 @@ table.reptable td, table.reptable th {
       {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
-      <tr><td>{{KNOWL('gg.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</tr>
+      <tr><td>{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>
       <tr><td>{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
     </table>


### PR DESCRIPTION
This fulfills a request to be able to search Galois groups based on whether or not they are nilpotent.  Rather than yes/no, we have computed the nilpotency class as an integer.  You can include it in searches (1 for abelian, -1 for not nilpotent, ...).

To see the display the value on a home page of a group, from 

  http://127.0.0.1:37777/GaloisGroup/?solv=True&n=8

you can click on Q_8 to see a group of class 2, and 8T37 for a group which is not nilpotent, in which case there is a little added message on the page.

There is an issue for copying data to the cloud before this goes to the main server.