### PR TITLE
Remove <h2></h2> from top knowl title

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -236,9 +236,9 @@
     {% endif %}
     {% if KNOWL_ID %}
     {% if BACKUP_KNOWL_ID %}
-    <h2>{{ KNOWL_INC(KNOWL_ID+'.top', title='', backupid=BACKUP_KNOWL_ID+'.top') }}</h2>
+    {{ KNOWL_INC(KNOWL_ID+'.top', title='', backupid=BACKUP_KNOWL_ID+'.top') }}
     {% else %}
-    <h2>{{ KNOWL_INC(KNOWL_ID+'.top', title='') }}</h2>
+    {{ KNOWL_INC(KNOWL_ID+'.top', title='') }}
     {% endif %}
     {% endif %}
     {% block content -%}


### PR DESCRIPTION
This change removes the `<h2></h2>` from the empty top knowl title in the homepage template.  This currently wastes two lines of of the most precious screen real estate on every objects home page.  The only benefit of having this tag there is that it makes it easier for knowl editors to see the link to add a top knowl, which is a very rare event.  It makes no sense to punish all of our users for for benefit of small number of knowl editors (who surely know where to find the top knowl link when they need it).

@roed314 Can you please review this and merge it before merging the other PR?