### PR TITLE
Work around copy-tex selection issue

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -16,7 +16,7 @@
 {% endif %}
 {% set prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L %}
 {# keep the line below as is to avoid annoying line breaks #}
-<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<br>{% endfor %}</div>
+<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>{# this div is a workaround for a copy-tex bug where if a code block followed a hidden code block followed by math was selected and copied the hidden block would be also it is important that it has display: block #}{% endfor %}</div>
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -16,7 +16,7 @@
 {% endif %}
 {% set prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L %}
 {# keep the line below as is to avoid annoying line breaks #}
-<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>{# this div is a workaround for a copy-tex bug where if a code block followed a hidden code block followed by math was selected and copied the hidden block would be also it is important that it has display: block #}{% endfor %}</div>
+<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{{prompt}}:&nbsp;{{line}}<br /><div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>{# this div is a workaround for a copy-tex bug where if a code block followed a hidden code block followed by math was selected and copied the hidden block would be also it is important that it has display: block #}{% endfor %}</div>
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1774,7 +1774,6 @@ div.box {
 div.codebox {
     padding: 5px;
     text-padding: 10px;
-    overflow: auto;
     border: 1px solid {{color.knowl_thin_border}};
     border-radius: 5px;
     background-color: {{color.knowl_background}};


### PR DESCRIPTION
 by adding an invisible div with a block display style after code blocks

This should have no visible effect but if one visits www.lmfdb.xyz/Genus2Curve/Q/18272/a/36544/1 clicks Magma and triple clicks to select the first line of magma code, before the (invisible!) sage code would also be selected and appear when copy-paste, after this should not occur

See also https://github.com/KaTeX/KaTeX/issues/1981 for a report upstream.