### PR TITLE
adding a .lgtm.yml config file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup:
+      version: 3


### PR DESCRIPTION
This will just tell LGTM to check the code for python3 and not for python2

It will for instance remove the warnings about old-style classes.