### PR TITLE
Rename _search_cols and _extra_cols, removing underscore

### DIFF
--- a/lmfdb/api2/utils.py
+++ b/lmfdb/api2/utils.py
@@ -229,7 +229,7 @@ def patch_up_old_inventory(data, table_name):
 
     table = db[table_name]
     result = {}
-    for el in table._search_cols:
+    for el in table.search_cols:
         try:
             result[el] = data[el]
         except KeyError:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1093,17 +1093,17 @@ class PostgresTable(PostgresBase):
         PostgresBase.__init__(self, search_table, db)
         self.col_type = {}
         self.has_id = False
-        self._search_cols = []
+        self.search_cols = []
         if has_extras:
             self.extra_table = search_table + "_extras"
-            self._extra_cols, self.col_type, _ = self._column_types(
+            self.extra_cols, self.col_type, _ = self._column_types(
                                                         self.extra_table,
                                                         data_types=data_types)
         else:
             self.extra_table = None
-            self._extra_cols = []
+            self.extra_cols = []
 
-        self._search_cols, extend_coltype, self.has_id = self._column_types(
+        self.search_cols, extend_coltype, self.has_id = self._column_types(
                                                         search_table,
                                                         data_types=data_types)
         self.col_type.update(extend_coltype)
@@ -1195,22 +1195,22 @@ class PostgresTable(PostgresBase):
         elif not projection:
             raise ValueError("You must specify at least one key.")
         if projection == 1:
-            return tuple(self._search_cols), ()
+            return tuple(self.search_cols), ()
         elif projection == 2:
-            return tuple(self._search_cols), tuple(self._extra_cols)
+            return tuple(self.search_cols), tuple(self.extra_cols)
         elif projection == 3:
-            return tuple(["id"] + self._search_cols), tuple(self._extra_cols)
+            return tuple(["id"] + self.search_cols), tuple(self.extra_cols)
         elif isinstance(projection, dict):
             projvals = set(bool(val) for val in projection.values())
             if len(projvals) > 1:
                 raise ValueError("You cannot both include and exclude.")
             including = projvals.pop()
             include_id = projection.pop("id", False)
-            for col in self._search_cols:
+            for col in self.search_cols:
                 if (col in projection) == including:
                     search_cols.append(col)
                 projection.pop(col, None)
-            for col in self._extra_cols:
+            for col in self.extra_cols:
                 if (col in projection) == including:
                     extra_cols.append(col)
                 projection.pop(col, None)
@@ -1222,9 +1222,9 @@ class PostgresTable(PostgresBase):
             include_id = False
             for col in projection:
                 colname = col.split('[',1)[0]
-                if colname in self._search_cols:
+                if colname in self.search_cols:
                     search_cols.append(col)
-                elif colname in self._extra_cols:
+                elif colname in self.extra_cols:
                     extra_cols.append(col)
                 elif col == 'id':
                     include_id = True
@@ -1463,7 +1463,7 @@ class PostgresTable(PostgresBase):
                         path = [SQL("[{0}]").format(Literal(p)) for p in path[1:]]
                 else:
                     path = None
-                if key != 'id' and key not in self._search_cols:
+                if key != 'id' and key not in self.search_cols:
                     raise ValueError("%s is not a column of %s"%(key, self.search_table))
                 # Have to determine whether key is jsonb before wrapping it in Identifier
                 col_type = self.col_type[key]
@@ -2363,7 +2363,7 @@ class PostgresTable(PostgresBase):
                 if key not in _valid_storage_params[type]:
                     raise ValueError("Invalid storage parameter %s"%key)
         for col in columns:
-            if col != "id" and col not in self._search_cols:
+            if col != "id" and col not in self.search_cols:
                 raise ValueError("%s not a column"%(col))
         if name is None:
             # Postgres has a maximum name length of 64 bytes
@@ -2611,11 +2611,11 @@ class PostgresTable(PostgresBase):
         for col in columns:
             if col == "id":
                 continue
-            if col in self._search_cols:
+            if col in self.search_cols:
                 if search is False:
                     raise ValueError("Cannot mix search and extra columns")
                 search = True
-            elif col in self._extra_cols:
+            elif col in self.extra_cols:
                 if search is True:
                     raise ValueError("Cannot mix search and extra columns")
                 search = False
@@ -2652,7 +2652,7 @@ class PostgresTable(PostgresBase):
         elif cur.rowcount == 0:
             raise ValueError("Constraint %s does not exist in meta_constraints"%(name,))
         type, columns, check_func = cur.fetchone()
-        search = (columns[0] in self._search_cols)
+        search = (columns[0] in self.search_cols)
         table = self.search_table + suffix if search else self.extra_table + suffix
         return type, columns, check_func, table
 
@@ -2789,12 +2789,12 @@ class PostgresTable(PostgresBase):
             ....:     return rec
             sage: db.artin_reps.rewrite(add_signs)
         """
-        search_cols = ["id"] + self._search_cols
+        search_cols = ["id"] + self.search_cols
         if self.extra_table is None:
             projection = search_cols
         else:
-            projection = search_cols + self._extra_cols
-            extra_cols = ["id"] + self._extra_cols
+            projection = search_cols + self.extra_cols
+            extra_cols = ["id"] + self.extra_cols
         # It would be nice to just use Postgres' COPY TO here, but it would then be hard
         # to give func access to the data to process. 
         # An alternative approach would be to use COPY TO and have func and filter both
@@ -2867,10 +2867,10 @@ class PostgresTable(PostgresBase):
                 raise ValueError("You must specify a column that is contained in the datafile and uniquely specifies each row")
         with open(datafile) as F:
             tables = [self.search_table]
-            columns = self._search_cols
+            columns = self.search_cols
             if self.extra_table is not None:
                 tables.append(self.extra_table)
-                columns.extend(self._extra_cols)
+                columns.extend(self.extra_cols)
             columns = self._check_header_lines(F, tables, set(columns), sep=sep, prohibit_missing=False)
             if columns[0] != label_col:
                 raise ValueError("%s must be the first column in the data file" % label_col)
@@ -2904,9 +2904,9 @@ class PostgresTable(PostgresBase):
                     Identifier(label_col))
                 self._execute(idadder)
             # don't include the label col
-            scols = [col for col in columns[1:] if col in self._search_cols]
+            scols = [col for col in columns[1:] if col in self.search_cols]
             if self.extra_table is not None:
-                ecols = [col for col in columns[1:] if col in self._extra_cols]
+                ecols = [col for col in columns[1:] if col in self.extra_cols]
             suffix = '' if inplace else '_tmp'
             stable = self.search_table + suffix
             etable = None if self.extra_table is None else self.extra_table + suffix
@@ -2983,7 +2983,7 @@ class PostgresTable(PostgresBase):
 
     def update(self, query, changes, resort=True, restat=True, commit=True):
         for col in changes:
-            if col in self._extra_cols:
+            if col in self.extra_cols:
                 # Have to find the ids using the query, then update....
                 raise NotImplementedError
         with DelayCommit(self, commit):
@@ -3037,20 +3037,20 @@ class PostgresTable(PostgresBase):
         if "id" in data:
             raise ValueError("Cannot set id")
         for col in query:
-            if col != "id" and col not in self._search_cols:
+            if col != "id" and col not in self.search_cols:
                 raise ValueError("%s is not a column of %s"%(col, self.search_table))
         if self.extra_table is None:
             search_data = dict(data)
             for col in data:
-                if col not in self._search_cols:
+                if col not in self.search_cols:
                     raise ValueError("%s is not a column of %s"%(col, self.search_table))
         else:
             search_data = {}
             extras_data = {}
             for col, val in data.items():
-                if col in self._search_cols:
+                if col in self.search_cols:
                     search_data[col] = val
-                elif col in self._extra_cols:
+                elif col in self.extra_cols:
                     extras_data[col] = val
                 else:
                     raise ValueError("%s is not a column of %s"%(col, self.search_table))
@@ -3141,8 +3141,8 @@ class PostgresTable(PostgresBase):
         if not data:
             raise ValueError("No data provided")
         if self.extra_table is not None:
-            search_cols = [col for col in self._search_cols if col in data[0]]
-            extra_cols = [col for col in self._extra_cols if col in data[0]]
+            search_cols = [col for col in self.search_cols if col in data[0]]
+            extra_cols = [col for col in self.extra_cols if col in data[0]]
             search_data = [{col: D[col] for col in search_cols} for D in data]
             extra_data = [{col: D[col] for col in extra_cols} for D in data]
         else:
@@ -3221,7 +3221,7 @@ class PostgresTable(PostgresBase):
                 now = time.time()
                 search_table, extra_table = self._identify_tables(search_table, extra_table)
                 newid = "newid"
-                while newid in self._search_cols or newid in self._extra_cols:
+                while newid in self.search_cols or newid in self.extra_cols:
                     newid += "_"
                 newid = Identifier(newid)
                 oldid = Identifier("id")
@@ -3269,7 +3269,7 @@ class PostgresTable(PostgresBase):
         INPUT:
 
         - ``F`` -- a writable open file handle, at the beginning of the file.
-        - ``cols`` -- a list of columns to write (either self._search_cols or self._extra_cols)
+        - ``cols`` -- a list of columns to write (either self.search_cols or self.extra_cols)
         - ``sep`` -- a string giving the column separator.  You should not use comma.
         """
         if cols and cols[0] != "id":
@@ -3373,8 +3373,8 @@ class PostgresTable(PostgresBase):
 
         tables = []
         counts = {}
-        tabledata = [(self.search_table, self._search_cols, True, searchfile),
-                     (self.extra_table, self._extra_cols, True, extrafile),
+        tabledata = [(self.search_table, self.search_cols, True, searchfile),
+                     (self.extra_table, self.extra_cols, True, extrafile),
                      (self.stats.counts, _counts_cols, False, countsfile),
                      (self.stats.stats, _stats_cols, False, statsfile)]
         addedid = None
@@ -3607,9 +3607,9 @@ class PostgresTable(PostgresBase):
             if reindex:
                 self.drop_indexes()
             now = time.time()
-            search_addid, search_count = self._copy_from(searchfile, self.search_table, self._search_cols, True, kwds)
+            search_addid, search_count = self._copy_from(searchfile, self.search_table, self.search_cols, True, kwds)
             if extrafile is not None:
-                extra_addid, extra_count = self._copy_from(extrafile, self.extra_table, self._extra_cols, True, kwds)
+                extra_addid, extra_count = self._copy_from(extrafile, self.extra_table, self.extra_cols, True, kwds)
                 if search_count != extra_count:
                     self.conn.rollback()
                     raise ValueError("Different number of rows in searchfile and extrafile")
@@ -3634,7 +3634,7 @@ class PostgresTable(PostgresBase):
         Efficiently copy data from the database to a file.
 
         The result will have one line per row of the table, tab separated and in order
-        given by self._search_cols and self._extra_cols.
+        given by self.search_cols and self.extra_cols.
 
         INPUT:
 
@@ -3653,8 +3653,8 @@ class PostgresTable(PostgresBase):
 
         tabledata = [
                 # tablename, cols, addid, write_header, filename
-                (self.search_table, self._search_cols, True, True, searchfile),
-                (self.extra_table, self._extra_cols, True, True, extrafile),
+                (self.search_table, self.search_cols, True, True, searchfile),
+                (self.extra_table, self.extra_cols, True, True, extrafile),
                 (self.stats.counts, _counts_cols, False, False, countsfile),
                 (self.stats.stats, _stats_cols, False, False, statsfile)
                 ]
@@ -3733,7 +3733,7 @@ class PostgresTable(PostgresBase):
         - ``label_col`` -- a search column of this table, or ``None``.
           If ``None``, the current label column will be cleared without a replacement.
         """
-        if not (label_col is None or label_col in self._search_cols):
+        if not (label_col is None or label_col in self.search_cols):
             raise ValueError("%s is not a search column" % label_col)
         modifier = SQL("UPDATE meta_tables SET label_col = %s WHERE name = %s")
         self._execute(modifier, [label_col, self.search_table])
@@ -3758,9 +3758,9 @@ class PostgresTable(PostgresBase):
         - ``label`` -- whether this column should be set as the label column for this table
           (used in the ``lookup`` method for example).
         """
-        if name in self._search_cols:
+        if name in self.search_cols:
             raise ValueError("%s already has column %s"%(self.search_table, name))
-        if name in self._extra_cols:
+        if name in self.extra_cols:
             raise ValueError("%s already has column %s"%(self.extra_table, name))
         if label and extra:
             raise ValueError("label must be a search column")
@@ -3780,9 +3780,9 @@ class PostgresTable(PostgresBase):
             modifier = SQL("ALTER TABLE {0} ADD COLUMN {1} %s"%datatype).format(Identifier(table), Identifier(name))
             self._execute(modifier)
             if extra and name != 'id':
-                self._extra_cols.append(name)
+                self.extra_cols.append(name)
             elif not extra and name != 'id':
-                self._search_cols.append(name)
+                self.search_cols.append(name)
             if label:
                 self.set_label(name)
             self.log_db_change("add_column", name=name, datatype=datatype)
@@ -3795,7 +3795,7 @@ class PostgresTable(PostgresBase):
         if name in self._sort_keys:
             raise ValueError("Sorting for %s depends on %s; change default sort order with set_sort() before dropping column"%(self.search_table, name))
         with DelayCommit(self, commit, silence=True):
-            if name in self._search_cols:
+            if name in self.search_cols:
                 table = self.search_table
                 counts_table = table + "_counts"
                 stats_table = table + "_stats"
@@ -3807,10 +3807,10 @@ class PostgresTable(PostgresBase):
                 self._execute(deleter, [jname])
                 deleter = SQL("DELETE FROM {0} WHERE cols @> %s OR constraint_cols @> %s").format(Identifier(stats_table))
                 self._execute(deleter, [jname, jname])
-                self._search_cols.remove(name)
-            elif name in self._extra_cols:
+                self.search_cols.remove(name)
+            elif name in self.extra_cols:
                 table = self.extra_table
-                self._extra_cols.remove(name)
+                self.extra_cols.remove(name)
             else:
                 raise ValueError("%s is not a column of %s"%(name, self.search_table))
             modifier = SQL("ALTER TABLE {0} DROP COLUMN {1}").format(Identifier(table), Identifier(name))
@@ -3863,7 +3863,7 @@ class PostgresTable(PostgresBase):
                     if not any(regexp.match(typ.lower()) for regexp in param_types_whitelist):
                         raise RuntimeError("%s is not a valid type"%(typ))
                 vars.append((col, typ))
-            self._extra_cols = []
+            self.extra_cols = []
             vars = SQL(", ").join(SQL("{0} %s"%typ).format(Identifier(col)) for col, typ in vars)
             creator = SQL("CREATE TABLE {0} ({1})").format(Identifier(self.extra_table), vars)
             self._execute(creator)
@@ -4534,7 +4534,7 @@ class PostgresStatsTable(PostgresBase):
         if col == "id":
             # We just use the count in this case
             return self.count()
-        if col not in self.table._search_cols:
+        if col not in self.table.search_cols:
             raise ValueError("%s not a column of %s"%(col, self.search_table))
         ccols, cvals = self._split_dict(constraint)
         m = self._quick_max(col, ccols, cvals)
@@ -5083,7 +5083,7 @@ class PostgresStatsTable(PostgresBase):
 
         - ``col`` -- a
         """
-        if col not in self.table._search_cols:
+        if col not in self.table.search_cols:
             raise ValueError("Column %s not a search column for %s"%(col, self.search_table))
         selecter = SQL("""SELECT v.{0}, (c.reltuples * freq)::int as estimate_ct
 FROM pg_stats s
@@ -5103,7 +5103,7 @@ ORDER BY v.ord LIMIT %s""").format(Identifier(col))
         Returns a list of columns where the most common value has a count of at least the given threshold.
         """
         common_cols = []
-        for col in self.table._search_cols:
+        for col in self.table.search_cols:
             most_common = self._approx_most_common(col, 1)
             if most_common and most_common[0][1] >= threshold:
                 common_cols.append(col)
@@ -5840,8 +5840,8 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
         """
         if isinstance(table, basestring):
             table = self[table]
-        search_columns = {typ: [col for col in table._search_cols if table.col_type[col] == typ] for typ in set(table.col_type.values())}
-        extra_columns = {typ: [col for col in table._extra_cols if table.col_type[col] == typ] for typ in set(table.col_type.values())}
+        search_columns = {typ: [col for col in table.search_cols if table.col_type[col] == typ] for typ in set(table.col_type.values())}
+        extra_columns = {typ: [col for col in table.extra_cols if table.col_type[col] == typ] for typ in set(table.col_type.values())}
         # Remove empty lists
         for D in [search_columns, extra_columns]:
             for typ, cols in list(D.items()):
@@ -5850,11 +5850,11 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
         if not extra_columns:
             extra_columns = extra_order = None
         else:
-            extra_order = table._extra_cols
+            extra_order = table.extra_cols
         label_col = table._label_col
         sort = table._sort_orig
         id_ordered = table._id_ordered
-        search_order = table._search_cols
+        search_order = table.search_cols
         self.create_table(new_name, search_columns, label_col, sort, id_ordered, extra_columns, search_order, extra_order, commit=commit)
 
     def create_table(self, name, search_columns, label_col, sort=None, id_ordered=None, extra_columns=None, search_order=None, extra_order=None, commit=True):

--- a/scripts/elliptic_curves/import_ec_data.py
+++ b/scripts/elliptic_curves/import_ec_data.py
@@ -676,14 +676,14 @@ def copy_records_to_file(records, fname, id0=0, verbose=True):
     
     fs = open(searchfile, 'w')
     fe = open(extrafile, 'w')
-    curves._write_header_lines(fs, ["id"]+curves._search_cols)
-    curves._write_header_lines(fe, ["id"]+curves._extra_cols)
+    curves._write_header_lines(fs, ["id"]+curves.search_cols)
+    curves._write_header_lines(fe, ["id"]+curves.extra_cols)
 
     id = id0
     for c in records:
-        fs.write("\t".join([str(id)]+[encode(c[k]) for k in curves._search_cols]))
+        fs.write("\t".join([str(id)]+[encode(c[k]) for k in curves.search_cols]))
         fs.write("\n")
-        fe.write("\t".join([str(id)]+[encode(c[k]) for k in curves._extra_cols]))
+        fe.write("\t".join([str(id)]+[encode(c[k]) for k in curves.extra_cols]))
         fe.write("\n")
         id +=1
     fs.close()

--- a/scripts/reports/jsonify_pg_structure.py
+++ b/scripts/reports/jsonify_pg_structure.py
@@ -23,7 +23,7 @@ def _get_db_records(table):
 
     """ Routine to get the keys for a specified table """
 
-    results = db[table]._search_cols
+    results = db[table].search_cols
     return results
 
 def _jsonify_record(name, record, parse_jsonb = False, inferred = False):


### PR DESCRIPTION
The list of search columns and extra columns should be part of a table's public interface, without an underscore.