### PR TITLE
EC/Q: fix for large a-invariants displaying an L

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -285,6 +285,7 @@ def elliptic_curve_search(info, query):
         # Instead, we use this more complicated query:
         # query.update({"$or":[{'iso':'990h', 'number':3}, {'iso':{'$ne':'990h'},'number':1}]})
 
+    info['curve_ainvs'] = lambda dbc: str([ZZ(ai) for ai in dbc['ainvs']])
     info['curve_url_LMFDB'] = lambda dbc: url_for(".by_triple_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1], number=dbc['lmfdb_number'])
     info['iso_url_LMFDB'] = lambda dbc: url_for(".by_double_iso_label", conductor=dbc['conductor'], iso_label=split_lmfdb_label(dbc['lmfdb_iso'])[1])
     info['curve_url_Cremona'] = lambda dbc: url_for(".by_ec_label", label=dbc['label'])

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -126,7 +126,7 @@ table td.params {
 <td class="center"><a href="{{info.curve_url_Cremona(curve)}}">{{curve.label}}</a></td>
 <td class="center"><a href="{{info.iso_url_LMFDB(curve)}}">{{curve.lmfdb_iso}}</a></td>
 <td class="center"><a href="{{info.iso_url_Cremona(curve)}}">{{curve.iso}}</a></td>
-<td class="params">{{curve.ainvs}}</td>
+<td class="params">{{info.curve_ainvs(curve)}}</td>
 <td class="center">{{curve.rank}}</td>
 <td class="center">{{curve.torsion}}</td>
 {% if info.surj_primes or info.nonsurj_primes %}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -14,7 +14,7 @@ from sage.all import EllipticCurve, latex, ZZ, QQ, prod, Factorization, PowerSer
 
 ROUSE_URL_PREFIX = "http://users.wfu.edu/rouseja/2adic/" # Needs to be changed whenever J. Rouse and D. Zureick-Brown move their data
 
-OPTIMALITY_BOUND = 270000 # optimality of curve no. 1 in class (except class 990h) only proved in all cases for conductor less than this
+OPTIMALITY_BOUND = 300000 # optimality of curve no. 1 in class (except class 990h) only proved in all cases for conductor less than this
 
 cremona_label_regex = re.compile(r'(\d+)([a-z]+)(\d*)')
 lmfdb_label_regex = re.compile(r'(\d+)\.([a-z]+)(\d*)')
@@ -93,18 +93,6 @@ def parse_points(s):
     """
     return [parse_point(P) for P in s]
 
-def parse_ainvs(ai):
-    r""" converts a-invariants as stored in the database to a list of ints.
-    This will work whether the data is stored as a list of strings
-    (the old way), e.g. ['0','0','0','0','1'] or as a single list
-    e.g. '[0,0,0,0,1]' with or without the brackets.
-    """
-    if '[' in ai: # strip the brackets
-        ai = ai[1:-1]
-    if ',' in ai: # it's a single string so split it on commas
-        ai = ai.split(',')
-    return [int(a) for a in ai]
-
 def EC_ainvs(E):
     """ Return the a-invariants of a Sage elliptic curve in the correct format for the database.
     """
@@ -172,7 +160,7 @@ class WebEC(object):
         # is still included.
 
         data = self.data = {}
-        data['ainvs'] = self.ainvs
+        data['ainvs'] = [ZZ(ai) for ai in self.ainvs]
         data['conductor'] = N = ZZ(self.conductor)
         data['j_invariant'] = QQ(str(self.jinv))
         data['j_inv_factor'] = latex(0)


### PR DESCRIPTION
This fixes the issue at #3366.  It also removes a redundant functoin, and increases the value of OPTIMALITY_BOUND (see #3181).

To test compare go to http://localhost:37777/EllipticCurve/Q/ and search for conductor 146370, then look at the bottom of the table.