### PR TITLE
Add searchers for API2

### DIFF
--- a/lmfdb/artin_representations/__init__.py
+++ b/lmfdb/artin_representations/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 artin_representations_page = Blueprint(
     "artin_representations", __name__, template_folder='templates', static_folder="static")
@@ -18,3 +19,10 @@ import main
 assert main # silence pyflakes
 
 app.register_blueprint(artin_representations_page, url_prefix="/ArtinRepresentation")
+
+register_search_function(
+    "artin_representations",
+    "Artin representations",
+    "Search over Artin representations",
+    auto_search = 'artin_reps'
+)

--- a/lmfdb/characters/__init__.py
+++ b/lmfdb/characters/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 characters_page = Blueprint("characters", __name__, template_folder='templates',
     static_folder="static")
@@ -16,3 +17,16 @@ import main
 assert main # silence pyflakes
 
 app.register_blueprint(characters_page, url_prefix="/Character")
+
+register_search_function(
+    "char_dirichlet_orbits",
+    "Orbits of Dirichlet characters",
+    "Search over orbits of Dirichlet characters",
+    auto_search = 'char_dir_orbits'
+)
+register_search_function(
+    "char_dirichlet_values",
+    "Individual Dirichlet characters",
+    "Search over individual Dirichlet characters",
+    auto_search = 'char_dir_values'
+)

--- a/lmfdb/ecnf/__init__.py
+++ b/lmfdb/ecnf/__init__.py
@@ -2,7 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
-from lmfdb.api2.searchers import register_singleton
+from lmfdb.api2.searchers import register_singleton, register_search_function
 import searchers
 
 ecnf_page = Blueprint("ecnf", __name__, template_folder='templates', static_folder="static")
@@ -18,5 +18,11 @@ assert main # to keep pyflakes quiet
 
 app.register_blueprint(ecnf_page, url_prefix="/EllipticCurve")
 
+register_search_function(
+    "elliptic_curves_nf",
+    "Elliptic Curves over Number Fields",
+    "Search over elliptic curves devined over number fields",
+    auto_search='ec_nfcurves'
+)
 register_singleton('EllipticCurve', 'ec_nfcurves',
     simple_search = searchers.ecnf_simple_label_search)

--- a/lmfdb/galois_groups/__init__.py
+++ b/lmfdb/galois_groups/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 galois_groups_page = Blueprint("galois_groups", __name__, template_folder='templates', static_folder="static")
 logger = make_logger(galois_groups_page)
@@ -15,3 +16,10 @@ import main
 assert main
 
 app.register_blueprint(galois_groups_page, url_prefix="/GaloisGroup")
+
+register_search_function(
+    "transitive_groups",
+    "Galois groups",
+    "Search over Galois groups",
+    auto_search = 'gps_transitive'
+)

--- a/lmfdb/genus2_curves/__init__.py
+++ b/lmfdb/genus2_curves/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 g2c_page = Blueprint("g2c", __name__, template_folder='templates',
         static_folder="static")
@@ -15,3 +16,16 @@ import main
 assert main # silence pyflakes
 
 app.register_blueprint(g2c_page, url_prefix="/Genus2Curve")
+
+register_search_function(
+    "genus_2_curves",
+    "Genus 2 curves over rationals",
+    "Search over genus 2 curves defined over rationals",
+    auto_search = 'g2c_curves'
+)
+register_search_function(
+    "genus_2_curve_ratpoints",
+    "Rational points on genus 2 curves over rationals",
+    "Search over genus 2 curve rational points",
+    auto_search = 'g2c_ratpts'
+)

--- a/lmfdb/higher_genus_w_automorphisms/__init__.py
+++ b/lmfdb/higher_genus_w_automorphisms/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 higher_genus_w_automorphisms_page = Blueprint("higher_genus_w_automorphisms",
                                        __name__, template_folder='templates',
@@ -18,4 +19,9 @@ assert main # silence pyflakes
 
 app.register_blueprint(higher_genus_w_automorphisms_page, url_prefix="/HigherGenus/C/Aut")
 
-
+register_search_function(
+    "group_actions_higher_genus_curves",
+    "Group actions on higher genus curves",
+    "Search over group actions on higher genus curves",
+    auto_search = 'hgcwa_passports'
+)

--- a/lmfdb/local_fields/__init__.py
+++ b/lmfdb/local_fields/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 local_fields_page = Blueprint("local_fields", __name__, template_folder='templates', static_folder="static")
 logger = make_logger(local_fields_page)
@@ -15,3 +16,10 @@ import main
 assert main
 
 app.register_blueprint(local_fields_page, url_prefix="/LocalNumberField")
+
+register_search_function(
+    "local_fields",
+    "Local number fields",
+    "Search over local number fields",
+    auto_search = 'lf_fields'
+)

--- a/lmfdb/number_fields/__init__.py
+++ b/lmfdb/number_fields/__init__.py
@@ -2,6 +2,7 @@
 from lmfdb.app import app
 from lmfdb.logger import make_logger
 from flask import Blueprint
+from lmfdb.api2.searchers import register_search_function
 
 nf_page = Blueprint("number_fields", __name__, template_folder='templates', static_folder="static")
 nf_logger = make_logger(nf_page)
@@ -14,3 +15,10 @@ import number_field
 assert number_field
 
 app.register_blueprint(nf_page, url_prefix="/NumberField")
+
+register_search_function(
+    "number_fields",
+    "Global number fields",
+    "Search over global number fields",
+    auto_search = 'nf_fields'
+)


### PR DESCRIPTION
This pull request essentially adds the on-main searchers of the LMFDB to API2.

## Example comparison between API1 and API2

Let me suggest a comparison between the old API and API2 to see what this pull request helps implement. 

### API2

Going to `/api2/description/searchers` returns the available API2 endpoints. Suppose we are interested in `char_dirichlet_orbits`. One can go to `/api2/description/char_dirichlet_orbits` to see the available keys and their meaning (as taken from the Inventory `/inventory`). I see that modulus is a key. Suppose we want to look at the orbits of modulus 7. One can go to `/api2/data/char_dirichlet_orbits?modulus=7`.

In practice the idea is for this to be mostly machine-readable as opposed to human-readable --- but the discoverability is a nice bonus.


### API1

One goes to `/api/` and sees **dir_orbits**, taking them to `http://localhost:37777/api/char_dir_orbits/`. After reading a few of the first 100 entries in the database, one can get a sense for the available keys. To use API1 to do the same modulus examination as before, one can go to`http://localhost:37777/api/char_dir_orbits/?modulus=i7`, where the `i` in the address means that the modulus is an integer. This sort of type-adding is necessary for the old API.

## Notes

In the original API, database collections that aren't on production, or are maybe even grayed on beta, are exposed. I did not match this.

Chris and Heather also added the ability to have "singleton" pages that reflect the data on the webpage for any individual object in the LMFDB. This is implemented for elliptic curves over Q, but no other collection. This takes a bit more work, and is also something that I haven't done.