### PR TITLE
Use precomuted data for number fields

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -4,7 +4,7 @@ import ast, os, re, StringIO, time
 
 import flask
 from flask import render_template, request, url_for, redirect, send_file, make_response
-from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, primes, pari, RealField
+from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, primes, RealField
 
 from lmfdb import db
 from lmfdb.app import app

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -419,7 +419,10 @@ def render_field_webpage(args):
         data['discriminant'] = "\(%s\)" % str(D)
     else:
         data['discriminant'] = "\(%s=%s\)" % (str(D), data['disc_factor'])
-    data['frob_data'], data['seeram'] = frobs(nf)
+    if nf.frobs():
+        data['frob_data'], data['seeram'] = see_frobs(nf.frobs())
+    else: # fallback in case we haven't computed them in a case
+        data['frob_data'], data['seeram'] = frobs(nf)
     # This could put commas in the rd, we don't want to trigger spaces
     data['rd'] = ('$%s$' % fixed_prec(nf.rd(),2)).replace(',','{,}')
     # Bad prime information
@@ -472,15 +475,7 @@ def render_field_webpage(args):
         pretty_label = "%s: %s" % (label, pretty_label)
 
     info.update(data)
-    if nf.degree() > 1:
-        gpK = nf.gpK()
-        rootof1coeff = gpK.nfrootsof1()
-        rootofunityorder = int(rootof1coeff[0])
-        rootof1coeff = rootof1coeff[1]
-        rootofunity = web_latex(Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a'))) 
-        rootofunity += ' (order $%d$)' % rootofunityorder
-    else:
-        rootofunity = web_latex(Ra('-1'))+ ' (order $2$)'
+    rootofunity = '%s (order $%d$)' % (nf.root_of_1_gen(),nf.root_of_1_order())
 
     info.update({
         'label': pretty_label,
@@ -775,9 +770,36 @@ def residue_field_degrees_function(nf):
 
     return decomposition
 
+# Format Frobenius cycle types coming from the database
+def see_frobs(frob_data):
+    ans = []
+    seeram = False
+    plist = [p for p in primes(2, 60)]
+    for i in range(len(plist)):
+        p = plist[i]
+        dec = frob_data[i][1]
+        if dec[0] == 0:
+            ans.append([p, 'R'])
+            seeram = True
+        else:
+            s = '$'
+            firstone = True
+            for j in dec:
+                if firstone == False:
+                    s += '{,}\,'
+                if j[0]<15:
+                    s += r'{\href{%s}{%d} }'%(url_for('local_fields.by_label', 
+                        label="%d.%d.0.1"%(p,j[0])), j[0])
+                else:
+                    s += str(j[0])
+                if j[1] > 1:
+                    s += '^{' + str(j[1]) + '}'
+                firstone = False
+            s += '$'
+            ans.append([p, s])
+    return ans, seeram
+
 # Compute Frobenius cycle types, returns string nicely presenting this
-
-
 def frobs(nf):
     frob_at_p = residue_field_degrees_function(nf.gpK())
     D = nf.disc()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -37,7 +37,7 @@ nfields = None
 max_deg = None
 init_nf_flag = False
 
-# For imaginary quadratic field class group data
+# For imaginary quadratic field class group data 
 class_group_data_directory = os.path.expanduser('~/data/class_numbers')
 
 def init_nf_count():

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -732,27 +732,10 @@ class WebNumberField:
         """ Computes the conductor if the extension is abelian.
             It raises an exception if the field is not abelian.
         """
-        if not self.is_abelian():
+        cond = self._data['conductor']
+        if cond == 0: # Code for not an abelian field
             raise Exception('Invalid field for conductor')
-        D = self.disc()
-        plist = self.ramified_primes()
-        K = self.K()
-        f = ZZ(1)
-        for p in plist:
-            e = K.factor(p)[0][0].ramification_index()
-            if p == ZZ(2):
-                e = K.factor(p)[0][0].ramification_index()
-                # ramification index must be a power of 2
-                f *= e * 2
-                c = D.valuation(p)
-                res_deg = ZZ(self.degree() / e)
-                # adjust disc expo for unramified part
-                c = ZZ(c / res_deg)
-                if is_odd(c):
-                    f *= 2
-            else:
-                f *= p ** (e.valuation(p) + 1)
-        return f
+        return ZZ(cond)
 
     def artin_reps(self, nfgg=None):
         if nfgg is not None:
@@ -813,44 +796,8 @@ class WebNumberField:
 
         return []
 
-    def dirichlet_group(self, prime_bound=10000):
-        f = self.conductor()
-        if f == 1:  # To make the trivial case work correctly
-            return [1]
-        if euler_phi(f) > dir_group_size_bound:
-            return []
-        # Can do quadratic fields directly
-        if self.degree() == 2:
-            if is_odd(f):
-                return [1, f-1]
-            f1 = f/4
-            if is_odd(f1):
-                return [1, f-1]
-            # we now want f with all powers of 2 removed
-            f1 = f1/2
-            if is_even(f1):
-                raise Exception('Invalid conductor')
-            if (self.disc()/8) % 4 == 3:
-                return [1, 4*f1-1]
-            # Finally we want congruent to 5 mod 8 and -1 mod f1
-            if (f1 % 4) == 3:
-                return [1, 2*f1-1]
-            return [1, 6*f1-1]
-
-        from dirichlet_conrey import DirichletGroup_conrey
-        G = DirichletGroup_conrey(f)
-        K = self.K()
-        S = Set(G[1].kernel()) # trivial character, kernel is whole group
-
-        for P in K.primes_of_bounded_norm_iter(ZZ(prime_bound)):
-            a = P.norm() % f
-            if gcd(a,f)>1:
-                continue
-            S = S.intersection(Set(G[a].kernel()))
-            if len(S) == self.degree():
-                return list(S)
-
-        raise Exception('Failure in dirichlet group for K=%s using prime bound %s' % (K,prime_bound))
+    def dirichlet_group(self):
+        return self._data['dirichlet_group']
 
     def full_dirichlet_group(self):
         from dirichlet_conrey import DirichletGroup_conrey

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -630,21 +630,9 @@ class WebNumberField:
         return self.gen_name
 
     def root_of_1_order(self):
-        if 'torsion_order' not in self._data:
-            if self.degree()== 1:
-                self._data['torsion_order'] = int(2)
-                self._data['torsion_gen'] = r'\(-1\)'
-            else:
-                gpK = self.gpK()
-                rootof1coeff = gpK.nfrootsof1()
-                self._data['torsion_order'] = int(rootof1coeff[0])
-                rootof1coeff = rootof1coeff[1]
-                self._data['torsion_gen'] = web_latex(Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a')))
         return self._data['torsion_order']
 
     def root_of_1_gen(self):
-        if 'torsion_gen' not in self._data:
-            self.root_of_1_order() # fills in the data
         return self._data['torsion_gen']
 
     def unit_rank(self):
@@ -747,9 +735,7 @@ class WebNumberField:
         return ''
 
     def frobs(self):
-        if 'frobs' in self._data:
-            return self._data['frobs']
-        return False
+        return self._data['frobs']
 
     def conductor(self):
         """ Computes the conductor if the extension is abelian.

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -4,7 +4,7 @@ import os, yaml
 
 from flask import url_for
 from sage.all import (
-    gcd, Set, ZZ, is_even, is_odd, euler_phi, CyclotomicField, gap, RealField,
+    Set, ZZ, euler_phi, CyclotomicField, gap, RealField,
     QQ, NumberField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -629,6 +629,24 @@ class WebNumberField:
         # For consistency with Sage number fields
         return self.gen_name
 
+    def root_of_1_order(self):
+        if 'torsion_order' not in self._data:
+            if self.degree()== 1:
+                self._data['torsion_order'] = int(2)
+                self._data['torsion_gen'] = r'\(-1\)'
+            else:
+                gpK = self.gpK()
+                rootof1coeff = gpK.nfrootsof1()
+                self._data['torsion_order'] = int(rootof1coeff[0])
+                rootof1coeff = rootof1coeff[1]
+                self._data['torsion_gen'] = web_latex(Ra(str(pari("lift(%s)" % gpK.nfbasistoalg(rootof1coeff))).replace('x','a')))
+        return self._data['torsion_order']
+
+    def root_of_1_gen(self):
+        if 'torsion_gen' not in self._data:
+            self.root_of_1_order() # fills in the data
+        return self._data['torsion_gen']
+
     def unit_rank(self):
         if not self.haskey('unit_rank'):
             sig = self.signature()
@@ -727,6 +745,11 @@ class WebNumberField:
         if self.used_grh():
             return '<span style="font-size: x-small">(GRH)</span>'
         return ''
+
+    def frobs(self):
+        if 'frobs' in self._data:
+            return self._data['frobs']
+        return False
 
     def conductor(self):
         """ Computes the conductor if the extension is abelian.

--- a/scripts/number_fields/Readme
+++ b/scripts/number_fields/Readme
@@ -1,23 +1,23 @@
-The import script can be run by
+Adding new fields to the lmfdb involves computing more data for them,
+managing labels, and then importing them.
 
-  sage -python import_nf_data.py list of files to import
+Fields are represented in the form [polynomial in x, [list of ramified primes]]
+Polynomials should always be run through polredabs first
 
-Each file should consist of a single list of fields.  The format is
-described in the import script.  The file prep.gp can be used with
-pari to generate a file in the correct format.  In gp,
+To add new fields, we only process fields of a given degree one at a time
+  - optionally, dump existing fields by running dump_alldeg.py which creates
+    files p-alldeg-n where 1<n<48. Then remove any existing fields from your
+    list (so save the time it takes to reprocess them)
+  - run them through gp with prep.gp.  The main function is doall1 which is
+    takes as input a list of pairs [polynomial in x, [list of ramfied primes]]
+    Save the result in a file, referred to below as newstuff.prep
+  - dump labels with python using dump-label-data.py which dumps files 
+    called label-data-k where k is the degree.  This command takes as an 
+    optional argument a list of degrees to dump, otherwise it does them all
+  - make labels for the new ones (here k is the degree of the fields)
+      make-labels.py label-data-k newstuff.prep
+    which creates the file newstuff.prep.out
+    This command also fills in some fields to make the import step easier
+  - add the new stuff with
+      import_nf_data-new.py newstuff.prep.out
 
-\r prep.gp
-all = doall([list of polynomials])
-write("myoutputfile", all)
-
-Then myoutputfile can be imported as above.  The gp script will only
-work for polynomials of degree <12 because pari can only compute Galois
-groups in this range.
-
-...
-
-After renaming database to fields, 
-
-  create_random_object_index(nf, "fields")
-
-after loading jj.py

--- a/scripts/number_fields/import_nf_data.py
+++ b/scripts/number_fields/import_nf_data.py
@@ -1,215 +1,37 @@
+#!/usr/local/bin/sage -python
 # -*- coding: utf-8 -*-
-r""" Import number field data.  Note: This code 
-can be run on all files in any order. Even if you rerun this code 
-on previously entered files, it should have no affect.  This code 
-checks if the entry exists, if so returns that and updates with 
-new information. If the entry does not exist then it creates it 
-and returns that.
+r""" Import number field data.  
 
-Initial version (Warwick 2014), modified 7/14
-Adding zk, 7/15
+Imports from a json file directly to the database.
 
-Data is imported to the collection 'fields' in the database 'numberfields'.
-The structure of the database entries is described in lmfdb/Database-info.
-
-Each file should contain a single list, with each list entry being data for
-a field: [field1, field2, ..., ]
-
-Each field entry is a list:
-
-  [coeffs, galois t, disc, r1, h, clgp, extras, reg, fu, nogrh, subs, reduced, zk]
-
-where
-
-   - coeffs: (list of ints) a polredabs'ed polynomial defining the field, so
-       [3,2,1] represents x^2+2*x+3
-   - galois t: (int) the T-number for the Galois group
-   - disc:  (int) the field discriminant
-   - r1: (int) the number of real places of the field
-   - h: (int) the class number (if known)
-   - clgp: (list of ints) the class group structure [a_1,a_2,...] where
-        each a_i is a multiple of a_{i+1}
-   - extras: (int 0 or 1) 1 if there is (optional) entries, 0 if not
-   - reg: (float - optional) regulator
-   - fu: (list of strings - optional) a list of fundimental units in 
-        terms of a root of the defining polynomial where the root is 
-        written as "a"
-   - nogrh: (int 0 or 1) 1 indicates that everything above
-        after class group does not depend on GRH
-   - subs: list of subfields, such as 
-           [[[3, 0, 1], 2], [[6, -2, 1, 0, 1], 1]]
-        to indicate that there are two subfields isomorphic to the field
-        defined by x^2+3 and one subfield isomorphic to the field
-        defined by x^4+x^2-2*x+6
-   - reduced: is the polynomial known to be polredabs'ed
-   - zk: list of strings of integral basis elements in the variable a
+Data is imported to the collection 'nf_fields'.
 """
 
-import sys, time, os
-assert time
-import bson
+import sys
 import re
-import hashlib
 import json
-import sage
-from sage.all import ZZ, QQ, PolynomialRing, prime_factors
-from zlib import gzip
 
-pw_filename = "../../../xyzzy"
-password = open(pw_filename, "r").readlines()[0].strip()
+sys.path.append('/scratch/home/jj/lmfdb')
 
-from pymongo.mongo_client import MongoClient
-C= MongoClient(port=37010)
-C['numberfields'].authenticate('editor', password)
-fields = C.numberfields.fields
+from lmfdb import db
 
+fields = db.nf_fields
 
-saving = True 
-
-PR = PolynomialRing(QQ, 'a')
-R = PolynomialRing(QQ, 'x')
-
-
-#def coeffs(s):
-#    return [a for a in s[1:-1].split(',')]
-
-def sd(f):
-  for k in f.keys():
-    print '%s ---> %s'%(k, f[k])
-
-def base_label(d,r1,D,ind):
-    return str(d)+"."+str(r1)+"."+str(abs(D))+"."+str(ind)
-
-def makeb(n,t):
-  return bson.SON([('n', n), ('t', t)])
-
-def makes(n,t):
-  return '%02d,%03d'%(n,t)
-
-def makels(li):
-  li2 = [str(x) for x in li]
-  return ','.join(li2)
-
-def make_disc_key(D):
-  s=1
-  if D<0: s=-1
-  Dz = D.abs()
-  if Dz==0: D1 = 0
-  else: D1 = int(Dz.log(10))
-  return s, '%03d%s'%(D1,str(Dz))
-
-def coeff_to_poly(c):
-    return PolynomialRing(QQ, 'x')(c)
-
-def web_latex(u):
-  return "\( %s \)" % sage.all.latex(u)
-
-def mismatch(oldval, newval, valtype):
-    print "%s mismatch %s | %s"(valtype, str(oldval), str(newval))
-    sys.exit()
-
-# polredabs: if we want to compute on the fly
-#def polredabs(pol):
-#    return R(str(gp.polredabs(pol)))
-
-# If we ever compute Galois groups here, set
-#gp.set_default("new_galois_format", 1)
-
-# only use for degree < 12
-#def galt(pol):
-#    return int(ZZ(gp.polgalois(str(pol))[3]))
-
-def string2list(s):
-  s = str(s)
-  if s=='': return []
-  return [int(a) for a in s.split(',')]
-
-count = 0
-#t = time.time()
-
-def do_import(ll):
-  global count
-  print "Importing list of length %d" %(len(ll))
-  for F in ll:
-    count += 1
-    coeffs, T, D, r1, h, clgp, extras, reg, fu, nogrh, subs, reduc, zk = F
-    print "%d: %s"%(count, F)
-    #pol = coeff_to_poly(coeffs)
-    d = int(len(coeffs))-1
-    D = ZZ(D)
-    absD = abs(D)
-    s, dstr = make_disc_key(D)
-    # default for r1 is -1 if we should compute it
-    sig = [int(r1), int((d-r1)/2)]
-    data = {
-        'degree': d,
-        'disc_abs_key': dstr,
-        'disc_sign': s,
-        'coeffs': makels(coeffs),
-        'signature': makels(sig)
-    }
-    # Default is that polynomials are polredabs'ed
-    if reduc == 0:
-        data['reduced'] = 0
-    # See if we have it and build a label
-    index=1
-    is_new = True
-    for field in fields.find({'degree': d,
-                 'signature': data['signature'],
-                 'disc_abs_key': dstr}):
-      index +=1
-      if field['coeffs'] == data['coeffs']:
-        is_new = False
-        break
-
-    if is_new:
-        print "new field"
-        label = base_label(d,sig[0],absD,index)
-        data['label'] = label
-        data['ramps'] = [str(x) for x in prime_factors(D)]
-        subs = [[makels(z[0]), z[1]] for z in subs]
-        zk = [str(z) for z in zk]
-        zk = [z.replace('x','a') for z in zk]
-        data['zk'] = zk
-        data['subs'] = subs
-        dak = data['disc_abs_key']
-        if len(dak)<19:
-          dakhash=int(dak)
-        else:
-          dakhash = int(dak[0:19])
-        data['dischash'] = dakhash *data['disc_sign']
-        data['coeffhash'] = hashlib.md5(data['coeffs']).hexdigest()
-############
-        if h>0:
-            data['class_number'] = h
-            data['class_group'] = makels(clgp)
-        if extras>0:
-            data['reg'] = reg
-            fu = [web_latex(PR(str(u))) for u in fu]
-            data['units'] = fu
-        if nogrh==0:
-            data['used_grh'] = True
-        #print "entering %s into database"%info
-        if saving:
-            data['galois'] = makeb(d, T)
-            fields.save(data)
-    else:
-        print "field already in database"
-
-# Do the main work
-
+outrecs = []
+tot = 0
 for path in sys.argv[1:]:
     print path
-    filename = os.path.basename(path)
-    fn = gzip.open(path) if filename[-3:] == '.gz' else open(path)
+    fn = open(path)
     for line in fn.readlines():
         line.strip()
         if re.match(r'\S',line):
             l = json.loads(line)
-            do_import(l)
+            outrecs.append(l)
+            tot += 1
 
-#sys.exit()
+if len(outrecs)>0:
+    fields.insert_many(outrecs)
 
-#from outlist  import li # this reads in the list called li
+print "Added %d records"% tot
 
 

--- a/scripts/number_fields/prep.gp
+++ b/scripts/number_fields/prep.gp
@@ -16,7 +16,7 @@ assoc(entry, lis, bnd=-1) =my(b);b=#lis;if(bnd>-1,b=bnd);for(j=1,b,if(lis[j]==en
 
 /* Needs to be adjusted for higher degree polynomials */
 galt(pol) = return(polgalois(pol)[3]);
-galt(pol) = if(poldegree(pol)<12, return(polgalois(pol)[3]), return(galtord(pol)[1]));
+galt(pol) = if(poldegree(pol)<8, return(polgalois(pol)[3]), return(galtord(pol)[1]));
 
 mult(lis) =
 {
@@ -42,7 +42,21 @@ getsubs(pol)=
   return(mult(sbs));
 }
 
-load(p,n)=return(read(Str("/home/jj/data/localfields-lmfdb/file-src/p"p"d"n"all")));
+iscm(pol,subs)=
+{
+  my(deg,s2);
+  deg=poldegree(pol);
+  if(deg % 2 == 1, return(0));
+  if(polsturm(pol) != 0, return(0));
+  subs = apply(z->z[1],subs);
+  subs = apply(Polrev,subs);
+  s2 = select(z->poldegree(z)*2==deg, subs);
+  for(j=1,#s2,
+    if(polsturm(s2[j]) == deg/2, return(1)));
+  return(0);
+}
+
+load(p,n)=return(read(Str("/scratch/home/jj/local-fields/file-src/p"p"d"n"all")));
 
 onealg(pol,p)=
 {
@@ -88,7 +102,7 @@ doit(pol)=
     );
     localg = apply(z->onealg(pol,z), rmps);
     subs = getsubs(nf);
-    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps,localg]);
+    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps,localg,iscm(pol,subs)]);
     /* reg and units if slow */
     /* grh if certify is too slow */
 }
@@ -123,7 +137,7 @@ doit1(ll)=
     );
     localg = apply(z->onealg(pol,z), rmps);
     subs = getsubs(nf);
-    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps, localg]);
+    return([Vecrev(pol), galt(pol), nf.disc, nf.r1,h,clgp,extras,reg,fu,nogrh,subs,1,zk,rmps, localg,iscm(pol,subs)]);
     /* reg and units if slow */
     /* grh if certify is too slow */
 }


### PR DESCRIPTION
Several pieces of data have now been precomputed for number fields and put in the database: conductor and Dirichlet character groups for abelian fields, roots of unity information and Frobenius splittings for all number fields.  This changes the code to just read that data from the database.  Some pages will load significantly faster fixing issue #3266 .  Most pages should look the same as before, such as

http://127.0.0.1:37777/NumberField/16.0.675821419082285056.2
http://beta.lmfdb.org/NumberField/16.0.675821419082285056.2

which has root of unity of order bigger than 2 (although the two pages give different generators for the torsion part of the unit group, they are just different choices of generators).

Now

http://127.0.0.1:37777/NumberField/47.47.6807739517051283990370106856968124192474229146184900948675688481754810058334971205734548194436392534997735758198660848138706901604387352879006731328411841.1

loads quickly instead of timing out.  (On the downside, katex cannot handle its integral basis, but that is a different issue.)