### PR TITLE
Search for invariants upgrade

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -294,7 +294,7 @@ def genus2_curve_search(info, query):
     if 'torsion' in query:
         query['torsion_subgroup'] = str(query['torsion']).replace(" ","")
         query.pop('torsion') # search using string key, not array of ints
-    geom_inv_type = info.get('geometric_invariants_type', 'igusa_clebsch')
+    geom_inv_type = info.get('geometric_invariants_type', 'igusa_clebsch_inv')
     if 'geometric_invariants' in info:
         query[geom_inv_type] = (str(info['geometric_invariants']).replace(" ", "")).replace(",","','").replace("[","['").replace("]","']")
 

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -10,7 +10,7 @@ from sage.all import ZZ
 from lmfdb import db
 from lmfdb.utils import (
     to_dict, comma, flash_error, display_knowl,
-    parse_bool, parse_ints, parse_bracketed_posints, parse_primes,
+    parse_bool, parse_ints, parse_bracketed_posints, parse_bracketed_rats, parse_primes,
     search_wrap,
     Downloader,
     StatsDisplay, formatters)
@@ -295,9 +295,13 @@ def genus2_curve_search(info, query):
         query['torsion_subgroup'] = str(query['torsion']).replace(" ","")
         query.pop('torsion') # search using string key, not array of ints
     geom_inv_type = info.get('geometric_invariants_type', 'igusa_clebsch_inv')
-    if 'geometric_invariants' in info:
-        query[geom_inv_type] = (str(info['geometric_invariants']).replace(" ", "")).replace(",","','").replace("[","['").replace("]","']")
-
+    if geom_inv_type == 'igusa_clebsch_inv':
+        invlength = 4
+    elif geom_inv_type == 'igusa_inv':
+        invlength = 5
+    else:
+        invlength = 3
+    parse_bracketed_rats(info,query,'geometric_invariants',qfield=geom_inv_type,exactlength=invlength,split=False,keepbrackets=True)
     parse_ints(info,query,'two_selmer_rank','2-Selmer rank')
     parse_ints(info,query,'analytic_rank','analytic rank')
     # G2 invariants and drop-list items don't require parsing -- they are all strings (supplied by us, not the user)

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -176,6 +176,9 @@ class Genus2Test(LmfdbTest):
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants_type=igusa_clebsch_inv&geometric_invariants=[1824%2C179520%2C140795904%2C207474688]')
         assert '1369.a.50653.1' in L.data
         assert '169.a.169.1' not in L.data
+        L = self.tc.get('/Genus2Curve/Q/?geometric_invariants=[1824%2C179520%2C140795904%2C207474688]')
+        assert '1369.a.50653.1' in L.data
+        assert '169.a.169.1' not in L.data
 
     def test_igusa_search(self):
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants_type=igusa_inv&geometric_invariants=[228%2C296%2C-98568%2C-5640280%2C50653]')
@@ -202,7 +205,11 @@ class Genus2Test(LmfdbTest):
         assert '324.a.648.1' in L.data
         assert '450.a.2700.1' in L.data
         assert not('169.a.169.1' in L.data)
-        
+        L = self.tc.get('/Genus2Curve/Q/?bad_primes=2%2C3')
+        assert '324.a.648.1' in L.data
+        assert '450.a.2700.1' in L.data
+        assert not('169.a.169.1' in L.data)
+                
 
     def test_related_objects(self):
         for url, friends in [

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -22,7 +22,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'image_callback', 'encode_plot',
            'KeyedDefaultDict', 'make_tuple', 'range_formatter',
            'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_rational',
-           'parse_rats', 'parse_bracketed_posints', 'parse_bool',
+           'parse_rats', 'parse_bracketed_posints', 'parse_bracketed_rats', 'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of',
            'parse_subset', 'parse_submultiset', 'parse_list',
            'parse_list_start', 'parse_string_start', 'parse_restricted',
@@ -63,7 +63,7 @@ from .utilities import (
 
 from .search_parsing import (
     parse_ints, parse_signed_ints, parse_floats, parse_rational, parse_rats,
-    parse_bracketed_posints, parse_bool, parse_bool_unknown, parse_primes,
+    parse_bracketed_posints, parse_bracketed_rats, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_subset, parse_submultiset, parse_list,
     parse_list_start, parse_string_start, parse_restricted, parse_noop,
     parse_equality_constraints, parse_gap_id, parse_galgrp, parse_nf_string,

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -14,6 +14,7 @@ LIST_RE = re.compile(r'^(\d+|(\d*-(\d+)?))(,(\d+|(\d*-(\d+)?)))*$')
 FLOAT_STR = r'((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?'
 LIST_FLOAT_RE = re.compile(r'^({0}|{0}-|{0}-{0})(,({0}|{0}-|{0}-{0}))*$'.format(FLOAT_STR))
 BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
+BRACKETED_RAT_RE = re.compile(r'^\[\]|\[-?(\d+|\d+/\d+)(,-?(\d+|\d+/\d+))*\]$')
 QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
 # Single non-negative rational, allowing decimals, used in parse_range2rat
 QQ_DEC_RE = re.compile(r'^\d+((\.\d+)|(/\d+))?$')
@@ -515,6 +516,55 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
         else:
             inp = '[%s]'%','.join([str(a) for a in L])
             query[qfield] = inp if keepbrackets else inp[1:-1]
+            
+@search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_bracketed_rats(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, listprocess=None, keepbrackets=False, extractor=None):
+    if (not BRACKETED_RAT_RE.match(inp) or
+        (maxlength is not None and inp.count(',') > maxlength - 1) or
+        (exactlength is not None and inp.count(',') != exactlength - 1) or
+        (exactlength is not None and inp == '[]' and exactlength > 0)):
+        if exactlength == 2:
+            lstr = "pair of rational numbers"
+            example = "[2,3/2] or [3,3]"
+        elif exactlength == 1:
+            lstr = "list of 1 rational number"
+            example = "[2/5]"
+        elif exactlength is not None:
+            lstr = "list of %s rational numbers" % exactlength
+            example = str(range(2,exactlength+2)).replace(", ","/13,") + " or " + str([3]*exactlength).replace(", ","/4,")
+        elif maxlength is not None:
+            lstr = "list of at most %s rational numbers" % maxlength
+            example = str(range(2,maxlength+2)).replace(", ","/13,") + " or " + str([2]*max(1, maxlength-2)).replace(", ","/41,")
+        else:
+            lstr = "list of rational numbers"
+            example = "[1/7,2,3] or [5,6/71]"
+        raise ValueError("It needs to be a %s in square brackets, such as %s." % (lstr, example))
+    else:
+        if inp == '[]': # fixes bug in the code below (split never returns an empty list)
+            if split:
+                query[qfield] = []
+            else:
+                query[qfield] = ''
+            return
+        L = [QQ(a) for a in inp[1:-1].split(',')]
+        if process is not None:
+            L = [process(a) for a in L]
+        if listprocess is not None:
+            L = listprocess(L)
+        if extractor is not None:
+            for qf, v in zip(qfield, extractor(L)):
+                if qf in query and query[qf] != v:
+                    raise ValueError("Inconsistent specification of %s: %s vs %s"%(qf, query[qf], v))
+                query[qf] = v
+        elif split:
+            query[qfield] = L
+        else:
+            inp = '[%s]'%','.join([str(a) for a in L])
+            if keepbrackets:
+                inp = inp.replace("[","['").replace("]","']").replace(",","','")
+                query[qfield] = inp
+            else:
+                query[qfield] = inp[1:-1]
 
 def parse_gap_id(info, query, field='group', name='Group', qfield='group'):
     parse_bracketed_posints(info,query,field, split=False, exactlength=2, keepbrackets=True, name=name, qfield=qfield)


### PR DESCRIPTION
This fixes an error induced by #3419 plus it adds tests to avoid similar errors.

Moreover, there is now parsing done for geometric invariants. For this purpose there is a new function to parse lists of rational numbers. This addresses #3413.