### PR TITLE
whitelisting www.lmfdb.org/Representation

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -692,6 +692,7 @@ WhiteListedRoutes = [
     'ModularForm/GL2/Q/holomorphic',
     'ModularForm/GL2/TotallyReal',
     'NumberField',
+    'Representation/foo',  # allows /Representation but not /Representation/Galois/ModL/
     'SatoTateGroup',
     'Variety/Abelian/Fq',
     'about',


### PR DESCRIPTION
By whitelisting 
"Representation/foo"
we allow the bread
www.lmfdb.org/Representation
but not
www.lmfdb.org/Representation/Galois/ModL/
