### PR TITLE
Work on backslashes

### DIFF
--- a/lmfdb/abvar/fq/isog_class.py
+++ b/lmfdb/abvar/fq/isog_class.py
@@ -125,9 +125,9 @@ class AbvarFq_isoclass(object):
         else:
             p, r = Integer(q).is_prime_power(get_data=True)
         if r == 1:
-            return "\F_{%s}" % p
+            return r"\F_{%s}" % p
         else:
-            return "\F_{%s^{%s}}" % (p, r)
+            return r"\F_{%s^{%s}}" % (p, r)
 
     def nf(self):
         if self.is_simple:
@@ -289,16 +289,16 @@ class AbvarFq_isoclass(object):
 
     def alg_clo_field(self):
         if self.r == 1:
-            return "\\overline{\F}_{%s}" % (self.p)
+            return r"\overline{\F}_{%s}" % (self.p)
         else:
-            return "\\overline{\F}_{%s^{%s}}" % (self.p, self.r)
+            return r"\overline{\F}_{%s^{%s}}" % (self.p, self.r)
 
     def ext_field(self, s):
         n = s * self.r
         if n == 1:
-            return "\F_{%s}" % (self.p)
+            return r"\F_{%s}" % (self.p)
         else:
-            return "\F_{%s^{%s}}" % (self.p, n)
+            return r"\F_{%s^{%s}}" % (self.p, n)
 
     @cached_method
     def endo_extensions(self):
@@ -439,7 +439,7 @@ def describe_end_algebra(p, extension_label):
     ans = ["", ""]
     if center == "1.1.1.1" and divalg_dim == 4:
         ans[0] = "B"
-        ans[1] = "the quaternion algebra over {0} ramified at ${1}$ and $\infty$.".format(nf_display_knowl(center, field_pretty(center)), p)
+        ans[1] = r"the quaternion algebra over {0} ramified at ${1}$ and $\infty$.".format(nf_display_knowl(center, field_pretty(center)), p)
     elif int(center.split(".")[1]) > 0:
         ans[0] = "B"
         if divalg_dim == 4:
@@ -460,13 +460,13 @@ def describe_end_algebra(p, extension_label):
         ans[1] += '</td></tr><tr><td><table class = "ntdata"><tr><td>$v$</td>'
         for prime in places:
             ans[1] += '<td class="center"> {0} </td>'.format(primeideal_display(p, prime))
-        ans[1] += "</tr><tr><td>$\operatorname{inv}_v$</td>"
+        ans[1] += r"</tr><tr><td>$\operatorname{inv}_v$</td>"
         for inv in brauer_invariants:
             ans[1] += '<td class="center">${0}$</td>'.format(inv)
         ans[1] += "</tr></table>\n"
         center_poly = db.nf_fields.lookup(center, 'coeffs')
         center_poly = latex.latex(ZZ["x"](center_poly))
-        ans[1] += "where $\pi$ is a root of ${0}$.\n".format(center_poly)
+        ans[1] += r"where $\pi$ is a root of ${0}$.\n".format(center_poly)
     return ans
 
 def primeideal_display(p, prime_ideal):
@@ -503,9 +503,9 @@ def g2_table(field, entry, is_bold):
 
 def matrix_display(factor, end_alg):
     if end_alg[0] == "K" and end_alg[1] != factor[0] + ".":
-        ans = "$\mathrm{{M}}_{{{0}}}(${1}$)$".format(factor[1], end_alg[1][:-1])
+        ans = r"$\mathrm{{M}}_{{{0}}}(${1}$)$".format(factor[1], end_alg[1][:-1])
     else:
-        ans = "$\mathrm{{M}}_{{{0}}}({1})$, where ${1}$ is {2}".format(factor[1], end_alg[0], end_alg[1])
+        ans = r"$\mathrm{{M}}_{{{0}}}({1})$, where ${1}$ is {2}".format(factor[1], end_alg[0], end_alg[1])
     return ans
 
 def non_simple_loop(p, factors):

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -166,7 +166,7 @@ class ArtinRepresentation(object):
                 return " " + str(p) + " "
             else:
                 return " " + str(p) + "^{" + str(exponent) + "}"
-        tmp = " \cdot ".join(power_prime(p, val) for (p, val) in self.factored_conductor())
+        tmp = r" \cdot ".join(power_prime(p, val) for (p, val) in self.factored_conductor())
         return tmp
 
     def hard_primes(self):
@@ -901,4 +901,4 @@ class NumberFieldGaloisGroup(object):
         return tmp
 
     def display_title(self):
-        return "The Galois group of the number field $\mathbb{Q}[x]/(%s)" % self.polynomial().latex() + "$"
+        return r"The Galois group of the number field $\mathbb{Q}[x]/(%s)" % self.polynomial().latex() + "$"

--- a/lmfdb/belyi/web_belyi.py
+++ b/lmfdb/belyi/web_belyi.py
@@ -174,7 +174,7 @@ class WebBelyiGalmap(object):
             data["base_field"] = F
         crv_str = galmap["curve"]
         if crv_str == "PP1":
-            data["curve"] = "\mathbb{P}^1"
+            data["curve"] = r"\mathbb{P}^1"
         else:
             data["curve"] = make_curve_latex(crv_str)
 
@@ -183,9 +183,9 @@ class WebBelyiGalmap(object):
         embed_strs = []
         for el in embeds:
             if el[1] < 0:
-                el_str = str(el[0]) + str(el[1]) + "\sqrt{-1}"
+                el_str = str(el[0]) + str(el[1]) + r"\sqrt{-1}"
             else:
-                el_str = str(el[0]) + "+" + str(el[1]) + "\sqrt{-1}"
+                el_str = str(el[0]) + "+" + str(el[1]) + r"\sqrt{-1}"
             embed_strs.append(el_str)
 
         data["map"] = make_map_latex(galmap["map"])
@@ -195,7 +195,7 @@ class WebBelyiGalmap(object):
                 triple_cyc = data["triples_cyc"][i]
                 data["embeddings_and_triples"].append(
                     [
-                        "\\text{not applicable (over $\mathbb{Q}$)}",
+                        r"\text{not applicable (over $\mathbb{Q}$)}",
                         triple_cyc[0],
                         triple_cyc[1],
                         triple_cyc[2],

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -54,8 +54,8 @@ def index():
         info = {}
         gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11]]
         sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [19,43,67,163,20]]
-        gl2_names = ["\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11]]
-        sl2_names = gl2_names + ["\(\Q(\sqrt{-%s})\)" % d for d in [19,43,67,163,5]]
+        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11]]
+        sl2_names = gl2_names + [r"\(\Q(\sqrt{-%s})\)" % d for d in [19,43,67,163,5]]
         info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
@@ -63,13 +63,13 @@ def index():
         bc_examples.append(('base-change of a newform with rational coefficients',
                          '2.0.4.1-100.2-a',
                          url_for('.render_bmf_webpage',field_label='2.0.4.1', level_label='100.2', label_suffix='a'),' (with an associated elliptic curve which is a base-change)'))
-        bc_examples.append(('base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{2})\)',
+        bc_examples.append((r'base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{2})\)',
                          '2.0.4.1-16384.1-d',
                          url_for('.render_bmf_webpage',field_label='2.0.4.1', level_label='16384.1', label_suffix='d'),' (with an associated elliptic curve which is not a base-change)'))
-        bc_examples.append(('base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{6})\)',
+        bc_examples.append((r'base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{6})\)',
                          '2.0.3.1-6561.1-b',
                          url_for('.render_bmf_webpage',field_label='2.0.3.1', level_label='6561.1', label_suffix='b'),' (with no associated elliptic curve)'))
-        bc_examples.append(('base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{5})\), with CM by \(\mathbb{Q}(\sqrt{-35})\)',
+        bc_examples.append((r'base-change of a newform with coefficients in \(\mathbb{Q}(\sqrt{5})\), with CM by \(\mathbb{Q}(\sqrt{-35})\)',
                          '2.0.7.1-10000.1-b',
                          url_for('.render_bmf_webpage',field_label='2.0.7.1', level_label='10000.1', label_suffix='b'),' (with no associated elliptic curve)'))
 
@@ -180,10 +180,10 @@ def bmf_field_dim_table(**args):
     query['field_label'] = field_label
     if gl_or_sl=='gl2_dims':
         info['group'] = 'GL(2)'
-        info['bgroup'] = '\GL(2,\mathcal{O}_K)'
+        info['bgroup'] = r'\GL(2,\mathcal{O}_K)'
     else:
         info['group'] = 'SL(2)'
-        info['bgroup'] = '\SL(2,\mathcal{O}_K)'
+        info['bgroup'] = r'\SL(2,\mathcal{O}_K)'
     if level_flag == 'all':
         query[gl_or_sl] = {'$exists': True}
     else:

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -130,7 +130,7 @@ class WebBMF(object):
             self.anrank = "not determined"
         else:
             self.Lratio = QQ(self.Lratio)
-            self.anrank = "\(0\)" if self.Lratio!=0 else "odd" if self.sfe==-1 else "\(\ge2\), even"
+            self.anrank = r"\(0\)" if self.Lratio!=0 else "odd" if self.sfe==-1 else r"\(\ge2\), even"
 
         self.properties = [('Base field', pretty_field),
                             ('Weight', str(self.weight)),
@@ -165,14 +165,14 @@ class WebBMF(object):
         elif self.bc >1:
             self.bcd = self.bc
             self.bc = 'yes'
-            self.bc_extra = ', of a form over \(\mathbb{Q}\) with coefficients in \(\mathbb{Q}(\sqrt{'+str(self.bcd)+'})\)'
+            self.bc_extra = r', of a form over \(\mathbb{Q}\) with coefficients in \(\mathbb{Q}(\sqrt{' + str(self.bcd) + r'})\)'
         elif self.bc == -1:
             self.bc = 'no'
-            self.bc_extra = ', but is a twist of the base-change of a form over \(\mathbb{Q}\)'
+            self.bc_extra = r', but is a twist of the base-change of a form over \(\mathbb{Q}\)'
         elif self.bc < -1:
             self.bcd = -self.bc
             self.bc = 'no'
-            self.bc_extra = ', but is a twist of the base-change of a form over \(\mathbb{Q}\) with coefficients in \(\mathbb{Q}(\sqrt{'+str(self.bcd)+'})\)'
+            self.bc_extra = r', but is a twist of the base-change of a form over \(\mathbb{Q}\) with coefficients in \(\mathbb{Q}(\sqrt{'+str(self.bcd)+r'})\)'
         self.properties.append(('Base-change', str(self.bc)))
 
         curve_bc = db.ec_nfcurves.lucky({'class_label':self.label}, projection="base_change")

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -35,7 +35,7 @@ def parse_interval(arg, name):
     elif re.match('^[0-9]+..[0-9]+$', arg):
         s = arg.split('..')
         a,b = (int(s[0]), int(s[1]))
-    elif re.match('^\[[0-9]+..[0-9]+\]$', arg):
+    elif re.match(r'^\[[0-9]+..[0-9]+\]$', arg):
         s = arg[1:-1].split('..')
         a,b = (int(s[0]), int(s[1]))
     if a <= 0 or b < a:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -222,7 +222,7 @@ def render_Dirichletwebpage(modulus=None, number=None):
     if modulus is None:
         return render_DirichletNavigation()
     modulus = modulus.replace(' ','')
-    if number is None and re.match('^[1-9][0-9]*\.([1-9][0-9]*|[a-z]+)$', modulus):
+    if number is None and re.match(r'^[1-9][0-9]*\.([1-9][0-9]*|[a-z]+)$', modulus):
         modulus, number = modulus.split('.')
         return redirect(url_for(".render_Dirichletwebpage", modulus=modulus, number=number), 301)
 

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -140,7 +140,7 @@ class WebNewform(object):
 
         #self.char_conrey = self.conrey_indexes[0]
         #self.char_conrey_str = '\chi_{%s}(%s,\cdot)' % (self.level, self.char_conrey)
-        self.character_label = "\(" + str(self.level) + "\)." + self.char_orbit_label
+        self.character_label = r"\(" + str(self.level) + r"\)." + self.char_orbit_label
 
         self.hecke_ring_character_values = None
         self.single_generator = None
@@ -215,12 +215,12 @@ class WebNewform(object):
         self.properties += [('Dimension', str(self.dim))]
 
         if self.projective_image:
-            self.properties += [('Projective image', '\(%s\)' % self.projective_image_latex)]
+            self.properties += [('Projective image', r'\(%s\)' % self.projective_image_latex)]
         # Artin data would make the property box scroll
         #if self.artin_degree: # artin_degree > 0
         #    self.properties += [('Artin image size', str(self.artin_degree))]
         #if self.artin_image:
-        #    self.properties += [('Artin image', '\(%s\)' %  self.artin_image_display)]
+        #    self.properties += [('Artin image', r'\(%s\)' %  self.artin_image_display)]
 
         if self.is_cm and self.is_rm:
             disc = ', '.join([ str(d) for d in self.self_twist_discs ])
@@ -294,7 +294,7 @@ class WebNewform(object):
         res.append(('Newspace ' + ns_label, ns_url))
         nf_url = ns_url + '/' + self.hecke_orbit_label
         if self.sato_tate_group:
-            res.append(('Sato-Tate group \({}\)'.format(get_name(self.sato_tate_group)[0]),
+            res.append((r'Sato-Tate group \({}\)'.format(get_name(self.sato_tate_group)[0]),
                         '/SatoTateGroup/' + self.sato_tate_group))
         if self.embedding_label is not None:
             res.append(('Newform ' + self.label, nf_url))
@@ -594,7 +594,7 @@ class WebNewform(object):
     @property
     def hecke_ring_index_factored(self):
         if self.hecke_ring_index_factorization is not None:
-            return "\( %s \)" % factor_base_factorization_latex(self.hecke_ring_index_factorization)
+            return r"\( %s \)" % factor_base_factorization_latex(self.hecke_ring_index_factorization)
         return None
 
     def ring_index_display(self):
@@ -655,7 +655,7 @@ class WebNewform(object):
             if paren:
                 return r"\((\)%s\()/%s\)" % (num, den)
             else:
-                return "%s\(/%s\)" % (num, den)
+                return r"%s\(/%s\)" % (num, den)
         else:
             if paren:
                 return r"\((\)%s\()/%s\)" % (num, make_bigint(web_latex(den, enclose=False)))
@@ -713,7 +713,7 @@ class WebNewform(object):
         return self._make_table(basis)
 
     def _order_basis_inverse(self):
-        basis = [('\(1\)', r'\(\beta_0\)')]
+        basis = [(r'\(1\)', r'\(\beta_0\)')]
         for i, (num, den) in enumerate(zip(self.hecke_ring_inverse_numerators[1:], self.hecke_ring_inverse_denominators[1:])):
             num = web_latex_poly(num, r'\beta', superscript=False)
             if i == 0:
@@ -991,14 +991,14 @@ function switch_basis(btype) {
                 s += '' + latexterm + ' '
         # Work around bug in Sage's latex
         s = s.replace('betaq', 'beta q')
-        return '\(' + s + '+O(q^{%d})\)' % prec
+        return r'\(' + s + r'+O(q^{%d})\)' % prec
 
     def q_expansion_cc(self, prec_max):
         eigseq = self.cc_data[self.embedding_m]['an_normalized']
         prec = min(max(eigseq.keys()) + 1, prec_max)
         if prec == 0:
-            return '\(O(1)\)'
-        s = '\(q'
+            return r'\(O(1)\)'
+        s = r'\(q'
         for j in range(2, prec):
             term = eigseq[j]
             latexterm = display_complex(term[0]*self.analytic_shift[j], term[1]*self.analytic_shift[j], 6, method = "round", parenthesis = True, try_halfinteger=False)
@@ -1013,7 +1013,7 @@ function switch_basis(btype) {
                 s += '' + latexterm + ' '
         # Work around bug in Sage's latex
         s = s.replace('betaq', 'beta q')
-        return s + '+O(q^{%d})\)' % prec
+        return s + r'+O(q^{%d})\)' % prec
 
 
     def q_expansion(self, prec_max=10):

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -230,7 +230,7 @@ class WebNewformSpace(object):
         self.trace_bound = data.get('trace_bound')
         self.has_trace_form = (data.get('traces') is not None)
         self.char_conrey = self.conrey_indexes[0]
-        self.char_conrey_str = '\chi_{%s}(%s,\cdot)' % (self.level, self.char_conrey)
+        self.char_conrey_str = r'\chi_{%s}(%s,\cdot)' % (self.level, self.char_conrey)
         self.newforms = list(db.mf_newforms.search({'space_label':self.label}, projection=2))
         oldspaces = db.mf_subspaces.search({'label':self.label, 'sub_level':{'$ne':self.level}}, ['sub_level', 'sub_char_orbit_index', 'sub_conrey_indexes', 'sub_mult'])
         self.oldspaces = [(old['sub_level'], old['sub_char_orbit_index'], old['sub_conrey_indexes'][0], old['sub_mult']) for old in oldspaces]
@@ -466,7 +466,7 @@ class WebGamma1Space(object):
         return common_latex(*(self._vec() + ["S",1,"old"]))
 
     def header_latex(self):
-        return r'\(' + common_latex(*(self._vec() + ["S",0,"new",True])) + '\)'
+        return r'\(' + common_latex(*(self._vec() + ["S",0,"new",True])) + r'\)'
 
     def _link(self, N, i=None, form=None, typ="new", label=True):
         if form is not None:
@@ -507,7 +507,7 @@ class WebGamma1Space(object):
             chi_rep = '<a href="' + url_for('characters.render_Dirichletwebpage',
                                              modulus=space['level'],
                                              number=space['conrey_indexes'][0])
-            chi_rep += '">\({}\)</a>'.format(chi_str)
+            chi_rep += r'">\({}\)</a>'.format(chi_str)
 
             num_chi = space['char_degree']
             link = self._link(space['level'], space['char_orbit_label'])

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -106,7 +106,7 @@ def ideal_from_string(K,s, IQF_format=False):
 def pretty_ideal(I):
     easy = I.number_field().degree()==2 or I.norm()==1
     gens = I.gens_reduced() if easy else I.gens()
-    return "\((" + ",".join([latex(g) for g in gens]) + ")\)"
+    return r"\((" + ",".join([latex(g) for g in gens]) + r")\)"
 
 # HNF of an ideal I in a quadratic field
 
@@ -227,7 +227,7 @@ def EC_nf_plot(K, ainvs, base_field_gen_name):
             cols = ["red", "darkorange", "gold", "forestgreen", "blue", "darkviolet"]
         elif n1==7:
             cols = ["red", "darkorange", "gold", "forestgreen", "blue", "darkviolet", "fuchsia"]
-        return sum([EC_R_plot([S[i](c) for c in ainvs], xmin, xmax, ymin, ymax, cols[i], "$" + base_field_gen_name + " \mapsto$ " + str(S[i].im_gens()[0].n(20))+"$\dots$") for i in range(n1)]) 
+        return sum([EC_R_plot([S[i](c) for c in ainvs], xmin, xmax, ymin, ymax, cols[i], "$" + base_field_gen_name + r" \mapsto$ " + str(S[i].im_gens()[0].n(20)) + r"$\dots$") for i in range(n1)])
     except:
         return text("Unable to plot", (1, 1), fontsize=36)
 
@@ -385,16 +385,16 @@ class ECNF(object):
 
         # CM and End(E)
         self.cm_bool = "no"
-        self.End = "\(\Z\)"
+        self.End = r"\(\Z\)"
         if self.cm:
             self.rational_cm = K(self.cm).is_square()
             self.cm_sqf = ZZ(self.cm).squarefree_part()
-            self.cm_bool = "yes (\(%s\))" % self.cm
+            self.cm_bool = r"yes (\(%s\))" % self.cm
             if self.cm % 4 == 0:
                 d4 = ZZ(self.cm) // 4
-                self.End = "\(\Z[\sqrt{%s}]\)" % (d4)
+                self.End = r"\(\Z[\sqrt{%s}]\)" % (d4)
             else:
-                self.End = "\(\Z[(1+\sqrt{%s})/2]\)" % self.cm
+                self.End = r"\(\Z[(1+\sqrt{%s})/2]\)" % self.cm
 
         # Galois images in CM case:
         if self.cm and self.galois_images != '?':
@@ -434,7 +434,7 @@ class ECNF(object):
         if self.tr == 0:
             self.tor_struct_pretty = "Trivial"
         if self.tr == 1:
-            self.tor_struct_pretty = "\(\Z/%s\Z\)" % self.torsion_structure[0]
+            self.tor_struct_pretty = r"\(\Z/%s\Z\)" % self.torsion_structure[0]
         if self.tr == 2:
             self.tor_struct_pretty = r"\(\Z/%s\Z\times\Z/%s\Z\)" % tuple(self.torsion_structure)
 
@@ -590,7 +590,7 @@ class ECNF(object):
         ]
 
         for E0 in self.base_change:
-            self.friends += [('Base-change of %s /\(\Q\)' % E0, url_for("ec.by_ec_label", label=E0))]
+            self.friends += [(r'Base-change of %s /\(\Q\)' % E0, url_for("ec.by_ec_label", label=E0))]
 
         self._code = None # will be set if needed by get_code()
 

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -126,7 +126,7 @@ class ECNF_stats(StatsDisplay):
                         self.nf_knowls, ' of ',
                         self.deg_knowl,
                         r' from 2 up to {}.'.format(self.maxdeg),
-                        ' Elliptic curves defined over $\mathbb{Q}$ are contained in a <a href="/EllipticCurve/Q/">separate database</a>.'])
+                        r' Elliptic curves defined over $\mathbb{Q}$ are contained in a <a href="/EllipticCurve/Q/">separate database</a>.'])
 
     @cached_method
     def field_summary(self, field):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -39,7 +39,7 @@ def split_full_label(lab):
     try:
         # field 3.1.23.1 uses upper case letters
         isoclass_label = re.search("(CM)?[a-zA-Z]+", data[2]).group()
-        curve_number = re.search("\d+", data[2]).group()  # (a string)
+        curve_number = re.search(r"\d+", data[2]).group()  # (a string)
     except AttributeError:
         flash_error("%s is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1",  lab)
         raise ValueError
@@ -58,7 +58,7 @@ def split_short_label(lab):
     try:
         # field 3.1.23.1 uses upper case letters
         isoclass_label = re.search("[a-zA-Z]+", data[1]).group()
-        curve_number = re.search("\d+", data[1]).group()  # (a string)
+        curve_number = re.search(r"\d+", data[1]).group()  # (a string)
     except AttributeError:
         flash_error("%s is not a valid elliptic curve label. The last part must contain both an isogeny class label (a sequence of letters), followed by a curve id (an integer), such as a1", lab)
         raise ValueError

--- a/lmfdb/elliptic_curves/ec_stats.py
+++ b/lmfdb/elliptic_curves/ec_stats.py
@@ -99,19 +99,19 @@ class ECstats(object):
             ncu = ecdb.count({'torsion':t})
             if t in [4,8,12]: # two possible structures
                 ncyc = ecdb.count({'torsion_structure':[t]})
-                gp = "\(C_{%s}\)"%t
+                gp = r"\(C_{%s}\)"%t
                 prop = format_percentage(ncyc,ncurves)
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncyc, 'prop': prop})
                 nncyc = ncu-ncyc
-                gp = "\(C_{2}\\times C_{%s}\)"%(t//2)
+                gp = r"\(C_{2}\\times C_{%s}\)"%(t//2)
                 prop = format_percentage(nncyc,ncurves)
                 tor_counts2.append({'t': t, 'gp': gp, 'ncurves': nncyc, 'prop': prop})
             elif t==16: # all C_2 x C_8
-                gp = "\(C_{2}\\times C_{8}\)"
+                gp = r"\(C_{2}\\times C_{8}\)"
                 prop = format_percentage(ncu,ncurves)
                 tor_counts2.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
             else: # all cyclic
-                gp = "\(C_{%s}\)"%t
+                gp = r"\(C_{%s}\)"%t
                 prop = format_percentage(ncu,ncurves)
                 tor_counts.append({'t': t, 'gp': gp, 'ncurves': ncu, 'prop': prop})
         stats['tor_counts'] = tor_counts+tor_counts2

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -85,8 +85,8 @@ def rational_elliptic_curves(err_args=None):
         'counts': counts,
         'stats_url': url_for(".statistics")
     }
-    t = 'Elliptic Curves over $\Q$'
-    bread = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', ' ')]
+    t = r'Elliptic Curves over $\Q$'
+    bread = [('Elliptic Curves', url_for("ecnf.index")), (r'$\Q$', ' ')]
     if err_args.get("err_msg"):
         # this comes from elliptic_curve_jump_error
         flash_error(err_args.pop("err_msg"), err_args.pop("label"))
@@ -121,9 +121,9 @@ def statistics():
         'counts': get_stats().counts(),
         'stats': get_stats().stats(),
     }
-    t = 'Elliptic Curves over $\Q$: Statistics'
+    t = r'Elliptic Curves over $\Q$: Statistics'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
-             ('$\Q$', url_for(".rational_elliptic_curves")),
+             (r'$\Q$', url_for(".rational_elliptic_curves")),
              ('Statistics', ' ')]
     return render_template("ec-stats.html", info=info, credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list())
 
@@ -131,8 +131,8 @@ def statistics():
 @ec_page.route("/<int:conductor>/")
 def by_conductor(conductor):
     info = to_dict(request.args)
-    info['bread'] = [('Elliptic Curves', url_for("ecnf.index")), ('$\Q$', url_for(".rational_elliptic_curves")), ('%s' % conductor, url_for(".by_conductor", conductor=conductor))]
-    info['title'] = 'Elliptic Curves over $\Q$ of Conductor %s' % conductor
+    info['bread'] = [('Elliptic Curves', url_for("ecnf.index")), (r'$\Q$', url_for(".rational_elliptic_curves")), ('%s' % conductor, url_for(".by_conductor", conductor=conductor))]
+    info['title'] = r'Elliptic Curves over $\Q$ of Conductor %s' % conductor
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'conductor' in request.args and request.args['conductor'] != str(conductor):
@@ -156,7 +156,7 @@ def elliptic_curve_jump_error(label, args, wellformed_label=False, cremona_label
     elif not label:
         err_args['err_msg'] = "Please enter a non-empty label"
     else:
-        err_args['err_msg'] = "%s does not define a recognised elliptic curve over $\mathbb{Q}$"
+        err_args['err_msg'] = r"%s does not define a recognised elliptic curve over $\mathbb{Q}$"
     return rational_elliptic_curves(err_args)
 
 def elliptic_curve_jump(info):
@@ -242,7 +242,7 @@ def download_search(info):
              shortcuts={'jump':elliptic_curve_jump,
                         'download':download_search},
              bread=lambda:[('Elliptic Curves', url_for("ecnf.index")),
-                           ('$\Q$', url_for(".rational_elliptic_curves")),
+                           (r'$\Q$', url_for(".rational_elliptic_curves")),
                            ('Search Results', '.')],
              credit=ec_credit)
 
@@ -529,36 +529,36 @@ def download_EC_all(label):
 
 @ec_page.route("/Completeness")
 def completeness_page():
-    t = 'Completeness of the Elliptic Curve data over $\Q$'
+    t = r'Completeness of the Elliptic Curve data over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
-             ('$\Q$', url_for("ec.rational_elliptic_curves")),
+             (r'$\Q$', url_for("ec.rational_elliptic_curves")),
              ('Completeness', '')]
     return render_template("single.html", kid='dq.ec.extent',
                            credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @ec_page.route("/Source")
 def how_computed_page():
-    t = 'Source of the Elliptic Curve data over $\Q$'
+    t = r'Source of the Elliptic Curve data over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
-             ('$\Q$', url_for("ec.rational_elliptic_curves")),
+             (r'$\Q$', url_for("ec.rational_elliptic_curves")),
              ('Source', '')]
     return render_template("single.html", kid='dq.ec.source',
                            credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ec_page.route("/Reliability")
 def reliability_page():
-    t = 'Reliability of the Elliptic Curve data over $\Q$'
+    t = r'Reliability of the Elliptic Curve data over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
-             ('$\Q$', url_for("ec.rational_elliptic_curves")),
+             (r'$\Q$', url_for("ec.rational_elliptic_curves")),
              ('Source', '')]
     return render_template("single.html", kid='dq.ec.reliability',
                            credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ec_page.route("/Labels")
 def labels_page():
-    t = 'Labels for Elliptic Curves over $\Q$'
+    t = r'Labels for Elliptic Curves over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
-             ('$\Q$', url_for("ec.rational_elliptic_curves")),
+             (r'$\Q$', url_for("ec.rational_elliptic_curves")),
              ('Labels', '')]
     return render_template("single.html", kid='ec.q.lmfdb_label',
                            credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -157,7 +157,7 @@ class ECisog_class(object):
 
 
         self.bread = [('Elliptic Curves', url_for("ecnf.index")),
-                      ('$\Q$', url_for(".rational_elliptic_curves")),
+                      (r'$\Q$', url_for(".rational_elliptic_curves")),
                       ('%s' % N, url_for(".by_conductor", conductor=N)),
                       ('%s' % iso, ' ')]
         self.code = {}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -243,7 +243,7 @@ class WebEC(object):
 
         data['CMD'] = self.cm
         data['CM'] = "no"
-        data['EndE'] = "\(\Z\)"
+        data['EndE'] = r"\(\Z\)"
         if self.cm:
             data['cm_ramp'] = [p for p in ZZ(self.cm).support() if not p in self.non_maximal_primes]
             data['cm_nramp'] = len(data['cm_ramp'])
@@ -253,12 +253,12 @@ class WebEC(object):
                 data['cm_ramp'] = ", ".join([str(p) for p in data['cm_ramp']])
             data['cm_sqf'] = ZZ(self.cm).squarefree_part()
 
-            data['CM'] = "yes (\(D=%s\))" % data['CMD']
+            data['CM'] = r"yes (\(D=%s\))" % data['CMD']
             if data['CMD']%4==0:
                 d4 = ZZ(data['CMD'])//4
-                data['EndE'] = "\(\Z[\sqrt{%s}]\)" % d4
+                data['EndE'] = r"\(\Z[\sqrt{%s}]\)" % d4
             else:
-                data['EndE'] = "\(\Z[(1+\sqrt{%s})/2]\)" % data['CMD']
+                data['EndE'] = r"\(\Z[(1+\sqrt{%s})/2]\)" % data['CMD']
             data['ST'] = st_link_by_name(1,2,'N(U(1))')
         else:
             data['ST'] = st_link_by_name(1,2,'SU(2)')
@@ -403,7 +403,7 @@ class WebEC(object):
                            ('j-invariant', '%s' % data['j_inv_latex']),
                            ('CM', '%s' % data['CM']),
                            ('Rank', '%s' % self.mw['rank']),
-                           ('Torsion Structure', '\(%s\)' % self.mw['tor_struct'])
+                           ('Torsion Structure', r'\(%s\)' % self.mw['tor_struct'])
                            ]
 
         if self.label_type == 'Cremona':
@@ -412,7 +412,7 @@ class WebEC(object):
             self.title = "Elliptic Curve with LMFDB label {} (Cremona label {})".format(self.lmfdb_label, self.label)
 
         self.bread = [('Elliptic Curves', url_for("ecnf.index")),
-                           ('$\Q$', url_for(".rational_elliptic_curves")),
+                           (r'$\Q$', url_for(".rational_elliptic_curves")),
                            ('%s' % N, url_for(".by_conductor", conductor=N)),
                            ('%s' % iso, url_for(".by_double_iso_label", conductor=N, iso_label=iso)),
                            ('%s' % num,' ')]
@@ -435,10 +435,10 @@ class WebEC(object):
         mw['tor_order'] = self.torsion
         tor_struct = [int(c) for c in self.torsion_structure]
         if mw['tor_order'] == 1:
-            mw['tor_struct'] = '\mathrm{Trivial}'
+            mw['tor_struct'] = r'\mathrm{Trivial}'
             mw['tor_gens'] = ''
         else:
-            mw['tor_struct'] = ' \\times '.join(['\Z/{%s}\Z' % n for n in tor_struct])
+            mw['tor_struct'] = r' \times '.join([r'\Z/{%s}\Z' % n for n in tor_struct])
             mw['tor_gens'] = ', '.join(web_latex(tuple(P)) for P in parse_points(self.torsion_generators))
 
     def make_bsd(self):
@@ -543,7 +543,7 @@ class WebEC(object):
                 deg = F.count(",")
             tg1['d'] = deg
             tg1['f'] = field_data
-            tg1['t'] = '\(' + ' \\times '.join(['\Z/{}\Z'.format(n) for n in T.split(",")]) + '\)'
+            tg1['t'] = r'\(' + r' \times '.join([r'\Z/{}\Z'.format(n) for n in T.split(",")]) + r'\)'
             tg1['m'] = 0
             tgextra.append(tg1)
 

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -219,8 +219,8 @@ def render_group_webpage(args):
         if db.nf_fields.exists({'degree': n, 'galt': t}):
             friends.append(('Number fields with this Galois group', url_for('number_fields.number_field_render_webpage')+"?galois_group=%dT%d" % (n, t) ))
         prop2 = [('Label', label),
-            ('Order', '\(%s\)' % order),
-            ('n', '\(%s\)' % data['n']),
+            ('Order', r'\(%s\)' % order),
+            ('n', r'\(%s\)' % data['n']),
             ('Cyclic', yesno(data['cyc'])),
             ('Abelian', yesno(data['ab'])),
             ('Solvable', yesno(data['solv'])),

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -107,8 +107,8 @@ def index_Q():
     info["geom_aut_grp_dict"] = geom_aut_grp_dict
     info["geom_end_alg_list"] = geom_end_alg_list
     info["geom_end_alg_dict"] = geom_end_alg_dict
-    title = 'Genus 2 Curves over $\\Q$'
-    bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', ' '))
+    title = r'Genus 2 Curves over $\Q$'
+    bread = (('Genus 2 Curves', url_for(".index")), (r'$\Q$', ' '))
     return render_template("g2c_browse.html", info=info, credit=credit_string, title=title, learnmore=learnmore_list(), bread=bread)
 
 @g2c_page.route("/Q/random/")
@@ -134,7 +134,7 @@ def by_url_isogeny_class_discriminant(cond, alpha, disc):
         return abort(404, 'Genus 2 isogeny class %s not found in database.'%clabel)
     data['title'] = 'Genus 2 Curves in Isogeny Class %s of Discriminant %s' % (clabel,disc)
     data['bread'] = [('Genus 2 Curves', url_for(".index")),
-        ('$\\Q$', url_for(".index_Q")),
+        (r'$\Q$', url_for(".index_Q")),
         ('%s' % cond, url_for(".by_conductor", cond=cond)),
         ('%s' % alpha, url_for(".by_url_isogeny_class_label", cond=cond, alpha=alpha)),
         ('%s' % disc, url_for(".by_url_isogeny_class_discriminant", cond=cond, alpha=alpha, disc=disc))]
@@ -158,7 +158,7 @@ def by_url_isogeny_class_label(cond, alpha):
 def by_conductor(cond):
     data = to_dict(request.args)
     data['title'] = 'Genus 2 Curves of Conductor %s' % cond
-    data['bread'] = [('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index_Q")), ('%s' % cond, url_for(".by_conductor", cond=cond))]
+    data['bread'] = [('Genus 2 Curves', url_for(".index")), (r'$\Q$', url_for(".index_Q")), ('%s' % cond, url_for(".by_conductor", cond=cond))]
     if len(request.args) > 0:
         # if conductor changed, fall back to a general search
         if 'cond' in request.args and request.args['cond'] != str(cond):
@@ -264,7 +264,7 @@ class G2C_download(Downloader):
                        "equation_formatted": lambda v: min_eqn_pretty(literal_eval(v.pop("eqn"))),
                        "st_group_link": lambda v: st_link_by_name(1,4,v.pop('st_group'))},
              bread=lambda:[('Genus 2 Curves', url_for(".index")),
-                           ('$\\Q$', url_for(".index_Q")),
+                           (r'$\Q$', url_for(".index_Q")),
                            ('Search Results', '.')],
              learnmore=learnmore_list,
              credit=lambda:credit_string)
@@ -333,13 +333,13 @@ def genus2_curve_search(info, query):
 ################################################################################
 
 def aut_grp_format(id):
-    return "\\("+aut_grp_dict[id]+"\\)"
+    return r"\("+aut_grp_dict[id]+r"\)"
 
 def geom_aut_grp_format(id):
-    return "\\("+geom_aut_grp_dict[id]+"\\)"
+    return r"\("+geom_aut_grp_dict[id]+r"\)"
 
 def st0_group_format(name):
-    return "\\("+st0_group_name(name)+"\\)"
+    return r"\("+st0_group_name(name)+r"\)"
 
 def st_group_format(name):
     return st_link_by_name(1,4,name)
@@ -357,7 +357,7 @@ class G2C_stats(StatsDisplay):
     def short_summary(self):
         stats_url = url_for(".statistics")
         g2c_knowl = display_knowl('g2c.g2curve', title='genus 2 curves')
-        return 'The database currently contains %s %s over $\\Q$ of %s up to %s.  Here are some <a href="%s">further statistics</a>.' % (self.ncurves, g2c_knowl, self.disc_knowl, self.max_D, stats_url)
+        return r'The database currently contains %s %s over $\Q$ of %s up to %s.  Here are some <a href="%s">further statistics</a>.' % (self.ncurves, g2c_knowl, self.disc_knowl, self.max_D, stats_url)
 
     @property
     def summary(self):
@@ -392,12 +392,12 @@ class G2C_stats(StatsDisplay):
                   'torsion_order': 'torsion order'}
     top_titles = {'num_rat_pts': 'rational points',
                   'num_rat_wpts': 'rational Weierstrass points',
-                  'aut_grp_id': '$\\mathrm{Aut}(X)$',
-                  'geom_aut_grp_id': '$\\mathrm{Aut}(X_{\overline{\mathbb{Q}}})$',
+                  'aut_grp_id': r'$\mathrm{Aut}(X)$',
+                  'geom_aut_grp_id': r'$\mathrm{Aut}(X_{\overline{\mathbb{Q}}})$',
                   'analytic_sha': 'analytic order of &#1064;',
                   'has_square_sha': 'squareness of &#1064;',
                   'locally_solvable': 'local solvability',
-                  'is_gl2_type': '$\\mathrm{GL}_2$-type',
+                  'is_gl2_type': r'$\mathrm{GL}_2$-type',
                   'real_geom_end_alg': 'Sato-Tate group identity components',
                   'st_group': 'Sato-Tate groups',
                   'torsion_order': 'torsion subgroup orders'}
@@ -426,36 +426,36 @@ class G2C_stats(StatsDisplay):
 
 @g2c_page.route("/Q/stats")
 def statistics():
-    title = 'Genus 2 curves over $\\Q$: Statistics'
-    bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index_Q")), ('Statistics', ' '))
+    title = r'Genus 2 curves over $\Q$: Statistics'
+    bread = (('Genus 2 Curves', url_for(".index")), (r'$\Q$', url_for(".index_Q")), ('Statistics', ' '))
     return render_template("display_stats.html", info=G2C_stats(), credit=credit_string, title=title, bread=bread, learnmore=learnmore_list())
 
 
 
 @g2c_page.route("/Q/Completeness")
 def completeness_page():
-    t = 'Completeness of Genus 2 Curve Data over $\\Q$'
-    bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index")),('Completeness',''))
+    t = r'Completeness of Genus 2 Curve Data over $\Q$'
+    bread = (('Genus 2 Curves', url_for(".index")), (r'$\Q$', url_for(".index")),('Completeness',''))
     return render_template("single.html", kid='rcs.cande.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @g2c_page.route("/Q/Source")
 def source_page():
-    t = 'Source of Genus 2 Curve Data over $\\Q$'
-    bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index")),('Source',''))
+    t = r'Source of Genus 2 Curve Data over $\Q$'
+    bread = (('Genus 2 Curves', url_for(".index")), (r'$\Q$', url_for(".index")),('Source',''))
     return render_template("single.html", kid='rcs.source.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @g2c_page.route("/Q/Reliability")
 def reliability_page():
-    t = 'Reliability of Genus 2 Curve Data over $\\Q$'
-    bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index")),('Reliability',''))
+    t = r'Reliability of Genus 2 Curve Data over $\Q$'
+    bread = (('Genus 2 Curves', url_for(".index")), (r'$\Q$', url_for(".index")),('Reliability',''))
     return render_template("single.html", kid='rcs.rigor.g2c',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @g2c_page.route("/Q/Labels")
 def labels_page():
-    t = 'Labels for Genus 2 Curves over $\\Q$'
+    t = r'Labels for Genus 2 Curves over $\Q$'
     bread = (('Genus 2 Curves', url_for(".index")), ('$\\Q$', url_for(".index")),('Labels',''))
     return render_template("single.html", kid='g2c.label',
                            credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -136,8 +136,8 @@ def ring_pretty(L, f):
 
 def QpName(p):
     if p==0:
-        return "$\\R$"
-    return "$\\Q_{"+str(p)+"}$"
+        return r"$\R$"
+    return r"$\Q_{"+str(p)+"}$"
 
 ###############################################################################
 # Plot functions
@@ -156,7 +156,7 @@ def eqn_list_to_curve_plot(L,rat_pts):
     h = poly_tup[1]
     g = f+h**2/4
     if len(g.real_roots())==0 and g(0)<0:
-        return text("$X(\mathbb{R})=\emptyset$",(1,1),fontsize=50)
+        return text(r"$X(\mathbb{R})=\emptyset$",(1,1),fontsize=50)
     X0 = [real(z[0]) for z in g.base_extend(CC).roots()]+[real(z[0]) for z in g.derivative().base_extend(CC).roots()]
     a,b = inflate_interval(min(X0),max(X0),1.5)
     groots = [a]+g.real_roots()+[b]
@@ -209,13 +209,13 @@ def eqn_list_to_curve_plot(L,rat_pts):
 
 def real_geom_end_alg_name(name):
     name_dict = {
-        "R":"\\R",
-        "C":"\\C",
-        "R x R":"\\R \\times \\R",
-        "C x R":"\\C \\times \\R",
-        "C x C":"\\C \\times \\C",
-        "M_2(R)":"\\mathrm{M}_2(\\R)",
-        "M_2(C)":"\\mathrm{M}_2(\\C)"
+        "R":r"\R",
+        "C":r"\C",
+        "R x R":r"\R \times \R",
+        "C x R":r"\C \times \R",
+        "C x C":r"\C \times \C",
+        "M_2(R)":r"\mathrm{M}_2(\R)",
+        "M_2(C)":r"\mathrm{M}_2(\C)"
         }
     if name in name_dict.keys():
         return name_dict[name]
@@ -224,15 +224,15 @@ def real_geom_end_alg_name(name):
 
 def geom_end_alg_name(name):
     name_dict = {
-        "Q":"\\Q",
-        "RM":"\\mathrm{RM}",
-        "Q x Q":"\\Q \\times \\Q",
-        "CM x Q":"\\mathrm{CM} \\times \\Q",
-        "CM":"\\mathrm{CM}",
-        "CM x CM":"\\mathrm{CM} \\times \\mathrm{CM}",
-        "QM":"\\mathrm{QM}",
-        "M_2(Q)":"\\mathrm{M}_2(\\Q)",
-        "M_2(CM)":"\\mathrm{M}_2(\\mathrm{CM})"
+        "Q":r"\Q",
+        "RM":r"\mathrm{RM}",
+        "Q x Q":r"\Q \times \Q",
+        "CM x Q":r"\mathrm{CM} \times \Q",
+        "CM":r"\mathrm{CM}",
+        "CM x CM":r"\mathrm{CM} \times \mathrm{CM}",
+        "QM":r"\mathrm{QM}",
+        "M_2(Q)":r"\mathrm{M}_2(\Q)",
+        "M_2(CM)":r"\mathrm{M}_2(\mathrm{CM})"
         }
     if name in name_dict.keys():
         return name_dict[name]
@@ -241,12 +241,12 @@ def geom_end_alg_name(name):
 
 def st0_group_name(name):
     st0_dict = {
-        'M_2(C)':'\\mathrm{U}(1)',
-        'M_2(R)':'\\mathrm{SU}(2)',
-        'C x C':'\\mathrm{U}(1)\\times\\mathrm{U}(1)',
-        'C x R':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)',
-        'R x R':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)',
-        'R':'\\mathrm{USp}(4)'
+        'M_2(C)':r'\mathrm{U}(1)',
+        'M_2(R)':r'\mathrm{SU}(2)',
+        'C x C':r'\mathrm{U}(1)\times\mathrm{U}(1)',
+        'C x R':r'\mathrm{U}(1)\times\mathrm{SU}(2)',
+        'R x R':r'\mathrm{SU}(2)\times\mathrm{SU}(2)',
+        'R':r'\mathrm{USp}(4)'
         }
     if name in st0_dict.keys():
         return st0_dict[name]
@@ -259,14 +259,14 @@ def st0_group_name(name):
 
 def gl2_statement_base(factorsRR, base):
     if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
-        return "Of \\(\\GL_2\\)-type over " + base
-    return "Not of \\(\\GL_2\\)-type over " + base
+        return r"Of \(\GL_2\)-type over " + base
+    return r"Not of \(\GL_2\)-type over " + base
 
 def gl2_simple_statement(factorsQQ, factorsRR):
     if factorsRR in [ ['RR', 'RR'], ['CC'] ]:
-        gl2 = "of \\(\\GL_2\\)-type"
+        gl2 = r"of \(\GL_2\)-type"
     else:
-        gl2 = "not of \\(\\GL_2\\)-type"
+        gl2 = r"not of \(\GL_2\)-type"
     if len(factorsQQ) == 1 and factorsQQ[0][2] != 1:
         simple = "simple"
     else:
@@ -276,14 +276,14 @@ def gl2_simple_statement(factorsQQ, factorsRR):
 def end_statement(factorsQQ, factorsRR, field='', ring=None):
     # field is a latex string describing the basechange field (default is empty)
     # ring is optional, if unspecified only endomorphism algebra is described
-    statement = """<table class="g2">"""
+    statement = '<table class="g2">'
     factorsQQ_number = len(factorsQQ)
     factorsQQ_pretty = [ field_pretty(fac[0]) for fac in factorsQQ if fac[0] ]
 
     # endomorphism ring is an invariant of the curve but not the isogeny class, so we make it optional
     if ring:
         # First row: description of the endomorphism ring as an order in the endomorphism algebra
-        statement += """<tr><td>\\(\\End (J_{%s})\\)</td><td>\\(\\simeq\\)</td><td>""" % field
+        statement += r"<tr><td>\(\End (J_{%s})\)</td><td>\(\simeq\)</td><td>" % field
         # First the case of a maximal order:
         if ring[0] == 1:
             # Single factor:
@@ -292,47 +292,47 @@ def end_statement(factorsQQ, factorsRR, field='', ring=None):
                 if factorsQQ[0][2] == -1:
                     # Prettify in quadratic case:
                     if len(factorsQQ[0][1]) in [2, 3]:
-                        statement += """\\(%s\\)""" % ring_pretty(factorsQQ[0][1], 1)
+                        statement += r"\(%s\)" % ring_pretty(factorsQQ[0][1], 1)
                     else:
-                        statement += """the maximal order of \\(\\End (J_{%s}) \\otimes \\Q\\)""" % field
+                        statement += r"the maximal order of \(\End (J_{%s}) \otimes \Q\)" % field
                 else:
                     # Use M_2 over integers if this applies:
                     if factorsQQ[0][2] == 1 and factorsQQ[0][0] == '1.1.1.1':
-                        statement += """\\(\\mathrm{M}_2 (\\Z)\\)"""
+                        statement += r"\(\mathrm{M}_2 (\Z)\)"
                     # TODO: Add flag that indicates whether we are over a PID, in
                     # which case we can use the following lines:
                     #if factorsQQ[0][2] == 1:
-                    #    statement += """\(\mathrm{M}_2 (%s)\)"""\
-                    #        % ring_pretty(factorsQQ[0][1], 1)
+                    #    statement += (r"\(\mathrm{M}_2 (%s)\)"
+                    #        % ring_pretty(factorsQQ[0][1], 1))
                     else:
-                        statement += """a maximal order of \\(\\End (J_{%s}) \\otimes \\Q\\)""" % field
+                        statement += r"a maximal order of \(\End (J_{%s}) \otimes \Q\)" % field
             # If there are two factors, then they are both at most quadratic
             # and we can prettify them
             else:
-                statement += r'\(' + ' \\times '.join([ ring_pretty(factorQQ[1], 1) for factorQQ in factorsQQ ]) + r'\)'
+                statement += r'\(' + r' \times '.join([ ring_pretty(factorQQ[1], 1) for factorQQ in factorsQQ ]) + r'\)'
         # Then the case where there is still a single factor:
         elif factorsQQ_number == 1:
             # Number field case:
             if factorsQQ[0][2] == -1:
                 # Prettify in quadratic case:
                 if len(factorsQQ[0][1]) in [2, 3]:
-                    statement += """\\(%s\\)""" % ring_pretty(factorsQQ[0][1], ring[0])
+                    statement += r"\(%s\)" % ring_pretty(factorsQQ[0][1], ring[0])
                 else:
-                    statement += """an order of conductor of norm \\(%s\\) in \\(\\End (J_{%s}) \\otimes \\Q\\)""" % (ring[0], field)
+                    statement += r"an order of conductor of norm \(%s\) in \(\End (J_{%s}) \otimes \Q\)" % (ring[0], field)
             # Otherwise mention whether the order is Eichler:
             elif ring[1] == 1:
-                statement += """an Eichler order of index \\(%s\\) in a maximal order of \\(\\End (J_{%s}) \\otimes \\Q\\)""" % (ring[0], field)
+                statement += r"an Eichler order of index \(%s\) in a maximal order of \(\End (J_{%s}) \otimes \Q\)" % (ring[0], field)
             else:
-                statement += """a non-Eichler order of index \\(%s\\) in a maximal order of \\(\\End (J_{%s}) \\otimes \\Q\\)""" % (ring[0], field)
+                statement += r"a non-Eichler order of index \(%s\) in a maximal order of \(\End (J_{%s}) \otimes \Q\)" % (ring[0], field)
         # Finally the case of two factors. We can prettify to some extent, since we
         # can describe the maximal order here
         else:
-            statement += """an order of index \\(%s\\) in \\(%s\\)""" % (ring[0], ' \\times '.join([ ring_pretty(factorQQ[1], 1) for factorQQ in factorsQQ ]))
+            statement += r"an order of index \(%s\) in \(%s\)" % (ring[0], r' \times '.join([ ring_pretty(factorQQ[1], 1) for factorQQ in factorsQQ ]))
         # End of first row:
-        statement += """</td></tr>"""
+        statement += "</td></tr>"
 
     # Second row: description of endomorphism algebra factors (this is the first row if ring=None)
-    statement += """<tr><td>\\(\\End (J_{%s}) \\otimes \\Q \\)</td><td>\\(\\simeq\\)</td><td>""" % field
+    statement += r"<tr><td>\(\End (J_{%s}) \otimes \Q \)</td><td>\(\simeq\)</td><td>" % field
     # In the case of only one factor we either get a number field or a
     # quaternion algebra:
     if factorsQQ_number == 1:
@@ -341,100 +341,100 @@ def end_statement(factorsQQ, factorsRR, field='', ring=None):
         if factorsQQ[0][2] == -1:
             # Prettify if labels available, otherwise return defining polynomial:
             if factorsQQ_pretty:
-                statement += """<a href=%s>%s</a>""" % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0])
+                statement += "<a href=%s>%s</a>" % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0])
             else:
-                statement += """the number field with defining polynomial \\(%s\\)""" % intlist_to_poly(factorsQQ[0][1])
+                statement += r"the number field with defining polynomial \(%s\)" % intlist_to_poly(factorsQQ[0][1])
             # Detect CM by presence of a quartic polynomial:
             if len(factorsQQ[0][1]) == 5:
-                statement += """ (CM)"""
+                statement += " (CM)"
                 # TODO: Get the following line to work
-                #statement += """ ({{ KNOWL('ag.complex_multiplication', title='CM') }})"""
+                #statement += " ({{ KNOWL('ag.complex_multiplication', title='CM') }})"
         # Up next is the case of a matrix ring (trivial disciminant), with
         # labels and full prettification always available:
         elif factorsQQ[0][2] == 1:
-            statement += """\\(\\mathrm{M}_2(\\)<a href=%s>%s</a>\\()\\)""" % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0])
+            statement += r"\(\mathrm{M}_2(\)<a href=%s>%s</a>\()\)" % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0])
         # And finally we deal with quaternion algebras over the rationals:
         else:
-            statement += """the quaternion algebra over <a href=%s>%s</a> of discriminant %s"""\
-                % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0], factorsQQ[0][2])
+            statement += ("the quaternion algebra over <a href=%s>%s</a> of discriminant %s"
+                % (url_for("number_fields.by_label", label=factorsQQ[0][0]), factorsQQ_pretty[0], factorsQQ[0][2]))
     # If there are two factors, then we get two at most quadratic fields:
     else:
-        statement += """<a href=%s>%s</a> \\(\\times\\) <a href=%s>%s</a>"""\
-            % (url_for("number_fields.by_label", label=factorsQQ[0][0]), 
+        statement += (r"<a href=%s>%s</a> \(\times\) <a href=%s>%s</a>"
+            % (url_for("number_fields.by_label", label=factorsQQ[0][0]),
                 factorsQQ_pretty[0], url_for("number_fields.by_label",
-                label=factorsQQ[1][0]), factorsQQ_pretty[1])
+                label=factorsQQ[1][0]), factorsQQ_pretty[1]))
     # End of second row:
-    statement += """</td></tr>"""
+    statement += "</td></tr>"
 
     # Third row: description of algebra tensored with RR (this is the second row if ring=None)
-    statement += """<tr><td>\\(\\End (J_{%s}) \\otimes \\R\\)</td><td>\\(\\simeq\\)</td> <td>\\(%s\\)</td></tr>""" % (field, factorsRR_raw_to_pretty(factorsRR))
+    statement += r"<tr><td>\(\End (J_{%s}) \otimes \R\)</td><td>\(\simeq\)</td> <td>\(%s\)</td></tr>" % (field, factorsRR_raw_to_pretty(factorsRR))
 
     # End of statement:
-    statement += """</table>"""
+    statement += "</table>"
     return statement
 
 def end_field_statement(field_label, poly):
     if field_label == '1.1.1.1':
-        return """All \\(\\overline{\\Q}\\)-endomorphisms of the Jacobian are defined over \\(\\Q\\)."""
+        return r"All \(\overline{\Q}\)-endomorphisms of the Jacobian are defined over \(\Q\)."
     elif field_label != '':
         pretty = field_pretty(field_label)
         url = url_for("number_fields.by_label", label=field_label)
-        return """Smallest field over which all endomorphisms are defined:<br>
-        Galois number field \\(K = \\Q (a) \\simeq \\) <a href=%s>%s</a> with defining polynomial \\(%s\\)""" % (url, pretty, poly)
+        return r"""Smallest field over which all endomorphisms are defined:<br>
+        Galois number field \(K = \Q (a) \simeq \) <a href=%s>%s</a> with defining polynomial \(%s\)""" % (url, pretty, poly)
     else:
-        return """Smallest field over which all endomorphisms are defined:<br>
-        Galois number field \\(K = \\Q (a)\\) with defining polynomial \\(%s\\)""" % poly
+        return r"""Smallest field over which all endomorphisms are defined:<br>
+        Galois number field \(K = \Q (a)\) with defining polynomial \(%s\)""" % poly
 
 def end_lattice_statement(lattice):
     statement = ''
     for ED in lattice:
         if ED[0][0]:
             # Add link and prettify if available:
-            statement += """Over subfield \\(F \\simeq \\) <a href=%s>%s</a> with generator \\(%s\\) with minimal polynomial \\(%s\\)"""\
+            statement += (r"Over subfield \(F \simeq \) <a href=%s>%s</a> with generator \(%s\) with minimal polynomial \(%s\)"
                 % (url_for("number_fields.by_label", label=ED[0][0]),
                    field_pretty(ED[0][0]), strlist_to_nfelt(ED[0][2], 'a'),
-                   intlist_to_poly(ED[0][1]))
+                   intlist_to_poly(ED[0][1])))
         else:
-            statement += """Over subfield \\(F\\) with generator \\(%s\\) with minimal polynomial \\(%s\\)"""\
-                % (strlist_to_nfelt(ED[0][2], 'a'), intlist_to_poly(ED[0][1]))
-        statement += """:<br>"""
+            statement += (r"Over subfield \(F\) with generator \(%s\) with minimal polynomial \(%s\)"
+                % (strlist_to_nfelt(ED[0][2], 'a'), intlist_to_poly(ED[0][1])))
+        statement += ":<br>"
         statement += end_statement(ED[1], ED[2], field=r'F', ring=ED[3])
-        statement += """Sato Tate group: %s""" % st_link_by_name(1,4,ED[4])
-        statement += """<br>"""
+        statement += "Sato Tate group: %s" % st_link_by_name(1,4,ED[4])
+        statement += "<br>"
         statement += gl2_simple_statement(ED[1], ED[2])
-        statement += """<p></p>"""
+        statement += "<p></p>"
     return statement
 
 def split_field_statement(is_simple_geom, field_label, poly):
     if is_simple_geom:
-        return """Simple over \\(\\overline{\\Q}\\)"""
+        return r"Simple over \(\overline{\Q}\)"
     elif field_label == '1.1.1.1':
-        return """Splits over \\(\\Q\\)"""
+        return r"Splits over \(\Q\)"
     elif field_label != '':
         pretty =  field_pretty(field_label)
         url = url_for("number_fields.by_label", label=field_label)
-        return """Splits over the number field \\(\\Q (b) \\simeq \\) <a href=%s>%s</a> with defining polynomial:<br>&nbsp;&nbsp;\\(%s\\)"""\
-            % (url, pretty, poly)
+        return (r"Splits over the number field \(\Q (b) \simeq \) <a href=%s>%s</a> with defining polynomial:<br>&nbsp;&nbsp;\(%s\)"
+            % (url, pretty, poly))
     else:
-        return """Splits over the number field \\(\\Q (b)\\) with defining polynomial:<br>&nbsp;&nbsp;\\(%s\\)""" % poly
+        return r"Splits over the number field \(\Q (b)\) with defining polynomial:<br>&nbsp;&nbsp;\(%s\)" % poly
 
 def split_statement(coeffs, labels, condnorms):
     if len(coeffs) == 1:
-        statement = """Decomposes up to isogeny as the square of the elliptic curve:"""
+        statement = "Decomposes up to isogeny as the square of the elliptic curve:"
     else:
-        statement = """Decomposes up to isogeny as the product of the non-isogenous elliptic curves:"""
+        statement = "Decomposes up to isogeny as the product of the non-isogenous elliptic curves:"
     for n in range(len(coeffs)):
         # Use labels when possible:
         label = labels[n] if labels else ''
         if label:
-            statement += """<br>&nbsp;&nbsp;Elliptic curve <a href=%s>%s</a>""" % (url_for_ec(label), label)
+            statement += "<br>&nbsp;&nbsp;Elliptic curve <a href=%s>%s</a>" % (url_for_ec(label), label)
         # Otherwise give defining equation:
         else:
-            statement += """<br>&nbsp;&nbsp;\(y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with<br>\
-            \(g_4 = %s\)<br>\
-            \(g_6 = %s\)<br>\
-            Conductor norm: %s""" \
-            % (strlist_to_nfelt(coeffs[n][0], 'b'), strlist_to_nfelt(coeffs[n][1], 'b'), condnorms[n])
+            statement += (r"""<br>&nbsp;&nbsp;\(y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with<br>
+            \(g_4 = %s\)<br>
+            \(g_6 = %s\)<br>
+            Conductor norm: %s"""
+            % (strlist_to_nfelt(coeffs[n][0], 'b'), strlist_to_nfelt(coeffs[n][1], 'b'), condnorms[n]))
     return statement
 
 # create friend entry from url (typically coming from lfunc_instances)
@@ -478,11 +478,11 @@ def add_friend(friends, friend):
 def th_wrap(kwl, title):
     return ' <th>%s</th>' % display_knowl(kwl, title=title)
 def td_wrapl(val):
-    return ' <td align="left">\\(%s\\)</td>' % val
+    return r' <td align="left">\(%s\)</td>' % val
 def td_wrapr(val):
-    return ' <td align="right">\\(%s\\)</td>' % val
+    return r' <td align="right">\(%s\)</td>' % val
 def td_wrapc(val):
-    return ' <td align="center">\\(%s\\)</td>' % val
+    return r' <td align="center">\(%s\)</td>' % val
 
 def mw_gens_table(invs,gens,hts):
     def list_to_divisor(P):
@@ -504,7 +504,7 @@ def mw_gens_table(invs,gens,hts):
         D = list_to_divisor(gens[i])
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
-                       td_wrapc('\\infty') if invs[i]==0 else td_wrapc(invs[i])])
+                       td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')
     gentab.extend(['</tbody>', '</table>'])
     return '\n'.join(gentab)
@@ -512,8 +512,8 @@ def mw_gens_table(invs,gens,hts):
 def local_table(D,N,tama,bad_lpolys):
     loctab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('ag.bad_prime', 'Prime'),
-              th_wrap('ag.conductor', 'ord(\\(N\\))'),
-              th_wrap('g2c.discriminant', 'ord(\\(\\Delta\\))'),
+              th_wrap('ag.conductor', r'ord(\(N\))'),
+              th_wrap('g2c.discriminant', r'ord(\(\Delta\))'),
               th_wrap('g2c.tamagawa', 'Tamagawa'),
               th_wrap('g2c.bad_lfactors', 'L-factor'),
               '</tr>', '</thead>', '<tbody>']
@@ -545,7 +545,7 @@ def ratpts_table(pts,pts_v):
     caption = 'Points' if pts_v else 'Known points'
     tabcols = 6
     if len(pts) <= tabcols+1:
-        return '<p>%s: \\(%s\\)</p>' % (display_knowl(kid,caption),',\\, '.join(strpts))
+        return r'<p>%s: \(%s\)</p>' % (display_knowl(kid,caption),r',\, '.join(strpts))
     ptstab = ['<table class="ntdata">', '<thead>', '<tr>', th_wrap(kid, caption)]
     ptstab.extend(['<th></th>' for i in range(tabcols-1)])
     ptstab.extend(['</tr>', '</thead>', '<tbody>'])
@@ -628,7 +628,7 @@ class WebG2C(object):
         # set attributes common to curves and isogeny classes here
         data['Lhash'] = str(curve['Lhash'])
         data['cond'] = ZZ(curve['cond'])
-        data['cond_factor_latex'] = web_latex(factor(int(data['cond']))).replace("-1 \\cdot","-")
+        data['cond_factor_latex'] = web_latex(factor(int(data['cond']))).replace(r"-1 \cdot","-")
         data['analytic_rank'] = ZZ(curve['analytic_rank'])
         data['mw_rank'] = ZZ(0) if curve.get('mw_rank') is None else ZZ(curve['mw_rank']) # 0 will be marked as a lower bound
         data['mw_rank_proved'] = curve['mw_rank_proved']
@@ -647,12 +647,12 @@ class WebG2C(object):
             data['disc'] = curve['disc_sign'] * data['abs_disc']
             data['min_eqn'] = literal_eval(curve['eqn'])
             data['min_eqn_display'] = min_eqns_pretty(data['min_eqn'])
-            data['disc_factor_latex'] = web_latex(factor(data['disc'])).replace("-1 \\cdot","-")
+            data['disc_factor_latex'] = web_latex(factor(data['disc'])).replace(r"-1 \cdot","-")
             data['igusa_clebsch'] = [ZZ(a) for a in literal_eval(curve['igusa_clebsch_inv'])]
             data['igusa'] = [ZZ(a) for a in literal_eval(curve['igusa_inv'])]
             data['g2'] = [QQ(a) for a in literal_eval(curve['g2_inv'])]
-            data['igusa_clebsch_factor_latex'] = [web_latex(zfactor(i)).replace("-1 \\cdot","-") for i in data['igusa_clebsch']]
-            data['igusa_factor_latex'] = [ web_latex(zfactor(j)).replace("-1 \\cdot","-") for j in data['igusa'] ]
+            data['igusa_clebsch_factor_latex'] = [web_latex(zfactor(i)).replace(r"-1 \cdot","-") for i in data['igusa_clebsch']]
+            data['igusa_factor_latex'] = [ web_latex(zfactor(j)).replace(r"-1 \cdot","-") for j in data['igusa'] ]
             data['aut_grp'] = small_group_label_display_knowl('%d.%d' % tuple(literal_eval(curve['aut_grp_id'])))
             data['geom_aut_grp'] = small_group_label_display_knowl('%d.%d' % tuple(literal_eval(curve['geom_aut_grp_id'])))
             data['num_rat_wpts'] = ZZ(curve['num_rat_wpts'])
@@ -693,7 +693,7 @@ class WebG2C(object):
             if len(invs) == 0:
                 data['mw_group'] = 'trivial'
             else:
-                data['mw_group'] = '\\(' + ' \\times '.join([ ('\\Z' if n == 0 else '\\Z/{%s}\\Z' % n) for n in invs]) + '\\)'
+                data['mw_group'] = r'\(' + r' \times '.join([ (r'\Z' if n == 0 else r'\Z/{%s}\Z' % n) for n in invs]) + r'\)'
             if lower >= upper:
                 data['mw_gens_table'] = mw_gens_table (ratpts['mw_invs'], ratpts['mw_gens'], ratpts['mw_heights'])
 
@@ -701,7 +701,7 @@ class WebG2C(object):
                 data['two_torsion_field_knowl'] = nf_display_knowl (curve['two_torsion_field'][0], field_pretty(curve['two_torsion_field'][0]))
             else:
                 t = curve['two_torsion_field']
-                data['two_torsion_field_knowl'] = """splitting field of \\(%s\\) with Galois group %s"""%(intlist_to_poly(t[1]),group_display_knowl(t[2][0],t[2][1]))
+                data['two_torsion_field_knowl'] = r"splitting field of \(%s\) with Galois group %s" % (intlist_to_poly(t[1]),group_display_knowl(t[2][0],t[2][1]))
 
             tamalist = [[item['p'],item['tamagawa_number']] for item in tama]
             data['local_table'] = local_table (data['abs_disc'],data['cond'],tamalist,data['bad_lfactors_pretty'])
@@ -723,8 +723,8 @@ class WebG2C(object):
         data['gl2_statement_base'] = gl2_statement_base(endo['factorsRR_base'], r'\(\Q\)')
         data['factorsQQ_base'] = endo['factorsQQ_base']
         data['factorsRR_base'] = endo['factorsRR_base']
-        data['end_statement_base'] = """Endomorphism %s over \\(\\Q\\):<br>""" %("ring" if is_curve else "algebra") + \
-            end_statement(data['factorsQQ_base'], endo['factorsRR_base'], ring=data['end_ring_base'] if is_curve else None)
+        data['end_statement_base'] = (r"Endomorphism %s over \(\Q\):<br>" %("ring" if is_curve else "algebra") +
+            end_statement(data['factorsQQ_base'], endo['factorsRR_base'], ring=data['end_ring_base'] if is_curve else None))
 
         # Field over which all endomorphisms are defined
         data['end_field_label'] = endo['fod_label']
@@ -736,8 +736,8 @@ class WebG2C(object):
         data['factorsRR_geom'] = endo['factorsRR_geom']
         if data['end_field_label'] != '1.1.1.1':
             data['gl2_statement_geom'] = gl2_statement_base(data['factorsRR_geom'], r'\(\overline{\Q}\)')
-            data['end_statement_geom'] = """Endomorphism %s over \\(\\overline{\\Q}\\):""" %("ring" if is_curve else "algebra") + \
-                end_statement(data['factorsQQ_geom'], data['factorsRR_geom'], field=r'\overline{\Q}', ring=data['end_ring_geom'] if is_curve else None)
+            data['end_statement_geom'] = (r"Endomorphism %s over \(\overline{\Q}\):" %("ring" if is_curve else "algebra") +
+                end_statement(data['factorsQQ_geom'], data['factorsRR_geom'], field=r'\overline{\Q}', ring=data['end_ring_geom'] if is_curve else None))
         data['real_geom_end_alg_name'] = real_geom_end_alg_name(curve['real_geom_end_alg'])
         data['geom_end_alg_name'] = geom_end_alg_name(curve['geom_end_alg'])
 
@@ -776,10 +776,10 @@ class WebG2C(object):
                 properties += [('Mordell-Weil group', data['mw_group'])]
         properties += [
             ('Sato-Tate group', data['st_group_link']),
-            ('\\(\\End(J_{\\overline{\\Q}}) \\otimes \\R\\)', '\\(%s\\)' % data['real_geom_end_alg_name']),
-            ('\\(\\End(J_{\\overline{\\Q}}) \\otimes \\Q\\)', '\\(%s\\)' % data['geom_end_alg_name']),
-            ('\\(\\overline{\\Q}\\)-simple', bool_pretty(data['is_simple_geom'])),
-            ('\\(\\mathrm{GL}_2\\)-type', bool_pretty(data['is_gl2_type'])),
+            (r'\(\End(J_{\overline{\Q}}) \otimes \R\)', r'\(%s\)' % data['real_geom_end_alg_name']),
+            (r'\(\End(J_{\overline{\Q}}) \otimes \Q\)', r'\(%s\)' % data['geom_end_alg_name']),
+            (r'\(\overline{\Q}\)-simple', bool_pretty(data['is_simple_geom'])),
+            (r'\(\mathrm{GL}_2\)-type', bool_pretty(data['is_gl2_type'])),
             ]
 
         # Friends
@@ -828,7 +828,7 @@ class WebG2C(object):
         # Breadcrumbs
         self.bread = bread = [
              ('Genus 2 Curves', url_for(".index")),
-             ('$\\Q$', url_for(".index_Q")),
+             (r'$\Q$', url_for(".index_Q")),
              ('%s' % data['slabel'][0], url_for(".by_conductor", cond=data['slabel'][0])),
              ('%s' % data['slabel'][1], url_for(".by_url_isogeny_class_label", cond=data['slabel'][0], alpha=data['slabel'][1]))
              ]

--- a/lmfdb/half_integral_weight_forms/half_integral_form.py
+++ b/lmfdb/half_integral_weight_forms/half_integral_form.py
@@ -30,7 +30,7 @@ def half_integral_weight_form_render_webpage():
              per_page=50,
              shortcuts={'label':lambda info:render_hiwf_webpage(label=info['label'])},
              projection=['level','label','weight','character','dim'],
-             cleaners={'char': lambda v:"\chi_{"+v['character'].split(".")[0]+"}("+v['character'].split(".")[1]+",\cdot)",
+             cleaners={'char': lambda v: r"\chi_{" + v['character'].split(".")[0] + "}(" + v['character'].split(".")[1] + r",\cdot)",
                        'ch_lab': lambda v: v.pop('character').replace('.','/'),
                        'dimension': lambda v: v.pop('dim')},
              bread=lambda:[('Half Integral Weight Cusp Forms', url_for(".half_integral_weight_form_render_webpage")),('Search Results', ' ')],
@@ -39,7 +39,7 @@ def half_integral_weight_form_search(info, query):
     parse_ints(info, query, 'weight')
     parse_ints(info, query, 'level')
     if info.get('character','').strip():
-        if re.match('^\d+.\d+$', info['character'].strip()):
+        if re.match(r'^\d+.\d+$', info['character'].strip()):
             query['character'] = info['character'].strip()
         else:
             flash_error("%s is not a valid Dirichlet character label, it should be of the form q.n", info['character'])
@@ -55,11 +55,11 @@ def print_q_expansion(list):
 
 def my_latex_from_qexp(s):
     ss = ""
-    ss += re.sub('x\d', 'x', s)
-    ss = re.sub("\^(\d+)", "^{\\1}", ss)
-    ss = re.sub('\*', '', ss)
-    ss = re.sub('zeta(\d+)', 'zeta_{\\1}', ss)
-    ss = re.sub('zeta', '\zeta', ss)
+    ss += re.sub(r'x\d', 'x', s)
+    ss = re.sub(r"\^(\d+)", r"^{\1}", ss)
+    ss = re.sub(r'\*', '', ss)
+    ss = re.sub(r'zeta(\d+)', r'zeta_{\1}', ss)
+    ss = re.sub('zeta', r'\zeta', ss)
     ss += ""
     return ss
 
@@ -91,7 +91,7 @@ def render_hiwf_webpage(**args):
     chi = data['character']
     info['ch_lab']= chi.replace('.','/')
     chi1=chi.split(".")
-    chi2="\chi_{"+chi1[0]+"}("+chi1[1]+",\cdot)"
+    chi2=r"\chi_{"+chi1[0]+"}("+chi1[1]+r",\cdot)"
     info['char']= chi2
     info['newpart']=data['newpart']
     new=[]
@@ -113,7 +113,7 @@ def render_hiwf_webpage(**args):
             for n in m:
                 n_lab= n.replace('.','/')
                 n_l=n.split(".")
-                n_lat="\chi_{"+n_l[0]+"}("+n_l[1]+",\cdot)"
+                n_lat=r"\chi_{"+n_l[0]+"}("+n_l[1]+r",\cdot)"
                 v=[n_lab, n_lat]
                 theta.append(v)
         info['theta']= theta

--- a/lmfdb/hecke_algebras/hecke_algebras_stats.py
+++ b/lmfdb/hecke_algebras/hecke_algebras_stats.py
@@ -11,7 +11,7 @@ def hecke_algebras_summary():
     hecke_knowl = '<a knowl="hecke_algebra.definition">Hecke algebras</a>'
     level_knowl = '<a knowl="cmf.level">level</a>'
     weight_knowl = '<a knowl="cmf.weight">weight</a>'
-    gamma0_knowl = '<a knowl="group.sl2z.subgroup.gamma0n">$\Gamma_0$</a>'
+    gamma0_knowl = r'<a knowl="group.sl2z.subgroup.gamma0n">$\Gamma_0$</a>'
     level_data = heckestats.get_oldstat('level')
     number = level_data['total']
     max_level = level_data['max']

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -642,10 +642,10 @@ def render_family(args):
         smallgroup="[" + str(gn) + "," +str(gt) + "]"
 
         prop2 = [
-            ('Genus', '\(%d\)' % g),
-             ('Quotient Genus', '\(%d\)' % g0),
-            ('Group', '\(%s\)' % pretty_group),
-            ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature'])))
+            ('Genus', r'\(%d\)' % g),
+             ('Quotient Genus', r'\(%d\)' % g0),
+            ('Group', r'\(%s\)' % pretty_group),
+            ('Signature', r'\(%s\)' % sign_display(ast.literal_eval(data['signature'])))
         ]
         info.update({'genus': data['genus'],
                     'sign': sign_display(ast.literal_eval(data['signature'])),
@@ -676,7 +676,7 @@ def render_family(args):
         g2List = ['[2,1]', '[4,2]', '[8,3]', '[10,2]', '[12,4]', '[24,8]', '[48,29]']
         if g == 2 and data['group'] in g2List:
             g2url = "/Genus2Curve/Q/?geom_aut_grp_id=" + data['group']
-            friends = [("Genus 2 curves over $\Q$", g2url)]
+            friends = [(r"Genus 2 curves over $\Q$", g2url)]
         else:
             friends = []
 
@@ -738,11 +738,11 @@ def render_passport(args):
         smallgroup="[" + str(gn) + "," +str(gt) +"]"
 
         prop2 = [
-            ('Genus', '\(%d\)' % g),
-            ('Quotient Genus', '\(%d\)' % g0),
-            ('Group', '\(%s\)' % pretty_group),
-            ('Signature', '\(%s\)' % sign_display(ast.literal_eval(data['signature']))),
-            ('Generating Vectors', '\(%d\)' % numb)
+            ('Genus', r'\(%d\)' % g),
+            ('Quotient Genus', r'\(%d\)' % g0),
+            ('Group', r'\(%s\)' % pretty_group),
+            ('Signature', r'\(%s\)' % sign_display(ast.literal_eval(data['signature']))),
+            ('Generating Vectors', r'\(%d\)' % numb)
         ]
         info.update({'genus': data['genus'],
                     'cc': cc_display(data['con']),

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -387,7 +387,7 @@ def render_hmf_webpage(**args):
     if 'numeigs' in request.args:
         display_eigs = True
 
-    info['hecke_polynomial'] = "\(" + teXify_pol(hecke_pol) + "\)"
+    info['hecke_polynomial'] = r"\(" + teXify_pol(hecke_pol) + r"\)"
 
     if not AL_eigs: # empty list
         if data['level_norm'] == 1: # OK, no bad primes
@@ -488,7 +488,7 @@ def statistics_by_degree(d):
     info = {}
     if not str(d) in counts['degrees']:
         if d==1:
-            info['error'] = "For modular forms over $\mathbb{Q}$ go <a href=%s>here</a>" % url_for('cmf.index')
+            info['error'] = r"For modular forms over $\mathbb{Q}$ go <a href=%s>here</a>" % url_for('cmf.index')
         else:
             info['error'] = "The database does not contain any Hilbert modular forms over fields of degree %s" % d
         d = 'bad'

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -34,7 +34,7 @@ def hmf_summary():
     return ''.join([r'The database currently contains %s ' % counts['nforms_c'],
                     hmf_knowl,
                     r', over %s ' % counts['nfields'],
-                    nf_knowl, ' (not including $\mathbb{Q}$)',
+                    nf_knowl, r' (not including $\mathbb{Q}$)',
                     ' of degree up to %s' % counts['maxdeg']
                 ])
 

--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -186,7 +186,7 @@ def make_t_label(t):
 def get_bread(breads=[]):
     bc = [("Motives", url_for("motive.index")),
           ("Hypergeometric", url_for("motive.index2")),
-          ("$\Q$", url_for(".index"))]
+          (r"$\Q$", url_for(".index"))]
     for b in breads:
         bc.append(b)
     return bc
@@ -263,7 +263,7 @@ def index():
     info = {'count': 50}
     return render_template(
             "hgm-index.html",
-            title="Hypergeometric Motives over $\Q$",
+            title=r"Hypergeometric Motives over $\Q$",
             bread=get_bread(),
             credit=HGM_credit,
             info=info,
@@ -437,12 +437,12 @@ def render_hgm_webpage(label):
     famhodge = data['famhodge']
     prop2 = [
         ('Label', '%s' % data['label']),
-        ('A', '\(%s\)' % A),
-        ('B', '\(%s\)' % B),
-        ('Degree', '\(%s\)' % data['degree']),
-        ('Weight',  '\(%s\)' % data['weight']),
-        ('Hodge vector',  '\(%s\)' % hodge),
-        ('Conductor', '\(%s\)' % data['cond']),
+        ('A', r'\(%s\)' % A),
+        ('B', r'\(%s\)' % B),
+        ('Degree', r'\(%s\)' % data['degree']),
+        ('Weight',  r'\(%s\)' % data['weight']),
+        ('Hodge vector',  r'\(%s\)' % hodge),
+        ('Conductor', r'\(%s\)' % data['cond']),
     ]
     # Now add factorization of conductor
     Cond = ZZ(data['cond'])
@@ -551,7 +551,7 @@ def random_motive():
 
 @hypergm_page.route("/Completeness")
 def completeness_page():
-    t = 'Completeness of Hypergeometric Motive Data over $\Q$'
+    t = r'Completeness of Hypergeometric Motive Data over $\Q$'
     bread = get_bread(('Completeness', ''))
     return render_template("single.html", kid='dq.hgm.extent',
            credit=HGM_credit, title=t, bread=bread,
@@ -559,7 +559,7 @@ def completeness_page():
 
 @hypergm_page.route("/Source")
 def how_computed_page():
-    t = 'Source of Hypergeometric Motive Data over $\Q$'
+    t = r'Source of Hypergeometric Motive Data over $\Q$'
     bread = get_bread(('Source',''))
     return render_template("single.html", kid='dq.hgm.source',
            credit=HGM_credit, title=t, bread=bread,
@@ -567,7 +567,7 @@ def how_computed_page():
 
 @hypergm_page.route("/Labels")
 def labels_page():
-    t = 'Labels for Hypergeometric Motives over $\Q$'
+    t = r'Labels for Hypergeometric Motives over $\Q$'
     bread = get_bread(('Labels',''))
     return render_template("single.html", kid='hgm.field.label',
            credit=HGM_credit, title=t, bread=bread,

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -183,10 +183,10 @@ class WebHyperGeometricFamily(object):
         return [
                 ('Label', self.label),
                 (None, self.plot_link),
-                ('A', '\({}\)'.format(self.A)),
-                ('B', '\({}\)'.format(self.B)),
-                ('Degree', '\({}\)'.format(self.degree)),
-                ('Weight',  '\({}\)'.format(self.weight)),
+                ('A', r'\({}\)'.format(self.A)),
+                ('B', r'\({}\)'.format(self.B)),
+                ('Degree', r'\({}\)'.format(self.degree)),
+                ('Weight',  r'\({}\)'.format(self.weight)),
                 ('Type', self.type)
                 ]
 
@@ -266,7 +266,7 @@ class WebHyperGeometricFamily(object):
     def bread(self):
         return [("Motives", url_for("motive.index")),
                 ("Hypergeometric", url_for("motive.index2")),
-                ("$\Q$", url_for(".index")),
+                (r"$\Q$", url_for(".index")),
                 ('family A = {}, B = {}'.format(str(self.A), str(self.B)), '')]
 
     @lazy_attribute
@@ -326,13 +326,13 @@ class WebHyperGeometricFamily(object):
             else:
                 factors, gal_groups = fG, ""
 
-            factors = make_bigint('\( %s \)' % factors)
+            factors = make_bigint(r'\( %s \)' % factors)
 
             if gal_groups:
                 if gal_groups[0] == [0,0]:
                     gal_groups = ""
                 else:
-                    gal_groups = "$\\times$".join(
+                    gal_groups = r"$\times$".join(
                             [group_display_knowl_C1_as_trivial(n, t)
                                 for n, t in gal_groups])
             return [gal_groups, factors, self.ordinary(f, p)]

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -172,8 +172,8 @@ def ref_to_link(txt):
         ref = ref.strip()    # because \cite{A, B, C,D} can have spaces
         this_link = ""
         if ref.startswith("href"):
-            the_link = re.sub(".*{([^}]+)}{.*", r"\1", ref)
-            click_on = re.sub(".*}{([^}]+)}\s*", r"\1", ref)
+            the_link = re.sub(r".*{([^}]+)}{.*", r"\1", ref)
+            click_on = re.sub(r".*}{([^}]+)}\s*", r"\1", ref)
             this_link = '{{ LINK_EXT("' + click_on + '","' + the_link + '") | safe}}'
         elif ref.startswith("doi"):
             ref = ref.replace(":","")  # could be doi:: or doi: or doi
@@ -218,7 +218,7 @@ def md_latex_accents(text):
     return knowl_content
 
 def md_preprocess(text):
-    """
+    r"""
     Markdown preprocessor: html paragraph breaks before display math,
     \cite{MR:...} and \cite{arXiv:...} converted to links.
     """

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -34,11 +34,11 @@ def print_q_expansion(list):
 
 def my_latex(s):
     ss = ""
-    ss += re.sub('x\d', 'x', s)
-    ss = re.sub("\^(\d+)", "^{\\1}", ss)
-    ss = re.sub('\*', '', ss)
-    ss = re.sub('zeta(\d+)', 'zeta_{\\1}', ss)
-    ss = re.sub('zeta', '\zeta', ss)
+    ss += re.sub(r'x\d', 'x', s)
+    ss = re.sub(r"\^(\d+)", r"^{\1}", ss)
+    ss = re.sub(r'\*', '', ss)
+    ss = re.sub(r'zeta(\d+)', r'zeta_{\1}', ss)
+    ss = re.sub('zeta', r'\zeta', ss)
     ss += ""
     return ss
 

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -62,7 +62,7 @@ def validate_required_args(errmsg, args, *keys):
 def validate_integer_args(errmsg, args, *keys):
     for key in keys:
         if key in args:
-            if not isinstance(args[key],int) and not re.match('^\d+$',args[key].strip()):
+            if not isinstance(args[key],int) and not re.match(r'^\d+$',args[key].strip()):
                 raise ValueError(errmsg, "Unable to convert parameter '%s' with value '%s' to a nonnegative integer." % (key, args[key]))
 
 def constructor_logger(object, args):
@@ -484,7 +484,7 @@ class Lfunction_Dirichlet(Lfunction):
         # Use ConreyCharacter to check primitivity (it can handle a huge modulus
         if not ConreyCharacter(self.charactermodulus,self.characternumber).is_primitive():
             raise ValueError('Unable to construct Dirichlet L-function,',
-                             'The Dirichlet character $\chi_{%d}(%d,\cdot)$ is imprimitive; only primitive characters have L-functions).'%(self.charactermodulus,self.characternumber))
+                             r'The Dirichlet character $\chi_{%d}(%d,\cdot)$ is imprimitive; only primitive characters have L-functions).'%(self.charactermodulus,self.characternumber))
 
         # Load data from the database
         self.label = str(self.charactermodulus) + "." + str(self.characternumber)
@@ -493,7 +493,7 @@ class Lfunction_Dirichlet(Lfunction):
         try:
             self.lfunc_data = get_lfunction_by_Lhash(Lhash)
         except:
-            raise KeyError('No L-function data for the Dirichlet character $\chi_{%d}(%d,\cdot)$ found in the database.'%(self.charactermodulus,self.characternumber))
+            raise KeyError(r'No L-function data for the Dirichlet character $\chi_{%d}(%d,\cdot)$ found in the database.'%(self.charactermodulus,self.characternumber))
 
         # Extract the data
         makeLfromdata(self)
@@ -530,7 +530,7 @@ class Lfunction_Dirichlet(Lfunction):
             self.texnamecompleted1ms_arithmetic = "\\Lambda(\\chi,1-s)"
         else:
             self.texnamecompleted1ms = "\\Lambda(1-s,\\overline{\\chi})"
-            self.texnamecompleted1ms_arithmetic = "\\Lambda(\overline{\\chi},1-s)"
+            self.texnamecompleted1ms_arithmetic = r"\Lambda(\overline{\chi},1-s)"
         title_end = ("where $\\chi$ is the Dirichlet character with label "
                      + self.label)
         self.credit = 'Sage'
@@ -716,7 +716,7 @@ class Lfunction_from_db(Lfunction):
     def chilatex(self):
         try:
             if int(self.characternumber) != 1:
-                return "character $\chi_{%s} (%s, \cdot)$" % (self.charactermodulus, self.characternumber)
+                return r"character $\chi_{%s} (%s, \cdot)$" % (self.charactermodulus, self.characternumber)
             else:
                 return "trivial character"
         except KeyError:
@@ -1577,7 +1577,7 @@ class DedekindZeta(Lfunction):
                     j += 1
                 dir_group.pop(j)
                 self.factorization = (r'\(\zeta_K(s) =\) ' +
-                                      '<a href="/L/Riemann/">\(\zeta(s)\)</a>')
+                                      r'<a href="/L/Riemann/">\(\zeta(s)\)</a>')
                 fullchargroup = wnf.full_dirichlet_group()
                 for j in dir_group:
                     chij = fullchargroup[j]
@@ -1589,7 +1589,7 @@ class DedekindZeta(Lfunction):
                 nfgg = wnf.factor_perm_repn() # first call cached it
                 ar = wnf.artin_reps() # these are in the same order
                 self.factorization = (r'\(\zeta_K(s) =\) <a href="/L/Riemann/">'
-                                           +'\(\zeta(s)\)</a>')
+                                           +r'\(\zeta(s)\)</a>')
                 for j in range(len(ar)):
                     if nfgg[j]>0:
                         the_rep = ar[j]
@@ -1889,9 +1889,9 @@ class SymmetricPowerLfunction(Lfunction):
         self.selfdual = True
 
         # Text for the web page
-        self.texname = "L(s, E, \mathrm{sym}^{%d})" % self.m
-        self.texnamecompleteds = "\\Lambda(s,E,\mathrm{sym}^{%d})" % self.S.m
-        self.texnamecompleted1ms = ("\\Lambda(1-{s}, E,\mathrm{sym}^{%d})"
+        self.texname = r"L(s, E, \mathrm{sym}^{%d})" % self.m
+        self.texnamecompleteds = r"\Lambda(s,E,\mathrm{sym}^{%d})" % self.S.m
+        self.texnamecompleted1ms = (r"\Lambda(1-{s}, E,\mathrm{sym}^{%d})"
                                     % self.S.m)
         self.credit = ' '
 
@@ -1916,7 +1916,7 @@ class SymmetricPowerLfunction(Lfunction):
                 return (str(n) + {1: 'st', 2: 'nd', 3: 'rd'}.get(n % 10, "th") +
                         " Power")
 
-        self.info['title'] = ("The Symmetric %s $L$-function $L(s,E,\mathrm{sym}^{%d})$ of Elliptic Curve Isogeny Class %s"
+        self.info['title'] = (r"The Symmetric %s $L$-function $L(s,E,\mathrm{sym}^{%d})$ of Elliptic Curve Isogeny Class %s"
                       % (ordinal(self.m), self.m, self.label))
 
 

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -82,8 +82,8 @@ def getGroupHtml(group):
         ans += "\\Gamma_\\R(s + i \\mu_2)"
         ans += "\\Gamma_\\R(s + i \\mu_3)"
         ans += "\\end{aligned}\\]\n"
-        ans += "with \\(\mu_j\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 = 0\\). \n"
-        ans += "By permuting and possibly taking the complex conjugate, we may assume \\(\\mu_1 \ge \\mu_2 \ge 0\\), \n"
+        ans += "with \\(\\mu_j\\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 = 0\\). \n"
+        ans += "By permuting and possibly taking the complex conjugate, we may assume \\(\\mu_1 \\ge \\mu_2 \\ge 0\\), \n"
         ans += "so the functional equation can be represented by a point \\( (\\mu_1, \\mu_2) \\) below "
         ans += "the diagonal in the first quadrant of the Cartesian plane.</div>\n"
     elif group == 'r0r0r0r0':
@@ -96,7 +96,7 @@ def getGroupHtml(group):
         ans += "\\Gamma_\\R(s + i \\mu_3)"
         ans += "\\Gamma_\\R(s + i \\mu_4)"
         ans += "\\end{aligned}\\]\n"
-        ans += "with \\(\mu_j\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 + \\mu_4 = 0\\). \n"
+        ans += "with \\(\\mu_j\\in \\R\\) and \\(\\mu_1 + \\mu_2 + \\mu_3 + \\mu_4 = 0\\). \n"
         ans += "By permuting and possibly conjugating, we may assume \\(0\\le \\mu_2 \\le \\mu_1 \\).\n"
         ans += "</div>\n"
     elif group == 'r0r0r0r0selfdual':
@@ -131,10 +131,10 @@ def getGroupHtml(group):
         ans += "to Maass cusp forms for GL(4) of level 1. "
         ans += "These satisfy a functional equation with \\(\\Gamma\\)-factors\n"
         ans += "\\[\\begin{aligned}"
-        ans += "\\Gamma_\R(s + i \\mu_1)"
-        ans += "\\Gamma_\R(s + i \\mu_2)"
-        ans += "\\Gamma_\R(s - i \\mu_3)"
-        ans += "\\Gamma_\R(s - i \\mu_4)"
+        ans += "\\Gamma_\\R(s + i \\mu_1)"
+        ans += "\\Gamma_\\R(s + i \\mu_2)"
+        ans += "\\Gamma_\\R(s - i \\mu_3)"
+        ans += "\\Gamma_\\R(s - i \\mu_4)"
         ans += "\\end{aligned}\\]\n"
         ans += "where \\(\\mu_1 + \\mu_2 = \\mu_3 + \\mu_4\\).</div>\n"
 
@@ -178,7 +178,7 @@ def getOneGraphHtml(gls):
     else:
         ans = ("<h4>L-functions of conductor " + str(gls[1]) + "</h4>\n")
     ans += "<div>The dots in the plot correspond to L-functions with \\((\\mu_1,\\mu_2)\\) "
-    ans += "in the \\(\\Gamma\\)-factors, colored according to the sign of the functional equation (blue indicates \\(\epsilon=1\\)). "
+    ans += "in the \\(\\Gamma\\)-factors, colored according to the sign of the functional equation (blue indicates \\(\\epsilon=1\\)). "
     ans += "Click on any of the dots for detailed information about "
     ans += "the L-function.</div>\n<br />"
     graphInfo = getGraphInfo(gls)

--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -185,11 +185,11 @@ class Lfunction(object):
             info['sv_edge_analytic'] = [svt_edge[0], svt_edge[2]]
             info['sv_edge_arithmetic'] = [svt_edge[1], svt_edge[2]]
 
-            chilatex = "$\chi_{" + str(self.charactermodulus) + "} (" + str(self.characternumber) +", \cdot )$"
+            chilatex = r"$\chi_{" + str(self.charactermodulus) + "} (" + str(self.characternumber) + r", \cdot )$"
             info['chi'] = ''
             if self.charactermodulus != self.level:
                 info['chi'] += "induced by "
-            info['chi'] += '<a href="' + url_for('characters.render_Dirichletwebpage', 
+            info['chi'] += '<a href="' + url_for('characters.render_Dirichletwebpage',
                                                     modulus=self.charactermodulus, number=self.characternumber)
             info['chi'] += '">' + chilatex + '</a>'
 

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -50,9 +50,9 @@ def string2number(s):
     try:
         if 'e' in strs:
             # check for e(m/n) := exp(2*pi*i*m/n), used by Dirichlet characters, for example
-            r = re.match('^\$?e\\\\left\(\\\\frac\{(?P<num>\d+)\}\{(?P<den>\d+)\}\\\\right\)\$?$',strs)
+            r = re.match(r'^\$?e\\left\(\\frac\{(?P<num>\d+)\}\{(?P<den>\d+)\}\\right\)\$?$',strs)
             if not r:
-                r = re.match('^e\((?P<num>\d+)/(?P<den>\d+)\)$',strs)
+                r = re.match(r'^e\((?P<num>\d+)/(?P<den>\d+)\)$',strs)
             if r:
                 q = Rational(r.groupdict()['num'])/Rational(r.groupdict()['den'])
                 return CDF(exp(2*pi*I*q))
@@ -164,7 +164,7 @@ def seriescoeff(coeff, index, seriescoefftype, seriestype, digits):
 
 def seriesvar(index, seriestype):
     if seriestype == "dirichlet":
-        return(" \\ " + str(index) + "^{-s}")
+        return(r" \ " + str(index) + "^{-s}")
     elif seriestype == "dirichlethtml":
       # WARNING: the following change has consequences which need to be addressed! (DF and SK, July 29, 2015)
       #  return(" " + str(index) + "<sup>-s</sup>")
@@ -172,7 +172,7 @@ def seriesvar(index, seriestype):
     elif seriestype == "":
         return("")
     elif seriestype == "qexpansion":
-        return("\\, " + "q^{" + str(index) + "}")
+        return(r"\, " + "q^{" + str(index) + "}")
     elif seriestype == "polynomial":
         if index == 0:
             return("")
@@ -190,7 +190,7 @@ def lfuncDShtml(L, fmt):
     """
 
     if len(L.dirichlet_coefficients) == 0:
-        return '\\text{No Dirichlet coefficients supplied.}'
+        return r'\text{No Dirichlet coefficients supplied.}'
 
     numperline = 4
     maxcoeffs = 20
@@ -255,16 +255,16 @@ def lfuncDShtml(L, fmt):
 
     elif fmt == "abstract":
         if L.Ltype() == "riemann":
-            ans = "\[\\begin{aligned} \n \\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s} \n \\end{aligned} \]\n"
+            ans = r"\[\begin{aligned}" + " \n " + r"\zeta(s) = \sum_{n=1}^{\infty} n^{-s}" + " \n " + r"\end{aligned} \]" + "\n"
 
         elif L.Ltype() == "dirichlet":
-            ans = "\[\\begin{aligned} \n L(s,\\chi) = \\sum_{n=1}^{\\infty} \\chi(n) n^{-s} \n \\end{aligned}\]"
-            ans = ans + "where $\\chi$ is the character modulo " + str(L.charactermodulus)
+            ans = r"\[\begin{aligned}" + " \n " + r"L(s,\chi) = \sum_{n=1}^{\infty} \chi(n) n^{-s}" + " \n " + r"\end{aligned}\]"
+            ans = ans + r"where $\chi$ is the character modulo " + str(L.charactermodulus)
             ans = ans + ", number " + str(L.characternumber) + "."
 
         else:
-            ans = "\[\\begin{aligned} \n " + L.texname + \
-                " = \\sum_{n=1}^{\\infty} a(n) n^{-s} \n \\end{aligned}\]"
+            ans = (r"\[\begin{aligned}" + " \n " + L.texname +
+                r" = \sum_{n=1}^{\infty} a(n) n^{-s}" + " \n " + r"\end{aligned}\]")
     return(ans)
 
 
@@ -289,53 +289,53 @@ def lfuncEPtex(L, fmt):
     ans = ""
     if fmt == "abstract" or fmt == "arithmetic":
         if fmt == "arithmetic":
-            ans = "\[\\begin{aligned} \n " + L.texname_arithmetic + " = "
+            ans = r"\[\begin{aligned}" + " \n " + L.texname_arithmetic + " = "
         else:
-            ans = "\[\\begin{aligned} \n " + L.texname + " = "
+            ans = r"\[\begin{aligned}" + " \n " + L.texname + " = "
         if L.Ltype() == "riemann":
-            ans += "\\prod_p (1 - p^{-s})^{-1}"
+            ans += r"\prod_p (1 - p^{-s})^{-1}"
 
         elif L.Ltype() == "dirichlet":
-            ans += "\\prod_p (1- \\chi(p) p^{-s})^{-1}"
+            ans += r"\prod_p (1- \chi(p) p^{-s})^{-1}"
 
         elif L.Ltype() == "classical modular form" and fmt == "arithmetic":
-                ans += "\\prod_{p\\ \\mathrm{bad}} (1- a(p) p^{-s})^{-1} \\prod_{p\\ \\mathrm{good}} (1- a(p) p^{-s} + \chi(p)p^{-2s})^{-1}"
+                ans += r"\prod_{p\ \mathrm{bad}} (1- a(p) p^{-s})^{-1} \prod_{p\ \mathrm{good}} (1- a(p) p^{-s} + \chi(p)p^{-2s})^{-1}"
             #FIXME, this is consistent with G2C and EC
             # but do we really want this?
             #else:
-            #    ans += "\\prod_{p\\ \\mathrm{bad}} (1- a(p) p^{-s/2})^{-1} \\prod_{p\\ \\mathrm{good}} (1- a(p) p^{-s/2} + \chi(p)p^{-s})^{-1}"
+            #    ans += r"\prod_{p\ \mathrm{bad}} (1- a(p) p^{-s/2})^{-1} \prod_{p\ \mathrm{good}} (1- a(p) p^{-s/2} + \chi(p)p^{-s})^{-1}"
         elif L.Ltype() == "hilbertmodularform":
-            ans += "\\prod_{\mathfrak{p}\\ \\mathrm{bad}} (1- a(\mathfrak{p}) (N\mathfrak{p})^{-s})^{-1} \\prod_{\mathfrak{p}\\ \\mathrm{good}} (1- a(\mathfrak{p}) (N\mathfrak{p})^{-s} + (N\mathfrak{p})^{-2s})^{-1}"
+            ans += r"\prod_{\mathfrak{p}\ \mathrm{bad}} (1- a(\mathfrak{p}) (N\mathfrak{p})^{-s})^{-1} \prod_{\mathfrak{p}\ \mathrm{good}} (1- a(\mathfrak{p}) (N\mathfrak{p})^{-s} + (N\mathfrak{p})^{-2s})^{-1}"
 
         elif L.Ltype() == "maass":
             if L.group == 'GL2':
-                ans += "\\prod_{p\\ \\mathrm{bad}} (1- a(p) p^{-s})^{-1} \\prod_{p\\ \\mathrm{good}} (1- a(p) p^{-s} + \chi(p)p^{-2s})^{-1}"
+                ans += r"\prod_{p\ \mathrm{bad}} (1- a(p) p^{-s})^{-1} \prod_{p\ \mathrm{good}} (1- a(p) p^{-s} + \chi(p)p^{-2s})^{-1}"
             elif L.group == 'GL3':
-                ans += "\\prod_{p\\ \\mathrm{bad}} (1- a(p) p^{-s})^{-1}  \\prod_{p\\ \\mathrm{good}} (1- a(p) p^{-s} + \\overline{a(p)} p^{-2s} - p^{-3s})^{-1}"
+                ans += r"\prod_{p\ \mathrm{bad}} (1- a(p) p^{-s})^{-1}  \prod_{p\ \mathrm{good}} (1- a(p) p^{-s} + \overline{a(p)} p^{-2s} - p^{-3s})^{-1}"
             else:
-                ans += "\\prod_p \\ \\prod_{j=1}^{" + str(L.degree) + \
-                    "} (1 - \\alpha_{j,p}\\,  p^{-s})^{-1}"
+                ans += (r"\prod_p \ \prod_{j=1}^{" + str(L.degree) +
+                    r"} (1 - \alpha_{j,p}\,  p^{-s})^{-1}")
         elif L.Ltype() == "SymmetricPower":
             ans += lfuncEpSymPower(L)
 
         elif L.langlands:
             if L.degree > 1:
                 if fmt == "arithmetic":
-                    ans += "\\prod_p \\ \\prod_{j=1}^{" + str(L.degree) + \
-                        "} (1 - \\alpha_{j,p}\\,    p^{" + str(L.motivic_weight) + "/2 - s})^{-1}"
+                    ans += (r"\prod_p \ \prod_{j=1}^{" + str(L.degree) +
+                        r"} (1 - \alpha_{j,p}\,    p^{" + str(L.motivic_weight) + "/2 - s})^{-1}")
                 else:
-                    ans += "\\prod_p \\ \\prod_{j=1}^{" + str(L.degree) + \
-                        "} (1 - \\alpha_{j,p}\\,  p^{-s})^{-1}"
+                    ans += (r"\prod_p \ \prod_{j=1}^{" + str(L.degree) +
+                        r"} (1 - \alpha_{j,p}\,  p^{-s})^{-1}")
             else:
-                ans += "\\prod_p \\  (1 - \\alpha_{p}\\,  p^{-s})^{-1}"
+                ans += r"\prod_p \  (1 - \alpha_{p}\,  p^{-s})^{-1}"
 
 
         else:
             return("No information is available about the Euler product.")
-        ans += " \n \\end{aligned}\]"
+        ans += " \n " + r"\end{aligned}\]"
         return(ans)
     else:
-        return("\\text{No information is available about the Euler product.}")
+        return(r"\text{No information is available about the Euler product.}")
 
 def lfuncEPhtml(L, fmt):
     """
@@ -344,24 +344,24 @@ def lfuncEPhtml(L, fmt):
 
 
     # Formula
-    texform_gen = "\[L(s) = "  # "\[L(A,s) = "
-    texform_gen += "\prod_{p \\text{ prime}} F_p(p^{-s})^{-1} \]\n"
+    texform_gen = r"\[L(s) = "  # r"\[L(A,s) = "
+    texform_gen += r"\prod_{p \text{ prime}} F_p(p^{-s})^{-1} \]" + "\n"
     pfactors = prime_divisors(L.level)
 
     if len(pfactors) == 0:
         pgoodset = None
         pbadset =  None
     elif len(pfactors) == 1:  #i.e., the conductor is prime
-        pgoodset = "$p \\neq " + str(pfactors[0]) + "$"
+        pgoodset = r"$p \neq " + str(pfactors[0]) + "$"
         pbadset = "$p = " + str(pfactors[0]) + "$"
     else:
-        badset = "\\{" + str(pfactors[0])
+        badset = r"\{" + str(pfactors[0])
         for j in range(1,len(pfactors)):
-            badset += ",\\;"
+            badset += r",\;"
             badset += str(pfactors[j])
-        badset += "\\}"
-        pgoodset = "$p \\notin " + badset + "$"
-        pbadset = "$p \\in " + badset + "$"
+        badset += r"\}"
+        pgoodset = r"$p \notin " + badset + "$"
+        pbadset = r"$p \in " + badset + "$"
 
 
     ans = ""
@@ -371,12 +371,12 @@ def lfuncEPhtml(L, fmt):
     ans += ",\n"
     if L.motivic_weight == 1 and L.characternumber == 1 and L.degree in [2,4]:
         if L.degree == 4:
-            ans += "\[F_p(T) = 1 - a_p T + b_p T^2 -  a_p p T^3 + p^2 T^4 \]"
+            ans += r"\[F_p(T) = 1 - a_p T + b_p T^2 -  a_p p T^3 + p^2 T^4 \]"
             ans += "with $b_p = a_p^2 - a_{p^2}$. "
         elif L.degree == 2:
-            ans += "\[F_p(T) = 1 - a_p T + p T^2 .\]"
+            ans += r"\[F_p(T) = 1 - a_p T + p T^2 .\]"
     else:
-        ans += "\(F_p(T)\) is a polynomial of degree " + str(L.degree) + ". "
+        ans += r"\(F_p(T)\) is a polynomial of degree " + str(L.degree) + ". "
     if pbadset is not None:
         ans += "If " + pbadset + ", then $F_p(T)$ is a polynomial of degree at most "
         ans += str(L.degree - 1) + ". "
@@ -411,7 +411,7 @@ def lfuncEPhtml(L, fmt):
     eptable += "<thead>"
     eptable += "<tr class='space'><th class='weight'></th><th class='weight'>$p$</th>"
     if display_galois:
-        eptable += "<th class='weight galois'>$\Gal(F_p)$</th>"
+        eptable += r"<th class='weight galois'>$\Gal(F_p)$</th>"
     eptable += r"""<th class='weight' style="text-align: left;">$F_p(T)$</th>"""
     eptable += "</tr>\n"
     eptable += "</thead>"
@@ -423,21 +423,21 @@ def lfuncEPhtml(L, fmt):
         out = ""
         try:
             if L.coefficient_field == "CDF" or None in poly:
-                factors = '\( %s \)' % pretty_poly(poly)
+                factors = r'\( %s \)' % pretty_poly(poly)
                 gal_groups = [[0,0]]
             elif not display_galois:
                 factors = galois_pretty_factors(poly, galois=display_galois, p = p)
-                factors =  make_bigint('\( %s \)' % factors)
+                factors =  make_bigint(r'\( %s \)' % factors)
             else:
                 factors, gal_groups = galois_pretty_factors(poly, galois=display_galois, p = p)
-                factors =  make_bigint('\( %s \)' % factors)
+                factors =  make_bigint(r'\( %s \)' % factors)
             out += "<tr" + trclass + "><td>" + goodorbad + "</td><td>" + str(p) + "</td>"
             if display_galois:
                 out += "<td class='galois'>"
                 if gal_groups[0]==[0,0]:
                     pass   # do nothing, because the local factor is 1
                 else:
-                    out += "$\\times$".join( [group_display_knowl_C1_as_trivial(n,k) for n, k in gal_groups] )
+                    out += r"$\times$".join( [group_display_knowl_C1_as_trivial(n,k) for n, k in gal_groups] )
                 out += "</td>"
             out += "<td> %s </td>" % factors
             out += "</tr>\n"
@@ -500,9 +500,9 @@ def lfuncEpSymPower(L):
                 elif poly[1] == -1:
                     poly_string += "-%d^{- s}" % p
                 elif poly[1] < 0:
-                    poly_string += "%d\\ %d^{- s}" % (poly[1], p)
+                    poly_string += r"%d\ %d^{- s}" % (poly[1], p)
                 else:
-                    poly_string += "+%d\\ %d^{- s}" % (poly[1], p)
+                    poly_string += r"+%d\ %d^{- s}" % (poly[1], p)
 
             for j in range(2, len(poly)):
                 if poly[j] == 0:
@@ -512,14 +512,14 @@ def lfuncEpSymPower(L):
                 elif poly[j] == -1:
                     poly_string += "-%d^{-%d s}" % (p, j)
                 elif poly[j] < 0:
-                    poly_string += "%d \\ %d^{-%d s}" % (poly[j], p, j)
+                    poly_string += r"%d \ %d^{-%d s}" % (poly[j], p, j)
                 else:
-                    poly_string += "+%d\\ %d^{-%d s}" % (poly[j], p, j)
+                    poly_string += r"+%d\ %d^{-%d s}" % (poly[j], p, j)
             poly_string += ")^{-1}"
         ans += poly_string
-    ans += '\\prod_{p \\nmid %d }\\prod_{j=0}^{%d} ' % (L.E.conductor(),L.m)
-    ans += '\\left(1- \\frac{\\alpha_p^j\\beta_p^{%d-j}}' % L.m
-    ans += '{p^{s}} \\right)^{-1}'
+    ans += r'\prod_{p \nmid %d }\prod_{j=0}^{%d} ' % (L.E.conductor(),L.m)
+    ans += r'\left(1- \frac{\alpha_p^j\beta_p^{%d-j}}' % L.m
+    ans += r'{p^{s}} \right)^{-1}'
     return ans
 
 #---------
@@ -550,15 +550,15 @@ def lfuncFEtex(L, fmt):
         tex_name_1ms = L.texnamecompleted1ms
     ans = ""
     if fmt == "arithmetic" or fmt == "analytic":
-        ans = "\\begin{aligned}\n" + tex_name_s + "=\\mathstrut &"
+        ans = r"\begin{aligned}" + "\n" + tex_name_s + r"=\mathstrut &"
         if L.level > 1:
             if L.level >= 10**8 and not is_prime(int(L.level)):
                 ans += r"\left(%s\right)^{s/2}" % latex(L.level_factored)
             else:
                 ans += latex(L.level) + "^{s/2}"
-            ans += " \\, "
+            ans += r" \, "
         def munu_str(factors_list, field):
-            assert field in ['\R','\C']
+            assert field in [r'\R',r'\C']
             # set up to accommodate multiplicity of Gamma factors
             old = ""
             res = ""
@@ -571,35 +571,35 @@ def lfuncFEtex(L, fmt):
                     if curr_exp > 1:
                         res += "^{" + str(curr_exp) + "}"
                     if curr_exp > 0:
-                        res += " \\, "
+                        res += r" \, "
                     curr_exp = 1
-                    res += "\Gamma_{" + field + "}(s" + seriescoeff(elt, 0, "signed", "", 3) + ")"
+                    res += r"\Gamma_{" + field + "}(s" + seriescoeff(elt, 0, "signed", "", 3) + ")"
             if curr_exp > 1:
                 res += "^{" + str(curr_exp) + "}"
             if res != "":
-                res +=  " \\, "
+                res +=  r" \, "
             return res
-        ans += munu_str(mu_list, '\R')
-        ans += munu_str(nu_list, '\C')
-        ans += texname + "\\cr\n"
-        ans += "=\\mathstrut & "
+        ans += munu_str(mu_list, r'\R')
+        ans += munu_str(nu_list, r'\C')
+        ans += texname + r"\cr" + "\n"
+        ans += r"=\mathstrut & "
         if L.sign == 0:
-            ans += "\epsilon \cdot "
+            ans += r"\epsilon \cdot "
         else:
-            ans += seriescoeff(L.sign, 0, "factor", "", 3) + "\\,"
+            ans += seriescoeff(L.sign, 0, "factor", "", 3) + r"\,"
         ans += tex_name_1ms
         if L.sign == 0 and L.degree == 1:
-            ans += "\quad (\\text{with }\epsilon \\text{ not computed})"
+            ans += r"\quad (\text{with }\epsilon \text{ not computed})"
         if L.sign == 0 and L.degree > 1:
-            ans += "\quad (\\text{with }\epsilon \\text{ unknown})"
-        ans += "\n\\end{aligned}\n"
+            ans += r"\quad (\text{with }\epsilon \text{ unknown})"
+        ans += "\n" + r"\end{aligned}\n"
     elif fmt == "selberg":
-        ans += "(" + str(int(L.degree)) + ",\\ "
+        ans += "(" + str(int(L.degree)) + r",\ "
         if L.level >= 10**8 and not is_prime(int(L.level)):
             ans += latex(L.level_factored)
         else:
             ans += str(int(L.level))
-        ans += ",\\ "
+        ans += r",\ "
         ans += "("
         # this is mostly a hack for GL2 Maass forms
         def real_digits(x):
@@ -616,7 +616,7 @@ def lfuncFEtex(L, fmt):
             else:
                 ans += ", ".join(mus)
         else:
-            ans += "\\ "
+            ans += r"\ "
         ans += ":"
         if L.nu_fe != []:
             if len(L.nu_fe) >= 6 and L.nu_fe == [L.nu_fe[0]]*len(L.nu_fe):
@@ -624,8 +624,8 @@ def lfuncFEtex(L, fmt):
             else:
                 ans += ", ".join(map(str, L.nu_fe))
         else:
-            ans += "\\ "
-        ans += "),\\ "
+            ans += r"\ "
+        ans += r"),\ "
         ans += seriescoeff(L.sign, 0, "literal", "", 3)
         ans += ")"
 
@@ -640,11 +640,11 @@ def specialValueString(L, s, sLatex, normalization="analytic"):
         _, tex, Lval =  specialValueTriple(L, s, '', sLatex)
     else:
         tex, _, Lval =  specialValueTriple(L, s, sLatex, '')
-    if Lval == "\\infty":
+    if Lval == r"\infty":
         operator = " = "
     else:
-        operator = "\\approx"
-    return "\\[{0} {1} {2}\\]".format(tex, operator, Lval)
+        operator = r"\approx"
+    return r"\[{0} {1} {2}\]".format(tex, operator, Lval)
 #    number_of_decimals = 10
 #    val = None
 #    if hasattr(L,"lfunc_data"):
@@ -668,15 +668,15 @@ def specialValueString(L, s, sLatex, normalization="analytic"):
 #    # We must test for NaN first, since it would show as zero otherwise
 #    # Try "RR(NaN) < float(1e-10)" in sage -- GT
 #    if CC(val).real().is_NaN():
-#        return "\\[{0}=\\infty\\]".format(lfunction_value_tex)
+#        return r"\[{0}=\infty\]".format(lfunction_value_tex)
 #    elif val.abs() < 1e-10:
-#        return "\\[{0}=0\\]".format(lfunction_value_tex)
+#        return r"\[{0}=0\]".format(lfunction_value_tex)
 #    elif normalization == "arithmetic":
 #        return(lfunction_value_tex,
 #               latex(round(val.real(), number_of_decimals)
 #                         + round(val.imag(), number_of_decimals) * I))
 #    else:
-#        return "\\[{0} \\approx {1}\\]".format(lfunction_value_tex,
+#        return r"\[{0} \approx {1}\]".format(lfunction_value_tex,
 #                                               latex(round(val.real(), number_of_decimals)
 #                                                     + round(val.imag(), number_of_decimals) * I))
 
@@ -719,7 +719,7 @@ def specialValueTriple(L, s, sLatex_analytic, sLatex_arithmetic):
         # We must test for NaN first, since it would show as zero otherwise
         # Try "RR(NaN) < float(1e-10)" in sage -- GT
         if ccval.real().is_NaN():
-            Lval = "$\\infty$"
+            Lval = r"$\infty$"
         else:
             Lval = display_complex(ccval.real(), ccval.imag(), number_of_decimals)
 
@@ -827,8 +827,8 @@ def signOfEmfLfunction(level, weight, coefs, tol=10 ** (-7), num=1.3):
     for i in range(1, len(coefs)):
         sum1 += coefs[i - 1] * math.exp(- 2 * math.pi * i * num / math.sqrt(level))
         logger.debug("Sum1: {0}".format(sum1))
-        sum2 += coefs[i - 1].conjugate() * math.exp(- 2 * math.pi * i / num / math.sqrt(level)) / \
-            num ** weight
+        sum2 += (coefs[i - 1].conjugate() * math.exp(- 2 * math.pi * i / num / math.sqrt(level)) /
+            num ** weight)
         logger.debug("Sum2: {0}".format(sum2))
     sign = sum1 / sum2
     if abs(abs(sign) - 1) > tol:

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -110,7 +110,7 @@ def l_function_cuspform_browse_page(degree):
         return abort(404)
     info = {"bread": get_bread(deg, [("Cusp Form", url_for('.l_function_cuspform_browse_page', degree=degree))])}
     info["contents"] = [LfunctionPlot.getOneGraphHtmlHolo(0.501),LfunctionPlot.getOneGraphHtmlHolo(1)]
-    return render_template("cuspformGL2.html", title='L-functions of Cusp Forms on \(\Gamma_1(N)\)', **info)
+    return render_template("cuspformGL2.html", title=r'L-functions of Cusp Forms on \(\Gamma_1(N)\)', **info)
 
 
 # L-function of GL(2) maass forms browsing page ##############################################
@@ -567,8 +567,8 @@ def set_bread_and_friends(info, L, request):
     friendlink = splitlink[0] + splitlink[2]
 
     if L.Ltype() == 'riemann':
-        info['friends'] = [('\(\mathbb Q\)', url_for('number_fields.by_label', label='1.1.1.1')),
-                           ('Dirichlet Character \(\\chi_{1}(1,\\cdot)\)',url_for('characters.render_Dirichletwebpage',
+        info['friends'] = [(r'\(\mathbb Q\)', url_for('number_fields.by_label', label='1.1.1.1')),
+                           (r'Dirichlet Character \(\chi_{1}(1,\cdot)\)',url_for('characters.render_Dirichletwebpage',
                                                                                   modulus=1, number=1)),
                            ('Artin Representation 1.1.1t1.1c1', url_for('artin_representations.render_artin_representation_webpage',label='1.1.1t1.1c1'))]
         info['bread'] = get_bread(1, [('Riemann Zeta', request.path)])
@@ -599,7 +599,7 @@ def set_bread_and_friends(info, L, request):
             info['friends'] = [('Maass Form ', friendlink)]
             info['bread'] = get_bread(2, [('Maass Form',
                                            url_for('.l_function_maass_browse_page')),
-                                          ('\(' + L.texname + '\)', request.path)])
+                                          (r'\(' + L.texname + r'\)', request.path)])
 
         else:
             if L.fromDB and not L.selfdual:
@@ -1176,7 +1176,7 @@ def processMaassNavigation(numrecs=35):
     """
     Produces a table of numrecs Maassforms with Fourier coefficients in the database
     """
-    s = '<h5>The L-functions attached to the first 4 weight 0 Maass newforms with trivial character on Hecke congruence groups $\Gamma_0(N)$</h5>'
+    s = r'<h5>The L-functions attached to the first 4 weight 0 Maass newforms with trivial character on Hecke congruence groups $\Gamma_0(N)$</h5>'
     s += '<table>\n'
     i = 0
     maxinlevel = 4

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -82,7 +82,7 @@ def local_field_data(label):
     if f['n'] < 3:
         nicename = ' = '+ prettyname(f)
     ans = 'Local number field %s%s<br><br>'% (label, nicename)
-    ans += 'Extension of $\Q_{%s}$ defined by %s<br>'%(str(f['p']),web_latex(coeff_to_poly(f['coeffs'])))
+    ans += r'Extension of $\Q_{%s}$ defined by %s<br>'%(str(f['p']),web_latex(coeff_to_poly(f['coeffs'])))
     gt = int(f['galois_label'].split('T')[1])
     gn = f['n']
     ans += 'Degree: %s<br>' % str(gn)
@@ -202,15 +202,15 @@ def render_field_webpage(args):
         the_gal = WebGaloisGroup.from_nt(gn,gt)
         isgal = ' Galois' if the_gal.order() == gn else ' not Galois'
         abelian = ' and abelian' if the_gal.is_abelian() else ''
-        galphrase = 'This field is'+isgal+abelian+' over $\Q_{%d}$.'%p
+        galphrase = 'This field is'+isgal+abelian+r' over $\Q_{%d}$.'%p
         autstring = r'\Gal' if the_gal.order() == gn else r'\Aut'
         prop2 = [
             ('Label', label),
-            ('Base', '\(%s\)' % Qp),
-            ('Degree', '\(%s\)' % data['n']),
-            ('e', '\(%s\)' % e),
-            ('f', '\(%s\)' % f),
-            ('c', '\(%s\)' % cc),
+            ('Base', r'\(%s\)' % Qp),
+            ('Degree', r'\(%s\)' % data['n']),
+            ('e', r'\(%s\)' % e),
+            ('f', r'\(%s\)' % f),
+            ('c', r'\(%s\)' % cc),
             ('Galois group', group_pretty_and_nTj(gn, gt)),
         ]
         # Look up the unram poly so we can link to it
@@ -310,15 +310,15 @@ def prettyname(ent):
 
 def printquad(code, p):
     if code == [1, 0]:
-        return('$\Q_{%s}$' % p)
+        return(r'$\Q_{%s}$' % p)
     if code == [1, 1]:
-        return('$\Q_{%s}(\sqrt{*})$' % p)
+        return(r'$\Q_{%s}(\sqrt{*})$' % p)
     if code == [-1, 1]:
-        return('$\Q_{%s}(\sqrt{-*})$' % p)
+        return(r'$\Q_{%s}(\sqrt{-*})$' % p)
     s = code[0]
     if code[1] == 1:
         s = str(s) + '*'
-    return('$\Q_{' + str(p) + '}(\sqrt{' + str(s) + '})$')
+    return(r'$\Q_{' + str(p) + r'}(\sqrt{' + str(s) + '})$')
 
 
 def search_input_error(info, bread):

--- a/lmfdb/modlmf/main.py
+++ b/lmfdb/modlmf/main.py
@@ -24,12 +24,13 @@ def print_q_expansion(list):
     return web_latex(Qq([c for c in list]).add_bigoh(len(list)))
 
 def my_latex(s):
+    # This code was copy pasted and should be refactored
     ss = ""
-    ss += re.sub('x\d', 'x', s)
-    ss = re.sub("\^(\d+)", "^{\\1}", ss)
-    ss = re.sub('\*', '', ss)
-    ss = re.sub('zeta(\d+)', 'zeta_{\\1}', ss)
-    ss = re.sub('zeta', '\zeta', ss)
+    ss += re.sub(r'x\d', 'x', s)
+    ss = re.sub(r"\^(\d+)", r"^{\1}", ss)
+    ss = re.sub(r'\*', '', ss)
+    ss = re.sub(r'zeta(\d+)', r'zeta_{\1}', ss)
+    ss = re.sub('zeta', r'\zeta', ss)
     ss += ""
     return ss
 

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/backend/mwf_utils.py
@@ -33,7 +33,7 @@ def get_args_mwf(**kwds):
 
 def set_info_for_maass_form(data):
     ret = []
-    ret.append(["Eigenvalue", "\(\\lambda=r^2 + \\frac{1}{4} \\ , \\quad r= \\ \)" + str(data['Eigenvalue'])])
+    ret.append(["Eigenvalue", r"\(\lambda=r^2 + \frac{1}{4} \ , \quad r= \ \)" + str(data['Eigenvalue'])])
     if data['Symmetry'] != "none":
         ret.append(["Symmetry", data['Symmetry']])
     if data['dbname'] == "HT":
@@ -218,17 +218,17 @@ def MakeTitle(level, weight, character):
     ret = "Maass cusp forms for "
     if level:
         if level == "1":
-            ret += "\(PSL(2,Z)\)"
+            ret += r"\(PSL(2,Z)\)"
         else:
-            ret += "\(\Gamma_0(" + str(level) + ")\)"
+            ret += r"\(\Gamma_0(" + str(level) + r")\)"
     else:
-        ret += "\(\Gamma_0(n)\)"
+        ret += r"\(\Gamma_0(n)\)"
     if weight:
         if float(weight) != 0:
             ret += ",k=" + weight
     if character:
         if character != "0":
-            ret += ",\(\chi_" + character + "\) (according to SAGE)"
+            ret += r",\(\chi_" + character + r"\) (according to SAGE)"
     return ret
 
 def ajax_once(callback, *arglist, **kwds):

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/views/mwf_main.py
@@ -257,9 +257,9 @@ def render_one_maass_waveform_wp(info, prec=9):
                      ('Maass Forms', url_for('.render_maass_waveforms'))]
     if hasattr(MF,'level'):
         info['bread'].append(('Level {0}'.format(MF.level), url_for('.render_maass_waveforms', level=MF.level)))
-        info['title'] += " on \(\Gamma_{0}( %s )\)" % info['MF'].level
+        info['title'] += r" on \(\Gamma_{0}( %s )\)" % info['MF'].level
         if hasattr(MF, 'R') and MF.R:
-            info['title'] += " with \(R=%s\)" % info['MF'].R
+            info['title'] += r" with \(R=%s\)" % info['MF'].R
 
     # make sure all the expected attributes of a WebMaassForm are actually present
     missing = [attr for attr in ['level', 'dim', 'num_coeff', 'R', 'character'] if not hasattr(MF, attr)]
@@ -301,7 +301,7 @@ def render_one_maass_waveform_wp(info, prec=9):
                                    download='coefficients')) ]
     mwf_logger.debug("count={0}".format(maass_db.count()))
     ch = info['MF'].character
-    s = "\( \chi_{" + str(level) + "}(" + str(ch) + ",\cdot) \)"
+    s = r"\( \chi_{" + str(level) + "}(" + str(ch) + r",\cdot) \)"
     # Q: Is it possible to get the knowls into the properties?
     # A: Not in a nice way and this is not done elsewhere in the LMFDB; the knowls should appear on labels in the template
     # knowls = {'level': 'mf.maass.mwf.level',
@@ -570,4 +570,4 @@ def cande():
 
 
 def conrey_character_name(N, chi):
-    return "\chi_{" + str(N) + "}(" + str(chi.number()) + ",\cdot)"
+    return r"\chi_{" + str(N) + "}(" + str(chi.number()) + r",\cdot)"

--- a/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
+++ b/lmfdb/modular_forms/maass_forms/picard/views/mwfp_main.py
@@ -26,7 +26,7 @@ def render_picard_maass_forms():
     data = None
     # TT= MaassformsPicardDisplay(mwfp_dbname,collection='all',skip=[0],limit=[10],keys=['Eigenvalue'])
     # TT.set_table_browsing()
-    return render_template("maass_form_picard.html", title="Maass Forms on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)", data=data, id=docid, ds=ds)
+    return render_template("maass_form_picard.html", title=r"Maass Forms on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)", data=data, id=docid, ds=ds)
 
 
 @mwfp.route("/<docid>", methods=['GET', 'POST'])
@@ -35,7 +35,7 @@ def render_picard_maass_forms_get_one(docid):
     PT = PicardFormTable(skip=[0, 0], limit=[20, 20], keys=['coef'], docid=docid)
     PT.set_table(name='browsing')
     info = dict()
-    title = "Maass Form on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)"
+    title = r"Maass Form on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)"
     bread = [('Modular Forms', url_for('mf.modular_form_main_page'))]
     info['title'] = title
     info['bread'] = bread
@@ -62,5 +62,5 @@ def render_picard_test():
     info['table'] = PT.table()
     info['nrows'] = PT.nrows()
     info['ncols'] = PT.ncols()
-    info['title'] = "Maass Forms on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)"
+    info['title'] = r"Maass Forms on \(\mathrm{PSL}(2,\mathbb{Z}[i])\)"
     return render_template("mwfp_navigation.html", **info)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -272,11 +272,11 @@ def statistics():
              'query': url_for(".number_field_render_webpage")+'?degree=%d&signature=[%d,%d]'%(nn+1,nn+1-2*r2,r2)} for r2 in range(len(nsig[nn]))] for nn in range(len(nsig))]
     h = [{'cnt': comma(h[j]),
           'prop': format_percentage(h[j], has_h),
-          'label': '$10^{' + str(j - 1) + '}<h\leq 10^{' + str(j) + '}$',
+          'label': '$10^{' + str(j - 1) + r'}<h\leq 10^{' + str(j) + '}$',
           'query': url_for(".number_field_render_webpage")+'?class_number=%s' % (str(1 + 10**(j - 1)) + '-' + str(10**j))} for j in range(len(h))]
     h[0]['label'] = '$h=1$'
-    h[1]['label'] = '$1<h\leq 10$'
-    h[2]['label'] = '$10<h\leq 10^2$'
+    h[1]['label'] = r'$1<h\leq 10$'
+    h[2]['label'] = r'$10<h\leq 10^2$'
     h[0]['query'] = url_for(".number_field_render_webpage")+'?class_number=1'
 
     # Class number 1 by signature
@@ -400,14 +400,14 @@ def render_field_webpage(args):
         data['conductor'] = conductor
         dirichlet_chars = nf.dirichlet_group()
         if len(dirichlet_chars)>0:
-            data['dirichlet_group'] = ['<a href = "%s">$\chi_{%s}(%s,&middot;)$</a>' % (url_for('characters.render_Dirichletwebpage',modulus=data['conductor'], number=j), data['conductor'], j) for j in dirichlet_chars]
+            data['dirichlet_group'] = [r'<a href = "%s">$\chi_{%s}(%s,&middot;)$</a>' % (url_for('characters.render_Dirichletwebpage',modulus=data['conductor'], number=j), data['conductor'], j) for j in dirichlet_chars]
             data['dirichlet_group'] = r'$\lbrace$' + ', '.join(data['dirichlet_group']) + r'$\rbrace$'
         if data['conductor'].is_prime() or data['conductor'] == 1:
-            data['conductor'] = "\(%s\)" % str(data['conductor'])
+            data['conductor'] = r"\(%s\)" % str(data['conductor'])
         else:
             factored_conductor = factor_base_factor(data['conductor'], ram_primes)
             factored_conductor = factor_base_factorization_latex(factored_conductor)
-            data['conductor'] = "\(%s=%s\)" % (str(data['conductor']), factored_conductor)
+            data['conductor'] = r"\(%s=%s\)" % (str(data['conductor']), factored_conductor)
     data['galois_group'] = group_pretty_and_nTj(n,t,True)
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
@@ -419,9 +419,9 @@ def render_field_webpage(args):
     D = nf.disc()
     data['disc_factor'] = nf.disc_factored_latex()
     if D.abs().is_prime() or D == 1:
-        data['discriminant'] = "\(%s\)" % str(D)
+        data['discriminant'] = r"\(%s\)" % str(D)
     else:
-        data['discriminant'] = "\(%s=%s\)" % (str(D), data['disc_factor'])
+        data['discriminant'] = r"\(%s=%s\)" % (str(D), data['disc_factor'])
     if nf.frobs():
         data['frob_data'], data['seeram'] = see_frobs(nf.frobs())
     else: # fallback in case we haven't computed them in a case
@@ -789,7 +789,7 @@ def see_frobs(frob_data):
             firstone = True
             for j in dec:
                 if not firstone:
-                    s += '{,}\,'
+                    s += r'{,}\,'
                 if j[0]<15:
                     s += r'{\href{%s}{%d} }'%(url_for('local_fields.by_label', 
                         label="%d.%d.0.1"%(p,j[0])), j[0])
@@ -820,7 +820,7 @@ def frobs(nf):
             firstone = 1
             for j in dec:
                 if firstone == 0:
-                    s += '{,}\,'
+                    s += r'{,}\,'
                 if j[0]<15:
                     s += r'{\href{%s}{%d} }'%(url_for('local_fields.by_label', 
                         label="%d.%d.0.1"%(p,j[0])), j[0])

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -208,7 +208,7 @@ def is_fundamental_discriminant(d):
 def field_pretty(label):
     d, r, D, i = label.split('.')
     if d == '1':  # Q
-        return '\(\Q\)'
+        return r'\(\Q\)'
     if d == '2':  # quadratic field
         D = ZZ(int(D))
         if r == '0':
@@ -216,9 +216,9 @@ def field_pretty(label):
         # Don't prettify invalid quadratic field labels
         if not is_fundamental_discriminant(D):
             return label
-        return '\(\Q(\sqrt{' + str(D if D%4 else D/4) + '}) \)'
+        return r'\(\Q(\sqrt{' + str(D if D%4 else D/4) + r'}) \)'
     if label in cycloinfo:
-        return '\(\Q(\zeta_{%d})\)' % cycloinfo[label]
+        return r'\(\Q(\zeta_{%d})\)' % cycloinfo[label]
     if d == '4':
         wnf = WebNumberField(label)
         subs = wnf.subfields()
@@ -233,10 +233,10 @@ def field_pretty(label):
                 labels.sort()
                 # put in +/- sign
                 labels = [z[0]*(-1)**(1+z[1]/2) for z in labels]
-                labels = ['i' if z == -1 else '\sqrt{%d}'% z for z in labels]
-                return '\(\Q(%s, %s)\)'%(labels[0],labels[1])
+                labels = ['i' if z == -1 else r'\sqrt{%d}'% z for z in labels]
+                return r'\(\Q(%s, %s)\)'%(labels[0],labels[1])
     if label in rcycloinfo:
-        return '\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
+        return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
     return label
 
 def psum(val, li):
@@ -284,13 +284,13 @@ def nf_knowl_guts(label):
     out += "Global number field %s" % label
     out += '<div>'
     out += 'Defining polynomial: '
-    out += "\(%s\)" % latex(wnf.poly())
+    out += r"\(%s\)" % latex(wnf.poly())
     D = wnf.disc()
     Dfact = wnf.disc_factored_latex()
     if D.abs().is_prime() or D == 1:
-        Dfact = "\(%s\)" % str(D)
+        Dfact = r"\(%s\)" % str(D)
     else:
-        Dfact = '%s = \(%s\)' % (str(D),Dfact)
+        Dfact = r'%s = \(%s\)' % (str(D),Dfact)
     out += '<br>Discriminant: '
     out += Dfact
     out += '<br>Signature: '
@@ -622,7 +622,7 @@ class WebNumberField:
     def generator_name(self):
         #Add special case code for the generator if desired:
         if self.gen_name=='phi':
-            return '\phi'
+            return r'\phi'
         else:
             return web_latex(self.gen_name)
 

--- a/lmfdb/rep_galois_modl/main.py
+++ b/lmfdb/rep_galois_modl/main.py
@@ -20,12 +20,13 @@ rep_galois_modl_credit = 'Samuele Anni, Anna Medvedovsky, Bartosz Naskrecki, Dav
 # utilitary functions for displays
 
 def my_latex(s):
+    # This code was copy pasted and should be refactored
     ss = ""
-    ss += re.sub('x\d', 'x', s)
-    ss = re.sub("\^(\d+)", "^{\\1}", ss)
-    ss = re.sub('\*', '', ss)
-    ss = re.sub('zeta(\d+)', 'zeta_{\\1}', ss)
-    ss = re.sub('zeta', '\zeta', ss)
+    ss += re.sub(r'x\d', 'x', s)
+    ss = re.sub(r"\^(\d+)", r"^{\1}", ss)
+    ss = re.sub(r'\*', '', ss)
+    ss = re.sub(r'zeta(\d+)', r'zeta_{\1}', ss)
+    ss = re.sub('zeta', r'\zeta', ss)
     ss += ""
     return ss
 
@@ -193,7 +194,7 @@ def render_rep_galois_modl_webpage(**args):
     if info['field_deg'] > int(1):
         try:
             pol=str(conway_polynomial(data['characteristic'], data['deg'])).replace("*", "")
-            info['field_str']=str('$\mathbb{F}_%s \cong \mathbb{F}_%s[a]$ where $a$ satisfies: $%s=0$' %(str(data['field_char']), str(data['field_char']), pol))
+            info['field_str']=str(r'$\mathbb{F}_%s \cong \mathbb{F}_%s[a]$ where $a$ satisfies: $%s=0$' %(str(data['field_char']), str(data['field_char']), pol))
         except:
             info['field_str']=""
 

--- a/lmfdb/riemann/stieltjes/stieltjes.py
+++ b/lmfdb/riemann/stieltjes/stieltjes.py
@@ -111,8 +111,8 @@ def getone(n=None, digits=None, plain=False):
                                n=n,
                                digits=digits,
                                gamma=g,
-                               title="Stieltjes Constant $\gamma_{{{}}}$".format(n),
+                               title=r"Stieltjes Constant $\gamma_{{{}}}$".format(n),
                                bread=[
                                     ('Stieltjes Constants',
                                      url_for('.stieltjes_constants')),
-                                    ('$\gamma_{{{}}}$'.format(n), ' '), ])
+                                    (r'$\gamma_{{{}}}$'.format(n), ' '), ])

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -18,12 +18,12 @@ from lmfdb.sato_tate_groups import st_page
 # Globals
 ###############################################################################
 
-MU_LABEL_RE = '^0\.1\.[1-9][0-9]*$'
+MU_LABEL_RE = r'^0\.1\.[1-9][0-9]*$'
 MU_LABEL_NAME_RE = r'^0\.1\.mu\([1-9][0-9]*\)$'
-NU1_MU_LABEL_RE = '^[1-9][0-9]*\.2\.1\.d[1-9][0-9]*$'
-SU2_MU_LABEL_RE = '^[1-9][0-9]*\.2\.3\.c[1-9][0-9]*$'
-ST_LABEL_RE = '^\d+\.\d+\.\d+\.\d+\.\d+[a-z]+$'
-ST_LABEL_SHORT_RE = '^\d+\.\d+\.\d+\.\d+\.\d+$'
+NU1_MU_LABEL_RE = r'^[1-9][0-9]*\.2\.1\.d[1-9][0-9]*$'
+SU2_MU_LABEL_RE = r'^[1-9][0-9]*\.2\.3\.c[1-9][0-9]*$'
+ST_LABEL_RE = r'^\d+\.\d+\.\d+\.\d+\.\d+[a-z]+$'
+ST_LABEL_SHORT_RE = r'^\d+\.\d+\.\d+\.\d+\.\d+$'
 ST_LABEL_NAME_RE = r'^\d+\.\d+\.[a-zA-z0-9\{\}\(\)\[\]\_\,]+'
 INFINITY = -1
 
@@ -99,12 +99,12 @@ def trace_moments(moments):
     return ''
 
 def st0_pretty(st0_name):
-    if re.match('SO\(1\)\_\d+', st0_name):
-        return '\\mathrm{SO}(1)_{%s}' % st0_name.split('_')[1]
-    if re.match('U\(1\)\_\d+', st0_name):
-        return '\\mathrm{U}(1)_{%s}' % st0_name.split('_')[1]
-    if re.match('SU\(2\)\_\d+', st0_name):
-        return '\\mathrm{SU}(2)_{%s}' % st0_name.split('_')[1]
+    if re.match(r'SO\(1\)\_\d+', st0_name):
+        return r'\\mathrm{SO}(1)_{%s}' % st0_name.split('_')[1]
+    if re.match(r'U\(1\)\_\d+', st0_name):
+        return r'\mathrm{U}(1)_{%s}' % st0_name.split('_')[1]
+    if re.match(r'SU\(2\)\_\d+', st0_name):
+        return r'\mathrm{SU}(2)_{%s}' % st0_name.split('_')[1]
     return st0_dict.get(st0_name,st0_name)
 
 def sg_pretty(sg_label):
@@ -115,15 +115,15 @@ def sg_pretty(sg_label):
     
 # dictionary for quick and dirty prettification that does not access the database
 st_pretty_dict = {
-    'USp(4)':'\\mathrm{USp}(4)',
-    'U(2)':'\\mathrm{U}(2)',
-    'SU(2)':'\\mathrm{SU}(2)',
-    'U(1)':'\\mathrm{U}(1)',
-    'N(U(1))':'N(\\mathrm{U}(1))'
+    'USp(4)':r'\mathrm{USp}(4)',
+    'U(2)':r'\mathrm{U}(2)',
+    'SU(2)':r'\mathrm{SU}(2)',
+    'U(1)':r'\mathrm{U}(1)',
+    'N(U(1))':r'N(\mathrm{U}(1))'
 }
 
 def st_pretty(st_name):
-    if re.match('mu\([1-9][0-9]*\)', st_name):
+    if re.match(r'mu\([1-9][0-9]*\)', st_name):
         return '\\' + st_name
     return st_pretty_dict.get(st_name,st_name)
 
@@ -319,10 +319,10 @@ def mu_info(n):
     rec['degree'] = 1
     rec['rational'] = boolean_name(True if n <= 2 else False)
     rec['name'] = 'mu(%d)'%n
-    rec['pretty'] = '\mu(%d)'%n
+    rec['pretty'] = r'\mu(%d)'%n
     rec['real_dimension'] = 0
     rec['components'] = int(n)
-    rec['ambient'] = '\mathrm{O}(1)' if n <= 2 else '\mathrm{U}(1)'
+    rec['ambient'] = r'\mathrm{O}(1)' if n <= 2 else r'\mathrm{U}(1)'
     rec['connected'] = boolean_name(rec['components'] == 1)
     rec['st0_name'] = 'SO(1)'
     rec['identity_component'] = st0_pretty(rec['st0_name'])
@@ -339,13 +339,13 @@ def mu_info(n):
     if n == 1:
         rec['supgroups'] = st_link("0.1.2")
     elif n > 2:
-        rec['supgroups'] = comma_separated_list([st_link("0.1.%d"%(p*n)) for p in [2,3,5]] + ["$\ldots$"])
-    rec['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%m for m in range(13)]]
+        rec['supgroups'] = comma_separated_list([st_link("0.1.%d"%(p*n)) for p in [2,3,5]] + [r"$\ldots$"])
+    rec['moments'] = [['x'] + [ r'\mathrm{E}[x^{%d}]'%m for m in range(13)]]
     rec['moments'] += [['a_1'] + ['1' if m % n == 0  else '0' for m in range(13)]]
     rec['trace_moments'] = trace_moments(rec['moments'])
     rational_traces = [1] if n%2 else [1,-1]
     rec['counts'] = [['a_1', [[t,1] for t in rational_traces]]]
-    rec['probabilities'] = [['\\mathrm{P}[a_1=%d]=\\frac{1}{%d}'%(m,n)] for m in rational_traces]
+    rec['probabilities'] = [[r'\mathrm{P}[a_1=%d]=\frac{1}{%d}'%(m,n)] for m in rational_traces]
     return rec
 
 def mu_portrait(n):
@@ -372,7 +372,7 @@ def su2_mu_info(w,n):
     rec['pretty'] = r'\mathrm{SU}(2)[C_{%d}]'%n if n > 1 else r'\mathrm{SU}(2)'
     rec['real_dimension'] = 3
     rec['components'] = int(n)
-    rec['ambient'] = '\mathrm{U}(2)'
+    rec['ambient'] = r'\mathrm{U}(2)'
     rec['connected'] = boolean_name(rec['components'] == 1)
     rec['st0_name'] = 'SU(2)'
     rec['identity_component'] = st0_pretty(rec['st0_name'])
@@ -385,8 +385,8 @@ def su2_mu_info(w,n):
     rec['gens'] = r'\begin{bmatrix} 1 & 0 \\ 0 & \zeta_{%d}\end{bmatrix}'%n
     rec['numgens'] = 1
     rec['subgroups'] = comma_separated_list([st_link("%d.2.3.c%d"%(w,n/p)) for p in n.prime_factors()])
-    rec['supgroups'] = comma_separated_list([st_link("%d.2.3.c%d"%(w,p*n)) for p in [2,3,5]] + ["$\ldots$"])
-    rec['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%m for m in range(13)]]
+    rec['supgroups'] = comma_separated_list([st_link("%d.2.3.c%d"%(w,p*n)) for p in [2,3,5]] + [r"$\ldots$"])
+    rec['moments'] = [['x'] + [ r'\mathrm{E}[x^{%d}]'%m for m in range(13)]]
     su2moments = ['1','0','1','0','2','0','5','0','14','0','42','0','132']
     rec['moments'] += [['a_1'] + [su2moments[m] if m % n == 0  else '0' for m in range(13)]]
     rec['trace_moments'] = trace_moments(rec['moments'])
@@ -420,11 +420,11 @@ def nu1_mu_info(w,n):
     rec['pretty'] = r'\mathrm{U}(1)[D_{%d}]'%n if n > 1 else r'N(\mathrm{U}(1))'
     rec['real_dimension'] = 1
     rec['components'] = int(2*n)
-    rec['ambient'] = '\mathrm{U}(2)'
+    rec['ambient'] = r'\mathrm{U}(2)'
     rec['connected'] = boolean_name(rec['components'] == 1)
     rec['st0_name'] = 'U(1)'
     rec['identity_component'] = st0_pretty(rec['st0_name'])
-    rec['st0_description'] = '\\left\\{\\begin{bmatrix}\\alpha&0\\\\0&\\bar\\alpha\\end{bmatrix}:\\alpha\\bar\\alpha = 1,\\ \\alpha\\in\\mathbb{C}\\right\\}'
+    rec['st0_description'] = r'\left\{\begin{bmatrix}\alpha&0\\0&\bar\alpha\end{bmatrix}:\alpha\bar\alpha = 1,\ \alpha\in\mathbb{C}\right\}'
     rec['component_group'] = 'D_{%d}'%n
     rec['abelian'] = boolean_name(n <= 2)
     rec['cyclic'] = boolean_name(n <= 1)
@@ -433,8 +433,8 @@ def nu1_mu_info(w,n):
     rec['gens'] = r'\left\{\begin{bmatrix} 0 & 1\\ -1 & 0\end{bmatrix}, \begin{bmatrix} 1 & 0 \\ 0 & \zeta_{%d}\end{bmatrix}\right\}'%n
     rec['numgens'] = 2
     rec['subgroups'] = comma_separated_list([st_link("%d.2.1.d%d"%(w,n/p)) for p in n.prime_factors()])
-    rec['supgroups'] = comma_separated_list([st_link("%d.2.1.d%d"%(w,p*n)) for p in [2,3,5]] + ["$\ldots$"])
-    rec['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%m for m in range(13)]]
+    rec['supgroups'] = comma_separated_list([st_link("%d.2.1.d%d"%(w,p*n)) for p in [2,3,5]] + [r"$\ldots$"])
+    rec['moments'] = [['x'] + [ r'\mathrm{E}[x^{%d}]'%m for m in range(13)]]
     nu1moments = ['1','0','1','0','3','0','10','0','35','0','126','0','462']
     rec['moments'] += [['a_1'] + [nu1moments[m] if m % n == 0  else '0' for m in range(13)]]
     rec['trace_moments'] = trace_moments(rec['moments'])
@@ -519,14 +519,14 @@ def render_st_group(info, portrait=None):
     if portrait:
         prop2 += [(None, '&nbsp;&nbsp;<img src="%s" width="220" height="124"/>' % portrait)]
     prop2 += [
-        ('Name', '\(%s\)'%info['pretty']),
+        ('Name', r'\(%s\)'%info['pretty']),
         ('Weight', '%d'%info['weight']),
         ('Degree', '%d'%info['degree']),
         ('Real dimension', '%d'%info['real_dimension']),
         ('Components', '%d'%info['components']),
-        ('Contained in','\(%s\)'%info['ambient']),
-        ('Identity Component', '\(%s\)'%info['identity_component']),
-        ('Component group', '\(%s\)'%info['component_group']),
+        ('Contained in',r'\(%s\)'%info['ambient']),
+        ('Identity Component', r'\(%s\)'%info['identity_component']),
+        ('Component group', r'\(%s\)'%info['component_group']),
     ]
     bread = [
         ('Sato-Tate Groups', url_for('.index')),
@@ -534,7 +534,7 @@ def render_st_group(info, portrait=None):
         ('Degree %d'% info['degree'], url_for('.index')+'?weight='+str(info['weight'])+'&degree='+str(info['degree'])),
         (info['name'], '')
     ]
-    title = 'Sato-Tate Group \(' + info['pretty'] + '\) of Weight %d'% info['weight'] + ' and Degree %d'% info['degree']
+    title = r'Sato-Tate Group \(' + info['pretty'] + r'\) of Weight %d'% info['weight'] + ' and Degree %d'% info['degree']
     return render_template('st_display.html',
                            properties=prop2,
                            credit=credit_string,

--- a/lmfdb/siegel_modular_forms/dimensions.py
+++ b/lmfdb/siegel_modular_forms/dimensions.py
@@ -52,7 +52,7 @@ def parse_dim_args(dim_args, default_dim_args):
 ####################################################################
 
 def dimension_Gamma_2(wt_range, j):
-    """
+    r"""
     <ul>
       <li>First entry of the respective triple: The full space.</li>
       <li>Second entry: The codimension of the subspace of cusp forms.</li>
@@ -80,7 +80,7 @@ def dimension_Gamma_2(wt_range, j):
     return _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)')
 
 def dimension_Gamma1_2(wt_range, j):
-    """
+    r"""
     <ul>
       <li>First entry of the respective triple: The full space.</li>
       <li>Second entry: The codimension of the subspace of cusp forms.</li>
@@ -199,7 +199,7 @@ def _dimension_Sp4Z(wt_range):
 
 
 def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
-    """
+    r"""
     Return the dict
     {(k-> partition ->  [ d(k), e(k), c(k)] for k in wt_range]},
     where d(k), e(k), c(k) are the dimensions
@@ -208,7 +208,7 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
     """
 
     partitions = [ u'6', u'51', u'42', u'411', u'33', u'321', u'3111', u'222', u'2211', u'21111', u'111111']
-    latex_names = { 'Gamma(2)':'\\Gamma(2)', 'Gamma0(2)':'\\Gamma_0(2)', 'Gamma1(2)':'\\Gamma_1(2)', 'Sp4(Z)':'\\mathrm{Sp}(4,\mathbb{Z})' }
+    latex_names = { 'Gamma(2)':r'\Gamma(2)', 'Gamma0(2)':r'\Gamma_0(2)', 'Gamma1(2)':r'\Gamma_1(2)', 'Sp4(Z)':r'\mathrm{Sp}(4,\mathbb{Z})' }
 
     if is_odd(j):
         dct = dict((k,dict((h,[0,0,0]) for h in partitions)) for k in wt_range)
@@ -229,16 +229,16 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
         return headers, dct
     
     if j>=2 and  wt_range[0] < 4:
-        raise NotImplementedError("Dimensions of \(M_{k,j}(%s)\) for <span style='color:black'>\(k<4\)</span> and <span style='color:black'>\(j\ge 2\)</span> not implemented" % latex_names.get(group,group))
+        raise NotImplementedError(r"Dimensions of \(M_{k,j}(%s)\) for <span style='color:black'>\(k<4\)</span> and <span style='color:black'>\(j\ge 2\)</span> not implemented" % latex_names.get(group,group))
 
     query = { 'sym_power': str(j), 'group' : 'Gamma(2)', 'space': 'total' }
     db_total = db.smf_dims.lucky(query)
     if not db_total:
-        raise NotImplementedError('Dimensions of \(M_{k,j}\) for \(j=%d\) not implemented' % j)
+        raise NotImplementedError(r'Dimensions of \(M_{k,j}\) for \(j=%d\) not implemented' % j)
     query['space'] = 'cusp'
     db_cusp = db.smf_dims.lucky(query)
     if not db_cusp:
-        raise NotImplementedError('Dimensions of \(M_{k,j}\) for \(j=%d\) not implemented' % j)
+        raise NotImplementedError(r'Dimensions of \(M_{k,j}\) for \(j=%d\) not implemented' % j)
     
     P = PowerSeriesRing(ZZ,  default_prec =wt_range[-1] + 1,  names = ('t'))
     Qt = FunctionField(QQ, names=('t'))
@@ -385,7 +385,7 @@ def _dimension_Sp8Z(wt):
         ('Total', 'Ikeda lifts', 'Miyawaki lifts', 'Other')
     """
     if wt > 16:
-        raise NotImplementedError('Dimensions of $M_{k}(Sp(8,Z))$ for \(k > 16\) not implemented')
+        raise NotImplementedError(r'Dimensions of $M_{k}(Sp(8,Z))$ for \(k > 16\) not implemented')
     if wt == 8:
         return (1, 1, 0, 0)
     if wt == 10:
@@ -488,7 +488,7 @@ def dimension_Gamma0_3_psi_3(wt_range):
 
 
 def _dimension_Gamma0_3_psi_3(wt):
-    """
+    r"""
     Return the dimensions of the space of Siegel modular forms
     on $Gamma_0(3)$ with character $\psi_3$.
 
@@ -531,7 +531,7 @@ def dimension_Gamma0_4_psi_4(wt_range):
 
 
 def _dimension_Gamma0_4_psi_4(wt):
-    """
+    r"""
     Return the dimensions of subspaces of Siegel modular forms
     on $Gamma_0(4)$
     with character $\psi_4$.
@@ -548,7 +548,7 @@ def _dimension_Gamma0_4_psi_4(wt):
     if is_even(wt):
         return (H_all_even[wt],)
     else:
-        raise NotImplementedError('Dimensions of $M_{k}(\Gamma_0(4), \psi_4)$ for odd $k$ not implemented')
+        raise NotImplementedError(r'Dimensions of $M_{k}(\Gamma_0(4), \psi_4)$ for odd $k$ not implemented')
 
 
 
@@ -650,7 +650,7 @@ def _dimension_Dummy_0(wt):
     """
     # Here goes your code ike e.g.:
     if wt > 37:
-        raise NotImplementedError('Dimensions of $Dummy_0$ for \(k > 37\) not implemented')
+        raise NotImplementedError(r'Dimensions of $Dummy_0$ for \(k > 37\) not implemented')
     a,b,c = 1728, 28, 37
 
     return (a,b,c)

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -79,8 +79,8 @@ def by_label(label):
 def Sp4Z_j_space(k,j):
     bread = [("Modular Forms", url_for('modular_forms')),
              ('Siegel Modular Forms', url_for('.index')),
-             ('$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z})$', url_for('.Sp4Z_j')),
-             ('$M_{%s,%s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k,j), '')]
+             (r'$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z})$', url_for('.Sp4Z_j')),
+             (r'$M_{%s,%s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k,j), '')]
     if j%2:
         # redirect to general page for Sp4Z_j which will display an error message
         return redirect(url_for(".Sp4Z_j",k=str(k),j=str(j)))
@@ -97,7 +97,7 @@ def Sp4Z_j_space(k,j):
         # redirect to general page for Sp4Z_j which will display an error message
         return redirect(url_for(".Sp4Z_j",k=str(k),j=str(j)))
     return render_template('ModularForm_GSp4_Q_full_level_space.html',
-                           title = '$M_{%s, %s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k, j),
+                           title = r'$M_{%s, %s}(\mathrm{Sp}(4, \mathbb{Z}))$'%(k, j),
                            bread=bread,
                            info=info)
 
@@ -124,7 +124,7 @@ def Sp4Z_2_space(k):
 def Sp4Z_j():
     bread = [("Modular Forms", url_for('modular_forms')),
              ('Siegel Modular Forms', url_for('.index')),
-             ('$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$', '')]
+             (r'$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$', '')]
     info={'args': request.args}
     try:
         dim_args = dimensions.parse_dim_args(request.args, {'k':'10-20','j':'0-30'})
@@ -139,7 +139,7 @@ def Sp4Z_j():
             flash_error(err)
             info['error'] = True
     return render_template('ModularForm_GSp4_Q_Sp4Zj.html',
-                           title='$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$',
+                           title=r'$M_{k,j}(\mathrm{Sp}(4, \mathbb{Z}))$',
                            bread = bread,
                            info = info
                            )

--- a/lmfdb/tensor_products/main.py
+++ b/lmfdb/tensor_products/main.py
@@ -99,7 +99,7 @@ def show():
 #            friends.append(('L-function of second object', url_for('.show', obj2=objLinks[1]))) 
 #            info['friends'] = friends
 
-            info['eulerproduct'] = 'L(s, V \otimes W) = \prod_{p} \det(1 - Frob_p p^{-s} | (V \otimes W)^{I_p})^{-1}'
+            info['eulerproduct'] = r'L(s, V \otimes W) = \prod_{p} \det(1 - Frob_p p^{-s} | (V \otimes W)^{I_p})^{-1}'
             info['bread'] = get_bread()
             return render_template('Lfunction.html', **info)
         except (KeyError,ValueError,RuntimeError,NotImplementedError) as err:

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -120,7 +120,7 @@ def try_int(foo):
         return foo
 
 
-def key_for_numerically_sort(elt, split="[\s\.\-]"):
+def key_for_numerically_sort(elt, split=r"[\s\.\-]"):
     return tuple(try_int(k) for k in re.split(split, elt))
 
 
@@ -493,10 +493,10 @@ def pol_to_html(p):
     '<i>x</i><sup>2</sup> + 2<i>x</i> + 1'
     """
     s = str(p)
-    s = re.sub("\^(\d*)", "<sup>\\1</sup>", s)
-    s = re.sub("\_(\d*)", "<sub>\\1</sub>", s)
-    s = re.sub("\*", "", s)
-    s = re.sub("x", "<i>x</i>", s)
+    s = re.sub(r"\^(\d*)", r"<sup>\\1</sup>", s)
+    s = re.sub(r"\_(\d*)", r"<sub>\\1</sub>", s)
+    s = re.sub(r"\*", r"", s)
+    s = re.sub(r"x", r"<i>x</i>", s)
     return s
 
 
@@ -506,7 +506,7 @@ def pol_to_html(p):
 ################################################################################
 
 def web_latex(x, enclose=True):
-    """
+    r"""
     Convert input to latex string unless it's a string or unicode. The key word
     argument `enclose` indicates whether to surround the string with
     `\(` and `\)` to tag it as an equation in html.
@@ -522,12 +522,12 @@ def web_latex(x, enclose=True):
     if isinstance(x, string_types):
         return x
     if enclose:
-        return "\( %s \)" % latex(x)
+        return r"\( %s \)" % latex(x)
     return " %s " % latex(x)
 
 
 def web_latex_ideal_fact(x, enclose=True):
-    """
+    r"""
     Convert input factored ideal to latex string.  The key word argument
     `enclose` indicates whether to surround the string with `\(` and
     `\)` to tag it as an equation in html.
@@ -546,13 +546,13 @@ def web_latex_ideal_fact(x, enclose=True):
     '\\( \\left(-a\\right)^{-1} \\)'
     """
     y = web_latex(x, enclose=enclose)
-    y = y.replace("(\\left(","\\left(")
-    y = y.replace("\\right))","\\right)")
+    y = y.replace(r"(\left(", r"\left(")
+    y = y.replace(r"\right))", r"\right)")
     return y
 
 
 def web_latex_split_on(x, on=['+', '-']):
-    """
+    r"""
     Convert input into a latex string. A different latex surround `\(` `\)` is
     used, with splits occuring at `on` (+ - by default).
 
@@ -564,15 +564,15 @@ def web_latex_split_on(x, on=['+', '-']):
     if isinstance(x, string_types):
         return x
     else:
-        A = "\( %s \)" % latex(x)
+        A = r"\( %s \)" % latex(x)
         for s in on:
-            A = A.replace(s, '\) ' + s + ' \( ')
+            A = A.replace(s, r'\) ' + s + r' \( ')
     return A
 
 
 # web_latex_split_on was not splitting polynomials, so we make an expanded version
 def web_latex_split_on_pm(x):
-    """
+    r"""
     Convert input into a latex string, with specific handling of expressions
     including `+` and `-`.
 
@@ -584,34 +584,34 @@ def web_latex_split_on_pm(x):
     on = ['+', '-']
  #   A = "\( %s \)" % latex(x)
     try:
-        A = "\(" + x + "\)"  # assume we are given LaTeX to split on
+        A = r"\(" + x + r"\)"  # assume we are given LaTeX to split on
     except:
-        A = "\( %s \)" % latex(x)
+        A = r"\( %s \)" % latex(x)
 
        # need a more clever split_on_pm that inserts left and right properly
-    A = A.replace("\\left","")
-    A = A.replace("\\right","")
+    A = A.replace(r"\left","")
+    A = A.replace(r"\right","")
     for s in on:
-  #      A = A.replace(s, '\) ' + s + ' \( ')
-   #     A = A.replace(s, '\) ' + ' \( \mathstrut ' + s )
-        A = A.replace(s, '\)' + ' \(\mathstrut ' + s + '\mathstrut ')
+  #      A = A.replace(s, r'\) ' + s + r' \( ')
+   #     A = A.replace(s, r'\) ' + r' \( \mathstrut ' + s )
+        A = A.replace(s, r'\)' + r' \(\mathstrut ' + s + r'\mathstrut ')
     # the above will be re-done using a more sophisticated method involving
     # regular expressions.  Below fixes bad spacing when the current approach
     # encounters terms like (-3+x)
     for s in on:
-        A = A.replace('(\) \(\mathstrut '+s,'(' + s)
-    A = A.replace('( {}','(')
-    A = A.replace('(\) \(','(')
-    A = A.replace('\(+','\(\mathstrut+')
-    A = A.replace('\(-','\(\mathstrut-')
-    A = A.replace('(  ','(')
-    A = A.replace('( ','(')
+        A = A.replace(r'(\) \(\mathstrut ' + s, '(' + s)
+    A = A.replace(r'( {}', r'(')
+    A = A.replace(r'(\) \(', r'(')
+    A = A.replace(r'\(+', r'\(\mathstrut+')
+    A = A.replace(r'\(-', r'\(\mathstrut-')
+    A = A.replace(r'(  ', r'(')
+    A = A.replace(r'( ', r'(')
 
     return A
     # return web_latex_split_on(x)
 
 def web_latex_split_on_re(x, r = '(q[^+-]*[+-])'):
-    """
+    r"""
     Convert input into a latex string, with splits into separate latex strings
     occurring on given regex `r`.
     CAUTION: this gives a different result than web_latex_split_on_pm
@@ -623,31 +623,31 @@ def web_latex_split_on_re(x, r = '(q[^+-]*[+-])'):
     """
 
     def insert_latex(s):
-        return s.group(1) + '\) \('
+        return s.group(1) + r'\) \('
 
     if isinstance(x, string_types):
         return x
     else:
-        A = "\( %s \)" % latex(x)
+        A = r"\( %s \)" % latex(x)
         c = re.compile(r)
-        A = A.replace('+', '\) \( {}+ ')
-        A = A.replace('-', '\) \( {}- ')
+        A = A.replace(r'+', r'\) \( {}+ ')
+        A = A.replace(r'-', r'\) \( {}- ')
 #        A = A.replace('\left(','\left( {}\\right.') # parantheses needs to be balanced
 #        A = A.replace('\\right)','\left.\\right)')
-        A = A.replace('\left(','\\bigl(')
-        A = A.replace('\\right)','\\bigr)')
+        A = A.replace(r'\left(',r'\bigl(')
+        A = A.replace(r'\right)',r'\bigr)')
         A = c.sub(insert_latex, A)
 
     # the above will be re-done using a more sophisticated method involving
     # regular expressions.  Below fixes bad spacing when the current approach
     # encounters terms like (-3+x)
-    A = A.replace('( {}','(')
-    A = A.replace('(\) \(','(')
-    A = A.replace('\(+','\(\mathstrut+')
-    A = A.replace('\(-','\(\mathstrut-')
-    A = A.replace('(  ','(')
-    A = A.replace('( ','(')
-    A = A.replace('+\) \(O','+O')
+    A = A.replace(r'( {}', r'(')
+    A = A.replace(r'(\) \(', r'(')
+    A = A.replace(r'\(+', r'\(\mathstrut+')
+    A = A.replace(r'\(-', r'\(\mathstrut-')
+    A = A.replace(r'(  ', r'(')
+    A = A.replace(r'( ', r'(')
+    A = A.replace(r'+\) \(O', r'+O')
     return A
 
 def display_knowl(kid, title=None, kwargs={}):
@@ -894,7 +894,7 @@ def web_latex_poly(coeffs, var='x', superscript=True, bigint_cutoff=20,  bigint_
         s += varpow
     s += r"\)"
     if s.startswith(plus):
-        return "\(" + make_bigint(s[len(plus):], bigint_cutoff)
+        return r"\(" + make_bigint(s[len(plus):], bigint_cutoff)
     else:
         return r"\(-" + make_bigint(s[len(minus):], bigint_cutoff)
 
@@ -1279,7 +1279,7 @@ def teXify_pol(pol_str):  # TeXify a polynomial (or other string containing poly
     return o_str
 
 def add_space_if_positive(texified_pol):
-    """
+    r"""
     Add a space if texified_pol is positive to match alignment of positive and
     negative coefficients.
 
@@ -1291,5 +1291,5 @@ def add_space_if_positive(texified_pol):
     """
     if texified_pol[0] == '-':
         return texified_pol
-    return "\phantom{-}" + texified_pol
+    return r"\phantom{-}" + texified_pol
 

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -493,8 +493,8 @@ def pol_to_html(p):
     '<i>x</i><sup>2</sup> + 2<i>x</i> + 1'
     """
     s = str(p)
-    s = re.sub(r"\^(\d*)", r"<sup>\\1</sup>", s)
-    s = re.sub(r"\_(\d*)", r"<sub>\\1</sub>", s)
+    s = re.sub(r"\^(\d*)", r"<sup>\1</sup>", s)
+    s = re.sub(r"\_(\d*)", r"<sub>\1</sub>", s)
     s = re.sub(r"\*", r"", s)
     s = re.sub(r"x", r"<i>x</i>", s)
     return s

--- a/lmfdb/zeros/zeta/zetazeros.py
+++ b/lmfdb/zeros/zeta/zetazeros.py
@@ -30,27 +30,27 @@ def zetazeros():
     if limit > 1000:
         return list_zeros(N=N, t=t, limit=limit)
     else:
-        title = "Zeros of $\zeta(s)$"
-        bread = [("L-functions", url_for("l_functions.l_function_top_page")), ('Zeros of $\zeta(s)$', ' ')]
+        title = r"Zeros of $\zeta(s)$"
+        bread = [("L-functions", url_for("l_functions.l_function_top_page")), (r'Zeros of $\zeta(s)$', ' ')]
         return render_template('zeta.html', N=N, t=t, limit=limit, title=title, bread=bread, learnmore=learnmore_list())
 
 
 @ZetaZeros.route("/Completeness")
 def completeness():
     t = 'Completeness of Riemann Zeta Zeros Data'
-    bread = [("L-functions", url_for("l_functions.l_function_top_page")),("Zeros of $\zeta(s)$", url_for(".zetazeros")),('Completeness', ' ')]
+    bread = [("L-functions", url_for("l_functions.l_function_top_page")),(r"Zeros of $\zeta(s)$", url_for(".zetazeros")),('Completeness', ' ')]
     return render_template("single.html", kid='rcs.cande.zeros.zeta', credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @ZetaZeros.route("/Source")
 def source():
     t = 'Source of Riemann Zeta Zeros Data'
-    bread = [("L-functions", url_for("l_functions.l_function_top_page")),("Zeros of $\zeta(s)$", url_for(".zetazeros")),('Source', ' ')]
+    bread = [("L-functions", url_for("l_functions.l_function_top_page")),(r"Zeros of $\zeta(s)$", url_for(".zetazeros")),('Source', ' ')]
     return render_template("single.html", kid='rcs.source.zeros.zeta', credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ZetaZeros.route("/Reliability")
 def reliability():
     t = 'Reliability of Riemann Zeta Zeros Data'
-    bread = [("L-functions", url_for("l_functions.l_function_top_page")),("Zeros of $\zeta(s)$", url_for(".zetazeros")),('Reliability', ' ')]
+    bread = [("L-functions", url_for("l_functions.l_function_top_page")),(r"Zeros of $\zeta(s)$", url_for(".zetazeros")),('Reliability', ' ')]
     return render_template("single.html", kid='rcs.rigor.zeros.zeta', credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @ZetaZeros.route("/list")
@@ -81,7 +81,7 @@ def list_zeros(N=None,
     if limit > 100000:
         # limit = 100000
         #
-        bread = [("L-functions", url_for("l_functions.l_function_top_page")),("Zeros of $\zeta(s)$", url_for(".zetazeros"))]
+        bread = [("L-functions", url_for("l_functions.l_function_top_page")),(r"Zeros of $\zeta(s)$", url_for(".zetazeros"))]
         return render_template('single.html', title="Too many zeros", bread=bread, kid = "dq.zeros.zeta.toomany")
 
     if N is not None:


### PR DESCRIPTION
When starting the LMFDB under Python 3, we get a ton of deprecation warnings due to improperly escaped backslashes.  This PR makes a bunch of strings raw strings to address this.