### PR TITLE
fixing the use of next for python3 (no .next)

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -99,7 +99,7 @@ class ECisog_class(object):
         from sage.matrix.all import Matrix
         if self.label_type == 'Cremona':
             # permute rows/cols
-            perm = lambda i: (c for c in self.curves if c['number']==i+1).next()['lmfdb_number']-1
+            perm = lambda i: next(c for c in self.curves if c['number']==i+1)['lmfdb_number']-1
             self.isogeny_matrix = [[self.isogeny_matrix[perm(i)][perm(j)] for i in range(ncurves)] for j in range(ncurves)]
 
         self.isogeny_matrix = Matrix(self.isogeny_matrix)

--- a/lmfdb/hilbert_modular_forms/q_expansion.py
+++ b/lmfdb/hilbert_modular_forms/q_expansion.py
@@ -30,7 +30,7 @@ def qexpansion(field_label=None):
 
     field_label = None
 
-    v = S.next()
+    v = next(S)
     while True:
         # NN_label = v["level_label"] # never used
         v_label = v["label"]
@@ -38,7 +38,7 @@ def qexpansion(field_label=None):
         print(v_label)
 
         if v.get('q_expansion') is not None:
-            v = S.next()
+            v = next(S)
             continue
 
         if field_label is None or not field_label != v["field_label"]:
@@ -124,4 +124,4 @@ def qexpansion(field_label=None):
         # UPDATES DON'T WORK
         #db.hmf_forms.save(v)
 
-        v = S.next()
+        v = next(S)

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -213,11 +213,11 @@ def primes_iter(K, condition=None, sort_key=prime_label, maxnorm=Infinity):
 
     # pop the first prime off each iterator (allowing for the
     # possibility that there may be none):
-    Ps = [0 for d in dlist]
-    ns = [Infinity for d in dlist]
-    for i,PP in enumerate(PPs):
+    Ps = [0 for _ in dlist]
+    ns = [Infinity for _ in dlist]
+    for i, PP in enumerate(PPs):
         try:
-            P = PP.next()
+            P = next(PP)
             Ps[i] = P
             ns[i] = P.norm()
         except StopIteration:
@@ -236,7 +236,7 @@ def primes_iter(K, condition=None, sort_key=prime_label, maxnorm=Infinity):
 
         # pop the next prime off that sub-iterator, detecting if it has finished:
         try:
-            Ps[i] = PPs[i].next()
+            Ps[i] = next(PPs[i])
             ns[i] = Ps[i].norm()
         except StopIteration:
             # prevent i'th sub-iterator from being used again

--- a/scripts/ecnf/hmf_check_find.py
+++ b/scripts/ecnf/hmf_check_find.py
@@ -772,7 +772,7 @@ def magma_output_iter(infilename):
 
     while True:
         try:
-            L = infile.next()
+            L = next(infile)
         except StopIteration:
             raise StopIteration
 

--- a/scripts/hmf/import_hmf_data.py
+++ b/scripts/hmf/import_hmf_data.py
@@ -98,7 +98,7 @@ def import_data(hmf_filename):
     assert cnt >= 1
     field_label = None
     for i in range(cnt):
-        nf = fields_matching.next()
+        nf = next(fields_matching)
         if nf['coefficients'] == coeffs:
             field_label = nf['label']
     assert field_label is not None
@@ -267,7 +267,7 @@ def import_data(hmf_filename):
         if existing_forms.count() == 0:
             hmf_forms.insert(info)
         else:
-            existing_form = existing_forms.next()
+            existing_form = next(existing_forms)
             assert info['hecke_eigenvalues'] == existing_form['hecke_eigenvalues']
             print("...duplicate")
 

--- a/scripts/hmf/import_hmf_data_fix_permuted_primes.py
+++ b/scripts/hmf/import_hmf_data_fix_permuted_primes.py
@@ -77,7 +77,7 @@ def import_data_fix_perm_primes(hmf_filename, fileprefix=None, ferrors=None, tes
     field_label = None
     co = str(coeffs)[1:-1].replace(" ","")
     for i in range(cnt):
-        nf = fields_matching.next()
+        nf = next(fields_matching)
         print("Comparing coeffs %s with %s" % (nf['coeffs'], co))
         if nf['coeffs'] == co:
             field_label = nf['label']

--- a/scripts/hmf/import_hmf_data_gnu_phase_0.py
+++ b/scripts/hmf/import_hmf_data_gnu_phase_0.py
@@ -98,7 +98,7 @@ def import_data(hmf_filename, fileprefix=None, ferrors=None, test=True):
     field_label = None
     co = str(coeffs)[1:-1].replace(" ","")
     for i in range(cnt):
-        nf = fields_matching.next()
+        nf = next(fields_matching)
         print("Comparing coeffs %s with %s" % (nf['coeffs'], co))
         if nf['coeffs'] == co:
             field_label = nf['label']
@@ -267,7 +267,7 @@ def import_data(hmf_filename, fileprefix=None, ferrors=None, test=True):
             else:
                 hmf_forms.insert_one(info)
         else:
-            existing_form = existing_forms.next()
+            existing_form = next(existing_forms)
             assert info['hecke_polynomial'] == existing_form['hecke_polynomial']
             try:
                 assert info['hecke_eigenvalues'] == existing_form['hecke_eigenvalues']

--- a/scripts/hmf/import_hmf_data_new_Galois_squarefull_forms.py
+++ b/scripts/hmf/import_hmf_data_new_Galois_squarefull_forms.py
@@ -78,7 +78,7 @@ def import_data(hmf_filename, fileprefix=None, ferrors=None, test=True):
     field_label = None
     co = str(coeffs)[1:-1].replace(" ","")
     for i in range(cnt):
-        nf = fields_matching.next()
+        nf = next(fields_matching)
         print("Comparing coeffs %s with %s" % (nf['coeffs'], co))
         if nf['coeffs'] == co:
             field_label = nf['label']
@@ -261,7 +261,7 @@ def import_data(hmf_filename, fileprefix=None, ferrors=None, test=True):
             else:
                 hmf_forms.insert(info)
         else:
-            existing_form = existing_forms.next()
+            existing_form = next(existing_forms)
             assert info['hecke_polynomial'] == existing_form['hecke_polynomial']
             try:
                 assert info['hecke_eigenvalues'] == existing_form['hecke_eigenvalues']

--- a/scripts/hmf/recompute_AL.py
+++ b/scripts/hmf/recompute_AL.py
@@ -21,7 +21,7 @@ def recompute_AL():
     S = S.sort("label")
 
     while True:
-        v = S.next()
+        v = next(S)
         NN_label = v["level_label"]
         v_label = v["label"]
 

--- a/scripts/hmf/recompute_AL_modp.py
+++ b/scripts/hmf/recompute_AL_modp.py
@@ -25,7 +25,7 @@ def recompute_AL(field_label=None, skip_odd=False):
 
     magma.eval('SetVerbose("ModFrmHil", 1);')
 
-    v = S.next()
+    v = next(S)
     while True:
         NN_label = v["level_label"]
         v_label = v["label"]
@@ -53,7 +53,7 @@ def recompute_AL(field_label=None, skip_odd=False):
         if skip_odd and F["degree"] % 2 == 1 and v["level_norm"] > 300:
             print("...level norm > 300, skipping!")
             try:
-                v = S.next()
+                v = next(S)
                 continue
             except StopIteration:
                 break
@@ -148,4 +148,4 @@ def recompute_AL(field_label=None, skip_odd=False):
         v["AL_eigenvalues_fixed"] = 'done'
         hmf_forms.save(v)
 
-        v = S.next()
+        v = next(S)

--- a/scripts/lfunctions/build_Lfunction_db_2.py
+++ b/scripts/lfunctions/build_Lfunction_db_2.py
@@ -25,8 +25,8 @@ def Lfunction_iterator(dirichlet_max=100):
     yield RiemannZeta()
     for L in Dirichlet_Lfunctions_iterator(dirichlet_max):
         yield L
-    for curve in EC_iterator():
-        yield L
+    for L_of_curve in EC_iterator():
+        yield L_of_curve
 
 
 def inject_Lfunctions(it):


### PR DESCRIPTION
mainly replacing xxx.next() by next(xxx) (which works both in py2 and py3)

plus two minor lgtm warning fixes, one for a bug in scripts/lfunctions/build_Lfunction_db_2.py