### PR TITLE
py3: do not use "long"

### DIFF
--- a/lmfdb/backend/encoding.py
+++ b/lmfdb/backend/encoding.py
@@ -2,6 +2,8 @@
 This module provides functions for encoding data for storage in Postgres
 and decoding the results.
 """
+from six import integer_types as six_integers
+
 from psycopg2.extras import register_json, Json as pgJson
 from psycopg2.extensions import adapt, register_type, register_adapter, new_type, new_array_type, UNICODE, UNICODEARRAY, AsIs, ISQLQuote
 from sage.functions.other import ceil
@@ -237,7 +239,7 @@ class Json(pgJson):
         elif isinstance(obj, datetime.datetime):
             return {'__datetime__': 0,
                     'data': "%s"%(obj)}
-        elif isinstance(obj, (basestring, int, long, bool, float)):
+        elif isinstance(obj, (basestring, bool, float) + six_integers):
             return obj
         else:
             raise ValueError("Unsupported type: %s"%(type(obj)))
@@ -354,7 +356,7 @@ def copy_dumps(inp, typ, recursing=False):
         return '{' + ",".join(copy_dumps(x, subtyp, recursing=True) for x in inp) + '}'
     elif isinstance(inp, RealLiteral):
         return inp.literal
-    elif isinstance(inp, (int, long, Integer, float, RealNumber)):
+    elif isinstance(inp, (Integer, float, RealNumber) + six_integers):
         return str(inp).replace('L','')
     elif typ=='boolean':
         return 't' if inp else 'f'

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -506,8 +506,8 @@ def jump_box(info):
     if OLD_SPACE_LABEL_RE.match(jump):
         jump = convert_spacelabel_from_conrey(jump)
     #handle direct trace_hash search
-    if re.match(r'^\#\d+$',jump) and long(jump[1:]) < 2**61:
-        label = db.mf_newforms.lucky({'trace_hash': long(jump[1:].strip())}, projection="label")
+    if re.match(r'^\#\d+$', jump) and ZZ(jump[1:]) < 2**61:
+        label = db.mf_newforms.lucky({'trace_hash': ZZ(jump[1:].strip())}, projection="label")
         if label:
             return redirect(url_for_label(label), 301)
         else:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -197,7 +197,6 @@ class WebEC(object):
         data['j_inv_factor'] = latex(0)
         if data['j_invariant']: # don't factor 0
             data['j_inv_factor'] = latex(data['j_invariant'].factor())
-        data['j_inv_str'] = unicode(str(data['j_invariant']))
         data['j_inv_latex'] = web_latex(data['j_invariant'])
 
         # extract data about MW rank, generators, heights and torsion:

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -4,6 +4,7 @@
 # @cached()
 # def func(): ...
 from six.moves import range
+from six import integer_types as six_integers
 
 import cmath
 import math
@@ -292,8 +293,10 @@ def to_dict(args, exclude = []):
             d[key] = values
     return d
 
+
 def is_exact(x):
-    return (type(x) in [int, long]) or (isinstance(x, Element) and x.parent().is_exact())
+    return isinstance(x, six_integers) or (isinstance(x, Element) and x.parent().is_exact())
+
 
 def display_float(x, digits, method = "truncate",
                              extra_truncation_digits=3,
@@ -820,7 +823,8 @@ def code_snippet_knowl(D, full=True):
         label = filename
     inner = u"<div>\n<pre></pre>\n</div>\n<div align='right'><a href='%s' target='_blank'>%s</a></div>"
     inner = inner % (url, link_text)
-    return ur'<a title="[code]" knowl="dynamic_show" pretext="%s" kwargs="%s">%s</a>'%(code, inner, label)
+    return u'<a title="[code]" knowl="dynamic_show" pretext="%s" kwargs="%s">%s</a>' % (code, inner, label)
+
 
 def web_latex_poly(coeffs, var='x', superscript=True, bigint_cutoff=20,  bigint_overallmin=400):
     """

--- a/lmfdb/verify/verification.py
+++ b/lmfdb/verify/verification.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from six import integer_types as six_integers
 import traceback, time, os, inspect, sys
 from types import MethodType
 from datetime import datetime
@@ -9,7 +10,7 @@ from sage.all import Integer, vector, ZZ
 
 from lmfdb.backend.database import db, SQL, Composable, IdentifierWrapper as Identifier, Literal
 
-integer_types = (int, long, Integer)
+integer_types = six_integers + (Integer,)
 def accumulate_failures(L):
     """
     Accumulates a list of bad labels


### PR DESCRIPTION
in the case calling long(), I used ZZ instead.

in the type testing cases, I used six.integer_types, see https://six.readthedocs.io/#six.integer_types

I also removed data['j_inv_str'] that was unused.

 and fix one string, because ur"sometext" is no longer allowed.