### PR TITLE
commiting buffered cursors

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -1593,7 +1593,8 @@ class PostgresTable(PostgresBase):
         finally:
             if isinstance(cur, pg_cursor):
                 cur.close()
-                if cur.withhold:  # to assure that it is a buffered cursor
+                if (cur.withhold and # to assure that it is a buffered cursor
+                    self._db._nocommit_stack == 0): # and there is nothing to commmit
                     cur.connection.commit()
 
     ##################################################################

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -341,8 +341,9 @@ class PostgresBase(object):
         - ``slow_note`` -- a tuple for generating more useful data for slow query logging.
         - ``reissued`` -- used internally to prevent infinite recursion when attempting to
             reset the connection.
-        - ``buffered`` -- whether to create a server side cursor that must be
-            manually closed after using it, this implies ``commit=False``.
+        - ``buffered`` -- whether to create a server side cursor that must be manually
+            closed and connection committed  (to closed the transaction) after using it,
+            this implies ``commit=False``.
 
         .. NOTE:
 
@@ -1592,6 +1593,8 @@ class PostgresTable(PostgresBase):
         finally:
             if isinstance(cur, pg_cursor):
                 cur.close()
+                if cur.withhold:  # to assure that it is a buffered cursor
+                    cur.connection.commit()
 
     ##################################################################
     # Methods for querying                                           #


### PR DESCRIPTION
This resolves #3494, by committing the connection instead of just closing the cursor.

To check that it works, run the following snippet with master and with the PR.
```
from lmfdb.backend.database import db, SQL
other = db.cursor()
relationid = list(db._execute(SQL("SELECT OID from pg_class where relname='g2c_curves'")))[0][0]
qactivity = "SELECT  1 from pg_locks l WHERE relation=%s" % relationid
other.execute(SQL(qactivity));
print 'locks at start: %d' % other.rowcount
for e in db.g2c_curves.search():
    other.execute(SQL(qactivity))
    print 'locks in the middle: %d' % other.rowcount
    break
other.execute(SQL(qactivity));
print 'locks at the end: %d' % other.rowcount
```

With the old code we get:
```
locks at start: 0
locks in the middle: 1
locks at the end: 1
```

with this PR you should get:
```
locks at start: 0
locks in the middle: 1
locks at the end: 0
```


This PR has one unintentional consequence, that was also present before we introduced buffered cursors.
If someone runs something like:
```
db.foo.update(..., commit = False)
c = something(db.bar.search(...))
```
outside a `with DelayCommit` the connection will be commited, on the search.