### PR TITLE
Fix character input handling on Maass form search page (#3372)

### DIFF
--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -68,7 +68,9 @@ FLOAT_RE = re.compile(r'^(\d+|\d+\.\d)$')
 @mwf.route("/<int:level>/<int:weight>/<int:character>/<float:r1>/<float:r2>/", methods=met)
 def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds):
     info = get_args_mwf(level=level, weight=weight, character=character, r1=r1, r2=r2, **kwds)
-    info["credit"] = ""
+    info["credit"] = "Data computed by Stefan Lemurell and Fredrik Str\u00f6mberg."
+    info["bread"] = [('Modular Forms', url_for('mf.modular_form_main_page')),
+             ('Maass Forms', url_for('.render_maass_waveforms'))]
     info["learnmore"] = learnmore_list()
     mwf_logger.debug("args=%s" % request.args)
     mwf_logger.debug("method=%s" % request.method)
@@ -189,7 +191,7 @@ def render_maass_browse_graph(min_level, max_level, min_R, max_R):
     info['coloreven'] = rgbtohex(signtocolour(1))
     info['colorodd'] = rgbtohex(signtocolour(-1))
     bread = [('Modular Forms', url_for('mf.modular_form_main_page')),
-             ('Maass Waveforms', url_for('.render_maass_waveforms'))]
+             ('Maass Forms', url_for('.render_maass_waveforms'))]
     info['bread'] = bread
     info['learnmore'] = learnmore_list()
 
@@ -251,7 +253,7 @@ def render_one_maass_waveform_wp(info, prec=9):
     info['MF'] = MF
     info['title'] = "Maass Form"
     info['bread'] = [('Modular Forms', url_for('mf.modular_form_main_page')),
-                     ('Maass Waveforms', url_for('.render_maass_waveforms'))]
+                     ('Maass Forms', url_for('.render_maass_waveforms'))]
     if hasattr(MF,'level'):
         info['bread'].append(('Level {0}'.format(MF.level), url_for('.render_maass_waveforms', level=MF.level)))
         info['title'] += " on \(\Gamma_{0}( %s )\)" % info['MF'].level
@@ -539,7 +541,7 @@ def get_table():
 def source():
     t = 'Source of Maass forms data'
     bread = [('Modular Forms', url_for('mf.modular_form_main_page')),
-                     ('Maass Waveforms', url_for('.render_maass_waveforms')), ("Source", '')]
+                     ('Maass Forms', url_for('.render_maass_waveforms')), ("Source", '')]
     learnmore = learnmore_list_remove('Source')
     return render_template("single.html", kid='rcs.source.maass',
                            title=t, bread=bread,
@@ -549,7 +551,7 @@ def source():
 def reliability():
     t = 'Reliability of Maass forms data'
     bread = [('Modular Forms', url_for('mf.modular_form_main_page')),
-                     ('Maass Waveforms', url_for('.render_maass_waveforms')), ("Reliability", '')]
+                     ('Maass Forms', url_for('.render_maass_waveforms')), ("Reliability", '')]
     learnmore = learnmore_list_remove('Reliability')
     return render_template("single.html", kid='rcs.rigor.maass',
                            title=t, bread=bread,

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -68,7 +68,7 @@ FLOAT_RE = re.compile(r'^(\d+|\d+\.\d)$')
 @mwf.route("/<int:level>/<int:weight>/<int:character>/<float:r1>/<float:r2>/", methods=met)
 def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds):
     info = get_args_mwf(level=level, weight=weight, character=character, r1=r1, r2=r2, **kwds)
-    info["credit"] = "Data computed by Stefan Lemurell and Fredrik Str\u00f6mberg."
+    info["credit"] = u"Data computed by Stefan Lemurell and Fredrik Str\u00f6mberg."
     info["bread"] = [('Modular Forms', url_for('mf.modular_form_main_page')),
              ('Maass Forms', url_for('.render_maass_waveforms'))]
     info["learnmore"] = learnmore_list()

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -100,7 +100,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                         flash_error("Character %s is ambiguous. Please either specify a level or use a character label of the form <span style='color:black'>q.n</span>, where q specifies the level.", info['character'])
                         return render_template('mwf_navigate.html', **info)
                     n = int(info['character'])
-                    if not gcd(N,n):
+                    if gcd(N,n) != 1:
                         flash_error("Character %s is not coprime to the level %s.", info['character'], str(N))
                         return render_template('mwf_navigate.html', **info)
                 else:

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -96,9 +96,12 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     flash_error("Only the trivial character can be specified in combination with a range of levels.", info['character'])
                     return render_template('mwf_navigate.html', **info)
                 if re.match(POSINT_RE, info['character']):
-                    n = int(s[1])
+                    if N==0:
+                        flash_error("Character %s is ambiguous. Please either specify the level or use a character label of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                        return render_template('mwf_navigate.html', **info)
+                    n = int(info['character'])
                     if not gcd(N,n):
-                        flash_error("Character number %s is not coprime to the level %s.", info['character'], str(N))
+                        flash_error("Character %s is not coprime to the level %s.", info['character'], str(N))
                         return render_template('mwf_navigate.html', **info)
                 else:
                     if  not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -97,7 +97,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     return render_template('mwf_navigate.html', **info)
                 if re.match(POSINT_RE, info['character']):
                     if N==0:
-                        flash_error("Character %s is ambiguous. Please either specify the level or use a character label of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                        flash_error("Character %s is ambiguous. Please either specify a level or use a character label of the form <span style='color:black'>q.n</span>, where q specifies the level.", info['character'])
                         return render_template('mwf_navigate.html', **info)
                     n = int(info['character'])
                     if not gcd(N,n):
@@ -107,16 +107,16 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     if  not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
                         flash_error("%s is not a valid label for a Dirichlet character.  It should be either be 1 (for the trivial character) or of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
                         return render_template('mwf_navigate.html', **info)
-                s = info['character'].split('.')
-                q,n = int(s[0]), int(s[1])
-                if n > q or gcd(q,n) != 1:
-                    flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
-                    return render_template('mwf_navigate.html', **info)
-                if  N > 0 and q != N:
-                    flash_error("The specified character %s is not compatible with the level %s.", info['character'], info['level'])
-                    return render_template('mwf_navigate.html', **info)
-                info['level_range'] = str(q)
-                info['character'] = str(n)
+                    s = info['character'].split('.')
+                    q,n = int(s[0]), int(s[1])
+                    if n > q or gcd(q,n) != 1:
+                        flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                        return render_template('mwf_navigate.html', **info)
+                    if  N > 0 and q != N:
+                        flash_error("The specified character %s is not compatible with the level %s.", info['character'], info['level'])
+                        return render_template('mwf_navigate.html', **info)
+                    info['level_range'] = str(q)
+                    info['character'] = str(n)
         if info['weight'] != -1:
             if not re.match(INT_RE, info['weight']):
                 flash_error("%s is not a valid weight.  It should be a nonnegative integer.", info['weight'])

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -87,21 +87,33 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                     flash_error("%s is not a level, please specify a positive integer <span style='color:black'>n</span> or postivie integer range <span style='color:black'>m..n</span>.", info['level_range'])
                     return render_template('mwf_navigate.html', **info)
         if info['character'] != -1:
-            try:
-                N = int(info.get('level_range','0'))
-            except:
-                flash_error("Character %s cannot be specified in combination with a range of levels.", info['character'])
-                return render_template('mwf_navigate.html', **info)
-            if not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
-                flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
-                return render_template('mwf_navigate.html', **info)
-            s = info['character'].split('.')
-            q,n = int(s[0]), int(s[1])
-            if n > q or gcd(q,n) != 1 or (N > 0 and q != N):
-                flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
-                return render_template('mwf_navigate.html', **info)
-            info['level_range'] = str(q)
-            info['character'] = str(n)
+            if info['character'] == '1' or info['character'] == '1.1':
+                info['character'] = '1'
+            else:
+                try:
+                    N = int(info.get('level_range','0'))
+                except:
+                    flash_error("Only the trivial character can be specified in combination with a range of levels.", info['character'])
+                    return render_template('mwf_navigate.html', **info)
+                if re.match(POSINT_RE, info['character']:
+                    n = int(s[1])
+                    if not gcd(N,n):
+                        flash_error("Character number %s is not coprime to the level %s.", info['character'], str(N))
+                        return render_template('mwf_navigate.html', **info)
+                else:
+                    if  not re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', info['character']):
+                        flash_error("%s is not a valid label for a Dirichlet character.  It should be either be 1 (for the trivial character) or of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                        return render_template('mwf_navigate.html', **info)
+                s = info['character'].split('.')
+                q,n = int(s[0]), int(s[1])
+                if n > q or gcd(q,n) != 1:
+                    flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", info['character'])
+                    return render_template('mwf_navigate.html', **info)
+                if  N > 0 and q != N:
+                    flash_error("The specified character %s is not compatible with the level %s.", info['character'], info['level'])
+                    return render_template('mwf_navigate.html', **info)
+                info['level_range'] = str(q)
+                info['character'] = str(n)
         if info['weight'] != -1:
             if not re.match(INT_RE, info['weight']):
                 flash_error("%s is not a valid weight.  It should be a nonnegative integer.", info['weight'])

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -95,7 +95,7 @@ def render_maass_waveforms(level=0, weight=-1, character=-1, r1=0, r2=0, **kwds)
                 except:
                     flash_error("Only the trivial character can be specified in combination with a range of levels.", info['character'])
                     return render_template('mwf_navigate.html', **info)
-                if re.match(POSINT_RE, info['character']:
+                if re.match(POSINT_RE, info['character']):
                     n = int(s[1])
                     if not gcd(N,n):
                         flash_error("Character number %s is not coprime to the level %s.", info['character'], str(N))


### PR DESCRIPTION
Addresses #3372 concerning how character input is parsed on Maass form pages (also fixes the bread problem, makes the bread consistent, and adds a credit string).

To test, goto the Maass form search page

http://127.0.0.1:37777/ModularForm/GL2/Q/Maass/

and try entering "1" in to the character input box as suggested (this should now work).  Entering the Conrey label 1.1 of the trivial character should produce the same results.

Entering a Conrey label such as 10.9 should still work (as it does now), and you should get the same results as when you put 10 in for the level and 9 for the character (which does not currently work on the live site but used to work this way).

Entering a range of levels and any character other than the trivial character should result in an error message (as it does now), but it should work with the trivial character (specified either as "1" or "1.1").

On all pages, including when an error is displayed, the bread should now begin "Modular Forms -> Maass Forms" (there were previously situations where either the bread was missing or in some places was "Modular Forms -> Maass Waveforms".

