### PR TITLE
weight-1 newform friends for odd 2D Artin rep orbit pages

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -228,6 +228,7 @@ def render_artin_representation_webpage(label):
             url_for(".render_artin_representation_webpage", label=orblabel)))
     else:
         add_lfunction_friends(friends,label)
+        friends.append(("L-function", url_for("l_functions.l_function_artin_page", label=the_rep.label())))
         for j in range(1,1+the_rep.galois_conjugacy_size()):
             newlabel = label+'c'+str(j)
             friends.append(("Artin representation "+newlabel,

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -62,11 +62,11 @@ def parse_artin_label(label):
 
 def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
-    print "add_lfunction_friends",label,rec
     if rec:
+        num = 10 if 'c' in label.split('.')[-1] else 8 # number of components of CMF lable based on artin label (rep or orbit)
         for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
             s = r['url'].split('/')
-            if r['type'] == 'CMF':
+            if r['type'] == 'CMF' and len(s) == num:
                 cmf_label = '.'.join(s[4:])
                 url = r['url'] if r['url'][0] == '/' else '/' + r['url']
                 friends.append(("Modular form " + cmf_label, url))

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -62,6 +62,7 @@ def parse_artin_label(label):
 
 def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
+    printf "add_lfunction_friends",label,rec
     if rec:
         for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
             s = r['url'].split('/')

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -62,7 +62,7 @@ def parse_artin_label(label):
 
 def add_lfunction_friends(friends, label):
     rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
-    printf "add_lfunction_friends",label,rec
+    print "add_lfunction_friends",label,rec
     if rec:
         for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
             s = r['url'].split('/')

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -65,8 +65,7 @@ def add_lfunction_friends(friends, label):
     if rec:
         for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
             s = r['url'].split('/')
-            # only friend embedded CMFs
-            if r['type'] == 'CMF' and len(s) == 10:
+            if r['type'] == 'CMF':
                 cmf_label = '.'.join(s[4:])
                 url = r['url'] if r['url'][0] == '/' else '/' + r['url']
                 friends.append(("Modular form " + cmf_label, url))
@@ -227,6 +226,7 @@ def render_artin_representation_webpage(label):
         friends.append(("Galois orbit "+orblabel,
             url_for(".render_artin_representation_webpage", label=orblabel)))
     else:
+        add_lfunction_friends(friends,label)
         for j in range(1,1+the_rep.galois_conjugacy_size()):
             newlabel = label+'c'+str(j)
             friends.append(("Artin representation "+newlabel,

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -874,7 +874,7 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/124/1/i/a/67/1/')
         assert 'Artin representation 2.2e2_31.16t60.1c3' in page.data
         assert 'SL(2,3):C_2' in page.data
-        assert '4.0.15376,1' in page.data
+        assert '4.0.15376.1' in page.data
 
     def test_AL_search(self):
         r"""

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -862,15 +862,19 @@ class CmfTest(LmfdbTest):
 
     def test_artin(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
-        assert 'Artin representation 2.3_5_197.8t11.1c1' in page.data
+        assert 'Artin representation 2.3_5_197.8t11.1' in page.data
         assert 'D_4:C_2' in page.data
         assert '8.0.1964705625.1' in page.data
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/1/d/a/')
-        assert 'Artin representation 2.2e2_281.4t3.2c1' in page.data
+        assert 'Artin representation 2.2e2_281.4t3.2' in page.data
         assert '4.0.4496.1' in page.data
         assert 'D_4' in page.data
 
+        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/124/1/i/a/67/1/')
+        assert 'Artin representation 2.2e2_31.16t60.1c3' in page.data
+        assert 'SL(2,3):C_2' in page.data
+        assert '4.0.15376,1' in page.data
 
     def test_AL_search(self):
         r"""


### PR DESCRIPTION
This PR adds newform related object links to home pages of Galois orbits of odd 2d Artin reps that correspond to a weight-1 newform stored in the database (so conductor <= 4000)

Currently artin reps have related object links to embedded newforms (and vice versa), and newforms have related object links Artin rep Galois orbit pages, but Artin rep Galois orbit pages do now know about newforms.  This PR makes a small change to address this.

Before:
https://beta.lmfdb.org/ArtinRepresentation/2.2e2_31.16t60.1 (no newform friend or L-function :()
https://beta.lmfdb.org/ArtinRepresentation/2.2e2_31.16t60.1c1 (embedded newform friend)
https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/124/1/i/a/87/2/ (atrin rep friend)
https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/124/1/i/a/ (artin rep Galois orbit friend)

After:
http://127.0.0.1:37777/ArtinRepresentation/2.2e2_31.16t60.1  (newform friend and L-function :))
http://127.0.0.1:37777/ArtinRepresentation/2.2e2_31.16t60.1c1 (embedded newform friend)
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/124/1/i/a/87/2/ (atrin rep friend)
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/124/1/i/a/ (artin rep Galois orbit friend)

L-function instance records have already been added so the (imprimitive) rational L-function page already sees everybody (newform, Artin rep Galois orbit, embedded newforms, Artin reps)

https://beta.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/124/1/i/a/
https://beta.lmfdb.org/L/ArtinRepresentation/2.2e2_31.16t60.1/

(note that these two URLs go to the same L-function page via two different origins -- eventually L-function URLs will be origin independent but not yet)

and each primitive L-function page sees both the Artin rep and the embedded modular form

https://beta.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/124/1/i/a/67/1/
https://beta.lmfdb.org/L/ArtinRepresentation/2.2e2_31.16t60.1c1/

Note: I have not updated lfunc_instances on the production server yet, so the new lfunction instance entries for these Artin reps only appear on beta.  I will copy lfunc_instances over tomorrow (but this has no impact on the code change in this PR).

