### PR TITLE
Remove optimization on split_ors, change criterion for when it's applied

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1844,9 +1844,6 @@ class PostgresTable(PostgresBase):
                 total = 0
                 prelimit = max(limit + offset, self._count_cutoff) if nres is None else limit + offset
                 exact_count = True # updated below if we have a subquery hitting the prelimit
-                # short_circuit determines whether we execute all queries; not all are needed
-                # if we reach the limit and the queries all include the primary sort key
-                short_circuit = primary_sort is None or all(primary_sort in Q for Q in queries)
                 for Q in queries:
                     cur = run_one_query(Q, prelimit, 0)
                     if cur.rowcount == prelimit and nres is None:
@@ -1856,12 +1853,8 @@ class PostgresTable(PostgresBase):
                     # but the sorting runtime is small compared to getting the records from
                     # postgres in the first place, so we use a simpler option.
                     # We override the projection on the iterator since we need to sort
-                    results.extend(list(self._search_iterator(cur, search_cols,
-                                                              extra_cols, projection=1)))
-                    if short_circuit and total >= prelimit:
-                        if nres is None:
-                            exact_count = False
-                        break
+                    results.extend(self._search_iterator(cur, search_cols,
+                                                         extra_cols, projection=1))
                 if all((asc == 1 or self.col_type[col] in number_types) for col, asc in raw_sort):
                     # every key is in increasing order or numeric so we can just use a tuple as a sort key
                     if raw_sort:

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1805,10 +1805,6 @@ class PostgresTable(PostgresBase):
             sort_cols = [col[0] for col in raw_sort]
             sort_only = tuple(col for col in sort_cols if col not in search_cols)
             search_cols = search_cols + sort_only
-            if raw_sort:
-                primary_sort = raw_sort[0][0]
-            else:
-                primary_sort = None
         vars = SQL(", ").join(map(IdentifierWrapper, search_cols + extra_cols))
         tbl = self._get_table_clause(extra_cols)
         nres = None if limit is None else self.stats.quick_count(query)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -721,7 +721,7 @@ def number_field_jump(info):
              shortcuts={'natural':number_field_jump,
                         #'algebra':number_field_algebra,
                         'download':download_search},
-             split_ors=['galois_group'],
+             split_ors=['galt'],
              bread=lambda:[('Global Number Fields', url_for(".number_field_render_webpage")),
                            ('Search Results', '.')],
              learnmore=learnmore_list)

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -86,3 +86,6 @@ class NumberFieldTest(LmfdbTest):
     def test_split_ors(self):
         self.check_args('/NumberField/?signature=%5B0%2C3%5D&galois_group=S3', '6.0.177147.2')
         self.check_args('/NumberField/?signature=%5B3%2C0%5D&galois_group=S3', '3.3.229.1')
+        self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=3%2C6','4.4.1311025.1')
+        self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=6%2C3','4.4.1311025.1')
+        self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=5-6%2C3','4.4.485809.1')

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -16,13 +16,13 @@ def use_split_ors(info, query, split_ors, offset, table):
 
     - ``info`` -- the info dictionary passed in from the front end
     - ``query`` -- the processed query dictionary for passage to postgres
-    - ``split_ors`` -- either None (never split ors), or a list of fields in ``info`` whose presence will lead to splitting ors.
+    - ``split_ors`` -- either None (never split ors), or a list of fields in ``query['$or']`` whose presence will lead to splitting ors.
     - ``offset`` -- the current offset for the query
     - ``table`` -- the search table on which the query will be executed
     """
     return (split_ors is not None and
-            any(field in info for field in split_ors) and
             len(query.get('$or',[])) > 1 and
+            any(field in opt for field in split_ors for opt in query['$or']) and
             # We don't support large offsets since sorting in Python requires
             #fetching all records, starting from 0
             offset < table._count_cutoff)


### PR DESCRIPTION
The bug in #3468 was caused by an invalid optimization that's this PR removes.  I also change the criterion for using split_ors to make it more restrictive, so that it isn't actually triggered in the example from that issue.