### PR TITLE
Fixing missing Q and Dirichlet in Learn more about routes

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -135,7 +135,7 @@ def render_DirichletNavigation():
        info['title'] = 'Dirichlet Characters'
        return render_template('CharacterNavigate.html', **info)
 
-@characters_page.route("/Labels")
+@characters_page.route("/Dirichlet/Labels")
 def labels_page():
     info = {}
     info['title'] = 'Dirichlet Character Labels'
@@ -144,7 +144,7 @@ def labels_page():
     info['learnmore'] = learn('labels')
     return render_template("single.html", kid='character.dirichlet.conrey', **info)
 
-@characters_page.route("/Source")
+@characters_page.route("/Dirichlet/Source")
 def how_computed_page():
     info = {}
     info['title'] = 'Source of Dirichlet Character Data'
@@ -153,7 +153,7 @@ def how_computed_page():
     info['learnmore'] = learn('source')
     return render_template("single.html", kid='rcs.source.character.dirichlet', **info)
 
-@characters_page.route("/Reliability")
+@characters_page.route("/Dirichlet/Reliability")
 def reliability():
     info = {}
     info['title'] = 'Reliability of Dirichlet Character Data'
@@ -162,7 +162,7 @@ def reliability():
     info['learnmore'] = learn('reliability')
     return render_template("single.html", kid='rcs.rigor.character.dirichlet', **info)
 
-@characters_page.route("/Completeness")
+@characters_page.route("/Dirichlet/Completeness")
 def extent_page():
     info = {}
     info['title'] = 'Completeness of Dirichlet Character Data'

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -422,28 +422,28 @@ def statistics():
 
 
 
-@g2c_page.route("/Completeness")
+@g2c_page.route("/Q/Completeness")
 def completeness_page():
     t = 'Completeness of Genus 2 Curve Data over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index")),('Completeness',''))
     return render_template("single.html", kid='rcs.cande.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
-@g2c_page.route("/Source")
+@g2c_page.route("/Q/Source")
 def source_page():
     t = 'Source of Genus 2 Curve Data over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index")),('Source',''))
     return render_template("single.html", kid='rcs.source.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
-@g2c_page.route("/Reliability")
+@g2c_page.route("/Q/Reliability")
 def reliability_page():
     t = 'Reliability of Genus 2 Curve Data over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index")),('Reliability',''))
     return render_template("single.html", kid='rcs.rigor.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
-@g2c_page.route("/Labels")
+@g2c_page.route("/Q/Labels")
 def labels_page():
     t = 'Labels for Genus 2 Curves over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\Q$', url_for(".index")),('Labels',''))


### PR DESCRIPTION
In Genus 2 curves and in Dirichlet Characters the links on the "Learn more about" in browse page, are all missing `Q` or `Dirichlet`. In their URL.
At the moment we point to:
www.lmfdb.org/Genus2Curve/Completeness
www.lmfdb.org/Genus2Curve/Labels
www.lmfdb.org/Genus2Curve/Reliability
www.lmfdb.org/Genus2Curve/Source
www.lmfdb.org/Character/Completeness
www.lmfdb.org/Character/Labels
www.lmfdb.org/Character/Reliability
www.lmfdb.org/Character/Source

When we really wanted to point to:
www.lmfdb.org/Genus2Curve/Q/Completeness
www.lmfdb.org/Genus2Curve/Q/Labels
www.lmfdb.org/Genus2Curve/Q/Reliability
www.lmfdb.org/Genus2Curve/Q/Source
www.lmfdb.org/Character/Dirichlet/Completeness
www.lmfdb.org/Character/Dirichlet/Labels
www.lmfdb.org/Character/Dirichlet/Reliability
www.lmfdb.org/Character/Dirichlet/Source