### PR TITLE
Tweak search button location (and uniformize Dirichlet search results count)

### DIFF
--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -107,13 +107,9 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
         <td><span class="formexample"> +1 for orthogonal, -1 for symplectic, 0 for non-real character </span></td>
     </tr>
 
-    <tr>
-        <td align=left>Results to display</td><td><input type='text' name='count' value='50' style="width: 160px;"></td>
-    </tr>
+    <tr><td align=left>Results to display</td><td><input type='text' name='count' value='50' style="width: 160px;"></td></tr>
+    <tr><td><button type='submit' value='Search'>Search</button></td></tr>
   </table>
-  
-
-<td><button type='submit' value='Search'>Search</button></td>
 </form>
 {# 
     <br>

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -44,7 +44,7 @@ def parse_interval(arg, name):
 
 def parse_limit (arg):
     if not arg:
-        return 25
+        return 50
     limit = -1
     arg = arg.replace  (' ','')
     if re.match('^[0-9]+$', arg):

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -84,7 +84,7 @@
                 </select>
             </td>
         </tr>
-        <td><tr><button type='submit' > Search </button></tr></td>
+        <tr><td><button type='submit' > Search </button></td></tr>
     </table>
 </form>
 

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -84,11 +84,8 @@
                 </select>
             </td>
         </tr>
+        <td><tr><button type='submit' > Search </button></tr></td>
     </table>
-    <p></p>
-    <td>
-        <button type='submit' > Search </button>
-    </td>
 </form>
 
 {#

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -163,17 +163,10 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
       </td>
       <td colspan=3>&nbsp;</td>
     </tr>
- <tr>
-<td>Results to display</td><td> <input type='text' name='count' value=50 size='10'></td>
- </tr>
-
-  </table>
-<p></p>
-<td><button type='submit' value='Search'>Search</button></td>
-<p></p>
+<tr><td>Results to display</td><td> <input type='text' name='count' value=50 size='10'></td></tr>
+<tr><td><button type='submit' value='Search'>Search</button></td></tr>
+</table>
 </form>
-
-
 
 
 {% if DEBUG %}

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -214,12 +214,10 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 <tr>
 <td>Results to display</td><td> <input type='text' name='count' value=50 size=10></td>
 </tr>
-
-
-  </table>
-<p></p>
+<tr>
 <td><button type='submit' value='Search'>Search</button></td>
-
+</tr>
+</table>
 </form>
 
 {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -211,12 +211,8 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
     </td>
 </tr>
 
-<tr>
-<td>Results to display</td><td> <input type='text' name='count' value=50 size=10></td>
-</tr>
-<tr>
-<td><button type='submit' value='Search'>Search</button></td>
-</tr>
+<tr><td>Results to display</td><td> <input type='text' name='count' value=50 size=10></td></tr>
+<tr><td><button type='submit' value='Search'>Search</button></td></tr>
 </table>
 </form>
 

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -146,20 +146,14 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 	      <span class="formexample">e.g. -1, or 1..3</span>
 	    </td>
           </tr>
-
-
-          <tr>
+         <tr>
           <td> Results to display </td>
           <td>
             <input type="text" name="count" value="{{info.count}}" size=10>
           </td>
         </tr>
-
+        <tr><td><button type="submit" value="Search">Search</button></td></tr>
        </table>
-        <button type="submit" value="Search">Search</button>
       </form>
-
-    
-
 
 {% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -152,14 +152,10 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 	<span class="formexample"></span>
 	 </td></tr>
 
-          <tr>
-          <td>
-              Results to display
-            </td><td><input id="count" type="text" name="count" value="50" size="10"></td>
-          </tr>
+    <tr><td>Results to display</td><td><input id="count" type="text" name="count" value="50" size="10"></td></tr>
+    <tr><td><button type='submit' value='search'>Search</button></td></tr>
   </table>
-        <button type='submit' value='search'>Search</button>
-      </form>
+  </form>
 
 
       {% endblock %}

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -113,53 +113,35 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
       <form id="search"  onsubmit="cleanSubmit(this.id)">
         <table class="">
           <tr align=left>
-            <td>
-          {{KNOWL('lf.degree',title='Degree')}}
-            </td><td><input type="text" name="n" value="" size=10 placeholder="6">
-      <td>
-	<span class="formexample">e.g. 6, or a range like 3..5</span>
-          <tr>
-            <td>
-              {{KNOWL('lf.qp',title='Prime $p$ for base field $\Q_p$')}}
-            <td><input type="text" name="p" value="" size=10 placeholder="3">
-      <td>
-	<span class="formexample">e.g. 3, or a range like 3..7</span>
-          <tr>
-            <td>
-              {{KNOWL('lf.discriminant_exponent',title='Discriminant
-              exponent $c$')}}
-            <td><input type="text" name="c" value="" size=10 placeholder="8">
-      <td>
-	<span class="formexample">e.g. 8, or a range like 2..6</span>
-          <tr>
-            <td>
-              {{KNOWL('lf.ramification_index',title='Ramification
-              index $e$')}}
-            <td><input type="text" name="e" value="" size=10 placeholder="3">
-      <td>
-	<span class="formexample">e.g. 3, or a range like 2..6</span>
-          <tr>
-            <td>
-              {{KNOWL('lf.top_slope',title='Top slope')}}
-            <td><input type="text" name="topslope" value="" size=10 placeholder="4/3">
-      <td>
-	<span class="formexample">e.g. 0, 1, 2, 4/3, 3.5, or a range like 3..5</span>
-          <tr>
-            <td>
-              {{KNOWL('nf.galois_group',title='Galois
-              group $G$')}}
-            <td><input type="text" name="gal" value="" size=10 placeholder="5T3">
-      <td>
-	<span class="formexample">e.g. 5T3, C4, or a list of
-{{KNOWL('nf.galois_group.name',title='labels')}}
-</span>
-          <tr>
-            <td>
-              Results to display
-            <td><td><input type="text" name="count" value="{{info.count}}" size=10>
-          <tr>
-            <td>
-              <button type="submit" value="Search">Search</button>
+            <td>{{KNOWL('lf.degree',title='Degree')}}</td>
+            <td><input type="text" name="n" value="" size=10 placeholder="6"></td>
+            <td><span class="formexample">e.g. 6, or a range like 3..5</span></td>
+          </tr><tr>
+            <td>{{KNOWL('lf.qp',title='Prime $p$ for base field $\Q_p$')}}</td>
+            <td><input type="text" name="p" value="" size=10 placeholder="3"></td>
+            <td><span class="formexample">e.g. 3, or a range like 3..7</span></td>
+          </tr><tr>
+            <td>{{KNOWL('lf.discriminant_exponent',title='Discriminant exponent $c$')}}</td>
+            <td><input type="text" name="c" value="" size=10 placeholder="8"></td>
+            <td><span class="formexample">e.g. 8, or a range like 2..6</span></td>
+          </tr><tr>
+            <td>{{KNOWL('lf.ramification_index',title='Ramification index $e$')}}</td>
+            <td><input type="text" name="e" value="" size=10 placeholder="3"></td>
+            <td><span class="formexample">e.g. 3, or a range like 2..6</span></td>
+          </tr><tr>
+            <td>{{KNOWL('lf.top_slope',title='Top slope')}}</td>
+            <td><input type="text" name="topslope" value="" size=10 placeholder="4/3"></td>
+            <td><span class="formexample">e.g. 0, 1, 2, 4/3, 3.5, or a range like 3..5</span></td>
+          </tr><tr>
+            <td>{{KNOWL('nf.galois_group',title='Galois group $G$')}}</td>
+            <td><input type="text" name="gal" value="" size=10 placeholder="5T3"></td>
+            <td><span class="formexample">e.g. 5T3, C4, or a list of {{KNOWL('nf.galois_group.name',title='labels')}}</span></td>
+          </tr><tr>
+            <td>Results to display</td>
+            <td><input type="text" name="count" value="{{info.count}}" size=10></td>
+          </tr><tr>
+            <td><button type="submit" value="Search">Search</button></td>
+          </tr>
       </table>
     </form>
 

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -154,14 +154,13 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
 {{KNOWL('nf.galois_group.name',title='labels')}}
 </span>
           <tr>
-          <td>
+            <td>
               Results to display
-            </td><td><input type="text" name="count" value="{{info.count}}" size=10>
-  </table>
-        <button type="submit" value="Search">Search</button>
-      </form>
-
-
-
+            <td><td><input type="text" name="count" value="{{info.count}}" size=10>
+          <tr>
+            <td>
+              <button type="submit" value="Search">Search</button>
+      </table>
+    </form>
 
 {% endblock %}

--- a/lmfdb/number_fields/templates/nf-index.html
+++ b/lmfdb/number_fields/templates/nf-index.html
@@ -129,8 +129,9 @@ A <a href={{url_for('.random_nfglobal')}}>random global number field</a> from th
 <tr>
 <td align="left">Results to display</td><td> <input type='text' name='count' value="{{info.count}}" size=10></td>
 <tr>
-<button type='submit'>Search</button></td>
-
+<tr>
+<td><button type='submit'>Search</button></td>
+</tr>
 
 </table>
 </form>


### PR DESCRIPTION
This is a minor follow up to the recent uniformization of search pages, it fixes an html tag issue in the number field search page that was causing the search button to appear at the top of the search form rather than the bottom:

https://beta.lmfdb.org/NumberField/ (button currently at the top of the search form, unlike others)
http://127.0.0.1:37777/NumberField/ (button now at bottom of the search form like all the others)

I also uniformized the loacation of the search button by making it an entry in the table of search inputs so that it appears slightly indented in the search form (this was previously the case for about half the search pages and not the case for the other hafl), compare:

https://beta.lmfdb.org/Genus2Curve/Q/ (button was already in search table)
https://beta.lmfdb.org/LocalNumberField/ (button was not in search table)
http://127.0.0.1:37777/Genus2Curve/Q/ (button still in search table -- no change)
http://127.0.0.1:37777/LocalNumberField/ (button is now in search table)

I also changed the default search count for Dirichlet characters to 50 to match all the other pages

https://beta.lmfdb.org/Character/Dirichlet/?all=1 (shows 25 results even though gray text says 50)
http://127.0.0.1:37777/Character/Dirichlet/?all=1 (shows 50 search results like all other pages)
