### PR TITLE
parsing list of rationals, not ranges

### DIFF
--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -22,7 +22,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'image_callback', 'encode_plot',
            'KeyedDefaultDict', 'make_tuple', 'range_formatter',
            'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_rational',
-           'parse_rats', 'parse_bracketed_posints', 'parse_bool',
+           'parse_rats', 'parse_range2rat', 'parse_bracketed_posints',
+           'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of',
            'parse_subset', 'parse_submultiset', 'parse_list',
            'parse_list_start', 'parse_string_start', 'parse_restricted',
@@ -63,6 +64,7 @@ from .utilities import (
 
 from .search_parsing import (
     parse_ints, parse_signed_ints, parse_floats, parse_rational, parse_rats,
+    parse_range2rat,
     parse_bracketed_posints, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_subset, parse_submultiset, parse_list,
     parse_list_start, parse_string_start, parse_restricted, parse_noop,

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -191,16 +191,16 @@ def parse_range2(arg, key, parse_singleton=int, parse_endpoint=None):
 
 # Like parse_range2, but to deal with strings which could be rational numbers
 # process is a function to apply to arguments after they have been parsed
-def parse_range2rat(arg, key, process):
+def parse_range2rat(arg, key, process, allow_range=True):
     if type(arg) == str:
         arg = arg.replace(' ', '')
     if QQ_DEC_RE.match(arg):
         return [key, process(arg)]
     if ',' in arg:
-        tmp = [parse_range2rat(a, key, process) for a in arg.split(',')]
+        tmp = [parse_range2rat(a, key, process, allow_range) for a in arg.split(',')]
         tmp = [{a[0]: a[1]} for a in tmp]
         return ['$or', tmp]
-    elif '-' in arg[1:]:
+    elif '-' in arg[1:] and allow_range:
         ix = arg.index('-', 1)
         start, end = arg[:ix], arg[ix + 1:]
         q = {}
@@ -259,6 +259,7 @@ def integer_options(arg, max_opts=None):
         else:
             ans.add(int(interval))
     return sorted(list(ans))
+
 
 def collapse_ors(parsed, query):
     # work around syntax for $or


### PR DESCRIPTION
Just adding the functionality of not allowing ranges when parsing rationals, and exposing `parse_range2rat`