### PR TITLE
Change to torsion structure instead of torsion order

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -17,7 +17,7 @@ text-align: center;
 <th>{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
 <th>{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
 <th>{{ KNOWL('ec.q.minimal_weierstrass_equation', title='Weierstrass coefficients') }}</th>
-<th>{{ KNOWL('ec.torsion_order', title='Torsion order') }}</th>
+<th>{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</th>
 <th>{{ KNOWL('ec.q.modular_degree', title='Modular degree') }}</th>
 <th>{{ KNOWL('ec.q.optimal', title='Optimality') }}</th>
 </tr>
@@ -30,7 +30,7 @@ text-align: center;
 <td class="center"><a href="{{c.curve_url_lmfdb}}">{{c.lmfdb_label}}</a></td>
 <td class="center"><a href="{{c.curve_url_cremona}}">{{c.label}}</a></td>
 <td class="center">{{c.ai}}</td>
-<td align="center">{{c.torsion}}</td>
+<td align="center">{{c.torsion_structure}}</td>
 <td align="center">
 {% if c.degree==0 %}Not available{% else %}{{c.degree}}{% endif %}
 </td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -139,7 +139,7 @@ table td.params {
   <th class="center">{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
   <th class="center">{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass Coefficients') }}</th>
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
-  <th class="center">{{ KNOWL('ec.torsion_order', title='Torsion order') }}</th>
+  <th class="center">{{ KNOWL('ec.torsion_structure', title='Torsion structure') }}</th>
 {% if info.surj_primes or info.nonsurj_primes  %}
   <th class="center">{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}</th>
 {% endif %}
@@ -152,7 +152,7 @@ table td.params {
 <td class="center"><a href="{{info.iso_url_Cremona(curve)}}">{{curve.iso}}</a></td>
 <td class="params">{{info.curve_ainvs(curve)}}</td>
 <td class="center">{{curve.rank}}</td>
-<td class="center">{{curve.torsion}}</td>
+<td class="center">{{curve.torsion_structure}}</td>
 {% if info.surj_primes or info.nonsurj_primes %}
 <td class="center">{{curve.nonmax_primes}}</td>
 {% endif %}

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -129,7 +129,7 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/990/i/')
         row = '\n'.join([
           '<td class="center">[1, -1, 1, -1568, -4669]</td>',
-          '<td align="center">6</td>',
+          '<td align="center">[6]</td>',
           '<td align="center">',
           '1728</td>',
           '<td>\(\Gamma_0(N)\)-optimal</td>'


### PR DESCRIPTION
This commit is intended to address issue 2977 "List torsion structure instead of torsion order"
https://github.com/LMFDB/lmfdb/issues/2977

I have made this change in the elliptic curve search results page and the elliptic curve isogeny class page.