### PR TITLE
Swap knowls "Weil polynomial" with "L-polynomial"

### DIFF
--- a/lmfdb/abvar/fq/templates/abvarfq-search-results.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-search-results.html
@@ -20,7 +20,7 @@ table td.params {
     <th class="center">{{ KNOWL('av.fq.lmfdb_label',title="LMFDB label") }}</th>
     <th class="center">{{ KNOWL('ag.dimension',title = "dimension") }}</th>
     <th class="center">{{ KNOWL('ag.base_field',title = "base field") }}</th>
-    <th class="center">{{ KNOWL('av.fq.weil_polynomial',title="Weil polynomial") }}</th>
+    <th class="center">{{ KNOWL('av.fq.l-polynomial',title="L-polynomial") }}</th>
     <th class="center">{{ KNOWL('av.fq.p_rank',title="$p$-rank") }}</th>
     <th align="left">{{ KNOWL('av.decomposition',title="isogeny factors") }}</th>
   </tr>

--- a/lmfdb/abvar/fq/templates/show-abvarfq.html
+++ b/lmfdb/abvar/fq/templates/show-abvarfq.html
@@ -8,7 +8,7 @@
 <table>
     <tr><td>{{ KNOWL('ag.base_field',title = "Base field") }}:</td><td>&nbsp;&nbsp;${{cl.field()}}$</td></tr>
     <tr><td>{{ KNOWL('ag.dimension',title = "Dimension") }}:</td><td>&nbsp;&nbsp;${{cl.g}}$</td></tr>
-    <tr><td>{{ KNOWL('av.fq.weil_polynomial',title='Weil polynomial') }}:</td><td>&nbsp;&nbsp;${{cl.formatted_polynomial}}$</td></tr>
+    <tr><td>{{ KNOWL('av.fq.l-polynomial',title='L-polynomial') }}:</td><td>&nbsp;&nbsp;${{cl.formatted_polynomial}}$</td></tr>
     <tr><td>{{KNOWL('av.fq.frobenius_angles',title='Frobenius angles')}}:</td><td>&nbsp;&nbsp;{{cl.frob_angles()}}</td></tr>
     <tr><td>{{ KNOWL('av.fq.angle_rank',title="Angle rank") }}:</td><td>&nbsp;&nbsp;${{cl.angle_rank}}$ ({{KNOWL('av.fq.frobenius_angles_correctness',title='numerical')}})</td></tr>
     {% if cl.is_simple %}


### PR DESCRIPTION
As per issue #3342, this PR swaps "Weil polynomial" with "L-polynomial" in both the search results and individual pages for abelian varieties over finite fields.