### PR TITLE
Cmf table

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -129,6 +129,9 @@ function get_all_embeddings(num_embeddings) {
       {% endif %} {# info.format #}
     </tr>
     {% endfor %} {# m loop #}
+    <tr style="max-height: 0px;" class="border-bottom"> {# Add a bottom border #}
+      <td style="max-height: 0px;margin: 0px;padding: 0px;" colspan="{{(2 if newform.has_exact_qexp else 1) + (1 if single_columns else 3) * (info.CC_n | length)}}"></td>
+    </tr>
     {% if info.CC_m[0] == 1 and (info.CC_m | length) < 100 and (info.CC_m | length) < newform.dim %}
     <tr>
       <td class="sticky-col" colspan="{{(2 if newform.has_exact_qexp else 1) + (1 if single_columns else 3) * (info.CC_n | length)}}">

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -709,7 +709,11 @@ table.ntdata > thead > tr:first-child {
 
 table.ntdata > tbody > tr:last-child {
     border-bottom:  2px solid {{ color.table_ntdata_border }};
-} 
+}
+
+table.sticky-embeddings > tbody > tr:last-child {
+    border-bottom:  2px solid {{ color.table_ntdata_border }};
+}
 
 table.ntdata > tr.even,
 table.ntdata > tbody > tr.even,

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -711,10 +711,6 @@ table.ntdata > tbody > tr:last-child {
     border-bottom:  2px solid {{ color.table_ntdata_border }};
 }
 
-table.sticky-embeddings > tbody > tr:last-child {
-    border-bottom:  2px solid {{ color.table_ntdata_border }};
-}
-
 table.ntdata > tr.even,
 table.ntdata > tbody > tr.even,
 table.ntdata > thead > tr.even,


### PR DESCRIPTION
Fixes the bottom border on the CMF embeddings table.  Compare
* https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/6900/2/f/l/
* https://blue.lmfdb.xyz/ModularForm/GL2/Q/holomorphic/6900/2/f/l/