### PR TITLE
fixing the route for api2/api.css

### DIFF
--- a/lmfdb/api2/api2.py
+++ b/lmfdb/api2/api2.py
@@ -4,7 +4,7 @@ from flask import render_template, request, Response, make_response
 from lmfdb.api2.searchers import searchers, singletons
 import utils
 
-@api2_page.route("api.css")
+@api2_page.route("/api.css")
 def api_css():
     response = make_response(render_template("api.css"))
     response.headers['Content-type'] = 'text/css'

--- a/lmfdb/api2/templates/api.css
+++ b/lmfdb/api2/templates/api.css
@@ -1,6 +1,4 @@
 
-{% import 'color.css' as color %}
-
 .disabledbutton{
     background-color :  {{color.button_background_inactive}}  !important;
     color : #b3b3b3;


### PR DESCRIPTION
Fixing the route for `api2/api.css`, as it was clearly missing a `/`.
And fixing the template, as it was importing the old template `color.css`