### PR TITLE
force encode

### DIFF
--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -137,11 +137,11 @@ class Downloader(object):
         filename = filebase + self.file_suffix[lang]
         c = self.comment_prefix[lang]
         mydate = time.strftime("%d %B %Y")
-        s =  '\n'
+        s = '\n'
         s += c + ' %s downloaded from the LMFDB on %s.\n' % (title, mydate)
         s += result
         strIO = StringIO()
-        strIO.write(s)
+        strIO.write(s.encode('utf-8'))
         strIO.seek(0)
         return send_file(strIO, attachment_filename=filename, as_attachment=True, add_etags=False)
 


### PR DESCRIPTION
This should fix various broken download links.
For example, any download link on https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/128/2/e/b/

According to, https://github.com/pallets/werkzeug/issues/960, we should encode utf-8 strings before passing them to strIO

