### PR TITLE
Address issue #3303

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -473,7 +473,7 @@ def resolve_display(resolves):
         if j[0] != old_deg:
             if old_deg < 0:
                 ans += '<table><tr><th>'
-                ans += '|G/N|<th>Galois groups for stem field(s)'
+                ans += '|G/N|<th>Galois groups for <a title = "stem field(s)" knowl="nf.stem_field">stem field(s)</a>'
             else:
                 ans += '</td></tr>'
             old_deg = j[0]


### PR DESCRIPTION
This just makes the words "stem field(s)" a knowl link, as suggested in issue #3303 .  To test, look at a random Galois group page, such as

  http://beta.lmfdb.org/GaloisGroup/36T1119
  http://127.0.0.1:37777/GaloisGroup/36T1119

and look in the area of low degree resolvents, and the table header "Galois groups for stem field(s)"