### PR TITLE
remove imprimitive L-function link on embedded newform pages

### DIFF
--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -303,7 +303,7 @@ class WebNewform(object):
 
         # finally L-functions
         if self.weight <= 200:
-            if db.lfunc_instances.exists({'url': nf_url[1:]}):
+            if (self.dim==1 or not self.embedding_label) and db.lfunc_instances.exists({'url': nf_url[1:]}):
                 res.append(('L-function ' + self.label, '/L' + nf_url))
             if self.embedding_label is None and len(self.conrey_indexes)*self.rel_dim > 50:
                 res = [list(map(str, elt)) for elt in res]


### PR DESCRIPTION
Addresses #3383 by removing links to imprimitive L-functions from embedded newform pages.

Before:
http://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/59/2/a/a/1/5/ (two related object L-function links)

After:
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/59/2/a/a/1/5/ (one related object L-function link)
