### PR TITLE
Fix group nicknames knowl

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -770,7 +770,8 @@ aliases['D47'] = [(47,2)]
 for ky in aliases.keys():
     nt = aliases[ky][0]
     label = "%sT%s"% nt
-    aliases[ky] = [z[0] for z in db.gps_transitive.lookup(label)['siblings']]
+    aliases[ky] = [tuple(z[0]) for z in db.gps_transitive.lookup(label)['siblings']]
     if nt not in aliases[ky]:
         aliases[ky].append(nt)
+    aliases[ky].sort()
 


### PR DESCRIPTION
On the number field index page next to the box for entering a Galois group is a knowl which shows the list of Galois group nicknames.  It is dynamically generated, so this is a code issue.

  http://127.0.0.1:37777/knowledge/show/nf.galois_group.name
  http://beta.lmfdb.org/knowledge/show/nf.galois_group.name

On beta, some groups, like A6 have entries listed twice, and they are not sorted by degree.  It is not wrong as it is, but looks odd.  This fixes both issues.