### PR TITLE
py3: get rid of unicode inside lmfdb

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from six import string_types
 
 import urllib2
 import re
@@ -14,11 +15,13 @@ from datetime import datetime
 from flask import render_template, request, url_for, current_app
 from lmfdb.api import api_page, api_logger
 
+
 def pluck(n, list):
     return [_[n] for _ in list]
 
+
 def quote_string(value):
-    if isinstance(value,unicode) or isinstance(value,str):
+    if isinstance(value, string_types):
         return repr(value)
     return value
 

--- a/lmfdb/hilbert_modular_forms/web_HMF.py
+++ b/lmfdb/hilbert_modular_forms/web_HMF.py
@@ -5,7 +5,7 @@
 #
 # In particular this code assumes that all the data for one HMF is in
 # a single collection, which is no longer the case.
-
+from six import text_type
 from sage.all import QQ, polygen
 
 from lmfdb import db
@@ -139,7 +139,7 @@ class WebHMF(object):
         i = L.rfind("[")
         j = L.rfind("]")
         data['hecke_eigenvalues'] = L[i+1:j].replace(" ","").split(",")
-        data['hecke_eigenvalues'] = [unicode(s) for s in data['hecke_eigenvalues']]
+        data['hecke_eigenvalues'] = [text_type(s) for s in data['hecke_eigenvalues']]
         #print("hecke_eigenvalues = %s..." % data['hecke_eigenvalues'][:20])
 
         # Find (some of the) AL-eigenvalues

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -87,7 +87,7 @@ def styleTheSign(sign):
 def seriescoeff(coeff, index, seriescoefftype, seriestype, digits):
     # seriescoefftype can be: series, serieshtml, signed, literal, factor
     try:
-        if isinstance(coeff,str) or isinstance(coeff,unicode):
+        if isinstance(coeff, string_types):
             if coeff == "I":
                 rp = 0
                 ip = 1

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 from __future__ import print_function
-from six import string_types
+from six import string_types, text_type
 # store passwords, check users, ...
 # password hashing is done with fixed and variable salting
 # Author: Harald Schilly <harald.schilly@univie.ac.at>
@@ -72,7 +72,7 @@ class PostgresUserTable(PostgresBase):
         try:
             import bcrypt
             if not existing_hash:
-                existing_hash = unicode(bcrypt.gensalt())
+                existing_hash = text_type(bcrypt.gensalt())
             return bcrypt.hashpw(pwd.encode('utf-8'), existing_hash.encode('utf-8'))
         except Exception:
             logger.warning("Failed to return bchash, perhaps bcrypt is not installed");

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -94,7 +94,7 @@ class Downloader(object):
     def to_lang(self, lang, inp, level = 0, prepend = ''):
         if inp is None:
             return self.none[lang]
-        if isinstance(inp, str) or isinstance(inp, unicode):
+        if isinstance(inp, string_types):
             return '"{0}"'.format(str(inp))
         if isinstance(inp, int):
             return str(inp)

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -516,7 +516,7 @@ def web_latex(x, enclose=True):
     >>> web_latex(x**23 + 2*x + 1)
     '\\( x^{23} + 2 \\, x + 1 \\)'
     """
-    if isinstance(x, (str, unicode)):
+    if isinstance(x, string_types):
         return x
     if enclose:
         return "\( %s \)" % latex(x)
@@ -558,7 +558,7 @@ def web_latex_split_on(x, on=['+', '-']):
     >>> web_latex_split_on(x**2 + 1)
     '\\( x^{2} \\) + \\(  1 \\)'
     """
-    if isinstance(x, (str, unicode)):
+    if isinstance(x, string_types):
         return x
     else:
         A = "\( %s \)" % latex(x)
@@ -622,7 +622,7 @@ def web_latex_split_on_re(x, r = '(q[^+-]*[+-])'):
     def insert_latex(s):
         return s.group(1) + '\) \('
 
-    if isinstance(x, (str, unicode)):
+    if isinstance(x, string_types):
         return x
     else:
         A = "\( %s \)" % latex(x)


### PR DESCRIPTION
following the removal of basestring, same logic
see https://six.readthedocs.io/#six.string_types and below