### PR TITLE
Resolving issue #3347 - EC/Q isogeny class modular form None

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -100,9 +100,12 @@ class ECisog_class(object):
 
 
         self.newform =  web_latex(PowerSeriesRing(QQ, 'q')(self.anlist, 20, check=True))
-        self.newform_label = db.mf_newforms.lucky({'level':N, 'weight':2, 'related_objects':{'$contains':'EllipticCurve/Q/%s/%s' % (N, iso)}},'label')
-        self.newform_exists_in_db = self.newform_label is not None
-        if self.newform_label is not None:
+        self.newform_label = ".".join([str(N), str(2), 'a', iso])
+#        self.newform_label = db.mf_newforms.lucky({'level':N, 'weight':2, 'related_objects':{'$contains':'EllipticCurve/Q/%s/%s' % (N, iso)}},'label')
+#        self.newform_exists_in_db = self.newform_label is not None
+        self.newform_exists_in_db = db.mf_newforms.label_exists(self.newform_label)
+#        if self.newform_label is not None:
+        if self.newform_exists_in_db:
             char_orbit, hecke_orbit = self.newform_label.split('.')[2:]
             self.newform_link = url_for("cmf.by_url_newform_label", level=N, weight=2, char_orbit_label=char_orbit, hecke_orbit=hecke_orbit)
 


### PR DESCRIPTION
Instead of looking for the modular forms in the DB based on conductor
and isogeny class, we use the fact that the character is trivial on
modular forms for elliptic curves over Q, and that the isogeny class
is the same as the Hecke orbit.