### PR TITLE
Updated Artin rep index and search results templates

### DIFF
--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -61,8 +61,8 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
 
     <tr>
         <td align="left">{{ KNOWL('artin.conductor',title = "Conductor") }}</td>
-        <td><input type='text' name='conductor' placeholder="50-100,150-210" size=10></td>
-        <td><span class="formexample"> e.g. 50, 100-200</span></td>
+        <td><input type='text' name='conductor' placeholder="51,100-200" size=10></td>
+        <td><span class="formexample"> e.g. 51, 100-200</span></td>
     </tr>
 
     <tr>
@@ -72,7 +72,7 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
 
     <tr>
         <td align="left">{{ KNOWL('artin.parity',title="Parity") }}</td>
-        <td><select name='Is_Even' style="width: 155px">
+        <td><select name='Is_Even' style="width: 127px">
            <option value=''>All</option>
            <option value='True'>Even</option>
            <option value='False'>Odd</option>

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -55,24 +55,24 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
   <table>
     <tr>
         <td align="left">{{ KNOWL('artin.dimension',title="Dimension") }}</td>
-        <td><input type='text' name='dimension' placeholder="2" size=10></td>
+        <td><input type='text' name='dimension' placeholder="2" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. 1, 2-4 </span></td>
     </tr>
 
     <tr>
         <td align="left">{{ KNOWL('artin.conductor',title = "Conductor") }}</td>
-        <td><input type='text' name='conductor' placeholder="51,100-200" size=10></td>
+        <td><input type='text' name='conductor' placeholder="51,100-200" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. 51, 100-200</span></td>
     </tr>
 
     <tr>
         <td align="left">{{ KNOWL('artin.gg_quotient',title="Group") }}</td>
-        <td><input type='text' name='group' placeholder="A5" size=10></td>
+        <td><input type='text' name='group' placeholder="A5" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. C5, or 8T12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
 
     <tr>
         <td align="left">{{ KNOWL('artin.parity',title="Parity") }}</td>
-        <td><select name='Is_Even' style="width: 127px">
+        <td><select name='Is_Even' style="width: 170px">
            <option value=''>All</option>
            <option value='True'>Even</option>
            <option value='False'>Odd</option>
@@ -80,35 +80,35 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
 
     <tr>
         <td align="left">{{ KNOWL('artin.permutation_container',title="Smallest permutation container") }}</td>
-        <td><input type='text' name='container' placeholder="6T13" size=10></td>
+        <td><input type='text' name='container' placeholder="6T13" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. 6T13 or 7T6</span></td>
 
     <tr>
         <td align="left">{{ KNOWL('artin.ramified_primes', title="Ramified primes") }}</td>
-        <td><input type='text' name='ramified' placeholder="2" size=10></td>
+        <td><input type='text' name='ramified' placeholder="2" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. 2, 3 (no range allowed)</span></td>
     </tr>
     
     <tr>
         <td align="left">{{ KNOWL('artin.unramified_primes', title="Unramified primes") }}</td>
-        <td><input type='text' name='unramified' placeholder="5,7" size=10></td>
+        <td><input type='text' name='unramified' placeholder="5,7" style="width: 160px;"></td>
         <td><span class="formexample"> e.g. 5, 7, 13  (no range allowed)</span></td>
     </tr>
     
     <tr>
         <td align="left">{{ KNOWL('artin.root_number',title="Root number") }}</td>
-        <td><input type='text' name='root_number' placeholder="1" size=10></td>
+        <td><input type='text' name='root_number' placeholder="1" style="width: 160px;"></td>
         <td><span class="formexample"> at the moment, one of 1 or -1 </span></td>
     </tr>
 
     <tr>
         <td align="left">{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}</td>
-        <td><input type='text' name='frobenius_schur_indicator' placeholder="1" size=10></td>
+        <td><input type='text' name='frobenius_schur_indicator' placeholder="1" style="width: 160px;"></td>
         <td><span class="formexample"> +1 for orthogonal, -1 for symplectic, 0 for non-real character </span></td>
     </tr>
 
     <tr>
-        <td align=left>Results to display</td><td><input type='text' name='count' value='50' size=10></td>
+        <td align=left>Results to display</td><td><input type='text' name='count' value='50' style="width: 160px;"></td>
     </tr>
   </table>
   

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -13,11 +13,11 @@
       <td>{{ KNOWL('artin.parity',title="Parity") }}</td>
 
     <tr>
-      <td><input type='text' name='dimension' value="{{info.dimension}}" size=15 placeholder="2"/></td>
-      <td><input type='text' name='conductor' value="{{info.conductor}}" size=15 placeholder="51,100-200"/></td>
-      <td><input type='text' name='group' value="{{info.group}}" size=15 placeholder="A5"></td>
-      <td><input type='text' name='root_number' placeholder="1" value = "{{info.root_number}}" size=15/></td>
-      <td><select name='Is_Even' width="105" style="width: 105px">
+      <td><input type='text' name='dimension' value="{{info.dimension}}" style="width: 160px;" placeholder="2"/></td>
+      <td><input type='text' name='conductor' value="{{info.conductor}}" style="width: 160px;" placeholder="51,100-200"/></td>
+      <td><input type='text' name='group' value="{{info.group}}" style="width: 160px;" placeholder="A5"></td>
+      <td><input type='text' name='root_number' placeholder="1" value = "{{info.root_number}}" style="width: 160px;"/></td>
+      <td><select name='Is_Even' style="width: 170px">
         <option value=''>All</option>
         <option value='True' {{ "selected" if info.Is_Even == 'True'}} >Even</option>
         <option value='False' {{ "selected" if info.Is_Even == 'False'}} >Odd</option>
@@ -31,10 +31,10 @@
       <td>{{ KNOWL('artin.frobenius_schur_indicator',title="Frobenius-Schur indicator") }}</td>
     </tr>
     <tr>
-      <td><input type='text' name='container' value="{{info.container}}" size=15 placeholder="6T13"></td>
-      <td><input type='text' name='ramified' value="{{info.ramified}}" size=15 placeholder="2" /></td>
-      <td><input type='text' name='unramified' value = "{{info.unramified}}" size=15 placeholder="5,7" /></td>
-      <td><input type='text' name='frobenius_schur_indicator' value = "{{info.frobenius_schur_indicator}}" size=15 placeholder="1" /></td>
+      <td><input type='text' name='container' value="{{info.container}}" style="width: 160px;" placeholder="6T13"></td>
+      <td><input type='text' name='ramified' value="{{info.ramified}}" style="width: 160px;" placeholder="2" /></td>
+      <td><input type='text' name='unramified' value = "{{info.unramified}}" style="width: 160px;" placeholder="5,7" /></td>
+      <td><input type='text' name='frobenius_schur_indicator' value = "{{info.frobenius_schur_indicator}}" style="width: 160px;" placeholder="1" /></td>
     </tr>
   <tr>
     <td class="button"><button type='submit' value='Search' onclick='resetStart()'>Search again</button></td>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -14,7 +14,7 @@
 
     <tr>
       <td><input type='text' name='dimension' value="{{info.dimension}}" size=15 placeholder="2"/></td>
-      <td><input type='text' name='conductor' value="{{info.conductor}}" size=15 placeholder="50-100,150-200"/></td>
+      <td><input type='text' name='conductor' value="{{info.conductor}}" size=15 placeholder="51,100-200"/></td>
       <td><input type='text' name='group' value="{{info.group}}" size=15 placeholder="A5"></td>
       <td><input type='text' name='root_number' placeholder="1" value = "{{info.root_number}}" size=15/></td>
       <td><select name='Is_Even' width="105" style="width: 105px">


### PR DESCRIPTION
To address https://github.com/LMFDB/lmfdb/issues/3373, I updated the templates so that the placeholders and formexamples match (so now the Conductor placeholder fits in the box), and resized the Parity box.