### PR TITLE
Fix nf stat template to stop at degree 23

### DIFF
--- a/lmfdb/number_fields/templates/nf-statistics.html
+++ b/lmfdb/number_fields/templates/nf-statistics.html
@@ -4,7 +4,9 @@
 <div>
 The database contains {{ info['total'] }} number fields.
 </div>
-{% set maxdeg = info['maxdeg'] %}
+{# Keeping first line if/when we include higher degrees #}
+{# set maxdeg = info['maxdeg'] #}
+{% set maxdeg = 23 %}
 
 <h2> Distribution by signature </h2>
 {% set ncols = (info['nsig'][maxdeg - 1] | length) %}


### PR DESCRIPTION
The first table on the number field statistics page

http://127.0.0.1:37777/NumberField/stats
https://beta.lmfdb.org/NumberField/stats

has the column headers messed up as well as the totals for each row being in position to be another signature instead of as a total.  This fixes it.

The cause was adding number fields in degrees higher than the previous limit of 23.  We could expand the tables in the future, but they are pretty wide now, and there are relatively few fields in higher degrees.