### PR TITLE
Fix $regex

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1369,7 +1369,7 @@ class PostgresTable(PostgresBase):
             elif key == '$like':
                 cmd = SQL("{0} LIKE %s")
             elif key == '$regex':
-                cmd = SQL("{0} ~ '%s'")
+                cmd = SQL("{0} ~ %s")
             else:
                 raise ValueError("Error building query: {0}".format(key))
             if col_type == 'jsonb':


### PR DESCRIPTION
With this change
```
db.ec_curves.search({'jinv': {'$regex': '12'}})
```
should work.