### PR TITLE
Accessing stored Maass forms

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_classes.py
@@ -157,6 +157,7 @@ class WebMaassForm(object):
                 else:
                     mwf_logger.debug("setting C!")
                     self.coeffs = C
+                    self.num_coeff = len(C[0][0])
         ## Make sure that self.coeffs is only the current coefficients
         if self._get_coeffs and isinstance(self.coeffs, dict) and not self._get_dirichlet_c_only:
             if not isinstance(self.coeffs, dict):


### PR DESCRIPTION
This is an attempt to solve issues #2576 and #2950. It is a bit of a hack, but it is only for the period until the data is regenerated. For example, http://localhost:37777/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032 is changed to include more coefficients, but there are more. All 5000 should show up when you download.

Currently I am assuming the following (which I cannot verify because of lack of knowledge about the data):
- there are no two forms with the same value of R up to the precision with which R is used in the index;
- the first hit in the database is the one with the smallest 'Ni' in the sense David is saying in #2576; I didn't manage to get sorted output, but this seemed to be always the case.