### PR TITLE
Fixing magma code snippets for magma relating to the disc of a number field

### DIFF
--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -39,17 +39,17 @@ signature:
 discriminant:
   sage:  K.disc()
   pari:  K.disc
-  magma: Discriminant(K);
+  magma: Discriminant(Integers(K));
 
 rd:
   sage: (K.disc().abs())^(1./K.degree())
   pari: abs(K.disc)^(1/poldegree(K.pol))
-  magma: Abs(Discriminant(K))^(1/Degree(K));
+  magma: Abs(Discriminant(Integers(K)))^(1/Degree(K));
 
 ramified_primes:
   sage:  K.disc().support()
   pari:  factor(abs(K.disc))[,1]~
-  magma: PrimeDivisors(Discriminant(K));
+  magma: PrimeDivisors(Discriminant(Integers(K)));
 
 integral_basis:
   sage:  K.integral_basis()


### PR DESCRIPTION
You can test by looking at any number field page.  The one suggested by the bug reporter

https://beta.lmfdb.org/NumberField/8.0.8653650625.2
http://127.0.0.1:37777//NumberField/8.0.8653650625.2

gives an example which, if you run the magma commands, makes a difference.