### PR TITLE
Fix decomposition of permutation representations

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -5,7 +5,7 @@ import os, yaml
 from flask import url_for
 from sage.all import (
     gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap, RealField,
-    QQ, NumberField, PolynomialRing, latex, pari, cached_function)
+    QQ, NumberField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,
@@ -16,6 +16,7 @@ wnflog = make_logger("WNF")
 
 dir_group_size_bound = 10000
 dnc = 'data not computed'
+
 
 # Dictionary of field label: n for abs(disc(Q(zeta_n)))
 # Does all cyclotomic fields of degree n s.t. 2<n<24
@@ -782,7 +783,7 @@ class WebNumberField:
             # cc is list, each has methods group, size, order, representative
             ccreps = [x.representative() for x in cc]
             ccns = [int(x.size()) for x in cc]
-            ccreps = [x.cycle_string() for x in ccreps]
+            ccreps = [Permutation(x).cycle_string() for x in ccreps]
             ccgen = '['+','.join(ccreps)+']'
             ar = nfgg.artin_representations() # list of artin reps from db
             arfull = nfgg.artin_representations_full_characters() # list of artin reps from db


### PR DESCRIPTION
When the artin representation code was made more like the lmfdb, I introduced the following bug.  When looking at a number field page where we have Artin representations of the number field, we display them at the bottom.  This is supposed to include markers which show how (not irreducible) Artin representation for the given number field decomposes as a sum of irreducibles.  That information is currently missing.  The error happens inside a try/except, so it went unnoticed until now.  This fixes that bug.

For example, check the bottom of the page

  http://127.0.0.1:37777/NumberField/3.1.31.1
  http://beta.lmfdb.org/NumberField/3.1.31.1
