### PR TITLE
Gsm link

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -15,6 +15,7 @@ from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.galois_groups.transitive_group import (
     group_display_knowl, group_display_inertia,
     group_pretty_and_nTj, small_group_data, WebGaloisGroup)
+from lmfdb.number_fields.web_number_field import formatfield
 
 import re
 
@@ -242,6 +243,7 @@ def render_field_webpage(args):
             gsm = 'Does not exist'
         else:
             gsm = web_latex(coeff_to_poly(gsm))
+            #gsm = formatfield(gsm)
 
 
         info.update({

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -3,7 +3,7 @@
 # Author: John Jones
 
 from flask import render_template, request, url_for, redirect
-from sage.all import PolynomialRing, QQ, RR
+from sage.all import PolynomialRing, QQ, RR, latex
 
 from lmfdb import db
 from lmfdb.app import app
@@ -15,7 +15,8 @@ from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.galois_groups.transitive_group import (
     group_display_knowl, group_display_inertia,
     group_pretty_and_nTj, small_group_data, WebGaloisGroup)
-from lmfdb.number_fields.web_number_field import formatfield
+from lmfdb.number_fields.web_number_field import (
+    WebNumberField, string2list, nf_display_knowl)
 
 import re
 
@@ -42,6 +43,14 @@ def display_poly(coeffs):
 
 def format_coeffs(coeffs):
     return pol_to_html(str(coeff_to_poly(coeffs)))
+
+def lf_formatfield(coef):
+    coef = string2list(coef)
+    thefield = WebNumberField.from_coeffs(coef)
+    thepoly = '$%s$' % latex(coeff_to_poly(coef))
+    if thefield._data is None:
+        return thepoly
+    return nf_display_knowl(thefield.get_label(),thepoly)
 
 def local_algebra_data(labels):
     labs = labels.split(',')
@@ -242,8 +251,7 @@ def render_field_webpage(args):
         elif gsm == [-1]:
             gsm = 'Does not exist'
         else:
-            gsm = web_latex(coeff_to_poly(gsm))
-            #gsm = formatfield(gsm)
+            gsm = lf_formatfield(','.join([str(b) for b in gsm]))
 
 
         info.update({

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -61,7 +61,7 @@
       <tr><td>{{ KNOWL('lf.tame_degree', title='Tame degree')}}:</td><td>${{info.t}}$</td></tr>
       <tr><td>{{ KNOWL('lf.wild_slopes', title='Wild slopes')}}:</td><td>{{info.slopes}}</td></tr>
       <tr><td>{{ KNOWL('lf.galois_mean_slope', title='Galois mean slope')}}:</td><td>${{info.gms}}$</td></tr>
-      <tr><td>{{KNOWL('lf.galois_splitting_model', title='Galois splitting model')}}:</td><td>{{info.gsm}}</td></tr>
+      <tr><td>{{KNOWL('lf.galois_splitting_model', title='Galois splitting model')}}:</td><td>{{info.gsm|safe}}</td></tr>
     </table>
   </p>
 


### PR DESCRIPTION
On the bottom of the home page of a local field is a Galois splitting model (if we have one).  This defines a global field, so it should be a number field knowl if we have the field.  This pull request does that.  One

http://127.0.0.1:37777/LocalNumberField/13.6.5.5
http://beta.lmfdb.org/LocalNumberField/13.6.5.5

the polynomial is such a knowl, but 

http://127.0.0.1:37777/LocalNumberField/5.15.15.6
http://beta.lmfdb.org/LocalNumberField/5.15.15.6


is a case where we do not have the field in the database, so it just prints the polynomial.
