### PR TITLE
Deprecated routes

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -9,7 +9,6 @@ from flask import render_template, url_for, request, redirect, send_file
 from sage.rings.all import PolynomialRing, ZZ
 
 from lmfdb import db
-from lmfdb.app import app
 from lmfdb.logger import make_logger
 from lmfdb.utils import (
     to_dict, flash_error, integer_options, display_knowl,

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -38,10 +38,6 @@ def get_bread(*breads):
 
 abvarfq_credit = "Taylor Dupuy, Kiran Kedlaya, David Roe, Christelle Vincent"
 
-@app.route("/EllipticCurves/Fq")
-def ECFq_redirect():
-    return redirect(url_for("abvarfq.abelian_varieties"), **request.args)
-
 def learnmore_list():
     return [
         ("Completeness of the data", url_for(".completeness_page")),

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -41,10 +41,6 @@ def sorting_label(lab1):
 #    Top level
 #########################
 
-@app.route("/EC")
-def EC_redirect():
-    return redirect(url_for("ec.rational_elliptic_curves", **request.args))
-
 def learnmore_list():
     return [('Completeness of the data', url_for(".completeness_page")),
             ('Source of the data', url_for(".how_computed_page")),

--- a/lmfdb/modular_forms/__init__.py
+++ b/lmfdb/modular_forms/__init__.py
@@ -7,7 +7,7 @@ from lmfdb.app import app
 
 MF_TOP = "Modular Forms"
 MF = "mf"
-mf = flask.Blueprint(MF, __name__, template_folder="views/templates", static_folder="views/static")
+mf = flask.Blueprint(MF, __name__, template_folder="views/templates")
 mf_logger = make_logger(mf)
 
 import maass_forms
@@ -16,7 +16,6 @@ import views
 assert views
 
 app.register_blueprint(mf, url_prefix="/ModularForm/")
-app.register_blueprint(mf, url_prefix="/AutomorphicForm/")
-app.register_blueprint(maass_forms.maassf, url_prefix="/ModularForm/Maass")
+# app.register_blueprint(maass_forms.maassf, url_prefix="/ModularForm/Maass")
 app.register_blueprint(maass_forms.maass_waveforms.mwf, url_prefix="/ModularForm/GL2/Q/Maass")
-app.register_blueprint(maass_forms.picard.mwfp, url_prefix="/ModularForm/GL2/C/Maass")
+# app.register_blueprint(maass_forms.picard.mwfp, url_prefix="/ModularForm/GL2/C/Maass")

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -104,11 +104,6 @@ def poly_to_field_label(pol):
     except:
         return None
 
-@app.route("/NF")
-@app.route("/NF/")
-def NF_redirect():
-    return redirect(url_for("number_fields.number_field_render_webpage", **request.args), 301)
-
 @nf_page.route("/Source")
 def source():
     learnmore = learnmore_list_remove('Source')


### PR DESCRIPTION
I have removed the following routes:
- https://beta.lmfdb.org/AutomorphicForm -- redirects to ModularForm
- https://beta.lmfdb.org/ModularForm/Maass  -- broken
- https://beta.lmfdb.org/ModularForm/GL2/C/Maas -- broken
- https://beta.lmfdb.org/EC -- redirects to EllipticCurve/Q/
- https://beta.lmfdb.org/NF -- redirects to NumberField/

All these are deprecated in my opinion.


