### PR TITLE
Fix typo in g2c_browse.html

### DIFF
--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -27,7 +27,7 @@ Some interesting curves:
 A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the database.
 </p>
 
-<h2> Find a specific curve or isgoeny class by {{ KNOWL('g2c.label', title='label')}} </h2>
+<h2> Find a specific curve or isogeny class by {{ KNOWL('g2c.label', title='label')}} </h2>
 
 <form>
 <input type='text' name='jump' placeholder='169.a.169.1'>


### PR DESCRIPTION
"isgoeny" -> "isogeny"