### PR TITLE
Fix to #3412

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -229,7 +229,7 @@ def search(**args):
                      'learnmore':learnmore_list()}
     title = 'Sato-Tate Group Search Results'
     err_title = 'Sato-Tate Groups Search Input Error'
-    count = parse_count(info, 25)
+    count = parse_count(info, 50)
     start = parse_start(info)
     # if user clicked refine search always restart at 0
     if 'refine' in info:

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -293,8 +293,8 @@ def search(**args):
                 results.append(v)
     else:
         info['number'] = 'infinity'
-        info['start'] = start
-        info['count'] = count
+    info['start'] = start
+    info['count'] = count
 
     info['st0_list'] = st0_list
     info['st0_dict'] = st0_dict

--- a/lmfdb/sato_tate_groups/templates/st_browse.html
+++ b/lmfdb/sato_tate_groups/templates/st_browse.html
@@ -86,8 +86,7 @@ Some of our favourite {{ KNOWL('st_group.definition', title='Sato-Tate groups') 
 </tr>
 <tr
 ><td>Results to display</td>
-<td><input type='text' name='count' value=25 size=10 /></td>
-<td><span class="formexample"> e.g. 25 or 50</td>
+<td><input type='text' name='count' value=50 size=10 /></td>
 </tr>
 <tr>
 <td><button type='submit' value='Search'>Search</button>

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -49,6 +49,8 @@ class SatoTateGroupTest(LmfdbTest):
         assert 'matches 1001-1025' in L.data
         L = self.tc.get('SatoTateGroup/?degree=1')
         assert 'both matches' in L.data
+        L = self.tc.get('SatoTateGroup/?count=47')
+        assert '1-47' in L.data
 
     def test_moments(self):
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')

--- a/scripts/elliptic_curves/hash.m
+++ b/scripts/elliptic_curves/hash.m
@@ -1,1 +1,0 @@
-/scratch/home/jcremona/CMFs/magma/hash.m


### PR DESCRIPTION
Fixes #3412 which was caused by a change in how the info dictionary is filled in on searches when we switched from mongo db to postgres (this fix simply changes the indentation of two lines so the the count and number get reset).