### PR TITLE
Update Dirichlet character search error message

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -264,7 +264,11 @@ def render_Dirichletwebpage(modulus=None, number=None):
 
     number = label_to_number(modulus, number)
     if number == 0:
-        flash_error("the value %s is invalid. It should be a positive integer coprime to and no greater than the modulus %s.", args['number'], args['modulus'])
+        flash_error(
+            "the value %s is invalid. It should either be a positive integer "
+            "coprime to and no greater than the modulus %s, or a letter that "
+            "corresponds to a valid orbit index.", args['number'], args['modulus']
+        )
         return redirect(url_for(".render_Dirichletwebpage"))
     args['number'] = number
     webchar = make_webchar(args)

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -35,11 +35,11 @@
 </p>
 
 <h2> Find a specific  {{KNOWL('character.dirichlet', title="Dirichlet character") }} or {{KNOWL('character.dirichlet.group', title="Dirichlet character group") }}  by
-  {{KNOWL('character.dirichlet.conrey', title="label") }} or {{KNOWL('character.dirichlet.modulus', title="modulus") }} </h2>
+  {{KNOWL('character.dirichlet.conrey', title="label") }}, {{KNOWL('character.dirichlet.modulus', title="modulus") }}, or {{KNOWL('character.dirichlet.galois_orbit_label', title="orbit label") }} </h2>
 <form>
     <input type='text' name='label' size=10 value="{{args.label}}" placeholder="13.2" required>
     <button type='submit' name='lookup' value='1'> Find  </button>
-    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13.</span>
+    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit.</span>
 </form>
 
 <h2> Search for characters </h2>


### PR DESCRIPTION
As a result of previous Dirichlet character updates, the Dirichlet
character search-by-label-or-modulus search also allows searching by
Galois orbit label. This means that one could search for

- `13.2` (to get the character with Contry label 13.2),
- `13`   (to get the group of characters mod 13), or
- `13.f` (to get that particular Galois orbit).

I hadn't noticed this before. Prior to this commit, if you gave an
invalid orbit label, like 13.z, a flash message would instruct you to
replace z with a valid *integer* that's coprime to the modulus.

This commit updates the error message to include the possibility that
the user is searching by Galois orbit. It also states that one can
search by orbit label, and gives a knowl to the orbit label.

This commit resolves #3357.