### PR TITLE
a better numeric converter

### DIFF
--- a/lmfdb/backend/encoding.py
+++ b/lmfdb/backend/encoding.py
@@ -66,7 +66,8 @@ def numeric_converter(value, cur=None):
 
     OUTPUT:
 
-    - either a sage integer (if there is no decimal point) or a real number whose precision depends on the number of digits in value.
+    - either a sage integer (if there is no decimal point) or
+      a real number whose precision depends on the number of digits in value.
     """
     if value is None:
         return None
@@ -74,7 +75,11 @@ def numeric_converter(value, cur=None):
         # The following is a good guess for the bit-precision,
         # but we use LmfdbRealLiterals to ensure that our number
         # prints the same as we got it.
-        prec = ceil(len(value)*3.322)
+
+        # drop the dot and zeros on the left
+        number_of_significant_digits = len(value.replace('.', '').lstrip('0'))
+        # log(10)/log(2) = 3.32192809488736
+        prec = ceil(number_of_significant_digits * 3.32192809488736)
         return LmfdbRealLiteral(RealField(prec), value)
     else:
         return Integer(value)


### PR DESCRIPTION
Our conversion from a numeric to sage was overcounting the number of the significant digit, and thus creating real numbers with too much precision.

By running the following snippet you can see some of the differences:
```
sage: foo = db.g2c_curves.lookup('713.a.713.1', 'regulator')
....: print("%s" % foo)
....: print("%s" % foo.str())
....: print("%s" % foo.str(truncate=True))
```
Old:
```
0.00459244230167
0.00459244230167000014
0.00459244230167000
```

New:
```
0.00459244230167
0.0045924423016714
0.0045924423017
```

I'm still unhappy with the numeric converter.
Perhaps, we should use intervals.
Either with `RealIntervalField`:
```
mid = ZZ(value.replace('.', '').lstrip('0'))*10
lower = mid - 5
upper = mid + 5
return RealIntervalField(prec+10)(lower, upper)/10**(len(value)-value.index('.'))
```
which would give `0.00459244230167?` with absolute diameter `1.0012823903338e-14`
or `RealBallField`
```
RealBallField(prec+10)(value).add_error(5*10**-(len(value)-value.index('.')))
```
which would give: `0.00459244230167 +/- 5.02e-15`

In both cases, the parent must have a bit more precision to handle the error correctly.