### PR TITLE
Uniformize searching of Galois groups

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -113,7 +113,7 @@ def artin_representation_search(info, query):
     parse_restricted(info,query,"frobenius_schur_indicator",qfield="Indicator",
                      allowed=[1,0,-1],process=int)
     parse_container(info,query, 'container',qfield='Container', name="Smallest permutation representation")
-    parse_galgrp(info,query,"group",name="Group",qfield=("GaloisLabel","Galn"))
+    parse_galgrp(info,query,"group",name="Group",qfield=("GaloisLabel",None))
     parse_ints(info,query,'dimension',qfield='Dim')
     parse_ints(info,query,'conductor',qfield='Conductor')
     parse_bool(info,query,'Is_Even')

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -113,7 +113,7 @@ def artin_representation_search(info, query):
     parse_restricted(info,query,"frobenius_schur_indicator",qfield="Indicator",
                      allowed=[1,0,-1],process=int)
     parse_container(info,query, 'container',qfield='Container', name="Smallest permutation representation")
-    parse_galgrp(info,query,"group",name="Group",qfield=("Galn","Galt"))
+    parse_galgrp(info,query,"group",name="Group",qfield=("GaloisLabel","Galn"))
     parse_ints(info,query,'dimension',qfield='Dim')
     parse_ints(info,query,'conductor',qfield='Conductor')
     parse_bool(info,query,'Is_Even')

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -379,10 +379,12 @@ class ArtinRepresentation(object):
             return nfgg.polredabshtml()
 
     def group(self):
-        return group_display_short(self._data['Galn'],self._data['Galt'])
+        n,t = [int(z) for z in self._data['GaloisLabel'].split("T")]
+        return group_display_short(n,t)
 
     def pretty_galois_knowl(self):
-        return group_display_knowl(self._data['Galn'],self._data['Galt'])
+        n,t = [int(z) for z in self._data['GaloisLabel'].split("T")]
+        return group_display_knowl(n,t)
 
     def __str__(self):
         try:

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -68,7 +68,12 @@ Artin representation: <input type='text' name='natural' size='50' example='3.2e3
     <tr>
         <td align="left">{{ KNOWL('artin.gg_quotient',title="Group") }}</td>
         <td><input type='text' name='group' placeholder="A5" style="width: 160px;"></td>
-        <td><span class="formexample"> e.g. C5, or 8T12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
+        <td><span class="formexample">list of 
+              {{KNOWL('group.small_group_label',title="GAP id's")}},
+          e.g. [8,3] or [16,7], group names from the
+          {{KNOWL('nf.galois_group.name','list of group labels')}}, e.g.
+          C5 or S12, and {{KNOWL('gg.label','transitive group labels')}}, 
+          e.g., 7T2 or 11T5</span></td>
 
     <tr>
         <td align="left">{{ KNOWL('artin.parity',title="Parity") }}</td>

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -11,7 +11,7 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.utils import (
     list_to_latex_matrix, flash_error, comma,
-    clean_input, prep_ranges, parse_bool, parse_ints, parse_bracketed_posints, parse_restricted,
+    clean_input, prep_ranges, parse_bool, parse_ints, parse_galgrp, parse_restricted,
     search_wrap)
 from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
@@ -123,7 +123,7 @@ def galois_group_search(info, query):
     parse_ints(info,query,'t')
     parse_ints(info,query,'order')
     parse_ints(info,query,'nilpotency')
-    parse_bracketed_posints(info, query, qfield='gapidfull', split=False, exactlength=2, keepbrackets=True, name='GAP id', field='gapid')
+    parse_galgrp(info, query, qfield=['label','n'], name='Galois group', field='gal')
     for param in ('cyc', 'solv', 'prim'):
         parse_bool(info, query, param, process=int, blank=['0','Any'])
     parse_restricted(info,query,'parity',allowed=[1,-1],process=int,blank=['0','Any'])

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -138,6 +138,14 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 	    </td>
           </tr>
 
+        <tr>
+          <td >Group name
+	      </td>
+            <td><input type='text' name='group_name' size=10 example='C5'></td>
+	    <td>
+            <span class="formexample"> e.g. C5, or S12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
+          </tr>
+
           <tr>
             <td>
               {{KNOWL('group.nilpotent',title='Nilpotency class')}} 

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -29,22 +29,22 @@ Browse by type:
 
 <p>
 Browse by abstract group:
-<a href="?gapid=[6,1]">$S_3$</a>,
-<a href="?gapid=[8,3]">$D_4$</a>,
-<a href="?gapid=[12,3]">$A_4$</a>,
-<a href="?gapid=[24,12]">$S_4$</a>,
-<a href="?gapid=[60,5]">$A_5$</a>,
-<a href="?gapid=[120,34]">$S_5$</a>,
-<a href="?gapid=[168,42]">$\GL(3,2)$</a>,
-<a href="?gapid=[360,118]">$A_6$</a>,
-<a href="?gapid=[504,156]">$\PSL(2,8)$</a>,
-<a href="?gapid=[660,13]">$\PSL(2,11)$</a>,
-<a href="?gapid=[1092,25]">$\PSL(2,13)$</a>,
-<a href="?solv=False&order=5616">$\PSL(3,3)$</a>,
-<a href="?solv=False&t=323%2C6815&order=6048">$\PSU(3,3)$</a>,
-<a href="?solv=False&t=993%2C12781%2C14345%2C666&order=25920">$\PSp(4,3)$</a>,
-<a href="?solv=False&n=11..22&order=7920">$M_{11}$</a>,
-<a href="?solv=False&n=12&order=95040">$M_{12}$</a>
+<a href="?gal=S3">$S_3$</a>,
+<a href="?gal=D4">$D_4$</a>,
+<a href="?gal=A4">$A_4$</a>,
+<a href="?gal=S4">$S_4$</a>,
+<a href="?gal=A5">$A_5$</a>,
+<a href="?gal=S5">$S_5$</a>,
+<a href="?gal=GL(3,2)">$\GL(3,2)$</a>,
+<a href="?gal=A6">$A_6$</a>,
+<a href="?gal=PSL(2,8)">$\PSL(2,8)$</a>,
+<a href="?gal=PSL(2,11)">$\PSL(2,11)$</a>,
+<a href="?gal=PSL(2,13)">$\PSL(2,13)$</a>,
+<a href="?gal=PSL(3,3)">$\PSL(3,3)$</a>,
+<a href="?gal=PSU(3,3)">$\PSU(3,3)$</a>,
+<a href="?gal=PSp(4,3)">$\PSp(4,3)$</a>,
+<a href="?gal=M11">$M_{11}$</a>,
+<a href="?gal=M12">$M_{12}$</a>
 <p>
 
 <p>
@@ -131,20 +131,18 @@ Search by {{KNOWL('gg.label',title="Galois group label")}}
 
           <tr>
             <td>
-              {{KNOWL('group.small_group_label',title='GAP id')}} 
-            </td><td><input type="text" name="gapid" value="" placeholder="[8,3]" size=10></td>
+              {{KNOWL('group',title='Group')}}
+            </td><td><input type="text" name="gal" value="" placeholder="[8,3]" size=10></td>
 	    <td>
-	      <span class="formexample">e.g. [8,3] or [16,7]</span>
+          <span class="formexample">list of 
+              {{KNOWL('group.small_group_label',title="GAP id's")}},
+          e.g. [8,3] or [16,7], group names from the
+          {{KNOWL('nf.galois_group.name','list of group labels')}}, e.g.
+          C5 or S12, and {{KNOWL('gg.label','transitive group labels')}}, 
+          e.g., 7T2 or 11T5</span>
 	    </td>
           </tr>
 
-        <tr>
-          <td >Group name
-	      </td>
-            <td><input type='text' name='group_name' size=10 example='C5'></td>
-	    <td>
-            <span class="formexample"> e.g. C5, or S12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
-          </tr>
 
           <tr>
             <td>

--- a/lmfdb/galois_groups/templates/gg-search.html
+++ b/lmfdb/galois_groups/templates/gg-search.html
@@ -64,7 +64,7 @@ table.ntdata a {
 {{KNOWL('group.order',title='Order')}} 
 
 <td align=left> 
-{{KNOWL('group.small_group_label',title='GAP id')}} 
+{{KNOWL('group',title='Group')}} 
 
 <td align=left> 
 {{KNOWL('group.nilpotent',title='Nilpotency')}} 
@@ -74,7 +74,7 @@ table.ntdata a {
 <td align=left> <input type="text" name="t" size="5" placeholder="2" value="{{info.t}}" ></td>
 <td align=left> <input type="text" name="order" size="5" placeholder="12" value="{{info.order}}" ></td>
 
-<td align=left><input type="text" name="gapid" size="5" placeholder="[6,3]" value="{{info.gapid}}" ></td>
+<td align=left><input type="text" name="gal" size="5" placeholder="[6,3]" value="{{info.gal}}" ></td>
 <td align=left><input type="text" name="nilpotency" size="5" placeholder="1..100" value="{{info.nilpotency}}" ></td>
 </tr>
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -558,6 +558,7 @@ def group_alias_table():
     ans = '<table border=1 cellpadding=5 class="right_align_table"><thead><tr><th>Alias</th><th>Group</th><th>\(n\)T\(t\)</th></tr></thead>'
     ans += '<tbody>'
     for j in akeys:
+        # Remove An, Cn, Dn, Sn since they are covered by a general comment
         if not re.match(r'^[ACDS]\d+$', j):
             name = group_display_short(aliases[j][0][0], aliases[j][0][1])
             ntlist = aliases[j]
@@ -593,6 +594,8 @@ def complete_group_code(code):
 def complete_group_codes(codes):
     codes = codes.upper()
     ans = []
+    # some commas separate groups, and others are internal to group names
+    # like PSL(2,7) and gap id [6,1]
     # after upper casing, we can replace commas we want to keep with "z"
     codes = re.sub(r'\((\d+),(\d+)\)', r'(\1z\2)', codes)
     codes = re.sub(r'\[(\d+),(\d+)\]', r'[\1z\2]', codes)

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -571,11 +571,18 @@ def group_alias_table():
 def complete_group_code(code):
     if code in aliases:
         return aliases[code]
+    # Try nTj notation
     rematch = re.match(r"^(\d+)T(\d+)$", code)
     if rematch:
         n = int(rematch.group(1))
         t = int(rematch.group(2))
         return [[n, t]]
+    # Try GAP code
+    rematch = re.match(r'^\[\d+,\d+\]$', code)
+    if rematch:
+        nts = list(db.gps_transitive.search({'gapidfull':code}, projection=['n','t']))
+        nts = [[z['n'], z['t']] for z in nts]
+        return nts
     else:
         raise NameError(code)
     return []
@@ -588,6 +595,7 @@ def complete_group_codes(codes):
     ans = []
     # after upper casing, we can replace commas we want to keep with "z"
     codes = re.sub(r'\((\d+),(\d+)\)', r'(\1z\2)', codes)
+    codes = re.sub(r'\[(\d+),(\d+)\]', r'[\1z\2]', codes)
     codelist = codes.split(',')
     # now turn the z's back into commas
     codelist = [re.sub('z', ',', x) for x in codelist]
@@ -784,6 +792,12 @@ aliases['D44'] = [(44,9)]
 aliases['D45'] = [(45,4)]
 aliases['D46'] = [(46,3)]
 aliases['D47'] = [(47,2)]
+
+aliases['M12'] = [(12,295)]
+aliases['PSL(3,3)'] = [(13,7)]
+aliases['PSL(2,13)'] = [(14,30)]
+aliases['PSP(4,3)'] = [(27,993)]
+aliases['PSU(3,3)'] = [(28,323)]
 
 # Load all sibling representations from the database
 labels = ["%sT%s" % elt[0] for elt in aliases.values()]

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -576,12 +576,12 @@ def complete_group_code(code):
     if rematch:
         n = int(rematch.group(1))
         t = int(rematch.group(2))
-        return [[n, t]]
+        return [(n, t)]
     # Try GAP code
     rematch = re.match(r'^\[\d+,\d+\]$', code)
     if rematch:
         nts = list(db.gps_transitive.search({'gapidfull':code}, projection=['n','t']))
-        nts = [[z['n'], z['t']] for z in nts]
+        nts = [(z['n'], z['t']) for z in nts]
         return nts
     else:
         raise NameError(code)

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -558,12 +558,12 @@ def group_alias_table():
     ans = '<table border=1 cellpadding=5 class="right_align_table"><thead><tr><th>Alias</th><th>Group</th><th>\(n\)T\(t\)</th></tr></thead>'
     ans += '<tbody>'
     for j in akeys:
-        name = group_display_short(aliases[j][0][0], aliases[j][0][1])
-        ntlist = aliases[j]
-        #ntlist = filter(lambda x: x[0] < 12, ntlist)
-        ntstrings = [str(x[0]) + "T" + str(x[1]) for x in ntlist]
-        ntstring = ", ".join(ntstrings)
-        ans += "<tr><td>%s</td><td>%s</td><td>%s</td></tr>" % (j, name, ntstring)
+        if not re.match(r'^[ACDS]\d+$', j):
+            name = group_display_short(aliases[j][0][0], aliases[j][0][1])
+            ntlist = aliases[j]
+            ntstrings = [str(x[0]) + "T" + str(x[1]) for x in ntlist]
+            ntstring = ", ".join(ntstrings)
+            ans += "<tr><td>%s</td><td>%s</td><td>%s</td></tr>" % (j, name, ntstring)
     ans += '</tbody></table>'
     return ans
 
@@ -601,7 +601,7 @@ def complete_group_codes(codes):
     codelist = [re.sub('z', ',', x) for x in codelist]
     for code in codelist:
         ans.extend(complete_group_code(code))
-    return ans
+    return list(set(ans))
 
 
 aliases = {}
@@ -794,6 +794,9 @@ aliases['D46'] = [(46,3)]
 aliases['D47'] = [(47,2)]
 
 aliases['M12'] = [(12,295)]
+aliases['M22'] = [(22,38)]
+aliases['M23'] = [(23,5)]
+aliases['M24'] = [(24,24680)]
 aliases['PSL(3,3)'] = [(13,7)]
 aliases['PSL(2,13)'] = [(14,30)]
 aliases['PSP(4,3)'] = [(27,993)]

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -82,7 +82,7 @@ def local_field_data(label):
         nicename = ' = '+ prettyname(f)
     ans = 'Local number field %s%s<br><br>'% (label, nicename)
     ans += 'Extension of $\Q_{%s}$ defined by %s<br>'%(str(f['p']),web_latex(coeff_to_poly(f['coeffs'])))
-    gt = f['gal']
+    gt = f['galT']
     gn = f['n']
     ans += 'Degree: %s<br>' % str(gn)
     ans += 'Ramification index $e$: %s<br>' % str(f['e'])
@@ -196,7 +196,7 @@ def render_field_webpage(args):
         e = data['e']
         f = data['f']
         cc = data['c']
-        gt = data['gal']
+        gt = data['galT']
         gn = data['n']
         the_gal = WebGaloisGroup.from_nt(gn,gt)
         isgal = ' Galois' if the_gal.order() == gn else ' not Galois'

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -68,7 +68,8 @@ def local_algebra_data(labels):
         ans += '<tr><td><a href="/LocalNumberField/%s">%s</a><td>'%(l,l)
         ans += format_coeffs(f['coeffs'])
         ans += '<td>%d<td>%d<td>%d<td>'%(f['e'],f['f'],f['c'])
-        ans += group_display_knowl(f['gal'][0],f['gal'][1])
+        galnt = [int(z) for z in f['galois_label'].split('T')]
+        ans += group_display_knowl(galnt[0],galnt[1])
         ans += '<td>$'+ show_slope_content(f['slopes'],f['t'],f['u'])+'$'
     ans += '</table>'
     if len(labs) != len(set(labs)):
@@ -82,7 +83,7 @@ def local_field_data(label):
         nicename = ' = '+ prettyname(f)
     ans = 'Local number field %s%s<br><br>'% (label, nicename)
     ans += 'Extension of $\Q_{%s}$ defined by %s<br>'%(str(f['p']),web_latex(coeff_to_poly(f['coeffs'])))
-    gt = f['galT']
+    gt = int(f['galois_label'].split('T')[1])
     gn = f['n']
     ans += 'Degree: %s<br>' % str(gn)
     ans += 'Ramification index $e$: %s<br>' % str(f['e'])
@@ -167,9 +168,9 @@ def local_field_jump(info):
              learnmore=learnmore_list,
              credit=lambda:LF_credit)
 def local_field_search(info,query):
-    parse_galgrp(info,query,'gal',qfield=('n','galT'))
     parse_ints(info,query,'p',name='Prime p')
     parse_ints(info,query,'n',name='Degree')
+    parse_galgrp(info,query,'gal',qfield=('galois_label','n'))
     parse_ints(info,query,'c',name='Discriminant exponent c')
     parse_ints(info,query,'e',name='Ramification index e')
     parse_rats(info,query,'topslope',qfield='top_slope',name='Top slope', process=ratproc)
@@ -196,7 +197,7 @@ def render_field_webpage(args):
         e = data['e']
         f = data['f']
         cc = data['c']
-        gt = data['galT']
+        gt = int(data['galois_label'].split('T')[1])
         gn = data['n']
         the_gal = WebGaloisGroup.from_nt(gn,gt)
         isgal = ' Galois' if the_gal.order() == gn else ' not Galois'

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -230,6 +230,8 @@ def render_field_webpage(args):
             unramp = r'$%s$' % Qp
             # Eliminate t from the eisenstein polynomial
             eisenp = Pxt(str(data['eisen']).replace('y','x'))
+            # prevent failure on resultant
+            if label != '2.4.4.1': return render_field_webpage({'label': '2.4.4.1'})
             eisenp = Pt(str(data['unram'])).resultant(eisenp)
             eisenp = web_latex(eisenp)
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -223,16 +223,11 @@ def render_field_webpage(args):
             unramdata = db.lf_fields.lookup(unramlabel)
 
         Px = PolynomialRing(QQ, 'x')
-        Pxt=PolynomialRing(Px,'t')
         Pt = PolynomialRing(QQ, 't')
         Ptx = PolynomialRing(Pt, 'x')
         if data['f'] == 1:
             unramp = r'$%s$' % Qp
-            # Eliminate t from the eisenstein polynomial
-            eisenp = Pxt(str(data['eisen']).replace('y','x'))
-            # prevent failure on resultant
-            if label != '2.4.4.1': return render_field_webpage({'label': '2.4.4.1'})
-            eisenp = Pt(str(data['unram'])).resultant(eisenp)
+            eisenp = Ptx(str(data['eisen']).replace('y','x'))
             eisenp = web_latex(eisenp)
 
         else:

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -135,7 +135,12 @@ A <a href={{url_for('.random_field')}}>random local number field</a> from the da
           </tr><tr>
             <td>{{KNOWL('nf.galois_group',title='Galois group $G$')}}</td>
             <td><input type="text" name="gal" value="" size=10 placeholder="5T3"></td>
-            <td><span class="formexample">e.g. 5T3, C4, or a list of {{KNOWL('nf.galois_group.name',title='labels')}}</span></td>
+            <td><span class="formexample">list of 
+              {{KNOWL('group.small_group_label',title="GAP id's")}},
+          e.g. [8,3] or [16,7], group names from the
+          {{KNOWL('nf.galois_group.name','list of group labels')}}, e.g.
+          C5 or S12, and {{KNOWL('gg.label','transitive group labels')}}, 
+          e.g., 7T2 or 11T5</span></td>
           </tr><tr>
             <td>Results to display</td>
             <td><input type="text" name="count" value="{{info.count}}" size=10></td>

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -730,7 +730,7 @@ def number_field_jump(info):
              learnmore=learnmore_list)
 def number_field_search(info, query):
     parse_ints(info,query,'degree')
-    parse_galgrp(info,query, qfield=('degree', 'galt'))
+    parse_galgrp(info,query, qfield=('galois_label', 'degree'))
     parse_bracketed_posints(info,query,'signature',qfield=('degree','r2'),exactlength=2,extractor=lambda L: (L[0]+2*L[1],L[1]))
     parse_signed_ints(info,query,'discriminant',qfield=('disc_sign','disc_abs'))
     parse_floats(info, query, 'rd')

--- a/lmfdb/number_fields/templates/nf-index.html
+++ b/lmfdb/number_fields/templates/nf-index.html
@@ -89,7 +89,12 @@ A <a href={{url_for('.random_nfglobal')}}>random global number field</a> from th
 <tr>
 <td align=left>{{KNOWL('nf.galois_group', title='Galois group')}} 
   <td colspan="2"><input type='text' name='galois_group' size=10 example='C5'>
-<span class="formexample"> e.g. C5, or 8T12, a list of {{KNOWL('nf.galois_group.name','group labels')}}</span></td>
+<span class="formexample">list of 
+              {{KNOWL('group.small_group_label',title="GAP id's")}},
+          e.g. [8,3] or [16,7], group names from the
+          {{KNOWL('nf.galois_group.name','list of group labels')}}, e.g.
+          C5 or S12, and {{KNOWL('gg.label','transitive group labels')}}, 
+          e.g., 7T2 or 11T5</span></td>
 
 <td align=left>{{KNOWL('nf.regulator', title='Regulator')}} 
   <td colspan="2"><input type='text' name='regulator' size=10 example='1..3.5'>

--- a/lmfdb/number_fields/templates/nf-statistics.html
+++ b/lmfdb/number_fields/templates/nf-statistics.html
@@ -9,7 +9,9 @@ The database contains {{ info['total'] }} number fields.
 {% set maxdeg = 23 %}
 
 <h2> Distribution by signature </h2>
+{# Keep first line for when we expand this #}
 {% set ncols = (info['nsig'][maxdeg - 1] | length) %}
+{% set ncols = 23 %}
 <div>
 There is one row for each degree $n$, and the column is indexed by
 $r_2$, the number of non-real embeddings, so the signature is

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -406,12 +406,12 @@ class WebNumberField:
         if not self.haskey('galt'):
             return 'Not computed'
         n = self._data['degree']
-        t = self._data['galt']
+        t = int(self._data['galois_label'].split('T')[1])
         return group_pretty_and_nTj(n, t)
 
     # Just return the t-number of the Galois group
     def galois_t(self):
-        return self._data['galt']
+        return int(self._data['galois_label'].split('T')[1])
 
     # return the Galois group
     def gg(self):
@@ -835,7 +835,7 @@ class WebNumberField:
                         int(LF['e']),
                         int(LF['f']),
                         int(LF['c']),
-                        group_display_knowl(LF['n'], LF['galT']),
+                        group_display_knowl(LF['n'], int(LF['galois_label'].split('T')[1])),
                         LF['t'],
                         LF['u'],
                         LF['slopes']

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -38,4 +38,4 @@ class DynamicKnowlTest(LmfdbTest):
 
     def test_galois_alias_knowl(self):
         L = self.tc.get('/knowledge/show/nf.galois_group.name', follow_redirects=True)
-        assert '3T2' in L.data
+        assert '11T6' in L.data

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -5,7 +5,7 @@ from six.moves import range
 from six import string_types
 
 import re
-from collections import defaultdict, Counter
+from collections import Counter
 
 from lmfdb.utils.utilities import flash_error
 from sage.all import ZZ, QQ, prod, PolynomialRing
@@ -585,8 +585,15 @@ def parse_galgrp(inp, query, qfield):
     from lmfdb.galois_groups.transitive_group import complete_group_codes
     try:
         gcs = complete_group_codes(inp)
+        gcs = list(set(gcs))
         galfield, nfield = qfield
-        # This currently does nothing with nfield, but it could in certain cases
+        if nfield not in query:
+            nvals = list(set([s[0] for s in gcs]))
+            if len(nvals) == 1:
+                query[nfield] = nvals[0]
+            else:
+                query[nfield] = {'$in': nvals}
+        # if nfield was already in the query, we could try to intersect it with nvals
         cands = ['{}T{}'.format(s[0],s[1]) for s in gcs]
         if len(cands) == 1:
             query[galfield] = cands[0]

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -602,7 +602,7 @@ def parse_galgrp(inp, query, qfield):
     try:
         gcs = complete_group_codes(inp)
         galfield, nfield = qfield
-        if nfield not in query:
+        if nfield and nfield not in query:
             nvals = list(set([s[0] for s in gcs]))
             if len(nvals) == 1:
                 query[nfield] = nvals[0]

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -585,7 +585,6 @@ def parse_galgrp(inp, query, qfield):
     from lmfdb.galois_groups.transitive_group import complete_group_codes
     try:
         gcs = complete_group_codes(inp)
-        gcs = list(set(gcs))
         galfield, nfield = qfield
         if nfield not in query:
             nvals = list(set([s[0] for s in gcs]))

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -518,9 +518,11 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
         if listprocess is not None:
             L = listprocess(L)
         if extractor is not None:
+            # This is currently only used by number field signatures
+            # The code assumes we have only a single item to deal with
+            # It needs to be fixed more generally if there are more items
+            # This needs to be run after degree and Galois group
             for qf, v in zip(qfield, extractor(L)):
-                if qf in query and query[qf] != v:
-                    raise ValueError("Inconsistent specification of %s: %s vs %s"%(qf, query[qf], v))
                 query[qf] = v
         elif split:
             query[qfield] = L

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -586,35 +586,68 @@ def parse_galgrp(inp, query, qfield):
     try:
         gcs = complete_group_codes(inp)
         nfield, tfield = qfield
-        if nfield in query:
-            gcs = [t for n,t in gcs if n == query[nfield]]
-            if len(gcs) == 0:
-                raise ValueError("Degree inconsistent with Galois group.")
-            elif len(gcs) == 1:
-                query[tfield] = gcs[0]
-            else:
-                query[tfield] = {'$in': gcs}
-        else:
-            gcsdict = defaultdict(list)
-            for n,t in gcs:
-                gcsdict[n].append(t)
-            if len(gcsdict) == 1:
-                query[nfield] = n # left over from the loop
-                if len(gcs) == 1:
-                    query[tfield] = t # left over from the loop
-                else:
-                    query[tfield] = {'$in': gcsdict[n]}
-            else:
-                options = []
-                for n, T in gcsdict.items():
-                    if len(T) == 1:
-                        options.append({nfield: n, tfield: T[0]})
-                    else:
-                        options.append({nfield: n, tfield: {'$in': T}})
-                collapse_ors(['$or', options], query)
+        galgrp_helper(nfield, tfield, query, gcs)
     except NameError:
         raise ValueError("It needs to be a <a title = 'Galois group labels' knowl='nf.galois_group.name'>group label</a>, such as C5 or 5T1, or a comma separated list of such labels.")
 
+def galgrp_helper(nfield, tfield, query, cands):
+    if nfield in query:
+        cands = [t for n,t in cands if n == query[nfield]]
+        print ""
+        print ""
+        print ""
+        print query[nfield]
+        if len(cands) == 0:
+            raise ValueError("Degree inconsistent with Galois group.")
+        elif len(cands) == 1:
+            query[tfield] = cands[0]
+        else:
+            query[tfield] = {'$in': cands}
+    else:
+        gcsdict = defaultdict(list)
+        for n,t in cands:
+            gcsdict[n].append(t)
+        if len(gcsdict) == 1:
+            query[nfield] = n # left over from the loop
+            if len(cands) == 1:
+                query[tfield] = t # left over from the loop
+            else:
+                query[tfield] = {'$in': gcsdict[n]}
+        else:
+            options = []
+            for n, T in gcsdict.items():
+                if len(T) == 1:
+                    options.append({nfield: n, tfield: T[0]})
+                else:
+                    options.append({nfield: n, tfield: {'$in': T}})
+            collapse_ors(['$or', options], query)
+
+# Parses a list of a combination of group names, gap id's, nTj's
+@search_parser(clean_info=True, error_is_safe=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_abstract_to_trans_grp(inp, query, qfield):
+    nfield, tfield = qfield
+    from lmfdb.galois_groups.transitive_group import complete_group_code
+    # Deal with the fact that commas separate a list, and also
+    mystr = inp.upper()
+    mystr = re.sub(r'\[(\d+),(\d+)\]', r'[\1q\2]', str(inp))
+    parts = mystr.split(',')
+    candidates = [] # build a list of [n,t] pairs
+    for part in parts:
+        if 'q' in part: # GAP id, amost right form except q instead of comma
+            nts = list(db.gps_transitive.search({'gapidfull':part.replace('q',',')}, projection=['n','t']))
+            candidates += nts
+        else:
+            try:
+                # this handles nTj and group nicknames
+                candidates += complete_group_code(part)
+            except NameError:
+                raise ValueError("It needs to be a list made up of GAP id's, such as [4,1] or [12,5], or <a title = 'Galois group labels' knowl='nf.galois_group.name'>group labels</a>, such as C5 or 5T1.")
+    print ""
+    print "***********************"
+    print ""
+    print candidates
+    candidates = list(set(candidates))
+    galgrp_helper(nfield, tfield, query, candidates)
 
 def nf_string_to_label(FF):  # parse Q, Qsqrt2, Qsqrt-4, Qzeta5, etc
     if FF in ['q', 'Q']:

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -479,7 +479,7 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
         (exactlength is not None and inp == '[]' and exactlength > 0)):
         if exactlength == 2:
             lstr = "pair of integers"
-            example = "[2,3] or [3,3]"
+            example = "[6,2] or [32,32]"
         elif exactlength == 1:
             lstr = "list of 1 integer"
             example = "[2]"


### PR DESCRIPTION
In the "telescope/microscope" workshop, it was suggested that when searching for transitive groups (in the Galois group pages), one should be able to use the same nicknames as for Galois groups of local or global fields.

We did have searching by GAP id in the transitive group pages, which is in principle the same idea: search by abstract group.  This pull request merges searching by GAP id, group nickname, and transitive label to a single box, and uses it for Galois group searching in local fields, global fields, and transitive groups.  We accept a list of any combination of these, such as S3, [4,1], 4T4:

http://127.0.0.1:37777/GaloisGroup/?gal=S3%2C+%5B4%2C1%5D%2C+4T4

Note, when a nTj is given, we only return that transitive representation, so the results are different for 3T2, [4,1], A4 even though it is the same list of abstract groups:

http://127.0.0.1:37777/GaloisGroup/?gal=3T2%2C+%5B4%2C1%5D%2C+A4

In forming the search query, duplicates are removed (e.g., if you specify both S3 and [6,1]).

If the degree is not part of the search, we add that.  If it were already part of the search query, we would need to intersect the two specifications.  Not doing that right was the source of  Issue #3565.  So, this also fixes that problem:

http://beta.lmfdb.org/NumberField/?degree=6..12&galois_group=S4
http://127.0.0.1:37777/NumberField/?degree=6..12&galois_group=S4
