### PR TITLE
Fixing display issues with L-function coefficients (issue #2863)

### DIFF
--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -91,9 +91,11 @@ def seriescoeff(coeff, index, seriescoefftype, seriestype, digits):
             if coeff == "I":
                 rp = 0
                 ip = 1
+                coeff = CDF(I)
             elif coeff == "-I":
                 rp = 0
                 ip = -1
+                coeff = CDF(-I)
             else:
                 coeff = string2number(coeff)
         if type(coeff) == complex:


### PR DESCRIPTION
This should hopefully fix the problem described in issue #2863. It is not entirely clear to me why the case "I" and "-I" are treated separately, but hopefully it should be fine now.