### PR TITLE
.get_data(as_text=True)

### DIFF
--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -89,7 +89,7 @@ class AVTest(LmfdbTest):
         r"""
         Check that the plot of the Newton polygon is included and computed correctly
         """
-        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").data
+        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").get_data(as_text=True)
         # The following is part of the base64 encoded image of the Newton
         # polygon for this isogeny class.
         assert r"data:image/png;base64,iVBORw0KGgo" in page
@@ -98,7 +98,7 @@ class AVTest(LmfdbTest):
         r"""
         Check that the plot showing the roots of the Weil polynomial displays correctly
         """
-        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").data
+        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").get_data(as_text=True)
         # The following is part of the base64 encoded image of the circle plot
         # for this isogeny class.
         assert r"data:image/png;base64,iVBORw0KGgo" in page
@@ -107,7 +107,7 @@ class AVTest(LmfdbTest):
         r"""
         Check that the property box displays.
         """
-        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").data.replace("\n", "").replace(" ", "")
+        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").get_data(as_text=True).replace("\n", "").replace(" ", "")
         assert '<divclass="properties-body"><table><tr><tdclass="label">Label</td><td>2.4.ad_g</td></tr><tr>' in page
         assert '<tdclass="label">BaseField</td><td>$\F_{2^{2}}$</td></tr><tr><tdclass="label">Dimension</td><td>' in page
         self.check_args("/Variety/Abelian/Fq/2/79/ar_go", "Principally polarizable")
@@ -116,7 +116,7 @@ class AVTest(LmfdbTest):
         r"""
         Check that the Frobenius angles are split into multiple math elements
         """
-        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").data
+        page = self.tc.get("/Variety/Abelian/Fq/2/4/ad_g").get_data(as_text=True)
         assert r"$\pm0.15043295046$, $\pm0.544835058382$" in page
 
     def test_av_download(self):

--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -3,10 +3,10 @@ from lmfdb.tests import LmfdbTest
 
 class AVTest(LmfdbTest):
     def check_args(self, path, text):
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def not_check_args(self, path, text):
-        assert not (text in self.tc.get(path, follow_redirects=True).data)
+        assert not (text in self.tc.get(path, follow_redirects=True).get_data(as_text=True))
 
     # All tests should pass
     def test_polynomial(self):
@@ -124,11 +124,11 @@ class AVTest(LmfdbTest):
         Test downloading on search results page.
         """
         response = self.tc.get("Variety/Abelian/Fq/5/2/?Submit=sage&download=1&query=%7B%27q%27%3A+2%2C+%27g%27%3A+5%7D")
-        self.assertTrue("Below is a list" in response.data)
-        self.assertTrue("32*x^10" in response.data)
+        self.assertTrue("Below is a list" in response.get_data(as_text=True))
+        self.assertTrue("32*x^10" in response.get_data(as_text=True))
         response = self.tc.get("Variety/Abelian/Fq/5/2/?Submit=gp&download=1&query=%7B%27q%27%3A+2%2C+%27g%27%3A+5%7D")
-        self.assertTrue("Below is a list" in response.data)
-        self.assertTrue("32*x^10" in response.data)
+        self.assertTrue("Below is a list" in response.get_data(as_text=True))
+        self.assertTrue("32*x^10" in response.get_data(as_text=True))
         response = self.tc.get("Variety/Abelian/Fq/5/2/?Submit=magma&download=1&query=%7B%27q%27%3A+2%2C+%27g%27%3A+5%7D")
-        self.assertTrue("Below is a list" in response.data)
-        self.assertTrue("32*x^10" in response.data)
+        self.assertTrue("Below is a list" in response.get_data(as_text=True))
+        self.assertTrue("32*x^10" in response.get_data(as_text=True))

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -16,28 +16,28 @@ class AVHomeTest(LmfdbTest):
         r"""
         Check that the Variety/Abelian/Fq index page works
         """
-        homepage = self.tc.get("/Variety/Abelian/Fq/").data
+        homepage = self.tc.get("/Variety/Abelian/Fq/").get_data(as_text=True)
         assert "Some interesting isogeny classes" in homepage
 
     def test_completeness_page(self):
         r"""
         Check that Variety/Abelian/Fq/Completeness works
         """
-        page = self.tc.get("/Variety/Abelian/Fq/Completeness").data
+        page = self.tc.get("/Variety/Abelian/Fq/Completeness").get_data(as_text=True)
         assert "the collection of isogeny classes is complete" in page
 
     def test_further_completeness_page(self):
         r"""
         Check that Variety/Abelian/Fq/Source works
         """
-        page = self.tc.get("/Variety/Abelian/Fq/Source").data
+        page = self.tc.get("/Variety/Abelian/Fq/Source").get_data(as_text=True)
         assert "characteristic polynomial" in page
 
     def test_labels_page(self):
         r"""
         Check that Variety/Abelian/Fq/Labels works
         """
-        page = self.tc.get("/Variety/Abelian/Fq/Labels").data
+        page = self.tc.get("/Variety/Abelian/Fq/Labels").get_data(as_text=True)
         assert "label format" in page
 
     # Various searches

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -3,10 +3,10 @@ from lmfdb.tests import LmfdbTest
 
 class AVHomeTest(LmfdbTest):
     def check_args(self, path, text):
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def not_check_args(self, path, text):
-        assert not (text in self.tc.get(path, follow_redirects=True).data)
+        assert not (text in self.tc.get(path, follow_redirects=True).get_data(as_text=True))
 
     # All tests should pass
     # TODO test link to random isogeny class

--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -8,7 +8,7 @@ class ApiTest(LmfdbTest):
         r"""
         Check that the top-level api page works
         """
-        data = self.tc.get("/api", follow_redirects=True).data
+        data = self.tc.get("/api", follow_redirects=True).get_data(as_text=True)
         assert "API for accessing the LMFDB Database" in data
 
     def test_api_databases(self):
@@ -24,7 +24,7 @@ class ApiTest(LmfdbTest):
                'gps_sato_tate', 'smf_dims', 'gps_transitive',
                'fq_fields', 'hecke_algebras', 'belyi_passports']
         for tbl in dbs:
-            data = self.tc.get("/api/{}".format(tbl), follow_redirects=True).data
+            data = self.tc.get("/api/{}".format(tbl), follow_redirects=True).get_data(as_text=True)
             assert "JSON" in data
 
     def test_api_examples_html(self):
@@ -39,7 +39,7 @@ class ApiTest(LmfdbTest):
                 'ec_curves/?_delim=%3B&torsion_structure=ls2%3B2',
                 ]
         for query in queries:
-            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).get_data(as_text=True)
             assert 'Query: <code><a href="/api/' in data
             assert not "Error:" in data
 
@@ -50,7 +50,7 @@ class ApiTest(LmfdbTest):
         queries = ['ec_curves/?ainvs=li0;1;1;-840;39800&_format=yaml&_delim=;',
                 ]
         for query in queries:
-            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).get_data(as_text=True)
             assert "!!python/unicode 'jinv': !!python/unicode '-65626385453056/656000554923'" in data
             assert not "Error:" in data
 
@@ -59,7 +59,7 @@ class ApiTest(LmfdbTest):
         Check that the sample queries on the top page all work (json output)
         """
         query = 'nf_fields/?degree=i12&r2=i5&_format=json'
-        data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+        data = self.tc.get("/api/{}".format(query), follow_redirects=True).get_data(as_text=True)
         assert '"label": "12.2.167630295667.1",' in data
 
 
@@ -71,7 +71,7 @@ class ApiTest(LmfdbTest):
                    'gps_transitive?_format=json&label=8T3',
                    'ec_curves?_format=json&label=11a1']
         for query in queries:
-            data = self.tc.get("/api/{}".format(query), follow_redirects=True).data
+            data = self.tc.get("/api/{}".format(query), follow_redirects=True).get_data(as_text=True)
             if '1T1' in query:
                 assert '"name": "Trivial group"' in data
             if '8T3' in query:

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -8,19 +8,19 @@ class ArtinRepTest(LmfdbTest):
     #
     def test_search_deg_condrange(self):
         L = self.tc.get('/ArtinRepresentation/?dimension=3&conductor=1988-2015&group=&ramified=&unramified=&root_number=&frobenius_schur_indicator=&count=15')
-        assert '41' in L.data # Only 1 result at the time this test was written, which has conductor 2009 = 7^2.41
+        assert '41' in L.get_data(as_text=True) # Only 1 result at the time this test was written, which has conductor 2009 = 7^2.41
 
     def test_search_gal_ram_rn_fn(self):
         L = self.tc.get('/ArtinRepresentation/?dimension=&conductor=&group=11T5&ramified=43&unramified=&root_number=1&frobenius_schur_indicator=1&count=15')
-        assert '2898947' in L.data # prime divisor of one of the conductors in the result
+        assert '2898947' in L.get_data(as_text=True) # prime divisor of one of the conductors in the result
 
     def test_display_page(self):
         #L = self.tc.get('/ArtinRepresentation/4/3655/1/')
         L = self.tc.get('/ArtinRepresentation/4.5_17_43.8t44.1c1')
-        assert ('Odd' in L.data)
+        assert ('Odd' in L.get_data(as_text=True))
 
     # big degree fields ok
     def test_big_degree(self):
         L = self.tc.get('/ArtinRepresentation/2.1951e2.120.1c1')
-        assert '24T201' in L.data # Galois group
+        assert '24T201' in L.get_data(as_text=True) # Galois group
 

--- a/lmfdb/belyi/test_belyi.py
+++ b/lmfdb/belyi/test_belyi.py
@@ -9,7 +9,7 @@ class BelyiTest(LmfdbTest):
 
     def test_stats(self):
         L = self.tc.get("/Belyi/stats")
-        assert "Galois orbits of Belyi maps" in L.get_data(as_text=True) and "proportion" in L.data
+        assert "Galois orbits of Belyi maps" in L.get_data(as_text=True) and "proportion" in L.get_data(as_text=True)
 
     def test_random(self):
         self.check_args("/Belyi/random", "Monodromy group")
@@ -83,7 +83,7 @@ class BelyiTest(LmfdbTest):
         )
         assert (
             "phi := 1/2*(7*nu - 15)*x^7/(x^7 + 1/10*(28*nu + 7)*x^6 + 1/100*(-56*nu + 511)*x^5 + 1/40*(-672*nu - 1323)*x^4 + 1/20*(-42*nu - 63)*x^3 + 1/40*(1701*nu + 3024)*x^2 + 1/200*(-6237*nu - 11178));"
-            in page.data
+            in page.get_data(as_text=True)
         )
         page = self.tc.get(
             "/Belyi/download_galmap_to_magma/6T15-%5B5%2C5%2C5%5D-51-51-51-g1-c",
@@ -91,7 +91,7 @@ class BelyiTest(LmfdbTest):
         )
         assert (
             "phi := (1/3125*(162*nu - 81)*x^2 + 1/78125*(972*nu - 486)*x + 1/390625*(-1458*nu + 729))/(x^6 - 9/25*x^5 + 27/125*x^4 + 1/3125*(-162*nu - 54)*x^3 + 1/78125*(729*nu - 486)*x^2 + 1/9765625*(-2187*nu + 5832)*x + 1/244140625*(-2187*nu - 1458))*y + (1/3125*(-162*nu + 81)*x^3 + 1/156250*(1458*nu - 729)*x^2 + 1/9765625*(-2187*nu + 10935)*x + 1/488281250*(-4374*nu - 76545))/(x^6 - 9/25*x^5 + 27/125*x^4 + 1/3125*(-162*nu - 54)*x^3 + 1/78125*(729*nu - 486)*x^2 + 1/9765625*(-2187*nu + 5832)*x + 1/244140625*(-2187*nu - 1458));"
-            in page.data
+            in page.get_data(as_text=True)
         )
         page = self.tc.get(
             "/Belyi/download_galmap_to_magma/7T5-%5B7%2C7%2C3%5D-7-7-331-g2-a",
@@ -99,5 +99,5 @@ class BelyiTest(LmfdbTest):
         )
         assert (
             "phi := (1/2*x^2 + 2/5*x + 1/200*(nu + 5))/(x^5 + 6/5*x^4 + 1/50*(7*nu + 5)*x^3 + 1/250*(35*nu - 57)*x^2 + 1/10000*(91*nu - 345)*x + 1/12500*(-133*nu + 71))*y + 1/2;"
-            in page.data
+            in page.get_data(as_text=True)
         )

--- a/lmfdb/belyi/test_belyi.py
+++ b/lmfdb/belyi/test_belyi.py
@@ -5,11 +5,11 @@ from lmfdb.tests import LmfdbTest
 class BelyiTest(LmfdbTest):
     def check_args(self, path, text):
         L = self.tc.get(path, follow_redirects=True)
-        assert text in L.data
+        assert text in L.get_data(as_text=True)
 
     def test_stats(self):
         L = self.tc.get("/Belyi/stats")
-        assert "Galois orbits of Belyi maps" in L.data and "proportion" in L.data
+        assert "Galois orbits of Belyi maps" in L.get_data(as_text=True) and "proportion" in L.data
 
     def test_random(self):
         self.check_args("/Belyi/random", "Monodromy group")
@@ -48,7 +48,7 @@ class BelyiTest(LmfdbTest):
 
     def test_deg_range(self):
         L = self.tc.get("/Belyi/?deg=2-7")
-        assert "5T4-[5,3,3]-5-311-311-g0-a" in L.data
+        assert "5T4-[5,3,3]-5-311-311-g0-a" in L.get_data(as_text=True)
 
     def test_group_search(self):
         self.check_args("/Belyi/?group=7T5", "7T5-[7,7,3]-7-7-331-g2-a")

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -14,7 +14,7 @@ class BMFTest(LmfdbTest):
             assert True
         else:
             print(text)
-            print(self.tc.get(path, follow_redirects=True).data)
+            print(self.tc.get(path, follow_redirects=True).get_data(as_text=True))
             assert False
 
     # All tests should pass

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -10,7 +10,7 @@ class BMFTest(LmfdbTest):
         assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def check_args(self, path, text):
-        if text in self.tc.get(path, follow_redirects=True).data:
+        if text in self.tc.get(path, follow_redirects=True).get_data(as_text=True):
             assert True
         else:
             print(text)

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -7,7 +7,7 @@ class BMFTest(LmfdbTest):
 
     def check(self, homepage, path, text):
         assert path in homepage
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def check_args(self, path, text):
         if text in self.tc.get(path, follow_redirects=True).data:
@@ -24,7 +24,7 @@ class BMFTest(LmfdbTest):
         Check that the home page loads
         """
         L = self.tc.get(base_url)
-        assert 'Bianchi modular forms' in L.data
+        assert 'Bianchi modular forms' in L.get_data(as_text=True)
 
     # Link to random newform
     def test_random(self):
@@ -120,10 +120,10 @@ class BMFTest(LmfdbTest):
                     ]:
             L = self.tc.get(url)
             for t in texts:
-                assert t in L.data
-            assert 'L-function' in L.data
+                assert t in L.get_data(as_text=True)
+            assert 'L-function' in L.get_data(as_text=True)
 
             # this test isn't very specific
             # but the goal is to test that itself doesn't show in the friends list
-            assert notitself not in L.data
+            assert notitself not in L.get_data(as_text=True)
 

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -31,7 +31,7 @@ class BMFTest(LmfdbTest):
         r"""
         Check that the link to a random curve works.
         """
-        homepage = self.tc.get(base_url).data
+        homepage = self.tc.get(base_url).get_data(as_text=True)
         self.check(homepage, base_url+"random", 'Hecke eigenvalues')
 
     # Browsing links
@@ -39,7 +39,7 @@ class BMFTest(LmfdbTest):
         r"""
         Check that the browsing links work.
         """
-        homepage = self.tc.get(base_url).data
+        homepage = self.tc.get(base_url).get_data(as_text=True)
         t = "?field_label=2.0.3.1"
         assert t in homepage
         self.check_args(base_url+t, "/ModularForm/GL2/ImaginaryQuadratic/2.0.3.1/124.1/a/")

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -26,16 +26,16 @@ class DirichletSearchTest(LmfdbTest):
 
     def test_condbrowse(self):
         W = self.tc.get('/Character/Dirichlet/?condbrowse=24-41')
-        assert '(\\frac{40}{\\bullet}\\right)' in W.data
+        assert '(\\frac{40}{\\bullet}\\right)' in W.get_data(as_text=True)
 
     def test_order(self):
         W = self.tc.get('/Character/Dirichlet/?order=19-23')
-        assert '\chi_{25}(2' in W.data
+        assert '\chi_{25}(2' in W.get_data(as_text=True)
 
     def test_even_odd(self):
         W = self.tc.get('/Character/Dirichlet/?modulus=35')
-        assert '>Even</t' in W.data
-        assert '>Odd</t' in W.data
+        assert '>Even</t' in W.get_data(as_text=True)
+        assert '>Odd</t' in W.get_data(as_text=True)
 
     def test_modbrowse(self):
         W = self.tc.get('/Character/Dirichlet/?modbrowse=51-81')
@@ -44,78 +44,78 @@ class DirichletSearchTest(LmfdbTest):
         There are 20 characters of conductor 27 in this modulus range
         """
         import re
-        assert len(re.findall('Dirichlet/[0-9][0-9]/27',W.data)) == 20
+        assert len(re.findall('Dirichlet/[0-9][0-9]/27',W.get_data(as_text=True))) == 20
 
     def test_search(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4&limit=25')
-        assert '\chi_{15}(2,' in W.data and '\chi_{195}(53,' in W.data
+        assert '\chi_{15}(2,' in W.get_data(as_text=True) and '\chi_{195}(53,' in W.data
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&limit=25')
-        assert '\chi_{25}(6,' in W.data and '\chi_{36}(7,' in W.data
+        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.data
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes&limit=25')
-        assert '\chi_{25}(6,' in W.data and '\chi_{36}(7,' in W.data
+        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.data
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&limit=25')
-        assert '\chi_{50}(11,' in W.data and '\chi_{72}(7,' in W.data
+        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{72}(7,' in W.data
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd&limit=25')
-        assert '\chi_{56}(23,' in W.data and '\chi_{112}(79,' in W.data
+        assert '\chi_{56}(23,' in W.get_data(as_text=True) and '\chi_{112}(79,' in W.data
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even&limit=25')
-        assert '\chi_{50}(11,' in W.data and '\chi_{75}(46,' in W.data
+        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{75}(46,' in W.data
 
     def test_condsearch(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=111&limit=100')
-        assert '111/17' in W.data
+        assert '111/17' in W.get_data(as_text=True)
 
     def test_nextprev(self):
         W = self.tc.get('/Character/Dirichlet/?start=200&count=25&order=3')
-        assert '\chi_{169}(22,' in W.data and '\chi_{182}(113,' in W.data
+        assert '\chi_{169}(22,' in W.get_data(as_text=True) and '\chi_{182}(113,' in W.data
         W = self.tc.get('/Character/Dirichlet/?start=100&count=25&order=3')
-        assert '\chi_{97}(35,' in W.data and '\chi_{117}(40,' in W.data
+        assert '\chi_{97}(35,' in W.get_data(as_text=True) and '\chi_{117}(40,' in W.data
 
 class DirichletTableTest(LmfdbTest):
 
     def test_table(self):
         get='modulus=35&poly=\%28+x^{6}+\%29+-+\%28+x^{5}+\%29+-+\%28+7+x^{4}+\%29+%2B+\%28+2+x^{3}+\%29+%2B+\%28+7+x^{2}+\%29+-+\%28+2+x+\%29+-+\%28+1+\%29&char_number_list=1%2C4%2C9%2C11%2C16%2C29'
         W = self.tc.get('/Character/Dirichlet/grouptable?%s'%get)
-        assert '35 }(29' in W.data
+        assert '35 }(29' in W.get_data(as_text=True)
 
 class DirichletCharactersTest(LmfdbTest):
 
     def test_navig(self):
         W = self.tc.get('/Character/', follow_redirects=True)
-        assert 'Browse' in W.data and 'search' in W.data
+        assert 'Browse' in W.get_data(as_text=True) and 'search' in W.data
 
     def test_dirichletfamily(self):
         W = self.tc.get('/Character/Dirichlet/')
-        assert 'Find a specific' in W.data
-        assert 'Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\)' in W.data
+        assert 'Find a specific' in W.get_data(as_text=True)
+        assert 'Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\)' in W.get_data(as_text=True)
 
     def test_dirichletgroup(self):
         W = self.tc.get('/Character/Dirichlet/23', follow_redirects=True)
-        assert 'Yes' in W.data
-        assert 'DirichletGroup_conrey(23)' in W.data
-        assert 'e\\left(\\frac{7}{11}\\right)' in W.data
-        assert '/Character/Dirichlet/23/10' in W.data
+        assert 'Yes' in W.get_data(as_text=True)
+        assert 'DirichletGroup_conrey(23)' in W.get_data(as_text=True)
+        assert 'e\\left(\\frac{7}{11}\\right)' in W.get_data(as_text=True)
+        assert '/Character/Dirichlet/23/10' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/91', follow_redirects=True)
-        assert 'Yes' in W.data
-        assert 'Properties' in W.data, "properties box"
-        assert 'DirichletGroup_conrey(91)' in W.data, "sage code example"
-        assert '\chi_{91}(15,' in W.data and '\chi_{91}(66' in W.data, "generators"
-        assert 'e\\left(\\frac{7}{12}\\right)' in W.data, "contents table"
-        assert '/Character/Dirichlet/91/6' in W.data, "link in contents table"
+        assert 'Yes' in W.get_data(as_text=True)
+        assert 'Properties' in W.get_data(as_text=True), "properties box"
+        assert 'DirichletGroup_conrey(91)' in W.get_data(as_text=True), "sage code example"
+        assert '\chi_{91}(15,' in W.get_data(as_text=True) and '\chi_{91}(66' in W.data, "generators"
+        assert 'e\\left(\\frac{7}{12}\\right)' in W.get_data(as_text=True), "contents table"
+        assert '/Character/Dirichlet/91/6' in W.get_data(as_text=True), "link in contents table"
 
         W = self.tc.get('/Character/Dirichlet/999999999', follow_redirects=True)
-        assert 'Properties' in W.data, "properties box"
-        assert '648646704' in W.data, "order"
-        assert 'C_{333666}' in W.data, "structure"
-        assert '\chi_{999999999}(234567902,' in W.data and '\chi_{999999999}(432432433,' in W.data and '\chi_{999999999}(332999668,' in W.data
+        assert 'Properties' in W.get_data(as_text=True), "properties box"
+        assert '648646704' in W.get_data(as_text=True), "order"
+        assert 'C_{333666}' in W.get_data(as_text=True), "structure"
+        assert '\chi_{999999999}(234567902,' in W.get_data(as_text=True) and '\chi_{999999999}(432432433,' in W.data and '\chi_{999999999}(332999668,' in W.data
 
     def test_dirichletchar11(self):
         W = self.tc.get('/Character/Dirichlet/1/1')
-        assert  '/NumberField/1.1.1.1' in W.data
+        assert  '/NumberField/1.1.1.1' in W.get_data(as_text=True)
 
     def test_valuefield(self):
         W = self.tc.get('/Character/Dirichlet/13/2')
-        assert  'Value Field' in W.data
+        assert  'Value Field' in W.get_data(as_text=True)
 
     #@unittest2.skip("wait for new DirichletConrey")
     def test_dirichletcharbig(self):
@@ -125,83 +125,83 @@ class DirichletCharactersTest(LmfdbTest):
             This test also makes sure the code scales a little bit.
         """
         W = self.tc.get('/Character/Dirichlet/40487/5')
-        assert '40486' in W.data
-        assert '12409' in W.data, "log on generator"
+        assert '40486' in W.get_data(as_text=True)
+        assert '12409' in W.get_data(as_text=True), "log on generator"
         W = self.tc.get('/Character/Dirichlet/40487.5', follow_redirects=True)
-        assert '40486' in W.data
-        assert '12409' in W.data, "log on generator"
+        assert '40486' in W.get_data(as_text=True)
+        assert '12409' in W.get_data(as_text=True), "log on generator"
 
     def test_dirichletchar43(self):
         W = self.tc.get('/Character/Dirichlet/4/3')
-        assert 'Kronecker symbol' in W.data
-        assert '\\left(\\frac{-4}{\\bullet}\\right)' in W.data
+        assert 'Kronecker symbol' in W.get_data(as_text=True)
+        assert '\\left(\\frac{-4}{\\bullet}\\right)' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/4.3', follow_redirects=True)
-        assert 'Kronecker symbol' in W.data
-        assert '\\left(\\frac{-4}{\\bullet}\\right)' in W.data
+        assert 'Kronecker symbol' in W.get_data(as_text=True)
+        assert '\\left(\\frac{-4}{\\bullet}\\right)' in W.get_data(as_text=True)
 
     def test_dirichlet_calc(self):
         W = self.tc.get('/Character/calc-gauss/Dirichlet/4/3?val=3')
-        assert '-2.0i' in W.data, "calc gauss"
-        assert '\Z/4\Z' in W.data
+        assert '-2.0i' in W.get_data(as_text=True), "calc gauss"
+        assert '\Z/4\Z' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/calc-kloosterman/Dirichlet/91/3?val=52,34')
-        assert '3.774980868' in W.data, "kloosterman"
+        assert '3.774980868' in W.get_data(as_text=True), "kloosterman"
 
         W = self.tc.get('Character/calc-jacobi/Dirichlet/91/3?val=37')
-        assert '-11 \\zeta_{12}^{2} + 5' in W.data
+        assert '-11 \\zeta_{12}^{2} + 5' in W.get_data(as_text=True)
 
         W = self.tc.get('Character/calc-value/Dirichlet/107/7?val=32')
-        assert 'frac{3}{106}' in W.data
+        assert 'frac{3}{106}' in W.get_data(as_text=True)
 
     def test_dirichletchar531(self):
         W = self.tc.get('/Character/Dirichlet/531/40')
-        assert '/Character/Dirichlet/531/247' in W.data
-        assert '(119,415)' in W.data, "generators"
-        #assert 'Kloosterman sum' in W.data
-        assert  '(\\zeta_{87})' in W.data, "field of values"
+        assert '/Character/Dirichlet/531/247' in W.get_data(as_text=True)
+        assert '(119,415)' in W.get_data(as_text=True), "generators"
+        #assert 'Kloosterman sum' in W.get_data(as_text=True)
+        assert  '(\\zeta_{87})' in W.get_data(as_text=True), "field of values"
 
     def test_dirichletchar6000lfunc(self):
         """ Check Sato-Tate group and L-function link for 6000/11  """
         W = self.tc.get('/Character/Dirichlet/6000/11')
-        assert '/SatoTateGroup/0.1.100' in W.data
-        assert 'L/Character/Dirichlet/6000/11' in W.data
+        assert '/SatoTateGroup/0.1.100' in W.get_data(as_text=True)
+        assert 'L/Character/Dirichlet/6000/11' in W.get_data(as_text=True)
         W = self.tc.get('/L/Character/Dirichlet/6000/11', follow_redirects=True)
-        assert '1.076603021' in W.data
+        assert '1.076603021' in W.get_data(as_text=True)
 
     def test_dirichletchar9999lfunc(self):
         """ Check that the L-function link for 9999/2 is displayed if and only if the L-function data is present"""
         W = self.tc.get('/Character/Dirichlet/9999/2')
-        assert '/SatoTateGroup/0.1.300' in W.data
+        assert '/SatoTateGroup/0.1.300' in W.get_data(as_text=True)
         b = get_lfunction_by_url('Character/Dirichlet/9999/2')
-        assert bool(b) == ('L/Character/Dirichlet/9999/2' in W.data)
+        assert bool(b) == ('L/Character/Dirichlet/9999/2' in W.get_data(as_text=True))
 
     def test_dirichletchar99999999999999999lfunc(self):
         """ Check Dirichlet character with very large modulus"""
         W = self.tc.get('/Character/Dirichlet/99999999999999999999/2')
-        assert 'Odd' in W.data and '536870912' in W.data
-        assert '/SatoTateGroup/0.1.3748806900' in W.data
+        assert 'Odd' in W.get_data(as_text=True) and '536870912' in W.data
+        assert '/SatoTateGroup/0.1.3748806900' in W.get_data(as_text=True)
 
 class HeckeCharactersTest(LmfdbTest):
 
     def test_heckeexamples(self):
         W = self.tc.get('/Character/Hecke/')
-        assert '2.2.8.1' in W.data
+        assert '2.2.8.1' in W.get_data(as_text=True)
 
     def test_heckefamily(self):
         W = self.tc.get('/Character/Hecke/3.1.44.1')
-        assert 'C_{5}' in W.data
+        assert 'C_{5}' in W.get_data(as_text=True)
 
     def test_heckegroup(self):
         W = self.tc.get('/Character/Hecke/3.1.44.1/4.1')
-        assert 'Related objects' in W.data
-        assert 'primitive' in W.data
+        assert 'Related objects' in W.get_data(as_text=True)
+        assert 'primitive' in W.get_data(as_text=True)
 
     def test_heckechar(self):
         W = self.tc.get('/Character/Hecke/2.0.4.1/25.2/2')
-        assert 'Related objects' in W.data
-        assert 'Primitive' in W.data
+        assert 'Related objects' in W.get_data(as_text=True)
+        assert 'Primitive' in W.get_data(as_text=True)
 
     def test_hecke_calc(self):
         W = self.tc.get('/Character/calc-value/Hecke/2.0.4.1/25.2/1?val=13.2')
-        assert '=-i' in W.data
+        assert '=-i' in W.get_data(as_text=True)
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -48,17 +48,17 @@ class DirichletSearchTest(LmfdbTest):
 
     def test_search(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4&limit=25')
-        assert '\chi_{15}(2,' in W.get_data(as_text=True) and '\chi_{195}(53,' in W.data
+        assert '\chi_{15}(2,' in W.get_data(as_text=True) and '\chi_{195}(53,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&limit=25')
-        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.data
+        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes&limit=25')
-        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.data
+        assert '\chi_{25}(6,' in W.get_data(as_text=True) and '\chi_{36}(7,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&limit=25')
-        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{72}(7,' in W.data
+        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{72}(7,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd&limit=25')
-        assert '\chi_{56}(23,' in W.get_data(as_text=True) and '\chi_{112}(79,' in W.data
+        assert '\chi_{56}(23,' in W.get_data(as_text=True) and '\chi_{112}(79,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even&limit=25')
-        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{75}(46,' in W.data
+        assert '\chi_{50}(11,' in W.get_data(as_text=True) and '\chi_{75}(46,' in W.get_data(as_text=True)
 
     def test_condsearch(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=111&limit=100')
@@ -66,9 +66,9 @@ class DirichletSearchTest(LmfdbTest):
 
     def test_nextprev(self):
         W = self.tc.get('/Character/Dirichlet/?start=200&count=25&order=3')
-        assert '\chi_{169}(22,' in W.get_data(as_text=True) and '\chi_{182}(113,' in W.data
+        assert '\chi_{169}(22,' in W.get_data(as_text=True) and '\chi_{182}(113,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?start=100&count=25&order=3')
-        assert '\chi_{97}(35,' in W.get_data(as_text=True) and '\chi_{117}(40,' in W.data
+        assert '\chi_{97}(35,' in W.get_data(as_text=True) and '\chi_{117}(40,' in W.get_data(as_text=True)
 
 class DirichletTableTest(LmfdbTest):
 
@@ -81,7 +81,7 @@ class DirichletCharactersTest(LmfdbTest):
 
     def test_navig(self):
         W = self.tc.get('/Character/', follow_redirects=True)
-        assert 'Browse' in W.get_data(as_text=True) and 'search' in W.data
+        assert 'Browse' in W.get_data(as_text=True) and 'search' in W.get_data(as_text=True)
 
     def test_dirichletfamily(self):
         W = self.tc.get('/Character/Dirichlet/')
@@ -99,7 +99,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'Yes' in W.get_data(as_text=True)
         assert 'Properties' in W.get_data(as_text=True), "properties box"
         assert 'DirichletGroup_conrey(91)' in W.get_data(as_text=True), "sage code example"
-        assert '\chi_{91}(15,' in W.get_data(as_text=True) and '\chi_{91}(66' in W.data, "generators"
+        assert '\chi_{91}(15,' in W.get_data(as_text=True) and '\chi_{91}(66' in W.get_data(as_text=True), "generators"
         assert 'e\\left(\\frac{7}{12}\\right)' in W.get_data(as_text=True), "contents table"
         assert '/Character/Dirichlet/91/6' in W.get_data(as_text=True), "link in contents table"
 
@@ -107,7 +107,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'Properties' in W.get_data(as_text=True), "properties box"
         assert '648646704' in W.get_data(as_text=True), "order"
         assert 'C_{333666}' in W.get_data(as_text=True), "structure"
-        assert '\chi_{999999999}(234567902,' in W.get_data(as_text=True) and '\chi_{999999999}(432432433,' in W.data and '\chi_{999999999}(332999668,' in W.data
+        assert '\chi_{999999999}(234567902,' in W.get_data(as_text=True) and '\chi_{999999999}(432432433,' in W.get_data(as_text=True) and '\chi_{999999999}(332999668,' in W.get_data(as_text=True)
 
     def test_dirichletchar11(self):
         W = self.tc.get('/Character/Dirichlet/1/1')
@@ -178,7 +178,7 @@ class DirichletCharactersTest(LmfdbTest):
     def test_dirichletchar99999999999999999lfunc(self):
         """ Check Dirichlet character with very large modulus"""
         W = self.tc.get('/Character/Dirichlet/99999999999999999999/2')
-        assert 'Odd' in W.get_data(as_text=True) and '536870912' in W.data
+        assert 'Odd' in W.get_data(as_text=True) and '536870912' in W.get_data(as_text=True)
         assert '/SatoTateGroup/0.1.3748806900' in W.get_data(as_text=True)
 
 class HeckeCharactersTest(LmfdbTest):

--- a/lmfdb/classical_modular_forms/cmf_test_pages.py
+++ b/lmfdb/classical_modular_forms/cmf_test_pages.py
@@ -23,15 +23,15 @@ class CMFTest(LmfdbTest):
             load = time.time() - now
             k = int(label.split(".")[1])
             if k > 1:
-                assert label in page.data
+                assert label in page.get_data(as_text=True)
                 if dim <= 80:
-                    assert 'L-function %s' % label in page.data
-                assert 'L-function %s.%s' % tuple(label.split('.')[:2])  in page.data
-                assert 'Analytic rank' in page.data
+                    assert 'L-function %s' % label in page.get_data(as_text=True)
+                assert 'L-function %s.%s' % tuple(label.split('.')[:2])  in page.get_data(as_text=True)
+                assert 'Analytic rank' in page.get_data(as_text=True)
             if dim == 1:
-                assert 'Satake parameters' in page.data
+                assert 'Satake parameters' in page.get_data(as_text=True)
             else:
-                assert 'Embeddings' in page.data
+                assert 'Embeddings' in page.get_data(as_text=True)
             return (load, url)
         except Exception as err:
             print("Error on page " + url)
@@ -85,15 +85,15 @@ class CMFTest(LmfdbTest):
             now = time.time()
             page = self.tc.get(url)
             load = time.time() - now
-            assert 'The following table gives the dimensions of various subspaces of' in page.data
+            assert 'The following table gives the dimensions of various subspaces of' in page.get_data(as_text=True)
             for space in newspaces:
-                assert space['label'] in page.data
+                assert space['label'] in page.get_data(as_text=True)
                 gamma1_dim += space['dim']
             assert gamma1_dim == dim
 
             gamma1_dim = 0
             for form in newforms:
-                assert form['label'] in page.data
+                assert form['label'] in page.get_data(as_text=True)
                 gamma1_dim += form['dim']
             assert gamma1_dim == dim
             res.append((load, url))
@@ -117,10 +117,10 @@ class CMFTest(LmfdbTest):
                 page = self.tc.get(url)
                 load = time.time() - now
                 space_dim = 0
-                assert label in page.data
+                assert label in page.get_data(as_text=True)
                 for nf in newforms:
                     if nf['space_label'] == label:
-                        assert nf['label'] in page.data
+                        assert nf['label'] in page.get_data(as_text=True)
                         space_dim += nf['dim']
                 assert space_dim == dim
                 res.append((load, url))
@@ -140,9 +140,9 @@ class CMFTest(LmfdbTest):
                 now = time.time()
                 page = self.tc.get(url)
                 load = time.time() - now
-                assert "There are no modular forms of weight" in page.data
-                assert "odd" in page.data
-                assert "even" in page.data
+                assert "There are no modular forms of weight" in page.get_data(as_text=True)
+                assert "odd" in page.get_data(as_text=True)
+                assert "even" in page.get_data(as_text=True)
                 res.append((load, url))
             except Exception as err:
                 print("Error on page " + url)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -131,7 +131,7 @@ class CmfTest(LmfdbTest):
         assert "No matches" in page.get_data(as_text=True)
         assert "Only for weight 1" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/maria/', follow_redirects=True)
-        assert 'maria' in page.get_data(as_text=True) and "is not a valid newform" in page.data   
+        assert 'maria' in page.get_data(as_text=True) and "is not a valid newform" in page.get_data(as_text=True)   
 
     def test_delta(self):
         r"""

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -14,13 +14,13 @@ class CmfTest(LmfdbTest):
         r"""
         Check browsing for elliptic modular forms
         """
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/").get_data(as_text=True)
         assert '?search_type=Dimensions&dim=1' in data
         assert '?search_type=SpaceDimensions&char_order=1' in data
         assert "./stats" in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions",follow_redirects=True).data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions",follow_redirects=True).get_data(as_text=True)
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/23/12/">229</a>' in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions&char_order=1", follow_redirects=True).data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions&char_order=1", follow_redirects=True).get_data(as_text=True)
         assert r'<a href="/ModularForm/GL2/Q/holomorphic/18/4/a/">1</a>' in data
 
     def test_stats(self):
@@ -36,17 +36,17 @@ class CmfTest(LmfdbTest):
         assert "character order" in page.get_data(as_text=True)
 
     def test_sidebar(self):
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Labels").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Labels").get_data(as_text=True)
         assert 'Labels for Classical Modular Forms' in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Completeness").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Completeness").get_data(as_text=True)
         assert "Completeness of Classical Modular Form Data" in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Reliability").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Reliability").get_data(as_text=True)
         assert "Reliability of Classical Modular Form Data" in data
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Source").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Source").get_data(as_text=True)
         assert "Source of Classical Modular Form Data" in data
 
     def test_badp(self):
-        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level_primes=7&count=50&search_type=List").data
+        data = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level_primes=7&count=50&search_type=List").get_data(as_text=True)
         assert '343.1.d.a' in data
         assert '343.2.a.a' in data
         assert '7.7.d.a' in data
@@ -81,7 +81,7 @@ class CmfTest(LmfdbTest):
                         assert str(N)+'.'+str(k) in rv.get_data(as_text=True)
 
     def test_favorite(self):
-        main_page = self.tc.get("/ModularForm/GL2/Q/holomorphic/").data
+        main_page = self.tc.get("/ModularForm/GL2/Q/holomorphic/").get_data(as_text=True)
         from lmfdb.classical_modular_forms.main import favorite_newform_labels, favorite_space_labels
         for l in favorite_newform_labels:
             for elt, desc in l:
@@ -550,7 +550,7 @@ class CmfTest(LmfdbTest):
                 ['24.3.h.c'
                     , '[a, -a^2 - 3, a^2]'],
                 ]:
-            sage_code = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_qexp/%s' % label, follow_redirects=True).data
+            sage_code = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_qexp/%s' % label, follow_redirects=True).get_data(as_text=True)
             assert "make_data" in sage_code
             assert "aps_data" in sage_code
             sage_code += "\n\nout = str(make_data().list()[2:5])\n"
@@ -634,7 +634,7 @@ class CmfTest(LmfdbTest):
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/%s' % label)
                 makenewform = 'MakeNewformModFrm_%s_%s_%s_%s' % tuple(label.split('.'))
                 assert makenewform  in page.get_data(as_text=True)
-                magma_code = page.data + '\n' + '%s();\n' % makenewform
+                magma_code = page.get_data(as_text=True) + '\n' + '%s();\n' % makenewform
                 assert expected == magma_free(magma_code)
 
             for label, expected in [['24.3.h.a',
@@ -653,7 +653,7 @@ class CmfTest(LmfdbTest):
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/%s' % label)
                 makenewform = 'MakeNewformModSym_%s_%s_%s_%s' % tuple(label.split('.'))
                 assert makenewform  in page.get_data(as_text=True)
-                magma_code = page.data + '\n' + '%s();\n' % makenewform
+                magma_code = page.get_data(as_text=True) + '\n' + '%s();\n' % makenewform
                 assert expected == magma_free(magma_code)
 
         except socket.timeout as err:

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -25,15 +25,15 @@ class CmfTest(LmfdbTest):
 
     def test_stats(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/stats")
-        assert "Cuspidal Newforms: Statistics" in page.data
-        assert "Distribution" in page.data
-        assert "proportion" in page.data
-        assert "count" in page.data
-        assert "CM disc" in page.data
-        assert "RM disc" in page.data
-        assert "inner twists" in page.data
-        assert "projective image" in page.data
-        assert "character order" in page.data
+        assert "Cuspidal Newforms: Statistics" in page.get_data(as_text=True)
+        assert "Distribution" in page.get_data(as_text=True)
+        assert "proportion" in page.get_data(as_text=True)
+        assert "count" in page.get_data(as_text=True)
+        assert "CM disc" in page.get_data(as_text=True)
+        assert "RM disc" in page.get_data(as_text=True)
+        assert "inner twists" in page.get_data(as_text=True)
+        assert "projective image" in page.get_data(as_text=True)
+        assert "character order" in page.get_data(as_text=True)
 
     def test_sidebar(self):
         data = self.tc.get("/ModularForm/GL2/Q/holomorphic/Labels").data
@@ -54,16 +54,16 @@ class CmfTest(LmfdbTest):
 
     def test_level_bread(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/', follow_redirects = True)
-        assert '1124.1.d.a' in page.data
-        assert r'\Q(\sqrt{-281})' in page.data
-        assert '1124.1.d.d' in page.data
-        assert '\Q(\zeta_{20})^+' in page.data
-        assert '1124.1.ba.a' in page.data
-        assert '\Q(\zeta_{35})' in page.data
+        assert '1124.1.d.a' in page.get_data(as_text=True)
+        assert r'\Q(\sqrt{-281})' in page.get_data(as_text=True)
+        assert '1124.1.d.d' in page.get_data(as_text=True)
+        assert '\Q(\zeta_{20})^+' in page.get_data(as_text=True)
+        assert '1124.1.ba.a' in page.get_data(as_text=True)
+        assert '\Q(\zeta_{35})' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/?weight=10&level=10', follow_redirects=True)
         assert 'Results (displaying all 4 matches)'
-        assert '10.10.b.a' in page.data
-        assert '2580' in page.data
+        assert '10.10.b.a' in page.get_data(as_text=True)
+        assert '2580' in page.get_data(as_text=True)
 
     @unittest2.skip("Long tests for many newform spaces, should be run & pass before any release")
     def test_many(self):
@@ -76,9 +76,9 @@ class CmfTest(LmfdbTest):
                         url  = "/ModularForm/GL2/Q/holomorphic/{0}/{1}/".format(N, k)
                         rv = self.tc.get(url,follow_redirects=True)
                         self.assertTrue(rv.status_code==200,"Request failed for {0}".format(url))
-                        assert str(N) in rv.data
-                        assert str(k) in rv.data
-                        assert str(N)+'.'+str(k) in rv.data
+                        assert str(N) in rv.get_data(as_text=True)
+                        assert str(k) in rv.get_data(as_text=True)
+                        assert str(N)+'.'+str(k) in rv.get_data(as_text=True)
 
     def test_favorite(self):
         main_page = self.tc.get("/ModularForm/GL2/Q/holomorphic/").data
@@ -89,49 +89,49 @@ class CmfTest(LmfdbTest):
                     elt in main_page
                     desc in main_page
                     page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%s" % elt, follow_redirects=True)
-                    assert ("Newform %s" % elt) in page.data
+                    assert ("Newform %s" % elt) in page.get_data(as_text=True)
                     # redirect to the same page
                     page = self.tc.get("/ModularForm/GL2/Q/holomorphic/%s" % elt, follow_redirects=True)
-                    assert ("Newform %s" % elt) in page.data
+                    assert ("Newform %s" % elt) in page.get_data(as_text=True)
         for l in favorite_space_labels:
             for elt, desc in l:
                 elt in main_page
                 desc in main_page
                 page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%s" % elt, follow_redirects=True)
-                assert elt in page.data
+                assert elt in page.get_data(as_text=True)
                 # redirect to the same page
-                assert "Space of Modular Forms of " in page.data
+                assert "Space of Modular Forms of " in page.get_data(as_text=True)
                 page = self.tc.get("/ModularForm/GL2/Q/holomorphic/%s" % elt, follow_redirects=True)
-                assert elt in page.data
-                assert "Space of Modular Forms of " in page.data
+                assert elt in page.get_data(as_text=True)
+                assert "Space of Modular Forms of " in page.get_data(as_text=True)
 
     def test_tracehash(self):
         for t, l in [[1329751273693490116,'7.3.b.a'],[1294334189658968734, '4.5.b.a'],[0,'not found']]:
             page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%%23%d" % t, follow_redirects=True)
-            assert l in page.data
+            assert l in page.get_data(as_text=True)
 
     def test_jump(self):
         for j, l in [['10','10.3.c.a'], ['3.6.1.a', '3.6.a.a'], ['55.3.d', '55.3.d'], ['55.3.54', '55.3.d'], ['20.5', '20.5'], ['yes','23.1.b.a'], ['yes&weight=2','11.2.a.a'], ['yes&weight=-2', 'There are no newforms specified by the query']]:
             page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?jump=%s" % j, follow_redirects=True)
-            assert l in page.data
+            assert l in page.get_data(as_text=True)
 
     def test_failure(self):
         r"""
         Check that bad inputs are handled correctly
         """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/983/2000/c/a/', follow_redirects=True)
-        assert "Level and weight too large" in page.data
-        assert "for non trivial character." in page.data
+        assert "Level and weight too large" in page.get_data(as_text=True)
+        assert "for non trivial character." in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1000/4000/a/a/', follow_redirects=True)
-        assert "Level and weight too large" in page.data
-        assert " for trivial character." in page.data
+        assert "Level and weight too large" in page.get_data(as_text=True)
+        assert " for trivial character." in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/100/2/z/a/', follow_redirects=True)
-        assert "Newform 100.2.z.a not found" in page.data
+        assert "Newform 100.2.z.a not found" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1000&weight=100-&search_type=List', follow_redirects=True)
-        assert "No matches" in page.data
-        assert "Only for weight 1" in page.data
+        assert "No matches" in page.get_data(as_text=True)
+        assert "Only for weight 1" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/maria/', follow_redirects=True)
-        assert 'maria' in page.data and "is not a valid newform" in page.data   
+        assert 'maria' in page.get_data(as_text=True) and "is not a valid newform" in page.data   
 
     def test_delta(self):
         r"""
@@ -139,146 +139,146 @@ class CmfTest(LmfdbTest):
         Recall that this version uses the old urls...
         """
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/1/12/")
-        assert '1.12.a.a' in page.data
+        assert '1.12.a.a' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/1/12/a/")
-        assert '1.12.a.a' in page.data
-        assert '16744' in page.data
+        assert '1.12.a.a' in page.get_data(as_text=True)
+        assert '16744' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/1/12/a/a/")
-        assert '24q^{2}' in page.data
-        assert '84480q^{8}' in page.data
+        assert '24q^{2}' in page.get_data(as_text=True)
+        assert '84480q^{8}' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/1/12/a/a/?format=satake")
-        assert '0.299367' in page.data
-        assert '0.954138' in page.data
+        assert '0.299367' in page.get_data(as_text=True)
+        assert '0.954138' in page.get_data(as_text=True)
         page = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/1/12/a/a/')
-        assert '0.792122' in page.data
+        assert '0.792122' in page.get_data(as_text=True)
 
     def test_level11(self):
         r"""
         Check that the weight 2 form of level 11 works.
         """
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/11/2/a/a/")
-        assert '2q^{2}' in page.data
-        assert '2q^{4}' in page.data
+        assert '2q^{2}' in page.get_data(as_text=True)
+        assert '2q^{4}' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/11/2/a/a/?format=satake")
-        assert r'0.707107' in page.data
-        assert r'0.957427' in page.data
-        assert r'0.223607' in page.data
-        assert r'0.974679' in page.data
+        assert r'0.707107' in page.get_data(as_text=True)
+        assert r'0.957427' in page.get_data(as_text=True)
+        assert r'0.223607' in page.get_data(as_text=True)
+        assert r'0.974679' in page.get_data(as_text=True)
         ## We also check that the L-function works
         page = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/11/2/a/a/')
-        assert '0.253841' in page.data
+        assert '0.253841' in page.get_data(as_text=True)
 
     def test_triv_character(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/2/8/a/a/")
-        assert r'1016q^{7}' in page.data
-        assert '1680' in page.data
+        assert r'1016q^{7}' in page.get_data(as_text=True)
+        assert '1680' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/3/6/a/a/")
-        assert '168q^{8}' in page.data
-        assert '36' in page.data
+        assert '168q^{8}' in page.get_data(as_text=True)
+        assert '36' in page.get_data(as_text=True)
 
     def test_non_triv_character(self):
         r"""
         Check that non-trivial characters are also working.
         """
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/13/2/e/a/")
-        assert r'\Q(\sqrt{-3})' in page.data
-        assert '0.866025' in page.data
-        assert r'6q^{6}' in page.data
+        assert r'\Q(\sqrt{-3})' in page.get_data(as_text=True)
+        assert '0.866025' in page.get_data(as_text=True)
+        assert r'6q^{6}' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/10/4/b/a/")
-        assert r'46q^{9}' in page.data
-        assert r'\Q(\sqrt{-1})' in page.data
-        assert r'10' in page.data
+        assert r'46q^{9}' in page.get_data(as_text=True)
+        assert r'\Q(\sqrt{-1})' in page.get_data(as_text=True)
+        assert r'10' in page.get_data(as_text=True)
 
     def test_get_args(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/13/10/a/")
-        assert '11241' in page.data
-        assert '10099' in page.data
+        assert '11241' in page.get_data(as_text=True)
+        assert '10099' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/13/10/1/",  follow_redirects=True)
-        assert '11241' in page.data
-        assert '10099' in page.data
+        assert '11241' in page.get_data(as_text=True)
+        assert '10099' in page.get_data(as_text=True)
 
     def test_empty(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/2/2/a/")
-        assert 'The following table gives the dimensions of various' in page.data   
-        assert 'subspaces' in page.data
-        assert '\(M_{2}(\Gamma_0(2))\)' in page.data
+        assert 'The following table gives the dimensions of various' in page.get_data(as_text=True)   
+        assert 'subspaces' in page.get_data(as_text=True)
+        assert '\(M_{2}(\Gamma_0(2))\)' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/3/a/")
-        assert 'weight is odd while the character is ' in page.data
+        assert 'weight is odd while the character is ' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/6/a/")
         for elt in ['Decomposition', 'S_{6}^{\mathrm{old}}(\Gamma_0(12))', 'lower level spaces']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
 
     def test_not_in_db(self):
         # The following redirects to "ModularForm/GL2/Q/holomorphic/12000/12/"
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12000/12/")
-        assert 'Space not in database' in page.data
+        assert 'Space not in database' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12000/12/a/")
-        assert 'Space 12000.12.a not found' in page.data
+        assert 'Space 12000.12.a not found' in page.get_data(as_text=True)
 
     def test_character_validation(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/10/e/")
-        assert 'Space 12.10.e not found' in page.data
+        assert 'Space 12.10.e not found' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/10/c/")
-        assert 'since the weight is even while the character is' in page.data
+        assert 'since the weight is even while the character is' in page.get_data(as_text=True)
 
     def test_decomposition(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/6/12/", follow_redirects=True)
-        assert r'Decomposition</a> of \(S_{12}^{\mathrm{new}}(\Gamma_1(6))\)' in page.data
+        assert r'Decomposition</a> of \(S_{12}^{\mathrm{new}}(\Gamma_1(6))\)' in page.get_data(as_text=True)
         page = self.tc.get('ModularForm/GL2/Q/holomorphic/38/9/')
         for elt in map(str,[378, 120, 258, 342, 120, 222, 36]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         for elt in ['38.9.b','38.9.d','38.9.f']:
-            assert elt in page.data
-            assert elt + '.a' in page.data
+            assert elt in page.get_data(as_text=True)
+            assert elt + '.a' in page.get_data(as_text=True)
         for elt in ['Decomposition', r"S_{9}^{\mathrm{old}}(\Gamma_1(38))", "lower level spaces"]:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
     def test_convert_conreylabels(self):
         for c in [27, 31]:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/38/9/%d/a/' % c,follow_redirects=True)
-            assert "Newform 38.9.d.a" in page.data
+            assert "Newform 38.9.d.a" in page.get_data(as_text=True)
             for e in range(1, 13):
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/38/9/d/a/%d/%d/' % (c, e),follow_redirects=True)
-                assert "Newform 38.9.d.a" in page.data
+                assert "Newform 38.9.d.a" in page.get_data(as_text=True)
 
     def test_dim_table(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?weight=12&level=23&search_type=Dimensions", follow_redirects=True)
-        assert 'Dimension Search Results' in page.data
-        assert '229' in page.data # Level 23, Weight 12
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
+        assert '229' in page.get_data(as_text=True) # Level 23, Weight 12
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?weight=12&level=1-100&search_type=Dimensions", follow_redirects=True)
-        assert 'Dimension Search Results' in page.data
-        assert '229' in page.data # Level 23, Weight 12
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
+        assert '229' in page.get_data(as_text=True) # Level 23, Weight 12
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?search_type=Dimensions", follow_redirects=True)
-        assert 'Dimension Search Results' in page.data
-        assert '1-12' in page.data
-        assert '1-24' in page.data
-        assert '229' in page.data # Level 23, Weight 12
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
+        assert '1-12' in page.get_data(as_text=True)
+        assert '1-24' in page.get_data(as_text=True)
+        assert '229' in page.get_data(as_text=True) # Level 23, Weight 12
 
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&weight=1-20&search_type=Dimensions', follow_redirects=True)
-        assert '253' in page.data # Level 23, Weight 13
-        assert '229' in page.data # Level 23, Weight 12
-        assert 'Dimension Search Results' in page.data
+        assert '253' in page.get_data(as_text=True) # Level 23, Weight 13
+        assert '229' in page.get_data(as_text=True) # Level 23, Weight 12
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=3900-4100&weight=1-12&char_order=2-&search_type=Dimensions", follow_redirects=True)
-        assert '426' in page.data # Level 3999, Weight 1
-        assert '128' in page.data # Level 4000, Weight 1
+        assert '426' in page.get_data(as_text=True) # Level 3999, Weight 1
+        assert '128' in page.get_data(as_text=True) # Level 4000, Weight 1
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=3900-4100&weight=1-12&char_order=1&search_type=Dimensions", follow_redirects=True)
-        assert 'Dimension Search Results' in page.data
-        assert '0' in page.data
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
+        assert '0' in page.get_data(as_text=True)
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=4002&weight=1&char_order=2-&search_type=Dimensions", follow_redirects=True)
-        assert 'Dimension Search Results' in page.data
-        assert 'n/a' in page.data
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
+        assert 'n/a' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=7,10&weight_parity=odd&char_parity=odd&count=50&search_type=Dimensions')
         for elt in map(str,[0,1,2,5,4,9,6,13,8,17,10]):
-            assert elt in page.data
-        assert 'Dimension Search Results' in page.data
+            assert elt in page.get_data(as_text=True)
+        assert 'Dimension Search Results' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=odd&level=1-1000&weight=1-100&search_type=Dimensions')
         assert 'Error: Table too large: must have at most 10000 entries'
@@ -287,24 +287,24 @@ class CmfTest(LmfdbTest):
 
         #the other dim table
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/10/2/")
-        assert '7' in page.data
+        assert '7' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/2/")
         for elt in map(str,[9,4,5]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/59/8/")
         for elt in map(str,[1044, 1042, 2, 986, 0, 58, 56]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         for etl in ['59.8.a', '59.8.a.a', '59.8.a.b', '59.8.c', '59.8.c.a']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
 
 
 
     def test_character_parity(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/10/c/")
-        assert 'since the weight is even while the character is' in page.data
+        assert 'since the weight is even while the character is' in page.get_data(as_text=True)
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/3/a/")
-        assert 'since the weight is odd while the character is' in page.data
+        assert 'since the weight is odd while the character is' in page.get_data(as_text=True)
 
 
 
@@ -329,13 +329,13 @@ class CmfTest(LmfdbTest):
                 page = self.tc.get(url)
                 for j, (other, name) in enumerate(urls):
                     if i != j:
-                        assert other in page.data
+                        assert other in page.get_data(as_text=True)
                         if i > 0:
-                            assert name in page.data
+                            assert name in page.get_data(as_text=True)
 
                 if i > 0:
-                    assert 'Embedding label' in page.data
-                    assert 'Root' in page.data
+                    assert 'Embedding label' in page.get_data(as_text=True)
+                    assert 'Root' in page.get_data(as_text=True)
 
     def test_embedded_invariants(self):
         for url in ['/ModularForm/GL2/Q/holomorphic/13/2/e/a/4/1/',
@@ -343,63 +343,63 @@ class CmfTest(LmfdbTest):
 
             page = self.tc.get(url)
             # root
-            assert 'Root' in page.data
-            assert '0.500000' in page.data
-            assert '0.866025' in page.data
+            assert 'Root' in page.get_data(as_text=True)
+            assert '0.500000' in page.get_data(as_text=True)
+            assert '0.866025' in page.get_data(as_text=True)
             # p = 13
             for n in ['2.50000', '2.59808', '0.693375', '0.720577']:
-                assert n in page.data
+                assert n in page.get_data(as_text=True)
 
             # p = 47
             for n in ['3.46410', '0.505291', '0.967559', '0.252646', '0.918699']:
-                assert n in page.data
+                assert n in page.get_data(as_text=True)
 
-            assert 'Newspace 13.2.e' in page.data
-            assert 'Newform 13.2.e.a' in page.data
-            assert 'Dual Form 13.2.e.a.' in page.data
-            assert 'L-function 13.2.e.a.' in page.data
+            assert 'Newspace 13.2.e' in page.get_data(as_text=True)
+            assert 'Newform 13.2.e.a' in page.get_data(as_text=True)
+            assert 'Dual Form 13.2.e.a.' in page.get_data(as_text=True)
+            assert 'L-function 13.2.e.a.' in page.get_data(as_text=True)
 
-            assert '0.103805522628' in page.data
+            assert '0.103805522628' in page.get_data(as_text=True)
 
-            assert '13.2.e.a.4.1' in page.data
-            assert '13.2.e.a.10.1' in page.data
+            assert '13.2.e.a.4.1' in page.get_data(as_text=True)
+            assert '13.2.e.a.10.1' in page.get_data(as_text=True)
 
 
     def test_satake(self):
         for url in ['/ModularForm/GL2/Q/holomorphic/11/2/a/a/?format=satake',
                 '/ModularForm/GL2/Q/holomorphic/11/2/a/a/1/1/']:
             page = self.tc.get(url)
-            assert r'0.707107' in page.data
-            assert r'0.957427' in page.data
-            assert r'0.223607' in page.data
-            assert r'0.974679' in page.data
-            assert r'0.288675' in page.data
+            assert r'0.707107' in page.get_data(as_text=True)
+            assert r'0.957427' in page.get_data(as_text=True)
+            assert r'0.223607' in page.get_data(as_text=True)
+            assert r'0.974679' in page.get_data(as_text=True)
+            assert r'0.288675' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/7/3/b/a/?&format=satake',
                 '/ModularForm/GL2/Q/holomorphic/7/3/b/a/6/1/']:
             page = self.tc.get(url)
-            assert r'0.750000' in page.data
-            assert r'0.661438' in page.data
-            assert r'0.272727' in page.data
-            assert r'0.962091' in page.data
-        assert r'1.00000' in page.data
+            assert r'0.750000' in page.get_data(as_text=True)
+            assert r'0.661438' in page.get_data(as_text=True)
+            assert r'0.272727' in page.get_data(as_text=True)
+            assert r'0.962091' in page.get_data(as_text=True)
+        assert r'1.00000' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/7/3/b/a/?&format=satake_angle',
                 '/ModularForm/GL2/Q/holomorphic/7/3/b/a/6/1/']:
             page = self.tc.get(url)
-            assert '\(\pi\)' in page.data
-            assert '\(0.769947\pi\)' in page.data
-            assert '\(0.587926\pi\)' in page.data
+            assert '\(\pi\)' in page.get_data(as_text=True)
+            assert '\(0.769947\pi\)' in page.get_data(as_text=True)
+            assert '\(0.587926\pi\)' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/21/2/e/a/?format=satake',
                 '/ModularForm/GL2/Q/holomorphic/21/2/e/a/4/1/',
                 '/ModularForm/GL2/Q/holomorphic/21/2/e/a/16/1/',
                 ]:
             page = self.tc.get(url)
-            assert r'0.965926' in page.data
-            assert r'0.258819' in page.data
-            assert r'0.990338' in page.data
-            assert r'0.550990' in page.data
+            assert r'0.965926' in page.get_data(as_text=True)
+            assert r'0.258819' in page.get_data(as_text=True)
+            assert r'0.990338' in page.get_data(as_text=True)
+            assert r'0.550990' in page.get_data(as_text=True)
 
 
         for url in ['/ModularForm/GL2/Q/holomorphic/5/9/c/a/?n=2-10&m=1-6&prec=6&format=satake',
@@ -407,15 +407,15 @@ class CmfTest(LmfdbTest):
                 '/ModularForm/GL2/Q/holomorphic/5/9/c/a/3/1/',
                 ]:
             page = self.tc.get(url)
-            assert '0.972878' in page.data
-            assert '0.231320' in page.data
+            assert '0.972878' in page.get_data(as_text=True)
+            assert '0.231320' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/5/9/c/a/?n=2-10&m=1-6&prec=6&format=satake',
                 '/ModularForm/GL2/Q/holomorphic/5/9/c/a/2/3/',
                 '/ModularForm/GL2/Q/holomorphic/5/9/c/a/3/3/',
                 ]:
             page = self.tc.get(url)
-            assert '0.00593626' in page.data
+            assert '0.00593626' in page.get_data(as_text=True)
 
 
         for url in ['/ModularForm/GL2/Q/holomorphic/31/2/c/a/?m=1-4&n=2-10&prec=6&format=satake',
@@ -423,109 +423,109 @@ class CmfTest(LmfdbTest):
                 '/ModularForm/GL2/Q/holomorphic/31/2/c/a/25/1/',
                 ]:
             page = self.tc.get(url)
-            assert '0.998759' in page.data
-            assert '0.0498090' in page.data
-            assert '0.542515' in page.data
-            assert '0.840046' in page.data
+            assert '0.998759' in page.get_data(as_text=True)
+            assert '0.0498090' in page.get_data(as_text=True)
+            assert '0.542515' in page.get_data(as_text=True)
+            assert '0.840046' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/31/2/c/a/?m=1-4&n=2-10&prec=6&format=satake_angle',
                 '/ModularForm/GL2/Q/holomorphic/31/2/c/a/5/1/',
                 '/ModularForm/GL2/Q/holomorphic/31/2/c/a/25/1/',
                 ]:
             page = self.tc.get(url)
-            assert '0.984139\pi' in page.data
-            assert '0.317472\pi' in page.data
+            assert '0.984139\pi' in page.get_data(as_text=True)
+            assert '0.317472\pi' in page.get_data(as_text=True)
 
 
         #test large floats
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/1/']:
             page = self.tc.get(url)
-            assert '213.765' in page.data
-            assert '5.39613e49' in page.data
-            assert '7.61562e49' in page.data
+            assert '213.765' in page.get_data(as_text=True)
+            assert '5.39613e49' in page.get_data(as_text=True)
+            assert '7.61562e49' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/2/']:
             page = self.tc.get(url)
-            assert '3412.77' in page.data
-            assert '1.55372e49' in page.data
-            assert '1.00032e49' in page.data
+            assert '3412.77' in page.get_data(as_text=True)
+            assert '1.55372e49' in page.get_data(as_text=True)
+            assert '1.00032e49' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/3/']:
             page = self.tc.get(url)
-            assert '3626.53' in page.data
-            assert '1.17540e49' in page.data
-            assert '1.20001e50' in page.data
+            assert '3626.53' in page.get_data(as_text=True)
+            assert '1.17540e49' in page.get_data(as_text=True)
+            assert '1.20001e50' in page.get_data(as_text=True)
 
         # same numbers but normalized
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/1/']:
             page = self.tc.get(url)
-            assert '0.993913' in page.data
-            assert '1.36787' in page.data
+            assert '0.993913' in page.get_data(as_text=True)
+            assert '1.36787' in page.get_data(as_text=True)
 
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/2/']:
             page = self.tc.get(url)
-            assert '0.286180' in page.data
-            assert '0.179671' in page.data
+            assert '0.286180' in page.get_data(as_text=True)
+            assert '0.179671' in page.get_data(as_text=True)
         for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/3/']:
             page = self.tc.get(url)
-            assert '0.216496' in page.data
-            assert '2.15537' in page.data
+            assert '0.216496' in page.get_data(as_text=True)
+            assert '2.15537' in page.get_data(as_text=True)
 
         # test some exact values
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/25/2/e/a/?n=97&m=8&prec=6&format=satake_angle')
-        assert '0.0890699' in page.data
-        assert '0.689070' in page.data
+        assert '0.0890699' in page.get_data(as_text=True)
+        assert '0.689070' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/25/2/d/a/?m=4&n=97&prec=6&format=satake_angle')
-        assert '0.237314' in page.data
-        assert '0.637314' in page.data
+        assert '0.237314' in page.get_data(as_text=True)
+        assert '0.637314' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/210/2/a/a/?format=satake&n=2-20')
         # alpha_11
-        assert '0.603023' in page.data
-        assert '0.797724' in page.data
+        assert '0.603023' in page.get_data(as_text=True)
+        assert '0.797724' in page.get_data(as_text=True)
         # alpha_13
-        assert '0.277350' in page.data
-        assert '0.960769' in page.data
+        assert '0.277350' in page.get_data(as_text=True)
+        assert '0.960769' in page.get_data(as_text=True)
         # alpha_17
-        assert '0.727607' in page.data
-        assert '0.685994' in page.data
+        assert '0.727607' in page.get_data(as_text=True)
+        assert '0.685994' in page.get_data(as_text=True)
 
         # specifying embeddings
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=2-10&m=2.1%2C+95.10&prec=6&format=embed')
         for elt in ['2.1','95.10','1.05074','0.946093', '2.90568', '0.305399']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/13/2/e/a/?m=1-2&n=2-10000&prec=6&format=embed')
-        assert "Only" in page.data
-        assert "up to 1000 are available" in page.data
+        assert "Only" in page.get_data(as_text=True)
+        assert "up to 1000 are available" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/7524/2/l/b/?n=5000&m=&prec=&format=embed')
-        assert "Only" in page.data
-        assert "up to 3000 are available" in page.data
-        assert "in specified range; resetting to default" in page.data
+        assert "Only" in page.get_data(as_text=True)
+        assert "up to 3000 are available" in page.get_data(as_text=True)
+        assert "in specified range; resetting to default" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/7524/2/l/b/?n=1500-4000&m=&prec=&format=embed')
-        assert "Only" in page.data
-        assert "up to 3000 are available" in page.data
-        assert "limiting to" in page.data
+        assert "Only" in page.get_data(as_text=True)
+        assert "up to 3000 are available" in page.get_data(as_text=True)
+        assert "limiting to" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/13/2/e/a/?m=1-2&n=3.5&prec=6&format=embed')
-        assert "must be an integer, range of integers or comma separated list of integers" in page.data
+        assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=2-10&m=1-20000&prec=6&format=embed', follow_redirects=True)
-        assert "Web interface only supports 1000 embeddings at a time.  Use download link to get more (may take some time)." in page.data
+        assert "Web interface only supports 1000 embeddings at a time.  Use download link to get more (may take some time)." in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=3.14&format=embed', follow_redirects=True)
-        assert "must be an integer, range of integers or comma separated list of integers" in page.data
+        assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=2-10&m=1-20&prec=16&format=embed')
-        assert 'must be a positive integer, at most 15 (for higher precision, use the download button)' in page.data
+        assert 'must be a positive integer, at most 15 (for higher precision, use the download button)' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=999-1001&m=1-20&prec=6&format=embed')
-        assert 'Only' in page.data
-        assert 'up to 1000 are available' in page.data
-        assert 'a_{1000}' in page.data
+        assert 'Only' in page.get_data(as_text=True)
+        assert 'up to 1000 are available' in page.get_data(as_text=True)
+        assert 'a_{1000}' in page.get_data(as_text=True)
 
 
 
@@ -559,7 +559,7 @@ class CmfTest(LmfdbTest):
             assert str(out) == exp
         for label in ['212.2.k.a', '887.2.a.b']:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_qexp/{}'.format(label), follow_redirects=True)
-            assert 'No q-expansion found for {}'.format(label) in page.data
+            assert 'No q-expansion found for {}'.format(label) in page.get_data(as_text=True)
 
     def test_download(self):
         r"""
@@ -567,50 +567,50 @@ class CmfTest(LmfdbTest):
         """
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/23.10', follow_redirects=True)
-        assert '[0, 187, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, 969023, -478731' in page.data
+        assert '[0, 187, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, 969023, -478731' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/1161.1.i', follow_redirects=True)
-        assert '[0, 14, 0, 0, -2, 0, 0, 0, 0, 0, -2, 0, 0, 1, 0, 0, -10, 0, 0, 1, 0, 0' in page.data
+        assert '[0, 14, 0, 0, -2, 0, 0, 0, 0, 0, -2, 0, 0, 1, 0, 0, -10, 0, 0, 1, 0, 0' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/1161.1.i.maria.josefina', follow_redirects=True)
-        assert 'Invalid label' in page.data
+        assert 'Invalid label' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/4021.2.mz', follow_redirects=True)
         assert 'Label not found:'
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/4021.2.c', follow_redirects=True)
-        assert 'We have not computed traces for' in page.data
+        assert 'We have not computed traces for' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/27.2.e.a', follow_redirects=True)
-        assert '[0, 12, -6, -6, -6, -3, 0, -6, 6, 0, -3, 3, 12, -6, 15, 9, 0, 9, 9, -3, -3, -12, 3, -12, -18, 3, -30' in page.data
+        assert '[0, 12, -6, -6, -6, -3, 0, -6, 6, 0, -3, 3, 12, -6, 15, 9, 0, 9, 9, -3, -3, -12, 3, -12, -18, 3, -30' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_cc_data/27.2.foo', follow_redirects=True)
-        assert 'Invalid label' in page.data
+        assert 'Invalid label' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_cc_data/27.2.foo.bar', follow_redirects=True)
-        assert 'No form found' in page.data
+        assert 'No form found' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_cc_data/27.2.e.a', follow_redirects=True)
-        assert '0.5, -2.2282699087' in page.data
-        assert '-0.498394' in page.data
+        assert '0.5, -2.2282699087' in page.get_data(as_text=True)
+        assert '-0.498394' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_satake_angles/27.2.e.a', follow_redirects=True)
-        assert '0.5, -2.2282699087' in page.data
-        assert '0.406839418685' in page.data
+        assert '0.5, -2.2282699087' in page.get_data(as_text=True)
+        assert '0.406839418685' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform/27.2.e.a', follow_redirects=True)
-        assert '"analytic_rank_proved": true' in page.data
-        assert '[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]' in page.data # a1 (make sure qexp is there)
-        assert '[1, 1, 27, 5, 1, 9, 0]' in page.data # non-trivial inner twist
-        assert '-2.2282699087' in page.data
-        assert '[0, 12, -6, -6, -6, -3, 0, -6, 6, 0, -3, 3, 12, -6, 15, 9, 0, 9, 9, -3, -3, -12, 3, -12, -18, 3, -30' in page.data
-        assert '-0.498394' in page.data
-        assert '0.406839418685' in page.data
-        assert '1.2.3.c9' in page.data # Sato-Tate group
+        assert '"analytic_rank_proved": true' in page.get_data(as_text=True)
+        assert '[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]' in page.get_data(as_text=True) # a1 (make sure qexp is there)
+        assert '[1, 1, 27, 5, 1, 9, 0]' in page.get_data(as_text=True) # non-trivial inner twist
+        assert '-2.2282699087' in page.get_data(as_text=True)
+        assert '[0, 12, -6, -6, -6, -3, 0, -6, 6, 0, -3, 3, 12, -6, 15, 9, 0, 9, 9, -3, -3, -12, 3, -12, -18, 3, -30' in page.get_data(as_text=True)
+        assert '-0.498394' in page.get_data(as_text=True)
+        assert '0.406839418685' in page.get_data(as_text=True)
+        assert '1.2.3.c9' in page.get_data(as_text=True) # Sato-Tate group
 
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_full_space/20.5', follow_redirects = True)
-        assert r"""["20.5.b.a", "20.5.d.a", "20.5.d.b", "20.5.d.c", "20.5.f.a"]""" in page.data
+        assert r"""["20.5.b.a", "20.5.d.a", "20.5.d.b", "20.5.d.c", "20.5.f.a"]""" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newspace/244.4.w')
-        assert "[7, 31, 35, 43, 51, 55, 59, 63, 67, 71, 79, 87, 91, 115, 139, 227]" in page.data
-        assert "244.4.w" in page.data
+        assert "[7, 31, 35, 43, 51, 55, 59, 63, 67, 71, 79, 87, 91, 115, 139, 227]" in page.get_data(as_text=True)
+        assert "244.4.w" in page.get_data(as_text=True)
 
     def test_download_magma(self):
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/23.1.b.a.z')
-        assert 'Label not found' in page.data
+        assert 'Label not found' in page.get_data(as_text=True)
 
         try:
             from sage.all import magma_free
@@ -633,7 +633,7 @@ class CmfTest(LmfdbTest):
                     ]:
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/%s' % label)
                 makenewform = 'MakeNewformModFrm_%s_%s_%s_%s' % tuple(label.split('.'))
-                assert makenewform  in page.data
+                assert makenewform  in page.get_data(as_text=True)
                 magma_code = page.data + '\n' + '%s();\n' % makenewform
                 assert expected == magma_free(magma_code)
 
@@ -652,7 +652,7 @@ class CmfTest(LmfdbTest):
                     ]:
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/%s' % label)
                 makenewform = 'MakeNewformModSym_%s_%s_%s_%s' % tuple(label.split('.'))
-                assert makenewform  in page.data
+                assert makenewform  in page.get_data(as_text=True)
                 magma_code = page.data + '\n' + '%s();\n' % makenewform
                 assert expected == magma_free(magma_code)
 
@@ -665,21 +665,21 @@ class CmfTest(LmfdbTest):
 
     def test_download_search(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=Traces', follow_redirects = True)
-        assert '5.10.a.a' in page.data
-        assert '1, -8, -114, -448, -625, 912, 4242, 7680, -6687, 5000, -46208, 51072, -115934, -33936' in page.data
+        assert '5.10.a.a' in page.get_data(as_text=True)
+        assert '1, -8, -114, -448, -625, 912, 4242, 7680, -6687, 5000, -46208, 51072, -115934, -33936' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=List', follow_redirects = True)
-        assert '5.10.a.a' in page.data
-        assert '5, 10, 1, 2.57517918082, [0, 1], "1.1.1.1", [], [], [-8, -114, -625, 4242]' in page.data
+        assert '5.10.a.a' in page.get_data(as_text=True)
+        assert '5, 10, 1, 2.57517918082, [0, 1], "1.1.1.1", [], [], [-8, -114, -625, 4242]' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=gp&download=1&query=%7B%27num_forms%27%3A+%7B%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+5%2C+%27level%27%3A+20%7D&search_type=Spaces')
         for elt in ["20.5.b", "20.5.d", "20.5.f"]:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+2000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
-        assert 'Error: We limit downloads of traces to' in page.data
+        assert 'Error: We limit downloads of traces to' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+30000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
-        assert '863.2.c' in page.data
+        assert '863.2.c' in page.get_data(as_text=True)
 
 
 
@@ -688,11 +688,11 @@ class CmfTest(LmfdbTest):
         Test that we don't hit any error on a random newform
         """
         def check(page):
-            assert 'Newspace' in page.data, page.url
-            assert 'parameters' in page.data, page.url
-            assert 'Properties' in page.data, page.url
-            assert 'Newform' in page.data, page.url
-            assert 'expansion' in page.data, page.url
+            assert 'Newspace' in page.get_data(as_text=True), page.url
+            assert 'parameters' in page.get_data(as_text=True), page.url
+            assert 'Properties' in page.get_data(as_text=True), page.url
+            assert 'Newform' in page.get_data(as_text=True), page.url
+            assert 'expansion' in page.get_data(as_text=True), page.url
         for i in range(100):
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/random', follow_redirects = True)
             check(page)
@@ -712,23 +712,23 @@ class CmfTest(LmfdbTest):
 
     def test_dimension(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=10&weight=1-14&dim=1&search_type=List', follow_redirects = True)
-        assert "displaying all 14 matches" in page.data
-        assert 'A-L signs' in page.data
+        assert "displaying all 14 matches" in page.get_data(as_text=True)
+        assert 'A-L signs' in page.get_data(as_text=True)
 
     def test_traces(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=244&weight=4&count=50&search_type=Traces', follow_redirects = True)
-        assert "Results (displaying all 18 matches)" in page.data
+        assert "Results (displaying all 18 matches)" in page.get_data(as_text=True)
         for elt in map(str,[-98,-347,739,0,147,-414,324,306,-144,0,24,-204,153,414,-344,-756,-24,164]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=244&weight=4&search_type=Traces&n=1-40&n_primality=prime_powers&an_constraints=a3%3D0%2Ca37%3D0', follow_redirects = True)
-        assert "Results (displaying all 3 matches)" in page.data
+        assert "Results (displaying all 3 matches)" in page.get_data(as_text=True)
         for elt in map(str,[-6,-68, 3224, 206, 4240, -408, -598, 1058]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?weight_parity=odd&level=7&weight=7&search_type=Traces&n=1-10&n_primality=all")
-        assert "Results (displaying all 4 matches)" in page.data
+        assert "Results (displaying all 4 matches)" in page.get_data(as_text=True)
         for elt in map(str,[17,0,-80,60,3780,-1200]):
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
 
 
@@ -746,7 +746,7 @@ class CmfTest(LmfdbTest):
                 s = '&'.join(['/ModularForm/GL2/Q/holomorphic/?search_type=List', begin[0]] + list(s))
                 page = self.tc.get(s,  follow_redirects=True)
                 for elt in begin[1]:
-                    assert elt in page.data, s
+                    assert elt in page.get_data(as_text=True), s
 
         for begin in [
                 ('level=1-330&weight=1&projective_image=D2',
@@ -760,15 +760,15 @@ class CmfTest(LmfdbTest):
                 s = '&'.join(['/ModularForm/GL2/Q/holomorphic/?search_type=List', begin[0]] + list(s))
                 page = self.tc.get(s,  follow_redirects=True)
                 for elt in begin[1]:
-                    assert elt in page.data, s
+                    assert elt in page.get_data(as_text=True), s
 
     def test_parity(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=even&char_parity=even&search_type=List')
-        assert '11.2.a.a' in page.data
+        assert '11.2.a.a' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=odd&char_parity=odd&search_type=List')
-        assert '23.1.b.a' in page.data
+        assert '23.1.b.a' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=even&char_parity=even&weight=3&search_type=List')
-        assert "No matches" in page.data
+        assert "No matches" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=even&char_parity=odd&search_type=List')
 
 
@@ -777,114 +777,114 @@ class CmfTest(LmfdbTest):
         Test the display of coefficient fields.
         """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/9/8/a/')
-        assert '\Q(\sqrt{10})' in page.data
+        assert '\Q(\sqrt{10})' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/11/6/a/')
-        assert '3.3.54492.1' in page.data
+        assert '3.3.54492.1' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/27/2/e/a/')
-        assert '12.0.1952986685049.1' in page.data
+        assert '12.0.1952986685049.1' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-500&weight=2&nf_label=16.0.1048576000000000000.1&prime_quantifier=subsets&search_type=List')
-        assert '\zeta_{40}' in page.data
-        assert "Results (displaying all 6 matches)" in page.data
+        assert '\zeta_{40}' in page.get_data(as_text=True)
+        assert "Results (displaying all 6 matches)" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-4000&weight=1&nf_label=9.9.16983563041.1&prime_quantifier=subsets&projective_image=D19&search_type=List')
-        assert r"Q(\zeta_{38})^+" in page.data
+        assert r"Q(\zeta_{38})^+" in page.get_data(as_text=True)
         assert "Results (displaying all 32 matches)"
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&weight=2&dim=4&nf_label=4.0.576.2&prime_quantifier=subsets&search_type=List')
-        assert 'Results (displaying all 7 matches)' in page.data
-        assert '\Q(\sqrt{2}, \sqrt{-3})' in page.data
+        assert 'Results (displaying all 7 matches)' in page.get_data(as_text=True)
+        assert '\Q(\sqrt{2}, \sqrt{-3})' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?dim=8&char_order=20&cm=no&rm=no&search_type=List')
-        assert "Results (displaying all 17 matches)" in page.data
-        assert r"Q(\zeta_{20})" in page.data
+        assert "Results (displaying all 17 matches)" in page.get_data(as_text=True)
+        assert r"Q(\zeta_{20})" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-4000&weight=1&dim=116&search_type=List')
-        assert "Results (displaying both matches)" in page.data
-        assert r"Q(\zeta_{177})" in page.data
+        assert "Results (displaying both matches)" in page.get_data(as_text=True)
+        assert r"Q(\zeta_{177})" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&weight=2&dim=4&nf_label=4.0.576.2&prime_quantifier=subsets')
-        assert 'Results (displaying all 7 matches)' in page.data
-        assert '\Q(\sqrt{2}, \sqrt{-3})' in page.data
+        assert 'Results (displaying all 7 matches)' in page.get_data(as_text=True)
+        assert '\Q(\sqrt{2}, \sqrt{-3})' in page.get_data(as_text=True)
 
     def test_inner_twist(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/3992/1/ba/a/')
-        assert "499.g" in page.data
-        assert "3992.ba" in page.data
+        assert "499.g" in page.get_data(as_text=True)
+        assert "3992.ba" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/190/2/i/a/')
         for elt in ['5.b', '19.c', '95.i']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1816/1/l/a/')
         for elt in ['227.c','1816.l']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
         for elt in ['3.b','5.b','197.b','2955.c']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/52/18/a/a/')
-        assert "This newform does not admit any (" in page.data
-        assert "nontrivial" in page.data
-        assert "inner twist" in page.data
+        assert "This newform does not admit any (" in page.get_data(as_text=True)
+        assert "nontrivial" in page.get_data(as_text=True)
+        assert "inner twist" in page.get_data(as_text=True)
 
 
     def test_self_twist(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
         for elt in ['\Q(\sqrt{-591})','\Q(\sqrt{-15})', '\Q(\sqrt{985})']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/1/d/a/')
         for elt in ['\Q(\sqrt{-281})','\Q(\sqrt{-1})', '\Q(\sqrt{281})']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
 
     def test_selft_twist_disc(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-40&weight=1-6&self_twist_discs=-3&search_type=List')
         for elt in ['\Q(\sqrt{-39})','\Q(\sqrt{-3})']:
-            assert elt in page.data
-        assert 'Results (displaying all 22 matches)' in page.data
+            assert elt in page.get_data(as_text=True)
+        assert 'Results (displaying all 22 matches)' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&self_twist_discs=5&search_type=List')
         for elt in [-55,-11,5,-5,-1,-95,-19]:
-            assert ('\Q(\sqrt{%d})' % elt) in page.data
-        assert 'Results (displaying all 3 matches)' in page.data
+            assert ('\Q(\sqrt{%d})' % elt) in page.get_data(as_text=True)
+        assert 'Results (displaying all 3 matches)' in page.get_data(as_text=True)
         for d in [3,-5]:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&self_twist_discs=%d&search_type=List' % d)
-            assert 'is not a valid input for' in page.data
+            assert 'is not a valid input for' in page.get_data(as_text=True)
 
 
     def test_projective(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
-        assert 'D_{2}' in page.data
-        assert '\Q(\sqrt{-15}, \sqrt{-591})' in page.data
+        assert 'D_{2}' in page.get_data(as_text=True)
+        assert '\Q(\sqrt{-15}, \sqrt{-591})' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/1/d/a/')
-        assert 'D_{2}' in page.data
-        assert '\Q(i, \sqrt{281})' in page.data
+        assert 'D_{2}' in page.get_data(as_text=True)
+        assert '\Q(i, \sqrt{281})' in page.get_data(as_text=True)
 
     def test_artin(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
-        assert 'Artin representation 2.3_5_197.8t11.1' in page.data
-        assert 'D_4:C_2' in page.data
-        assert '8.0.1964705625.1' in page.data
+        assert 'Artin representation 2.3_5_197.8t11.1' in page.get_data(as_text=True)
+        assert 'D_4:C_2' in page.get_data(as_text=True)
+        assert '8.0.1964705625.1' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/1/d/a/')
-        assert 'Artin representation 2.2e2_281.4t3.2' in page.data
-        assert '4.0.4496.1' in page.data
-        assert 'D_4' in page.data
+        assert 'Artin representation 2.2e2_281.4t3.2' in page.get_data(as_text=True)
+        assert '4.0.4496.1' in page.get_data(as_text=True)
+        assert 'D_4' in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/124/1/i/a/67/1/')
-        assert 'Artin representation 2.2e2_31.16t60.1c3' in page.data
-        assert 'SL(2,3):C_2' in page.data
-        assert '4.0.15376.1' in page.data
+        assert 'Artin representation 2.2e2_31.16t60.1c3' in page.get_data(as_text=True)
+        assert 'SL(2,3):C_2' in page.get_data(as_text=True)
+        assert '4.0.15376.1' in page.get_data(as_text=True)
 
     def test_AL_search(self):
         r"""
         Test that we display AL eigenvals/signs
         """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15&char_order=1&search_type=List', follow_redirects=True)
-        assert 'A-L signs' in page.data
+        assert 'A-L signs' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15&search_type=Spaces', follow_redirects=True)
-        assert 'AL-dims.' in page.data
-        assert '\(0\)+\(1\)+\(0\)+\(0\)' in page.data
+        assert 'AL-dims.' in page.get_data(as_text=True)
+        assert '\(0\)+\(1\)+\(0\)+\(0\)' in page.get_data(as_text=True)
 
 
 
@@ -895,24 +895,24 @@ class CmfTest(LmfdbTest):
         Test that we display Fricke sings
         """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15%2C20&weight=2&dim=1&search_type=List',  follow_redirects=True)
-        assert 'Fricke sign' in page.data
+        assert 'Fricke sign' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?char_order=1&search_type=List',  follow_redirects=True)
-        assert 'Fricke sign' in page.data
+        assert 'Fricke sign' in page.get_data(as_text=True)
 
 
     def displaying_weight1_search(self):
         for typ in ['List', 'Traces', 'Dimensions']:
             for search in ['weight=1', 'rm_discs=5','has_self_twist=rm','cm_discs=-3%2C+-39']:
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?%s&search_type=%s' % (search, typ),  follow_redirects=True)
-                assert 'Only for weight 1:' in page.data
+                assert 'Only for weight 1:' in page.get_data(as_text=True)
 
 
     def test_is_self_dual(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?is_self_dual=yes&search_type=List' ,  follow_redirects=True)
         for elt in ['23.1.b.a', '31.1.b.a', '111.1.d.a']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?is_self_dual=no&search_type=List',  follow_redirects=True)
         for elt in ['52.1.j.a', '57.1.h.a', '111.1.h.a']:
-            assert elt in page.data
+            assert elt in page.get_data(as_text=True)
 
 

--- a/lmfdb/ecnf/ecnf_test_pages.py
+++ b/lmfdb/ecnf/ecnf_test_pages.py
@@ -16,7 +16,7 @@ class ECNFTest(LmfdbTest):
             url = "EllipticCurve/%s/%d"%("/".join(e['class_label'].split("-")),e['number'])
             print("Checking " + url)
             page = self.tc.get(url, follow_redirects=True)
-            if not e['label'] in page.data or not 'Weierstrass equation' in page.data:
+            if not e['label'] in page.get_data(as_text=True) or not 'Weierstrass equation' in page.get_data(as_text=True):
                 print('Failed on', url)
                 errors.append(url)
         if errors:

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -10,72 +10,72 @@ class EllCurveTest(LmfdbTest):
         Check that the elliptic curve/#field tells about (non)existence of a global minimal model
         """
         L = self.tc.get('/EllipticCurve/2.2.89.1/81.1/a/1')
-        assert 'This is a <a title="Global minimal model' in L.data
+        assert 'This is a <a title="Global minimal model' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/2.2.229.1/9.3/a/2')
-        assert 'This is not a <a title="Global minimal model' in L.data
-        assert 'at all primes except' in L.data
+        assert 'This is not a <a title="Global minimal model' in L.get_data(as_text=True)
+        assert 'at all primes except' in L.get_data(as_text=True)
 
     def test_base_field(self):
         r"""
         Check that the elliptic curve/#field tells about its base field
         """
         L = self.tc.get('/EllipticCurve/3.1.23.1/89.1/A/1')
-        assert '3.1.23.1' in L.data
+        assert '3.1.23.1' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/2.2.5.1/49.1/a/2')
-        assert '\phi' in L.data
+        assert '\phi' in L.get_data(as_text=True)
 
     def test_bad_red(self):
         r"""
         Check that the elliptic curve/#field tells about its bad reduction primes
         """
         L = self.tc.get('/EllipticCurve/2.2.5.1/31.2/a/3')
-        assert 'Non-split multiplicative' in L.data
+        assert 'Non-split multiplicative' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/2.2.5.1/64.1/a/1')
-        assert 'Additive' in L.data
+        assert 'Additive' in L.get_data(as_text=True)
 
     def test_weierstrass(self):
         r"""
         Check that the elliptic curve/#field tells about its Weirstrass eqn
         """
         L = self.tc.get('/EllipticCurve/2.0.4.1/225.2/a/2')
-        assert '396' in L.data
-        assert '2982' in L.data
+        assert '396' in L.get_data(as_text=True)
+        assert '2982' in L.get_data(as_text=True)
 
     def test_conductor(self):
         r"""
         Check that the elliptic curve/#field tells about its conductor and disciminant
         """
         L = self.tc.get('/EllipticCurve/2.0.7.1/10000.5/a/1')
-        assert '10000' in L.data
-        assert '15625000000000000' in L.data
-        assert '87890625' in L.data
-        assert '25^{9}' in L.data
-        assert '12' in L.data
+        assert '10000' in L.get_data(as_text=True)
+        assert '15625000000000000' in L.get_data(as_text=True)
+        assert '87890625' in L.get_data(as_text=True)
+        assert '25^{9}' in L.get_data(as_text=True)
+        assert '12' in L.get_data(as_text=True)
 
     def test_j(self):
         r"""
         Check that the elliptic curve/#field tells about its j invariant
         """
         L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
-        assert '226834389543384' in L.data
-        assert '1490902050625' in L.data
+        assert '226834389543384' in L.get_data(as_text=True)
+        assert '1490902050625' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1') # Test factorisation
-        assert '8798344145175011328000' in L.data
+        assert '8798344145175011328000' in L.get_data(as_text=True)
 
     def test_download(self):
         r"""
         Check that the code download links work
         """
         L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
-        assert 'Code to Magma' in L.data
-        assert 'Code to SageMath' in L.data
-        assert 'Code to GP' in L.data
+        assert 'Code to Magma' in L.get_data(as_text=True)
+        assert 'Code to SageMath' in L.get_data(as_text=True)
+        assert 'Code to GP' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/magma')
-        assert 'Magma code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
+        assert 'Magma code for working with elliptic curve 2.2.89.1-81.1-a1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/sage')
-        assert 'SageMath code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
+        assert 'SageMath code for working with elliptic curve 2.2.89.1-81.1-a1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/gp')
-        assert 'Pari/GP code for working with elliptic curve 2.2.89.1-81.1-a1' in L.data
+        assert 'Pari/GP code for working with elliptic curve 2.2.89.1-81.1-a1' in L.get_data(as_text=True)
 
     def test_search(self):
         r"""
@@ -83,27 +83,27 @@ class EllCurveTest(LmfdbTest):
         """
         # Conductor 1
         L = self.tc.get('/EllipticCurve/?start=0&count=50&conductor_norm=1&include_isogenous=on&include_base_change=on')
-        assert '2115 a - 13286543' in L.data
+        assert '2115 a - 13286543' in L.get_data(as_text=True)
         # 4*4 torsion
         L = self.tc.get('/EllipticCurve/?start=0&count=50&include_isogenous=on&include_base_change=on&torsion=&torsion_structure=[4%2C4]')
-        assert '/EllipticCurve/2.0.4.1/5525.5/b/9' in L.data
+        assert '/EllipticCurve/2.0.4.1/5525.5/b/9' in L.get_data(as_text=True)
         # 13 torsion
         L = self.tc.get('/EllipticCurve/?torsion=13')
-        assert '2745' in L.data
-        assert '3.3.49.1' in L.data
+        assert '2745' in L.get_data(as_text=True)
+        assert '3.3.49.1' in L.get_data(as_text=True)
         #field (see what I did here?)
         L = self.tc.get('/EllipticCurve/?field=Qsqrt-11&include_base_change=on&conductor_norm=&include_isogenous=on&torsion=&torsion_structure=&count=')
-        assert '2.0.11.1' in L.data
-        assert '1681' in L.data
+        assert '2.0.11.1' in L.get_data(as_text=True)
+        assert '1681' in L.get_data(as_text=True)
 
     def test_isodeg(self):
         r"""
         Test that searching for isogeny degree works
         """
         L = self.tc.get('/EllipticCurve/?start=0&isodeg=2')
-        assert '27.2-a4' in L.data
+        assert '27.2-a4' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/?start=0&torsion=1&isodeg=2')
-        assert 'No matches' in L.data
+        assert 'No matches' in L.get_data(as_text=True)
 
     def test_related_objects(self):
         for url, text in [('/EllipticCurve/2.0.8.1/324.3/a/1',

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -127,7 +127,7 @@ class EllCurveTest(LmfdbTest):
                      'Isogeny class 2.2.44.1-16.1-a',
                      'Isogeny class 2.2.44.1-16.1-c',
                      'L-function'])]:
-            L = self.tc.get(url).data
+            L = self.tc.get(url).get_data(as_text=True)
             for t in text:
                 assert t in L
 

--- a/lmfdb/ecnf/test_isog_class.py
+++ b/lmfdb/ecnf/test_isog_class.py
@@ -9,7 +9,7 @@ class EcnfIsogClassTest(LmfdbTest):
         r"""
         Check rendering of title name and base field of ECNF isogeny class.
         """
-        L = self.tc.get('/EllipticCurve/2.0.7.1/16.1/CMa/').data
+        L = self.tc.get('/EllipticCurve/2.0.7.1/16.1/CMa/').get_data(as_text=True)
         assert 'Elliptic curves in class 16.1-CMa' in L
         assert 'minimal polynomial' in L
 
@@ -17,21 +17,21 @@ class EcnfIsogClassTest(LmfdbTest):
         r"""
         Check curve in ECNF isogeny class by label.
         """
-        L = self.tc.get('/EllipticCurve/2.0.3.1/2268.1/a/').data
+        L = self.tc.get('/EllipticCurve/2.0.3.1/2268.1/a/').get_data(as_text=True)
         assert '2268.1-a5' in L
 
     def test_ecnf_weiercoeffs_in_isgclass(self):
         r"""
         Check curve in ECNF isogeny class by Weierstrass coefficients.
         """
-        L = self.tc.get('/EllipticCurve/2.2.497.1/4.1/c/').data
+        L = self.tc.get('/EllipticCurve/2.2.497.1/4.1/c/').get_data(as_text=True)
         assert '142456112775' in L
 
     def test_ecnf_isgmatrix_in_ecnf_isgclass(self):
         r"""
         Check isogeny matrix of ECNF isogeny class.
         """
-        L = self.tc.get('/EllipticCurve/2.2.89.1/81.1/a/').data
+        L = self.tc.get('/EllipticCurve/2.2.89.1/81.1/a/').get_data(as_text=True)
         assert '267' in L
         assert '89' in L
 
@@ -39,15 +39,15 @@ class EcnfIsogClassTest(LmfdbTest):
         r"""
         Check related object (near Properties box) of an ECNF isogeny class.
         """
-        L = self.tc.get('/EllipticCurve/2.2.5.1/31.1/a/').data
+        L = self.tc.get('/EllipticCurve/2.2.5.1/31.1/a/').get_data(as_text=True)
         assert 'Hilbert modular form 2.2.5.1-31.1-a' in L
 
-        L = self.tc.get('/EllipticCurve/2.2.8.1/9.1/a/').data
+        L = self.tc.get('/EllipticCurve/2.2.8.1/9.1/a/').get_data(as_text=True)
         assert 'Hilbert modular form 2.2.8.1-9.1-a' in L
         assert 'Isogeny class 576.a' in L
         assert 'Modular form 24.2.d.a' in L
 
-        L = self.tc.get('/EllipticCurve/2.0.11.1/256.1/b/').data
+        L = self.tc.get('/EllipticCurve/2.0.11.1/256.1/b/').get_data(as_text=True)
         assert 'Bianchi modular form 2.0.11.1-256.1-a' in L
         assert 'Bianchi modular form 2.0.11.1-256.1-b' in L
         assert 'Hilbert modular form 2.2.44.1-16.1-a' in L

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -4,10 +4,10 @@ class HomePageTest(LmfdbTest):
 
     def check(self, homepage, path, text):
         assert path in homepage
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def check_args(self, path, text):
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
 
     def check_args_with_timeout(self, path, text):

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -12,7 +12,7 @@ class HomePageTest(LmfdbTest):
 
     def check_args_with_timeout(self, path, text):
         timeout_error = 'The search query took longer than expected!'
-        data = self.tc.get(path, follow_redirects=True).data
+        data = self.tc.get(path, follow_redirects=True).get_data(as_text=True)
         assert (text in data) or (timeout_error in data)
 
     # All tests should pass
@@ -22,7 +22,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the elliptic curve/Q search & browse page works.
         """
-        homepage = self.tc.get("/EllipticCurve/Q/").data
+        homepage = self.tc.get("/EllipticCurve/Q/").get_data(as_text=True)
         assert 'Find a specific curve' in homepage
 
     #
@@ -31,7 +31,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the link to the stats page works.
         """
-        homepage = self.tc.get("/EllipticCurve/Q/").data
+        homepage = self.tc.get("/EllipticCurve/Q/").get_data(as_text=True)
         self.check(homepage, "/EllipticCurve/Q/stats",
                    'Distribution of rank')
 
@@ -41,7 +41,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the link to a random curve works.
         """
-        homepage = self.tc.get("/EllipticCurve/Q/").data
+        homepage = self.tc.get("/EllipticCurve/Q/").get_data(as_text=True)
         self.check(homepage, "/EllipticCurve/Q/random",
                    'Minimal Weierstrass equation')
 
@@ -51,7 +51,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the browsing links work.
         """
-        homepage = self.tc.get("/EllipticCurve/Q/").data
+        homepage = self.tc.get("/EllipticCurve/Q/").get_data(as_text=True)
         t = "?conductor=100-999"
         assert t in homepage
         self.check_args("/EllipticCurve/Q/%s" % t,

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -13,56 +13,56 @@ class EllCurveTest(LmfdbTest):
     #
     def test_int_points(self):
         L = self.tc.get('/EllipticCurve/Q/234446/a/1')
-        assert '4532, 302803' in L.data
+        assert '4532, 302803' in L.get_data(as_text=True)
 
     def test_by_curve_label(self):
         L = self.tc.get('/EllipticCurve/Q/400/e/3')
-        assert '15, 50' in L.data
+        assert '15, 50' in L.get_data(as_text=True)
 
     def test_by_iso_label(self):
         L = self.tc.get('/EllipticCurve/Q/12350/s/')
-        assert '[1, -1, 1, -3655, -83403]' in L.data
+        assert '[1, -1, 1, -3655, -83403]' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/12350/s')
-        assert 'You should be redirected automatically to target URL:' in L.data
-        assert '/EllipticCurve/Q/12350/s/' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.get_data(as_text=True)
+        assert '/EllipticCurve/Q/12350/s/' in L.get_data(as_text=True)
 
     def test_Cremona_label_mal(self):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class', follow_redirects=True)
-        assert '12qx' in L.data and 'does not define a recognised elliptic curve' in L.data
+        assert '12qx' in L.get_data(as_text=True) and 'does not define a recognised elliptic curve' in L.data
 
     def test_missing_curve(self):
         L = self.tc.get('/EllipticCurve/Q/13.a1', follow_redirects=True)
-        assert '13.a1' in L.data and 'No curve' in L.data
+        assert '13.a1' in L.get_data(as_text=True) and 'No curve' in L.data
         L = self.tc.get('/EllipticCurve/Q/13a1', follow_redirects=True)
-        assert '13a1' in L.data and 'No curve' in L.data
+        assert '13a1' in L.get_data(as_text=True) and 'No curve' in L.data
 
     def test_Cond_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert '[0, 1, 0, -2133408, 1198675188]' in L.data
+        assert '[0, 1, 0, -2133408, 1198675188]' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/210/')
-        assert '[1, 0, 0, 729, -176985]' in L.data
+        assert '[1, 0, 0, 729, -176985]' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/210')
-        assert 'You should be redirected automatically to target URL:' in L.data
-        assert '/EllipticCurve/Q/210/' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.get_data(as_text=True)
+        assert '/EllipticCurve/Q/210/' in L.get_data(as_text=True)
 
     def test_Weierstrass_search(self):
         L = self.tc.get('/EllipticCurve/Q/[1,2,3,4,5]')
-        assert 'You should be redirected automatically to target URL:' in L.data
-        assert '/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/' in L.data
+        assert 'You should be redirected automatically to target URL:' in L.get_data(as_text=True)
+        assert '/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/' in L.get_data(as_text=True)
 
     def test_j_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2000&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert '41616.bi2' in L.data
+        assert '41616.bi2' in L.get_data(as_text=True)
 
     def test_jbad_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2.3&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert 'Error' in L.data
-        assert 'rational number' in L.data
+        assert 'Error' in L.get_data(as_text=True)
+        assert 'rational number' in L.get_data(as_text=True)
 
     def test_tors_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=[7]&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert '858.k1' in L.data
-        assert '[1, -1, 1, 9588, 2333199]' in L.data
+        assert '858.k1' in L.get_data(as_text=True)
+        assert '[1, -1, 1, 9588, 2333199]' in L.get_data(as_text=True)
 
     def test_SurjPrimes_search(self):
         self.check_args_with_timeout('/EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=2&surj_quantifier=include&nonsurj_primes=&count=100', '[0, 0, 1, -270, -1708]');
@@ -72,58 +72,58 @@ class EllCurveTest(LmfdbTest):
 
     def test_BadPrimes_search(self):
         L = self.tc.get('/EllipticCurve/Q/?bad_quantifier=include&bad_primes=3%2C5')
-        assert '15.a1' in L.data
-        assert '30.a1' in L.data
-        assert not('11.a1' in L.data)
+        assert '15.a1' in L.get_data(as_text=True)
+        assert '30.a1' in L.get_data(as_text=True)
+        assert not('11.a1' in L.get_data(as_text=True))
         L = self.tc.get('/EllipticCurve/Q/?bad_quantifier=exclude&bad_primes=3%2C5')
-        assert not('15.a1' in L.data)
-        assert not('30.a1' in L.data)
-        assert '11.a1' in L.data
+        assert not('15.a1' in L.get_data(as_text=True))
+        assert not('30.a1' in L.get_data(as_text=True))
+        assert '11.a1' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/?bad_quantifier=exactly&bad_primes=3%2C5')
-        assert '15.a1' in L.data
-        assert not('30.a1' in L.data)
-        assert not('11.a1' in L.data)
+        assert '15.a1' in L.get_data(as_text=True)
+        assert not('30.a1' in L.get_data(as_text=True))
+        assert not('11.a1' in L.get_data(as_text=True))
 
     def test_num_int_pts_search(self):
         L = self.tc.get('/EllipticCurve/Q/?num_int_pts=1')
-        assert '14.a2' in L.data
-        assert not('11.a1' in L.data)
+        assert '14.a2' in L.get_data(as_text=True)
+        assert not('11.a1' in L.get_data(as_text=True))
 
     def test_isogeny_class(self):
         L = self.tc.get('/EllipticCurve/Q/11/a/')
-        assert '[0, -1, 1, 0, 0]' in L.data
+        assert '[0, -1, 1, 0, 0]' in L.get_data(as_text=True)
 
     def test_dl_qexp(self):
         L = self.tc.get('/EllipticCurve/Q/download_qexp/66.c3/100')
-        assert '0,1,1,1,1,-4,1,-2,1,1,-4,1,1,4,-2,-4,1,-2,1,0,-4,-2,1,-6,1,11,4,1,-2,10,-4,-8,1,1,-2,8,1,-2,0,4,-4,2,-2,4,1,-4,-6,-2,1,-3,11,-2,4,4,1,-4,-2,0,10,0,-4,-8,-8,-2,1,-16,1,-12,-2,-6,8,2,1,-6,-2,11,0,-2,4,10,-4,1,2,4,-2,8,4,10,1,10,-4,-8,-6,-8,-2,0,1,-2,-3,1,11' in L.data
+        assert '0,1,1,1,1,-4,1,-2,1,1,-4,1,1,4,-2,-4,1,-2,1,0,-4,-2,1,-6,1,11,4,1,-2,10,-4,-8,1,1,-2,8,1,-2,0,4,-4,2,-2,4,1,-4,-6,-2,1,-3,11,-2,4,4,1,-4,-2,0,10,0,-4,-8,-8,-2,1,-16,1,-12,-2,-6,8,2,1,-6,-2,11,0,-2,4,10,-4,1,2,4,-2,8,4,10,1,10,-4,-8,-6,-8,-2,0,1,-2,-3,1,11' in L.get_data(as_text=True)
 
     def test_dl_all(self):
         L = self.tc.get('/EllipticCurve/Q/download_all/26.b2')
-        assert '[1, -1, 1, -3, 3]' in L.data
+        assert '[1, -1, 1, -3, 3]' in L.get_data(as_text=True)
 
     def test_sha(self):
         L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=2&torsion=&torsion_structure=&sha=2-&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert '[0, 1, 0, -73824640, -244170894880]' in L.data
-        assert '226920.h1' in L.data
+        assert '[0, 1, 0, -73824640, -244170894880]' in L.get_data(as_text=True)
+        assert '226920.h1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=81&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert '101592.p1' in L.data
+        assert '101592.p1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=8.999&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
-        assert 'Error' in L.data
+        assert 'Error' in L.get_data(as_text=True)
 
     def test_disc_factor(self):
         """
         Test for factorization of large discriminants
         """
         L = self.tc.get('/EllipticCurve/Q/26569/a/1')
-        assert r'\(-1 \cdot 163^{9} \)' in L.data
+        assert r'\(-1 \cdot 163^{9} \)' in L.get_data(as_text=True)
 
     def test_torsion_growth(self):
         """
         Test for torsion growth data
         """
         L = self.tc.get('/EllipticCurve/Q/392/c/1')
-        assert ' is strictly larger than ' in L.data
-        assert '<a href=/EllipticCurve/3.3.49.1/512.1/e/3>3.3.49.1-512.1-e3</a>' in L.data
+        assert ' is strictly larger than ' in L.get_data(as_text=True)
+        assert '<a href=/EllipticCurve/3.3.49.1/512.1/e/3>3.3.49.1-512.1-e3</a>' in L.get_data(as_text=True)
 
     def test_990h(self):
         """
@@ -139,11 +139,11 @@ class EllCurveTest(LmfdbTest):
           '1728</td>',
           '<td>\(\Gamma_0(N)\)-optimal</td>'
         ])
-        self.assertTrue(row in L.data,
+        self.assertTrue(row in L.get_data(as_text=True),
                         "990.i appears to have the wrong optimal curve.")
 
         L = self.tc.get('EllipticCurve/Q/990h/')
         #print row
         #print L.data
-        self.assertTrue(row in L.data,
+        self.assertTrue(row in L.get_data(as_text=True),
                         "990h appears to have the wrong optimal curve.")

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -28,13 +28,13 @@ class EllCurveTest(LmfdbTest):
 
     def test_Cremona_label_mal(self):
         L = self.tc.get('/EllipticCurve/Q/?label=Cremona%3A12qx&jump=label+or+isogeny+class', follow_redirects=True)
-        assert '12qx' in L.get_data(as_text=True) and 'does not define a recognised elliptic curve' in L.data
+        assert '12qx' in L.get_data(as_text=True) and 'does not define a recognised elliptic curve' in L.get_data(as_text=True)
 
     def test_missing_curve(self):
         L = self.tc.get('/EllipticCurve/Q/13.a1', follow_redirects=True)
-        assert '13.a1' in L.get_data(as_text=True) and 'No curve' in L.data
+        assert '13.a1' in L.get_data(as_text=True) and 'No curve' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/13a1', follow_redirects=True)
-        assert '13a1' in L.get_data(as_text=True) and 'No curve' in L.data
+        assert '13a1' in L.get_data(as_text=True) and 'No curve' in L.get_data(as_text=True)
 
     def test_Cond_search(self):
         L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -144,6 +144,6 @@ class EllCurveTest(LmfdbTest):
 
         L = self.tc.get('EllipticCurve/Q/990h/')
         #print row
-        #print L.data
+        #print L.get_data(as_text=True)
         self.assertTrue(row in L.get_data(as_text=True),
                         "990h appears to have the wrong optimal curve.")

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -6,7 +6,7 @@ class EllCurveTest(LmfdbTest):
 
     def check_args_with_timeout(self, path, text):
         timeout_error = 'The search query took longer than expected!'
-        data = self.tc.get(path, follow_redirects=True).data
+        data = self.tc.get(path, follow_redirects=True).get_data(as_text=True)
         assert (text in data) or (timeout_error in data)
 
     # All tests should pass

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -8,37 +8,37 @@ class GalGpTest(LmfdbTest):
     #
     def test_search_deg(self):
         L = self.tc.get('/GaloisGroup/?start=0&parity=0&cyc=0&solv=0&prim=0&n=7&t=&count=50')
-        assert 'all 7 matches' in L.data
+        assert 'all 7 matches' in L.get_data(as_text=True)
 
     def test_search_t_solv_prim(self):
         L = self.tc.get('/GaloisGroup/?start=0&parity=-1&cyc=0&solv=1&prim=-1&n=&t=18&count=50')
-        assert '14T18' in L.data
-        assert '294' in L.data # order of 21T18
+        assert '14T18' in L.get_data(as_text=True)
+        assert '294' in L.get_data(as_text=True) # order of 21T18
 
     def test_display_bigpage(self):
         L = self.tc.get('/GaloisGroup/22T29')
-        assert '22528' in L.data # order of 22T29
+        assert '22528' in L.get_data(as_text=True) # order of 22T29
 
     def test_search_range(self):
         L = self.tc.get('GaloisGroup/?start=0&parity=0&cyc=0&solv=0&prim=0&n=8-11&t=3-5&count=50')
-        assert '8T3' in L.data
-        assert '660' in L.data # order of 11T5
+        assert '8T3' in L.get_data(as_text=True)
+        assert '660' in L.get_data(as_text=True) # order of 11T5
 
     def test_search_order(self):
         L = self.tc.get('GaloisGroup/?order=18')
-        assert '9T5' in L.data
-        assert 'all 9 matches' in L.data
+        assert '9T5' in L.get_data(as_text=True)
+        assert 'all 9 matches' in L.get_data(as_text=True)
 
     def test_search_gapid(self):
         L = self.tc.get('GaloisGroup/?gapid=[60,5]')
-        assert '20T15' in L.data
-        assert '15T5' in L.data
+        assert '20T15' in L.get_data(as_text=True)
+        assert '15T5' in L.get_data(as_text=True)
 
     def test_bad_jump(self):
         L = self.tc.get('/GaloisGroup/notagroup', follow_redirects=True)
-        assert 'not a valid label for a Galois group' in L.data
+        assert 'not a valid label for a Galois group' in L.get_data(as_text=True)
 
     def test_bad_out_of_range(self):
         L = self.tc.get('/GaloisGroup/12345T678', follow_redirects=True)
-        assert 'was not found in the database' in L.data
+        assert 'was not found in the database' in L.get_data(as_text=True)
 

--- a/lmfdb/genus2_curves/g2c_test_pages.py
+++ b/lmfdb/genus2_curves/g2c_test_pages.py
@@ -17,7 +17,7 @@ class Genus2Test(LmfdbTest):
             try:
                 n = n+1
                 page = self.tc.get(url, follow_redirects=True)
-                assert c['label'] in page.data
+                assert c['label'] in page.get_data(as_text=True)
             except:
                 print("Internal server error on page " + url)
                 errors.append(url)
@@ -27,7 +27,7 @@ class Genus2Test(LmfdbTest):
             try:
                 n = n+1
                 page = self.tc.get(url, follow_redirects=True)
-                assert c['label'] in page.data
+                assert c['label'] in page.get_data(as_text=True)
             except:
                 print("Internal server error on page "+url)
                 errors.append(url)

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -282,7 +282,7 @@ class Genus2Test(LmfdbTest):
                         'Hilbert modular form 2.2.8.1-9.1-a',)
                     )
                 ]:
-            data = self.tc.get(url).data
+            data = self.tc.get(url).get_data(as_text=True)
             for friend in friends:
                 assert friend in data
 

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -6,7 +6,7 @@ class Genus2Test(LmfdbTest):
     # All tests should pass
     def test_stats(self):
         L = self.tc.get('/Genus2Curve/Q/stats')
-        assert 'Sato-Tate groups' in L.get_data(as_text=True) and 'proportion' in L.data
+        assert 'Sato-Tate groups' in L.get_data(as_text=True) and 'proportion' in L.get_data(as_text=True)
 
     def test_cond_range(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=100000-1000000')
@@ -18,19 +18,19 @@ class Genus2Test(LmfdbTest):
 
     def test_by_curve_label(self):
         L = self.tc.get('/Genus2Curve/Q/169.a.169.1',follow_redirects=True)
-        assert 'square of' in L.get_data(as_text=True) and 'E_6' in L.data
+        assert 'square of' in L.get_data(as_text=True) and 'E_6' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/1152.a.147456.1',follow_redirects=True)
-        assert 'non-isogenous elliptic curves' in L.get_data(as_text=True) and '24.a5' in L.data and '48.a5' in L.data
+        assert 'non-isogenous elliptic curves' in L.get_data(as_text=True) and '24.a5' in L.get_data(as_text=True) and '48.a5' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/15360.f.983040.2',follow_redirects=True)
-        assert 'N(G_{1,3})' in L.get_data(as_text=True) and '480.b3' in L.data and '32.a3' in L.data
+        assert 'N(G_{1,3})' in L.get_data(as_text=True) and '480.b3' in L.get_data(as_text=True) and '32.a3' in L.get_data(as_text=True)
 
     def test_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/1369/a/')
-        assert '1369.1' in L.get_data(as_text=True) and '50653.1' in L.data and 'G_{3,3}' in L.data
+        assert '1369.1' in L.get_data(as_text=True) and '50653.1' in L.get_data(as_text=True) and 'G_{3,3}' in L.get_data(as_text=True)
 
     def test_Lfunction_link(self):
         L = self.tc.get('/L/Genus2Curve/Q/1369/a',follow_redirects=True)
-        assert 'G_{3,3}' in L.get_data(as_text=True) and 'Motivic weight' in L.data
+        assert 'G_{3,3}' in L.get_data(as_text=True) and 'Motivic weight' in L.get_data(as_text=True)
 
     def test_twist_link(self):
         L = self.tc.get('/Genus2Curve/Q/?g22=1016576&g20=5071050752/9&g21=195344320/9')
@@ -51,22 +51,22 @@ class Genus2Test(LmfdbTest):
     def test_by_url_curve_label(self):
         # Two elliptic curve factors and decomposing endomorphism algebra:
         L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
-        assert '32.a1' in L.get_data(as_text=True) and '34.a3' in L.data
+        assert '32.a1' in L.get_data(as_text=True) and '34.a3' in L.get_data(as_text=True)
         # RM curve:
         L = self.tc.get('/Genus2Curve/Q/17689/e/866761/1')
-        assert ('simple' in L.get_data(as_text=True) or 'Simple' in L.data) and 'G_{3,3}' in L.data
+        assert ('simple' in L.get_data(as_text=True) or 'Simple' in L.get_data(as_text=True)) and 'G_{3,3}' in L.get_data(as_text=True)
         # QM curve:
         L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
-        assert 'quaternion algebra' in L.get_data(as_text=True) and 'J(E_2)' in L.data
+        assert 'quaternion algebra' in L.get_data(as_text=True) and 'J(E_2)' in L.get_data(as_text=True)
         L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
         # Square over a quadratic extension that is CM over one extension and
         # multiplication by a quaternion algebra ramifying at infinity over another
         assert 'square of' in L.get_data(as_text=True) and '2.2.8.1-64.1-a3'\
-            in L.data and r'\H' in L.data and '(CM)' in L.data
+            in L.get_data(as_text=True) and r'\H' in L.get_data(as_text=True) and '(CM)' in L.get_data(as_text=True)
 
     def test_by_url_isogeny_class_discriminant(self):
         L = self.tc.get('/Genus2Curve/Q/15360/f/983040/')
-        assert '15360.f.983040.1' in L.get_data(as_text=True) and '15360.f.983040.2' in L.data and not '15360.d.983040.1' in L.data
+        assert '15360.f.983040.1' in L.get_data(as_text=True) and '15360.f.983040.2' in L.get_data(as_text=True) and not '15360.d.983040.1' in L.get_data(as_text=True)
 
     def test_random(self):
         for i in range(5):
@@ -136,7 +136,7 @@ class Genus2Test(LmfdbTest):
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=3')
         assert 'No matches' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?has_square_sha=False')
-        assert  '336.a.172032.1' in L.get_data(as_text=True) and not '169.a.169.1' in L.data
+        assert  '336.a.172032.1' in L.get_data(as_text=True) and not '169.a.169.1' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?locally_solvable=True&has_square_sha=False')
         assert 'No matches' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=2&has_square_sha=True')
@@ -157,7 +157,7 @@ class Genus2Test(LmfdbTest):
         assert '6.2.1658432.2' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/969306/a/969306/1')
         assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.get_data(as_text=True)
-        assert '16y' in L.get_data(as_text=True) and '2xz^2 + 11z^3' in L.data
+        assert '16y' in L.get_data(as_text=True) and '2xz^2 + 11z^3' in L.get_data(as_text=True)
         assert '3.259671' in L.get_data(as_text=True)
         assert '\\infty' in L.get_data(as_text=True)
         assert 'D_4\\times C_2' in L.get_data(as_text=True)

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -6,80 +6,80 @@ class Genus2Test(LmfdbTest):
     # All tests should pass
     def test_stats(self):
         L = self.tc.get('/Genus2Curve/Q/stats')
-        assert 'Sato-Tate groups' in L.data and 'proportion' in L.data
+        assert 'Sato-Tate groups' in L.get_data(as_text=True) and 'proportion' in L.data
 
     def test_cond_range(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=100000-1000000')
-        assert '100000.a.200000.1' in L.data
+        assert '100000.a.200000.1' in L.get_data(as_text=True)
 
     def test_disc_range(self):
         L = self.tc.get('/Genus2Curve/Q/?abs_disc=100000-1000000')
-        assert '336.a.172032.1' in L.data
+        assert '336.a.172032.1' in L.get_data(as_text=True)
 
     def test_by_curve_label(self):
         L = self.tc.get('/Genus2Curve/Q/169.a.169.1',follow_redirects=True)
-        assert 'square of' in L.data and 'E_6' in L.data
+        assert 'square of' in L.get_data(as_text=True) and 'E_6' in L.data
         L = self.tc.get('/Genus2Curve/Q/1152.a.147456.1',follow_redirects=True)
-        assert 'non-isogenous elliptic curves' in L.data and '24.a5' in L.data and '48.a5' in L.data
+        assert 'non-isogenous elliptic curves' in L.get_data(as_text=True) and '24.a5' in L.data and '48.a5' in L.data
         L = self.tc.get('/Genus2Curve/Q/15360.f.983040.2',follow_redirects=True)
-        assert 'N(G_{1,3})' in L.data and '480.b3' in L.data and '32.a3' in L.data
+        assert 'N(G_{1,3})' in L.get_data(as_text=True) and '480.b3' in L.data and '32.a3' in L.data
 
     def test_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/1369/a/')
-        assert '1369.1' in L.data and '50653.1' in L.data and 'G_{3,3}' in L.data
+        assert '1369.1' in L.get_data(as_text=True) and '50653.1' in L.data and 'G_{3,3}' in L.data
 
     def test_Lfunction_link(self):
         L = self.tc.get('/L/Genus2Curve/Q/1369/a',follow_redirects=True)
-        assert 'G_{3,3}' in L.data and 'Motivic weight' in L.data
+        assert 'G_{3,3}' in L.get_data(as_text=True) and 'Motivic weight' in L.data
 
     def test_twist_link(self):
         L = self.tc.get('/Genus2Curve/Q/?g22=1016576&g20=5071050752/9&g21=195344320/9')
         for label in ['576.b.147456.1', '1152.a.147456.1', '2304.b.147456.1', '4608.a.4608.1','4608.b.4608.1']:
-            assert label in L.data
+            assert label in L.get_data(as_text=True)
 
     def test_by_conductor(self):
         L = self.tc.get('/Genus2Curve/Q/15360/')
         for x in "abcdefghij":
-            assert "15360."+x in L.data
+            assert "15360."+x in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/15360/?abs_disc=169')
-        assert 'No matches' in L.data
+        assert 'No matches' in L.get_data(as_text=True)
 
     def test_by_url_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/336/a/')
-        assert '336.a.172032.1' in L.data
+        assert '336.a.172032.1' in L.get_data(as_text=True)
 
     def test_by_url_curve_label(self):
         # Two elliptic curve factors and decomposing endomorphism algebra:
         L = self.tc.get('/Genus2Curve/Q/1088/b/2176/1')
-        assert '32.a1' in L.data and '34.a3' in L.data
+        assert '32.a1' in L.get_data(as_text=True) and '34.a3' in L.data
         # RM curve:
         L = self.tc.get('/Genus2Curve/Q/17689/e/866761/1')
-        assert ('simple' in L.data or 'Simple' in L.data) and 'G_{3,3}' in L.data
+        assert ('simple' in L.get_data(as_text=True) or 'Simple' in L.data) and 'G_{3,3}' in L.data
         # QM curve:
         L = self.tc.get('Genus2Curve/Q/262144/d/524288/1')
-        assert 'quaternion algebra' in L.data and 'J(E_2)' in L.data
+        assert 'quaternion algebra' in L.get_data(as_text=True) and 'J(E_2)' in L.data
         L = self.tc.get('Genus2Curve/Q/4096/b/65536/1')
         # Square over a quadratic extension that is CM over one extension and
         # multiplication by a quaternion algebra ramifying at infinity over another
-        assert 'square of' in L.data and '2.2.8.1-64.1-a3'\
+        assert 'square of' in L.get_data(as_text=True) and '2.2.8.1-64.1-a3'\
             in L.data and r'\H' in L.data and '(CM)' in L.data
 
     def test_by_url_isogeny_class_discriminant(self):
         L = self.tc.get('/Genus2Curve/Q/15360/f/983040/')
-        assert '15360.f.983040.1' in L.data and '15360.f.983040.2' in L.data and not '15360.d.983040.1' in L.data
+        assert '15360.f.983040.1' in L.get_data(as_text=True) and '15360.f.983040.2' in L.data and not '15360.d.983040.1' in L.data
 
     def test_random(self):
         for i in range(5):
             L = self.tc.get('/Genus2Curve/Q/random',follow_redirects=True)
-            assert 'Sato-Tate group' in L.data
+            assert 'Sato-Tate group' in L.get_data(as_text=True)
 
     def test_conductor_search(self):
         L = self.tc.get('/Genus2Curve/Q/?cond=1225')
-        assert '1225.a.6125.1' in L.data
+        assert '1225.a.6125.1' in L.get_data(as_text=True)
 
     def test_disc_search(self):
         L = self.tc.get('/Genus2Curve/Q/?abs_disc=3976')
-        assert '1988.a.3976.1' in L.data
+        assert '1988.a.3976.1' in L.get_data(as_text=True)
 
     def test_download(self):
         self.tc.get("/Genus2Curve/Q/?query={'abs_disc':3976}&download=gp")
@@ -88,118 +88,118 @@ class Genus2Test(LmfdbTest):
 
     def test_rational_weierstrass_points_search(self):
         L = self.tc.get('/Genus2Curve/Q/?num_rat_wpts=4')
-        assert '360.a.6480.1' in L.data
+        assert '360.a.6480.1' in L.get_data(as_text=True)
 
     def test_torsion_search(self):
         L = self.tc.get('/Genus2Curve/Q/?torsion=[2,2,2]')
-        assert '1584.a.684288.1' in L.data
+        assert '1584.a.684288.1' in L.get_data(as_text=True)
 
     def test_torsion_order_search(self):
         L = self.tc.get('/Genus2Curve/Q/?torsion_order=39')
-        assert '1116.a.214272.1' in L.data
+        assert '1116.a.214272.1' in L.get_data(as_text=True)
 
     def test_two_selmer_rank_search(self):
         L = self.tc.get('/Genus2Curve/Q/?two_selmer_rank=6')
-        assert '65520.b.131040.1' in L.data
+        assert '65520.b.131040.1' in L.get_data(as_text=True)
 
     def test_analytic_rank_search(self):
         L = self.tc.get('/Genus2Curve/Q/?analytic_rank=4')
-        assert '440509.a.440509.1' in L.data
+        assert '440509.a.440509.1' in L.get_data(as_text=True)
 
     def test_gl2_type_search(self):
         L = self.tc.get('/Genus2Curve/Q/?gl2_type=True')
-        assert '169.a.169.1' in L.data
+        assert '169.a.169.1' in L.get_data(as_text=True)
 
     def test_st_group_search(self):
         L = self.tc.get('/Genus2Curve/Q/?st_group=J(E_6)')
-        assert '6075.a.18225.1' in L.data
+        assert '6075.a.18225.1' in L.get_data(as_text=True)
 
     def test_st0_group_search(self):
         L = self.tc.get('/Genus2Curve/Q/?real_geom_end_alg=C x R')
-        assert '448.a.448.1' in L.data
+        assert '448.a.448.1' in L.get_data(as_text=True)
 
     def test_automorphism_group_search(self):
         L = self.tc.get('/Genus2Curve/Q/?aut_grp_id=[12,4]')
-        assert '196.a.21952.1' in L.data
+        assert '196.a.21952.1' in L.get_data(as_text=True)
 
     def test_geometric_automorphism_group_search(self):
         L = self.tc.get('/Genus2Curve/Q/?geom_aut_grp_id=[48,29]')
-        assert '4096.b.65536.1' in L.data
+        assert '4096.b.65536.1' in L.get_data(as_text=True)
 
     def test_locally_solvable_serach(self):
         L = self.tc.get('/Genus2Curve/Q/?locally_solvable=False')
-        assert '336.a.172032.1' in L.data
+        assert '336.a.172032.1' in L.get_data(as_text=True)
 
     def test_sha_search(self):
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=256')
-        assert '114240.d.114240.1' in L.data
+        assert '114240.d.114240.1' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=3')
-        assert 'No matches' in L.data
+        assert 'No matches' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?has_square_sha=False')
-        assert  '336.a.172032.1' in L.data and not '169.a.169.1' in L.data
+        assert  '336.a.172032.1' in L.get_data(as_text=True) and not '169.a.169.1' in L.data
         L = self.tc.get('/Genus2Curve/Q/?locally_solvable=True&has_square_sha=False')
-        assert 'No matches' in L.data
+        assert 'No matches' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=2&has_square_sha=True')
-        assert 'No matches' in L.data
+        assert 'No matches' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?analytic_sha=2&has_square_sha=False')
-        assert '336.a.172032.1' in L.data
+        assert '336.a.172032.1' in L.get_data(as_text=True)
 
     def test_torsion(self):
         L = self.tc.get('/Genus2Curve/Q/976/a/999424/1')
-        assert '\\Z/{29}\\Z' in L.data
+        assert '\\Z/{29}\\Z' in L.get_data(as_text=True)
 
     def test_mwgroup(self):
         L = self.tc.get('/Genus2Curve/Q/25913/a/25913/1')
-        assert "\\Z \\times \\Z \\times \\Z" in L.data
-        assert '-x^3 - z^3' in L.data
-        assert '0.375585' in L.data
-        assert '\\infty' in L.data
-        assert '6.2.1658432.2' in L.data
+        assert "\\Z \\times \\Z \\times \\Z" in L.get_data(as_text=True)
+        assert '-x^3 - z^3' in L.get_data(as_text=True)
+        assert '0.375585' in L.get_data(as_text=True)
+        assert '\\infty' in L.get_data(as_text=True)
+        assert '6.2.1658432.2' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/969306/a/969306/1')
-        assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.data
-        assert '16y' in L.data and '2xz^2 + 11z^3' in L.data
-        assert '3.259671' in L.data
-        assert '\\infty' in L.data
-        assert 'D_4\\times C_2' in L.data
+        assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.get_data(as_text=True)
+        assert '16y' in L.get_data(as_text=True) and '2xz^2 + 11z^3' in L.data
+        assert '3.259671' in L.get_data(as_text=True)
+        assert '\\infty' in L.get_data(as_text=True)
+        assert 'D_4\\times C_2' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/461/a/461/2')
-        assert 'trivial' in L.data
+        assert 'trivial' in L.get_data(as_text=True)
 
     def test_bsd_invariants(self):
         L = self.tc.get('/Genus2Curve/Q/70450/c/704500/1')
-        assert 'upper bound' in L.data
-        assert '0.046457' in L.data
-        assert '16.52129' in L.data
-        assert '0.767540' in L.data
-        assert 'rounded' in L.data
+        assert 'upper bound' in L.get_data(as_text=True)
+        assert '0.046457' in L.get_data(as_text=True)
+        assert '16.52129' in L.get_data(as_text=True)
+        assert '0.767540' in L.get_data(as_text=True)
+        assert 'rounded' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/1253/a/1253/1')
-        assert '0.207463' in L.data
-        assert '0.414927' in L.data
-        assert 'twice a square' in L.data
+        assert '0.207463' in L.get_data(as_text=True)
+        assert '0.414927' in L.get_data(as_text=True)
+        assert 'twice a square' in L.get_data(as_text=True)
 
     def test_local_invariants(self):
         L = self.tc.get('/Genus2Curve/Q/806069/a/806069/1')
-        assert '1 + 5 T + 11 T^{2}' in L.data
-        assert '1 + 2 T + 127 T^{2}' in L.data
-        assert '1 + 22 T + 577 T^{2}' in L.data
+        assert '1 + 5 T + 11 T^{2}' in L.get_data(as_text=True)
+        assert '1 + 2 T + 127 T^{2}' in L.get_data(as_text=True)
+        assert '1 + 22 T + 577 T^{2}' in L.get_data(as_text=True)
 
     def test_mfhilbert(self):
         L = self.tc.get('/Genus2Curve/Q/12500/a/12500/1')
-        assert '2.2.5.1-500.1-a' in L.data
+        assert '2.2.5.1-500.1-a' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/12500/a/')
-        assert '2.2.5.1-500.1-a' in L.data
+        assert '2.2.5.1-500.1-a' in L.get_data(as_text=True)
 
     def test_ratpts(self):
         L = self.tc.get('/Genus2Curve/Q/792079/a/792079/1')
-        assert '(-15 : -6579 : 14)' in L.data
-        assert '(13 : -4732 : 20)' in L.data
+        assert '(-15 : -6579 : 14)' in L.get_data(as_text=True)
+        assert '(13 : -4732 : 20)' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/126746/a/126746/1')
-        assert 'everywhere' in L.data
-        assert 'This curve has no' in L.data
+        assert 'everywhere' in L.get_data(as_text=True)
+        assert 'This curve has no' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/3319/a/3319/1')
-        assert 'Known points' in L.data
+        assert 'Known points' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/14880/c/238080/2')
-        assert 'rational points are known' in L.data
-        assert 'for this curve' in L.data
+        assert 'rational points are known' in L.get_data(as_text=True)
+        assert 'for this curve' in L.get_data(as_text=True)
 
     def test_endo_search(self):
         # first result for every search
@@ -214,44 +214,44 @@ class Genus2Test(LmfdbTest):
                 ('M_2(Q)', '169.a.169.1'),
                 ('M_2(CM)', '2916.b.11664.1')]:
             L = self.tc.get('/Genus2Curve/Q/?geom_end_alg={}'.format(endo))
-            assert text in L.data
+            assert text in L.get_data(as_text=True)
 
     # tests for searching by geometric invariants
     def test_igusa_clebsch_search(self):
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants_type=igusa_clebsch_inv&geometric_invariants=[1824%2C179520%2C140795904%2C207474688]')
-        assert '1369.a.50653.1' in L.data
-        assert '169.a.169.1' not in L.data
+        assert '1369.a.50653.1' in L.get_data(as_text=True)
+        assert '169.a.169.1' not in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants=[1824%2C179520%2C140795904%2C207474688]')
-        assert '1369.a.50653.1' in L.data
-        assert '169.a.169.1' not in L.data
+        assert '1369.a.50653.1' in L.get_data(as_text=True)
+        assert '169.a.169.1' not in L.get_data(as_text=True)
 
     def test_igusa_search(self):
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants_type=igusa_inv&geometric_invariants=[228%2C296%2C-98568%2C-5640280%2C50653]')
-        assert '1369.a.50653.1' in L.data
-        assert '169.a.169.1' not in L.data
+        assert '1369.a.50653.1' in L.get_data(as_text=True)
+        assert '169.a.169.1' not in L.get_data(as_text=True)
 
     def test_G2_search(self):
         L = self.tc.get('/Genus2Curve/Q/?geometric_invariants_type=g2_inv&geometric_invariants=[616132666368%2F50653%2C94818816%2F1369%2C-3742848%2F37]')
-        assert '1369.a.50653.1' in L.data
-        assert '169.a.169.1' not in L.data
+        assert '1369.a.50653.1' in L.get_data(as_text=True)
+        assert '169.a.169.1' not in L.get_data(as_text=True)
 
     def test_badprimes_search(self):
         L = self.tc.get('/Genus2Curve/Q/?bad_quantifier=exactly&bad_primes=2%2C3')
-        assert '324.a.648.1' in L.data
-        assert not('450.a.2700.1' in L.data)
-        assert not('169.a.169.1' in L.data)
+        assert '324.a.648.1' in L.get_data(as_text=True)
+        assert not('450.a.2700.1' in L.get_data(as_text=True))
+        assert not('169.a.169.1' in L.get_data(as_text=True))
         L = self.tc.get('/Genus2Curve/Q/?bad_quantifier=exclude&bad_primes=2%2C3')
-        assert not('324.a.648.1' in L.data)
-        assert not('450.a.2700.1' in L.data)
-        assert '169.a.169.1' in L.data
+        assert not('324.a.648.1' in L.get_data(as_text=True))
+        assert not('450.a.2700.1' in L.get_data(as_text=True))
+        assert '169.a.169.1' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/?bad_quantifier=include&bad_primes=2%2C3')
-        assert '324.a.648.1' in L.data
-        assert '450.a.2700.1' in L.data
-        assert not('169.a.169.1' in L.data)
+        assert '324.a.648.1' in L.get_data(as_text=True)
+        assert '450.a.2700.1' in L.get_data(as_text=True)
+        assert not('169.a.169.1' in L.get_data(as_text=True))
         L = self.tc.get('/Genus2Curve/Q/?bad_primes=2%2C3')
-        assert '324.a.648.1' in L.data
-        assert '450.a.2700.1' in L.data
-        assert not('169.a.169.1' in L.data)
+        assert '324.a.648.1' in L.get_data(as_text=True)
+        assert '450.a.2700.1' in L.get_data(as_text=True)
+        assert not('169.a.169.1' in L.get_data(as_text=True))
                 
     def test_related_objects(self):
         for url, friends in [

--- a/lmfdb/hecke_algebras/test_hecke_algebras.py
+++ b/lmfdb/hecke_algebras/test_hecke_algebras.py
@@ -15,53 +15,53 @@ class HomePageTest(LmfdbTest):
 
     # Hecke algebra browse page
     def test_hecke_algebra(self):
-        homepage = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/").data
+        homepage = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/").get_data(as_text=True)
         assert 'Hecke Algebras' in homepage
         assert '139.2.1' in homepage or "not yet available" in homepage
 
     # Hecke algebra single page
     def test_hecke_algebra_one(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?label=139.2.1").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?label=139.2.1").get_data(as_text=True)
         assert '2145245897' in L 
         assert 'T_{ 4} =\left' in L 
 
     # Hecke algebra l-adic  page
     def test_hecke_algebra_classnumber(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/139.2.1.2/2").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/139.2.1.2/2").get_data(as_text=True)
         assert 'Gorenstein' in L
         assert 'x^3 + x + 1' in L
 
     # Search no orbit
     def test_hecke_algebra_search(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=0&level=&weight=2&num_orbits=2&orbit_label=&ell=&count=50").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=0&level=&weight=2&num_orbits=2&orbit_label=&ell=&count=50").get_data(as_text=True)
         assert '86' in L 
 
     def test_hecke_algebra_search_next(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=50&level=&weight=&num_orbits=5&orbit_label=&ell=&count=50").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=50&level=&weight=&num_orbits=5&orbit_label=&ell=&count=50").get_data(as_text=True)
         assert '222.2.1' in L
         
             
     # Search with l
     def test_hecke_algebra_search_with_l(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=50&level=1-100&weight=&num_orbits=&orbit_label=&ell=2&count=50").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?start=50&level=1-100&weight=&num_orbits=&orbit_label=&ell=2&count=50").get_data(as_text=True)
         assert '17.4.1.1' in L 
             
     # Search orbit   
     def test_hecke_algebra_search_with_orbit(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?level=&weight=&num_orbits=&orbit_label=139.2.1.3&ell=").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?level=&weight=&num_orbits=&orbit_label=139.2.1.3&ell=").get_data(as_text=True)
         assert 'Labels' in L 
         
     def test_hecke_algebra_search_with_orbit_and_l(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?level=&weight=&num_orbits=&orbit_label=139.2.1.3&ell=2").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/?level=&weight=&num_orbits=&orbit_label=139.2.1.3&ell=2").get_data(as_text=True)
         assert 'Number of $\Z_{ 2 }$ orbits' in L 
                      
                      
     # Download Hecke operators
     def test_download_hecke_op(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/9.16.1.5/download/magma/operators").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/9.16.1.5/download/magma/operators").get_data(as_text=True)
         assert '10307091840' in L
             
     # Download idempotents
     def test_download_idempotent(self):
-        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/139.2.1.3/3/2/download/magma/idempotents").data
+        L = self.tc.get("/ModularForm/GL2/Q/HeckeAlgebra/139.2.1.3/3/2/download/magma/idempotents").get_data(as_text=True)
         assert '8504333379429738379' in L

--- a/lmfdb/hecke_algebras/test_hecke_algebras.py
+++ b/lmfdb/hecke_algebras/test_hecke_algebras.py
@@ -6,7 +6,7 @@ class HomePageTest(LmfdbTest):
 
     def check(self,homepage,path,text):
         assert path in homepage
-        assert text in self.tc.get(path).data
+        assert text in self.tc.get(path).get_data(as_text=True)
 
     def check_external(self, homepage, path, text):
         from six.moves.urllib.request import urlopen

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -8,48 +8,48 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
     #
     def test_url_label(self):
         L = self.tc.get('/HigherGenus/C/Aut/2.24-8.0.2-4-6')
-        assert '[ 0; 2, 4, 6 ]' in L.data
+        assert '[ 0; 2, 4, 6 ]' in L.get_data(as_text=True)
 
     def test_passport_label(self):
         L = self.tc.get('/HigherGenus/C/Aut/3.14-2.0.2-7-14.1')
-        assert '(1,8) (2,9) (3,10) (4,11) (5,12) (6,13) (7,14)'  in L.data
+        assert '(1,8) (2,9) (3,10) (4,11) (5,12) (6,13) (7,14)'  in L.get_data(as_text=True)
 
     def test_url_naturallabel(self):
         L = self.tc.get('/HigherGenus/C/Aut/junk',follow_redirects=True)
-        assert 'No family with label' in L.data
+        assert 'No family with label' in L.get_data(as_text=True)
 
     def test_search_genus_group(self):
         L = self.tc.get('/HigherGenus/C/Aut/?genus=2&group=%5B48%2C29%5D&signature=&dim=&hyperelliptic=include&count=20&Submit=Search')
-        assert 'both matches' in L.data
+        assert 'both matches' in L.get_data(as_text=True)
 
     def test_magma_download(self):
         L = self.tc.get('/HigherGenus/C/Aut/5.32-27.0.2-2-2-4.1/download/magma')
-        assert '// Here we add an action to data.' in L.data
+        assert '// Here we add an action to data.' in L.get_data(as_text=True)
 
     def test_full_auto_links(self):
         L = self.tc.get('/HigherGenus/C/Aut/4.9-1.0.9-9-9.1')
-        assert 'Full automorphism 4.18-2.0.2-9-18' in L.data
+        assert 'Full automorphism 4.18-2.0.2-9-18' in L.get_data(as_text=True)
 
     def test_index_page(self):
         L = self.tc.get('/HigherGenus/C/Aut/')
-        assert 'Find specific automorphisms of higher genus curves' in L.data
+        assert 'Find specific automorphisms of higher genus curves' in L.get_data(as_text=True)
 
     def test_stats_page(self):
         L = self.tc.get('/HigherGenus/C/Aut/stats')
-        assert 'unique groups' in L.data
+        assert 'unique groups' in L.get_data(as_text=True)
 
     def test_unique_groups_pages(self):
         L = self.tc.get('/HigherGenus/C/Aut/stats/groups_per_genus/5')
-        assert 'Distribution of groups in curves of genus 5' in L.data
+        assert 'Distribution of groups in curves of genus 5' in L.get_data(as_text=True)
 
     def test_quo_genus_gt_0(self):
         L = self.tc.get('/HigherGenus/C/Aut/3.2-1.2.0.1')
-        assert '[2;-]' in L.data
+        assert '[2;-]' in L.get_data(as_text=True)
 
     def test_quo_genus_search(self):
         L = self.tc.get('/HigherGenus/C/Aut/?genus=3&g0=1..3')
-        assert 'displaying all 10 matches' in L.data
+        assert 'displaying all 10 matches' in L.get_data(as_text=True)
 
     def idG_showing(self):
         L = self.tc.get('/HigherGenus/C/Aut/2.2-1.1.2-2.1')
-        assert 'Id(G)' in L.data
+        assert 'Id(G)' in L.get_data(as_text=True)

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -4,107 +4,107 @@ from lmfdb.tests import LmfdbTest
 class HMFTest(LmfdbTest):
     def test_home(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/')
-        assert 'Hilbert' in L.data
-        assert 'cusp forms' in L.data
-        assert 'modular' in L.data
-        assert 'Browse' in L.data
-        assert 'Search' in L.data
-        assert 'Find' in L.data
-        assert '\sqrt{2}' in L.data #552
+        assert 'Hilbert' in L.get_data(as_text=True)
+        assert 'cusp forms' in L.get_data(as_text=True)
+        assert 'modular' in L.get_data(as_text=True)
+        assert 'Browse' in L.get_data(as_text=True)
+        assert 'Search' in L.get_data(as_text=True)
+        assert 'Find' in L.get_data(as_text=True)
+        assert '\sqrt{2}' in L.get_data(as_text=True) #552
 
     def test_random(self): #993
         L = self.tc.get('/ModularForm/GL2/TotallyReal/random')
-        assert 'edirect' in L.data
+        assert 'edirect' in L.get_data(as_text=True)
 
     def test_EC(self): #778
         L = self.tc.get('ModularForm/GL2/TotallyReal/5.5.126032.1/holomorphic/5.5.126032.1-82.1-b')
-        assert 'EllipticCurve/5.5.126032.1/82.1/b/' in L.data
+        assert 'EllipticCurve/5.5.126032.1/82.1/b/' in L.get_data(as_text=True)
 
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.89.1/holomorphic/2.2.89.1-2.1-a')
-        assert 'Isogeny class' in L.data
-        assert 'EllipticCurve/2.2.89.1/2.1/a' in L.data
+        assert 'Isogeny class' in L.get_data(as_text=True)
+        assert 'EllipticCurve/2.2.89.1/2.1/a' in L.get_data(as_text=True)
 
     def test_typo(self): #771
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=2.2.5.1') 
-        assert 'Search again' in L.data
+        assert 'Search again' in L.get_data(as_text=True)
 
     def test_large(self): #616
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=4.4.2000.1&count=1200')
-        assert '719.2-c' in L.data
+        assert '719.2-c' in L.get_data(as_text=True)
 
     def test_range_search(self): #547
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?disc=1..100&count=100')
-        assert '209.1-b' in L.data
-        assert 'Next' in L.data #435
+        assert '209.1-b' in L.get_data(as_text=True)
+        assert 'Next' in L.get_data(as_text=True) #435
 
     def test_bad_input_search(self): #547
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=hello&count=100')
-        assert 'not a valid input' in L.data
+        assert 'not a valid input' in L.get_data(as_text=True)
 
     def test_search(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?start=0&deg=2..5&disc=60-200&level_norm=40-90&dimension=3..5&count=100')
-        assert '70.1-o' in L.data
+        assert '70.1-o' in L.get_data(as_text=True)
 
 
     def test_search_CM(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?start=0&field_label=&deg=5&disc=&weight=2&level_norm=&dimension=&cm=only&bc=include&count=100')
-        assert '121.1-b' in L.data
+        assert '121.1-b' in L.get_data(as_text=True)
 
     def test_search_base_change(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?start=0&field_label=&deg=5&disc=&cm=include&bc=exclude&count=100')
-        assert '/ModularForm/GL2/TotallyReal/5.5.14641.1/holomorphic/5.5.14641.1-67.5-a' in L.data
+        assert '/ModularForm/GL2/TotallyReal/5.5.14641.1/holomorphic/5.5.14641.1-67.5-a' in L.get_data(as_text=True)
 
     def test_hmf_page(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.73.1/holomorphic/2.2.73.1-48.4-b')
-        assert 'no' in L.data
-        assert '-6' in L.data
-        assert '2w + 10' in L.data
-        assert '\Q' in L.data
-        assert '[2, 2]' in L.data
+        assert 'no' in L.get_data(as_text=True)
+        assert '-6' in L.get_data(as_text=True)
+        assert '2w + 10' in L.get_data(as_text=True)
+        assert '\Q' in L.get_data(as_text=True)
+        assert '[2, 2]' in L.get_data(as_text=True)
 
     def test_hmf_page_higherdim(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.60.1/holomorphic/2.2.60.1-44.1-c')
-        assert '-2w - 4' in L.data
-        assert '2e' in L.data
-        assert 'defining polynomial' in L.data
+        assert '-2w - 4' in L.get_data(as_text=True)
+        assert '2e' in L.get_data(as_text=True)
+        assert 'defining polynomial' in L.get_data(as_text=True)
 
     def test_by_field(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/?field_label=4.4.725.1')
-        assert 'w - 4' in L.data
+        assert 'w - 4' in L.get_data(as_text=True)
 
     def test_download_sage(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/4.4.725.1/holomorphic/4.4.725.1-31.1-a/download/sage')
-        assert 'NN = ZF.ideal([31, 31, w^3 - 4*w + 1])' in L.data
-        assert '[89, 89, 3*w^3 - 2*w^2 - 7*w],\\' in L.data
-        assert 'hecke_eigenvalues_array = [4, -4,' in L.data
+        assert 'NN = ZF.ideal([31, 31, w^3 - 4*w + 1])' in L.get_data(as_text=True)
+        assert '[89, 89, 3*w^3 - 2*w^2 - 7*w],\\' in L.get_data(as_text=True)
+        assert 'hecke_eigenvalues_array = [4, -4,' in L.get_data(as_text=True)
 
     def test_download_magma(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/4.4.725.1/holomorphic/4.4.725.1-31.1-a/download/magma')
-        assert 'NN := ideal<ZF | {31, 31, w^3 - 4*w + 1}>;' in L.data
-        assert '[89, 89, 3*w^3 - 2*w^2 - 7*w],' in L.data
-        assert 'heckeEigenvaluesArray := [4, -4,' in L.data
+        assert 'NN := ideal<ZF | {31, 31, w^3 - 4*w + 1}>;' in L.get_data(as_text=True)
+        assert '[89, 89, 3*w^3 - 2*w^2 - 7*w],' in L.get_data(as_text=True)
+        assert 'heckeEigenvaluesArray := [4, -4,' in L.get_data(as_text=True)
 
     def test_Lfun_link(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a')
-        assert         'L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a' in L.data
+        assert         'L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a' in L.get_data(as_text=True)
 
     def test_browse(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/')
-        assert 'by field degree' in L.data
-        assert 'database contains' in L.data
-        assert 'data is complete up to' in L.data
+        assert 'by field degree' in L.get_data(as_text=True)
+        assert 'database contains' in L.get_data(as_text=True)
+        assert 'data is complete up to' in L.get_data(as_text=True)
 
     def test_browse_by_degree(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/browse/2/')
-        assert 'Number of newforms' in L.data
+        assert 'Number of newforms' in L.get_data(as_text=True)
 
     def test_missing_AL(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/3.3.49.1/holomorphic/3.3.49.1-512.1-a')
-        assert 'The Atkin-Lehner eigenvalues for this form are not in the database' in L.data
+        assert 'The Atkin-Lehner eigenvalues for this form are not in the database' in L.get_data(as_text=True)
 
     def test_level_one_AL(self):
         L = self.tc.get('/ModularForm/GL2/TotallyReal/2.2.173.1/holomorphic/2.2.173.1-1.1-a')
-        assert 'This form has no Atkin-Lehner eigenvalues' in L.data
+        assert 'This form has no Atkin-Lehner eigenvalues' in L.get_data(as_text=True)
 
     def test_friends(self):
         for url, texts, notitself in [
@@ -132,10 +132,10 @@ class HMFTest(LmfdbTest):
                 ]:
             L = self.tc.get(url)
             for t in texts:
-                assert t in L.data
-            assert 'L-function' in L.data
+                assert t in L.get_data(as_text=True)
+            assert 'L-function' in L.get_data(as_text=True)
 
             # this test isn't very specific
             # but the goal is to test that itself doesn't show in the friends list
-            assert notitself not in L.data
+            assert notitself not in L.get_data(as_text=True)
 

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -15,91 +15,91 @@ class HomePageTest(LmfdbTest):
 
     # The Lattice page
     def test_lattice(self):
-        homepage = self.tc.get("/Lattice/").data
+        homepage = self.tc.get("/Lattice/").get_data(as_text=True)
         assert 'random' in homepage
         assert 'Gram' in homepage
 
     def test_lattice_dim(self):
-        L = self.tc.get("/Lattice/9.8.16.1.1").data
+        L = self.tc.get("/Lattice/9.8.16.1.1").get_data(as_text=True)
         assert '115712' in L #coeff in theta series
         assert '1.58740105196819947475170563927' in L #Hermite number
         assert '11612160' in L #group order
 
 
     def test_lattice_classnumber(self):
-        L = self.tc.get("/Lattice/?class_number=1").data
+        L = self.tc.get("/Lattice/?class_number=1").get_data(as_text=True)
         assert '2.13.26.1.2' in L #label (class number 1)
 
     def test_lattice_classnumber_large(self):
-        L = self.tc.get("/Lattice/3.1942.3884.56.13").data
+        L = self.tc.get("/Lattice/3.1942.3884.56.13").get_data(as_text=True)
         assert '648' in L #test display genus representatives
 
     def test_lattice_classnumber_large_download(self):
-        L = self.tc.get("/Lattice/3.1942.3884.56.13/download/sage/genus_reps").data
+        L = self.tc.get("/Lattice/3.1942.3884.56.13/download/sage/genus_reps").get_data(as_text=True)
         assert 'Matrix([[2, 0, 0], [0, 14, -3], [0, -3, 70]]),' in L #test download genus representatives
 
     def test_lattice_search(self):
-        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=&minimum=&class_number=1&aut=&count=50").data
+        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=&minimum=&class_number=1&aut=&count=50").get_data(as_text=True)
         assert '56' in L #search
 
     def test_lattice_search_next(self):
-        L = self.tc.get("/Lattice/?start=50&dim=&det=&level=&gram=&minimum=&class_number=&aut=2&count=50").data
+        L = self.tc.get("/Lattice/?start=50&dim=&det=&level=&gram=&minimum=&class_number=&aut=2&count=50").get_data(as_text=True)
         assert '145' in L #search on the next page
 
     def test_lattice_searchdim(self):
-        L = self.tc.get("/Lattice/?dim=3").data
+        L = self.tc.get("/Lattice/?dim=3").get_data(as_text=True)
         assert '3.1.2.1.1' in L #dimension search
 
     def test_lattice_searchlevel(self):
-        L = self.tc.get("/Lattice/?start=&dim=&det=&level=90&gram=&minimum=&class_number=&aut=").data
+        L = self.tc.get("/Lattice/?start=&dim=&det=&level=90&gram=&minimum=&class_number=&aut=").get_data(as_text=True)
         assert '16' in L #level search
 
     def test_lattice_searchminvectlength(self):
-        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=&minimum=3&class_number=&aut=").data
+        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=&minimum=3&class_number=&aut=").get_data(as_text=True)
         assert '2.42.84.1.3' in L #search minimum vector length
 
     def test_lattice_searchGM(self):
-        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=[17%2C6%2C138]&minimum=&class_number=&aut=").data
+        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=[17%2C6%2C138]&minimum=&class_number=&aut=").get_data(as_text=True)
         assert '4620' in L #gram matrix search
 
     def test_lattice_searchGM_2(self):
-        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=5%2C3%2C2&minimum=&class_number=&aut=").data
+        L = self.tc.get("/Lattice/?dim=&det=&level=&gram=5%2C3%2C2&minimum=&class_number=&aut=").get_data(as_text=True)
         assert '2.1.2.1.1' in L #gram matrix search through isometries
 
     def test_latticeZ2(self):
-        L = self.tc.get("/Lattice/2.1.2.1.1").data
+        L = self.tc.get("/Lattice/2.1.2.1.1").get_data(as_text=True)
         assert '0.785398163397448309615660845820\dots' in L #Z2 lattice  
 
     def test_lattice_thetadisplay(self):
-        L = self.tc.get("/Lattice/theta_display/7.576.18.1.1/40").data
+        L = self.tc.get("/Lattice/theta_display/7.576.18.1.1/40").get_data(as_text=True)
         assert '41' in L # theta display
         assert '1848' in L # theta display
         assert '11466' in L # theta display
 
     def test_lattice_random(self):
-        L = self.tc.get("/Lattice/random").data
+        L = self.tc.get("/Lattice/random").get_data(as_text=True)
         assert 'redirected automatically' in L # random lattice
         L = self.tc.get("/Lattice/random", follow_redirects=True)
         assert 'Normalized minimal vectors' in L.get_data(as_text=True) # check redirection
 
     def test_downloadstring(self):
-        L = self.tc.get("/Lattice/5.648.12.1.1").data
+        L = self.tc.get("/Lattice/5.648.12.1.1").get_data(as_text=True)
         assert 'matrix' in L
 
     def test_downloadstring2(self):
-        L = self.tc.get("/Lattice/2.156.312.1.2").data
+        L = self.tc.get("/Lattice/2.156.312.1.2").get_data(as_text=True)
         assert 'vector' in L
 
     def test_downloadstring_search(self):
-        L = self.tc.get("/Lattice/?class_number=8").data
+        L = self.tc.get("/Lattice/?class_number=8").get_data(as_text=True)
         assert 'Download all search results for' in L
 
     def test_download_shortest(self):
-        L = self.tc.get("/Lattice/13.14.28.8.1/download/magma/shortest_vectors").data
+        L = self.tc.get("/Lattice/13.14.28.8.1/download/magma/shortest_vectors").get_data(as_text=True)
         assert 'data := ' in L
  
     def test_download_genus(self):
-        L = self.tc.get("/Lattice/4.5.5.1.1/download/gp/genus_reps").data
+        L = self.tc.get("/Lattice/4.5.5.1.1/download/gp/genus_reps").get_data(as_text=True)
         assert ']~)' in L 
 
 

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -6,7 +6,7 @@ class HomePageTest(LmfdbTest):
 
     def check(self,homepage,path,text):
         assert path in homepage
-        assert text in self.tc.get(path).data
+        assert text in self.tc.get(path).get_data(as_text=True)
 
     def check_external(self, homepage, path, text):
         from six.moves.urllib.request import urlopen
@@ -80,7 +80,7 @@ class HomePageTest(LmfdbTest):
         L = self.tc.get("/Lattice/random").data
         assert 'redirected automatically' in L # random lattice
         L = self.tc.get("/Lattice/random", follow_redirects=True)
-        assert 'Normalized minimal vectors' in L.data # check redirection
+        assert 'Normalized minimal vectors' in L.get_data(as_text=True) # check redirection
 
     def test_downloadstring(self):
         L = self.tc.get("/Lattice/5.648.12.1.1").data
@@ -109,11 +109,11 @@ class HomePageTest(LmfdbTest):
             L = self.tc.get(
                     "/Lattice/?label={}".format(elt),
                     follow_redirects=True)
-            assert elt in L.data
+            assert elt in L.get_data(as_text=True)
             L = self.tc.get(
                     "/Lattice/{}".format(elt),
                     follow_redirects=True)
-            assert elt in L.data
+            assert elt in L.get_data(as_text=True)
 
 
 

--- a/lmfdb/lfunctions/test_lfunction_degree_2.py
+++ b/lmfdb/lfunctions/test_lfunction_degree_2.py
@@ -6,7 +6,7 @@ class LfunctionTest(LmfdbTest):
 
     def check(self, homepage, path, text):
         assert path in homepage, "path not in homepage."
-        assert text in self.tc.get(path).data, "text %s not in pathpage %s."%(text, path)
+        assert text in self.tc.get(path).get_data(as_text=True), "text %s not in pathpage %s."%(text, path)
     
     # Testing all links in the home page
 

--- a/lmfdb/lfunctions/test_lfunction_degree_2.py
+++ b/lmfdb/lfunctions/test_lfunction_degree_2.py
@@ -14,7 +14,7 @@ class LfunctionTest(LmfdbTest):
         r"""
         Check that the links in the /L/degree2/ table work.
         """
-        homepage = self.tc.get("/L/degree2/").data
+        homepage = self.tc.get("/L/degree2/").get_data(as_text=True)
         self.check(homepage,
                    "/L/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032",
                    'Maass')

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -20,10 +20,10 @@ class LfunctionTest(LmfdbTest):
 
     def test_LDirichlet(self):
         L = self.tc.get('/L/Character/Dirichlet/19/9/')
-        assert '0.4813597783' in L.get_data(as_text=True) and 'mu(9)' in L.data
+        assert '0.4813597783' in L.get_data(as_text=True) and 'mu(9)' in L.get_data(as_text=True)
         assert '2.13818063440820276534' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/6400/3/')
-        assert '2.131285033' in L.get_data(as_text=True) in L.data and 'mu(320)' in L.data
+        assert '2.131285033' in L.get_data(as_text=True) in L.get_data(as_text=True) and 'mu(320)' in L.get_data(as_text=True)
         assert '3.1381043104275982' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/17/16/')
         assert '1.01608483' in L.get_data(as_text=True)
@@ -32,7 +32,7 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/Character/Dirichlet/6400/6399/')
         assert 'is imprimitive' in L.get_data(as_text=True)
         L = self.tc.get('L/Character/Dirichlet/1000000000/3/')
-        assert 'No L-function data' in L.get_data(as_text=True) and 'found in the database' in L.data
+        assert 'No L-function data' in L.get_data(as_text=True) and 'found in the database' in L.get_data(as_text=True)
         L = self.tc.get('L/Character/Dirichlet/1000000000000000000000/3/')
         assert 'too large' in L.get_data(as_text=True)
 
@@ -55,7 +55,7 @@ class LfunctionTest(LmfdbTest):
         assert '4.043044013797' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/Q/379998/d/')
-        assert '9.364311197' in L.get_data(as_text=True) and 'Isogeny class 379998.d' in L.data and '/SatoTateGroup/1.2.' in L.data
+        assert '9.364311197' in L.get_data(as_text=True) and 'Isogeny class 379998.d' in L.get_data(as_text=True) and '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/379998/d/')
         assert '0.8292065891985' in L.get_data(as_text=True)
 
@@ -178,7 +178,7 @@ class LfunctionTest(LmfdbTest):
         assert '18.17341115038590061946085869072' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1/')
-        assert '0.523757' in L.get_data(as_text=True) and '0.530517' in L.data
+        assert '0.523757' in L.get_data(as_text=True) and '0.530517' in L.get_data(as_text=True)
         assert '(16 + 27.7<em>i</em>)' in L.get_data(as_text=True)
         assert 'Dual L-function' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1/')
@@ -360,7 +360,7 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/NumberField/5.5.2337227518904161.1/')
         assert '3718837' in L.get_data(as_text=True)
         L = self.tc.get('L/NumberField/14.14.28152039412241052225421312.1/')
-        assert 'chi_{172}' in L.get_data(as_text=True) and 'chi_{43}' in L.data
+        assert 'chi_{172}' in L.get_data(as_text=True) and 'chi_{43}' in L.get_data(as_text=True)
 
     def test_Ldedekindabelian(self):
         L = self.tc.get('/L/NumberField/3.3.81.1/')
@@ -378,25 +378,25 @@ class LfunctionTest(LmfdbTest):
 
     def test_Lmain(self):
         L = self.tc.get('/L/', follow_redirects=True)
-        assert 'Riemann' in L.get_data(as_text=True) and 'modular form' in L.data
+        assert 'Riemann' in L.get_data(as_text=True) and 'modular form' in L.get_data(as_text=True)
 
     def test_Ldegree1(self):
         L = self.tc.get('/L/degree1/')
-        assert 'Dirichlet L-function' in L.get_data(as_text=True) and 'Conductor range' in L.data and 'Primitive Dirichlet character' in L.data
+        assert 'Dirichlet L-function' in L.get_data(as_text=True) and 'Conductor range' in L.get_data(as_text=True) and 'Primitive Dirichlet character' in L.get_data(as_text=True)
 
     def test_Ldegree2(self):
         L = self.tc.get('/L/degree2/')
-        assert '1.73353' in L.get_data(as_text=True) and '/EllipticCurve/Q/234446/a' in L.data
-        assert '17.02494' in L.get_data(as_text=True) and '/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032' in L.data
+        assert '1.73353' in L.get_data(as_text=True) and '/EllipticCurve/Q/234446/a' in L.get_data(as_text=True)
+        assert '17.02494' in L.get_data(as_text=True) and '/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032' in L.get_data(as_text=True)
 
     def test_Ldegree3(self):
         L = self.tc.get('/L/degree3/')
-        assert '6.42223' in L.get_data(as_text=True) and '/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864' in L.data
+        assert '6.42223' in L.get_data(as_text=True) and '/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864' in L.get_data(as_text=True)
 
     def test_Ldegree4(self):
         L = self.tc.get('/L/degree4/')
-        assert '5.06823' in L.get_data(as_text=True) and '/Genus2Curve/Q/169/a/' in L.data
-        assert '16.18901' in L.get_data(as_text=True) and '2.272' in L.data and '/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019' in L.data
+        assert '5.06823' in L.get_data(as_text=True) and '/Genus2Curve/Q/169/a/' in L.get_data(as_text=True)
+        assert '16.18901' in L.get_data(as_text=True) and '2.272' in L.get_data(as_text=True) and '/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019' in L.get_data(as_text=True)
 
     def test_LdegreeLarge(self):
         L = self.tc.get('L/degree1234567689/')
@@ -436,7 +436,7 @@ class LfunctionTest(LmfdbTest):
 
     def test_Lgenus2(self):
         L = self.tc.get('/L/Genus2Curve/Q/169/a/')
-        assert '0.0904903908' in L.get_data(as_text=True) and 'E_6' in L.data
+        assert '0.0904903908' in L.get_data(as_text=True) and 'E_6' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Zeros/Genus2Curve/Q/169/a/')
         assert '5.06823463541' in L.get_data(as_text=True)

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -12,127 +12,127 @@ class LfunctionTest(LmfdbTest):
 
     def test_history(self):
         L = self.tc.get('/L/history')
-        assert 'Anzahl der Primzahlen' in L.data
+        assert 'Anzahl der Primzahlen' in L.get_data(as_text=True)
 
     def test_riemann(self):
         L = self.tc.get('/L/Riemann/')
-        assert 'Riemann Zeta-function' in L.data
+        assert 'Riemann Zeta-function' in L.get_data(as_text=True)
 
     def test_LDirichlet(self):
         L = self.tc.get('/L/Character/Dirichlet/19/9/')
-        assert '0.4813597783' in L.data and 'mu(9)' in L.data
-        assert '2.13818063440820276534' in L.data
+        assert '0.4813597783' in L.get_data(as_text=True) and 'mu(9)' in L.data
+        assert '2.13818063440820276534' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/6400/3/')
-        assert '2.131285033' in L.data in L.data and 'mu(320)' in L.data
-        assert '3.1381043104275982' in L.data
+        assert '2.131285033' in L.get_data(as_text=True) in L.data and 'mu(320)' in L.data
+        assert '3.1381043104275982' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/17/16/')
-        assert '1.01608483' in L.data
+        assert '1.01608483' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/6400/2/')
-        assert '2 is not coprime to the modulus 6400' in L.data
+        assert '2 is not coprime to the modulus 6400' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/6400/6399/')
-        assert 'is imprimitive' in L.data
+        assert 'is imprimitive' in L.get_data(as_text=True)
         L = self.tc.get('L/Character/Dirichlet/1000000000/3/')
-        assert 'No L-function data' in L.data and 'found in the database' in L.data
+        assert 'No L-function data' in L.get_data(as_text=True) and 'found in the database' in L.data
         L = self.tc.get('L/Character/Dirichlet/1000000000000000000000/3/')
-        assert 'too large' in L.data
+        assert 'too large' in L.get_data(as_text=True)
 
     def test_Lec(self):
         L = self.tc.get('/L/EllipticCurve/Q/11/a/')
-        assert '0.253841' in L.data
-        assert 'Isogeny class 11.a' in L.data
-        assert 'Modular form 11.2.a.a' in L.data
-        assert '/SatoTateGroup/1.2.' in L.data
+        assert '0.253841' in L.get_data(as_text=True)
+        assert 'Isogeny class 11.a' in L.get_data(as_text=True)
+        assert 'Modular form 11.2.a.a' in L.get_data(as_text=True)
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/11/a/')
-        assert '6.362613894713' in L.data
+        assert '6.362613894713' in L.get_data(as_text=True)
         L = self.tc.get('/L/EllipticCurve/Q/27/a/')
-        assert '0.5888795834' in L.data
-        assert 'Isogeny class 27.a'in L.data
-        assert 'Modular form 27.2.a.a' in L.data
-        assert '/SatoTateGroup/1.2.' in L.data
+        assert '0.5888795834' in L.get_data(as_text=True)
+        assert 'Isogeny class 27.a'in L.get_data(as_text=True)
+        assert 'Modular form 27.2.a.a' in L.get_data(as_text=True)
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/27/a/')
-        assert '4.043044013797' in L.data
+        assert '4.043044013797' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/Q/379998/d/')
-        assert '9.364311197' in L.data and 'Isogeny class 379998.d' in L.data and '/SatoTateGroup/1.2.' in L.data
+        assert '9.364311197' in L.get_data(as_text=True) and 'Isogeny class 379998.d' in L.data and '/SatoTateGroup/1.2.' in L.data
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/379998/d/')
-        assert '0.8292065891985' in L.data
+        assert '0.8292065891985' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/2.2.5.1/31.1/a/')
-        assert '0.3599289594' in L.data
-        assert 'Isogeny class 2.2.5.1-31.1-a' in L.data
-        assert 'Isogeny class 2.2.5.1-31.2-a' in L.data
-        assert 'Hilbert modular form 2.2.5.1-31.1-a' in L.data
-        assert 'Hilbert modular form 2.2.5.1-31.2-a' in L.data
-        assert '/SatoTateGroup/1.2.' in L.data
+        assert '0.3599289594' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.5.1-31.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.5.1-31.2-a' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.5.1-31.1-a' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.5.1-31.2-a' in L.get_data(as_text=True)
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/2.2.5.1/80.1/a/')
-        assert '0.5945775518' in L.data
-        assert 'Isogeny class 2.2.5.1-80.1-a' in L.data
-        assert 'Isogeny class 20.a' in L.data
-        assert 'Isogeny class 100.a' in L.data
-        assert 'Hilbert modular form 2.2.5.1-80.1-a' in L.data
-        assert '/SatoTateGroup/1.2.' in L.data
+        assert '0.5945775518' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.5.1-80.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 20.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 100.a' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.5.1-80.1-a' in L.get_data(as_text=True)
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/2.0.11.1/256.1/a/')
-        assert 'Isogeny class 2.0.11.1-256.1-a' in L.data
-        assert 'Isogeny class 2.0.11.1-256.1-b' in L.data
-        assert 'Isogeny class 2.2.44.1-16.1-a' in L.data
-        assert 'Isogeny class 2.2.44.1-16.1-c' in L.data
-        assert 'Hilbert modular form 2.2.44.1-16.1-a' in L.data
-        assert 'Hilbert modular form 2.2.44.1-16.1-c' in L.data
-        assert 'Bianchi modular form 2.0.11.1-256.1-a' in L.data
-        assert 'Bianchi modular form 2.0.11.1-256.1-b' in L.data
-        assert '/SatoTateGroup/1.2.' in L.data
+        assert 'Isogeny class 2.0.11.1-256.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.11.1-256.1-b' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.44.1-16.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.44.1-16.1-c' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.44.1-16.1-a' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.44.1-16.1-c' in L.get_data(as_text=True)
+        assert 'Bianchi modular form 2.0.11.1-256.1-a' in L.get_data(as_text=True)
+        assert 'Bianchi modular form 2.0.11.1-256.1-b' in L.get_data(as_text=True)
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
 
         L = self.tc.get('/L/EllipticCurve/2.0.1879.1/1.0.1/a/')
-        assert '/SatoTateGroup/1.2.' in L.data
-        assert 'Isogeny class 2.0.1879.1-1.0.1-a' in L.data
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.1879.1-1.0.1-a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/2.0.4.1/100.2/a/')
-        assert '/SatoTateGroup/1.2.' in L.data
-        assert '0.5352579714' in L.data
-        assert 'Bianchi modular form 2.0.4.1-100.2-a' in L.data
-        assert 'Isogeny class 2.0.4.1-100.2-a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 20.a' in L.data
-        assert 'Isogeny class 80.b' in L.data
-        assert 'Modular form 20.2.a.a' in L.data
-        assert 'Modular form 80.2.a.b' in L.data
+        assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
+        assert '0.5352579714' in L.get_data(as_text=True)
+        assert 'Bianchi modular form 2.0.4.1-100.2-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.4.1-100.2-a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 20.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 80.b' in L.get_data(as_text=True)
+        assert 'Modular form 20.2.a.a' in L.get_data(as_text=True)
+        assert 'Modular form 80.2.a.b' in L.get_data(as_text=True)
         # check the zeros accross factors
-        assert '2.76929890617261215013507568311' in L.data
-        assert '4.78130792717525308450176413839' in L.data
+        assert '2.76929890617261215013507568311' in L.get_data(as_text=True)
+        assert '4.78130792717525308450176413839' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/20/2/a/a/')
-        assert '4.78130792717525308450176413839' in L.data
+        assert '4.78130792717525308450176413839' in L.get_data(as_text=True)
         L = self.tc.get('/L/EllipticCurve/Q/20/a/')
-        assert '4.781307927175253' in L.data
+        assert '4.781307927175253' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/80/2/a/b/')
-        assert '2.76929890617261215013507568311' in L.data
+        assert '2.76929890617261215013507568311' in L.get_data(as_text=True)
         L = self.tc.get('/L/EllipticCurve/Q/80/b/')
-        assert '2.769298906172612' in L.data
+        assert '2.769298906172612' in L.get_data(as_text=True)
 
 
 
         L = self.tc.get('/L/EllipticCurve/2.0.3.1/75.1/a/')
-        assert 'Bianchi modular form 2.0.3.1-75.1-a' in L.data
-        assert 'Isogeny class 2.0.3.1-75.1-a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 15.a' in L.data
-        assert 'Isogeny class 45.a' in L.data
-        assert 'Modular form 15.2.a.a' in L.data
-        assert 'Modular form 45.2.a.a' in L.data
+        assert 'Bianchi modular form 2.0.3.1-75.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.3.1-75.1-a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 15.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 45.a' in L.get_data(as_text=True)
+        assert 'Modular form 15.2.a.a' in L.get_data(as_text=True)
+        assert 'Modular form 45.2.a.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/EllipticCurve/2.0.8.1/2592.3/c/')
-        assert 'Bianchi modular form 2.0.8.1-2592.3-c' in L.data
-        assert 'Hilbert modular form 2.2.8.1-2592.1-f' in L.data
-        assert 'Isogeny class 2.0.8.1-2592.3-c' in L.data
-        assert 'Isogeny class 2.2.8.1-2592.1-f' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 288.a' in L.data
-        assert 'Isogeny class 576.i' in L.data
-        assert 'Modular form 288.2.a.a' in L.data
+        assert 'Bianchi modular form 2.0.8.1-2592.3-c' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.8.1-2592.1-f' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.8.1-2592.3-c' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.8.1-2592.1-f' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 288.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 576.i' in L.get_data(as_text=True)
+        assert 'Modular form 288.2.a.a' in L.get_data(as_text=True)
 
 
 
@@ -141,148 +141,148 @@ class LfunctionTest(LmfdbTest):
     def test_Lcmf(self):
         # test old links
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/11/2/1/a/0/', follow_redirects = True)
-        assert "Modular form 11.2.a.a.1.1" in L.data
+        assert "Modular form 11.2.a.a.1.1" in L.get_data(as_text=True)
 
         # check the zeros agree across 3 instances
         L = self.tc.get('/L/Zeros/EllipticCurve/2.0.11.1/11.1/a/')
-        assert '6.36261389471308870138602900888' in L.data
+        assert '6.36261389471308870138602900888' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/holomorphic/11/2/a/a/')
-        assert '6.36261389471308870138602900888' in L.data
+        assert '6.36261389471308870138602900888' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/11/a/')
-        assert '6.36261389471308' in L.data
+        assert '6.36261389471308' in L.get_data(as_text=True)
 
 
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/13/12/a/a/1/1/')
-        assert '4.84e4' in L.data # a_7
-        assert '71.7' in L.data # a_2
-        assert '1.51472556377341264746894823521' in L.data # first zero
+        assert '4.84e4' in L.get_data(as_text=True) # a_7
+        assert '71.7' in L.get_data(as_text=True) # a_2
+        assert '1.51472556377341264746894823521' in L.get_data(as_text=True) # first zero
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/13/12/a/a/')
-        assert '1.51472556377341264746894823521' in L.data # first zero
-        assert 'Origins of factors' in L.data
+        assert '1.51472556377341264746894823521' in L.get_data(as_text=True) # first zero
+        assert 'Origins of factors' in L.get_data(as_text=True)
         for i in range(1,6):
-            assert 'Modular form 13.12.a.a.1.%d' % i  in L.data
-        assert '371293' in L.data # L_3 root
-        assert '2.54e3' in L.data # a_13
+            assert 'Modular form 13.12.a.a.1.%d' % i  in L.get_data(as_text=True)
+        assert '371293' in L.get_data(as_text=True) # L_3 root
+        assert '2.54e3' in L.get_data(as_text=True) # a_13
 
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/7/3/b/a/')
-        assert '0.332981' in L.data
+        assert '0.332981' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/holomorphic/7/3/b/a/')
-        assert '7.21458918128718444354242474222' in L.data
+        assert '7.21458918128718444354242474222' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/1/18/a/a/')
-        assert '1.34e12' in L.data # a26
+        assert '1.34e12' in L.get_data(as_text=True) # a26
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/holomorphic/1/18/a/a/')
-        assert '18.17341115038590061946085869072' in L.data
+        assert '18.17341115038590061946085869072' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1/')
-        assert '0.523757' in L.data and '0.530517' in L.data
-        assert '(16 + 27.7<em>i</em>)' in L.data
-        assert 'Dual L-function' in L.data
+        assert '0.523757' in L.get_data(as_text=True) and '0.530517' in L.data
+        assert '(16 + 27.7<em>i</em>)' in L.get_data(as_text=True)
+        assert 'Dual L-function' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1/')
-        assert '5.68016097036963500634962429051' in L.data
+        assert '5.68016097036963500634962429051' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/11/2/a/a/')
-        assert '0.253841' in L.data
-        assert 'Isogeny class 11.a' in L.data
-        assert 'Modular form 11.2.a.a' in L.data
+        assert '0.253841' in L.get_data(as_text=True)
+        assert 'Isogeny class 11.a' in L.get_data(as_text=True)
+        assert 'Modular form 11.2.a.a' in L.get_data(as_text=True)
         #FIXME merge with EC to get sato-tate
-        #assert '/SatoTateGroup/1.2.' in L.data
+        #assert '/SatoTateGroup/1.2.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/13/2/e/a/')
-        assert 'Isogeny class 169.a' in L.data
-        assert 'Modular form 13.2.e.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Modular form 13.2.e.a.4.1' in L.data
-        assert 'Modular form 13.2.e.a.10.1' in L.data
+        assert 'Isogeny class 169.a' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a.4.1' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a.10.1' in L.get_data(as_text=True)
         #FIXME merge with G2C to get sato-tate
-        #assert '/SatoTateGroup/1.4.E_6' in L.data
+        #assert '/SatoTateGroup/1.4.E_6' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/18/2/c/a/')
-        assert 'Isogeny class 324.a' in L.data
-        assert 'Modular form 18.2.c.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Modular form 18.2.c.a.7.1' in L.data
-        assert 'Modular form 18.2.c.a.13.1' in L.data
+        assert 'Isogeny class 324.a' in L.get_data(as_text=True)
+        assert 'Modular form 18.2.c.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Modular form 18.2.c.a.7.1' in L.get_data(as_text=True)
+        assert 'Modular form 18.2.c.a.13.1' in L.get_data(as_text=True)
         #FIXME merge with G2C to get sato-tate
-        #assert '/SatoTateGroup/1.4.E_3' in L.data
+        #assert '/SatoTateGroup/1.4.E_3' in L.get_data(as_text=True)
 
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/490/2/a/a/')
-        assert 'Modular form 490.2.a.a' in L.data
-        assert 'Isogeny class 490.a' in L.data
-        assert '0.729971' in L.data
-        assert '(2,\ 490,\ (\ :1/2),\ 1)' in L.data
-        assert '0.940863335931152039286421559408' in L.data
-        assert '1 + 7 T + p T^{2}' in L.data
-        assert '\chi_{490} (1, \cdot )' in L.data
+        assert 'Modular form 490.2.a.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 490.a' in L.get_data(as_text=True)
+        assert '0.729971' in L.get_data(as_text=True)
+        assert '(2,\ 490,\ (\ :1/2),\ 1)' in L.get_data(as_text=True)
+        assert '0.940863335931152039286421559408' in L.get_data(as_text=True)
+        assert '1 + 7 T + p T^{2}' in L.get_data(as_text=True)
+        assert '\chi_{490} (1, \cdot )' in L.get_data(as_text=True)
         L = self.tc.get('/L/EllipticCurve/Q/490/a/')
-        assert '0.9408633359311520' in L.data
+        assert '0.9408633359311520' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/350/2/e/k/51/1/')
-        assert 'Modular form 350.2.e.k.51.1' in L.data
-        assert 'Dual L-function' in L.data
+        assert 'Modular form 350.2.e.k.51.1' in L.get_data(as_text=True)
+        assert 'Dual L-function' in L.get_data(as_text=True)
         assert '/L/ModularForm/GL2/Q/holomorphic/350/2/e/k/151/1/'
-        assert '\chi_{350} (51, \cdot )' in L.data
-        assert '(2,\ 350,\ (\ :1/2),\ 0.991 + 0.126i)' in L.data
-        assert '2.00692' in L.data
-        assert '0.127359' in L.data
-        assert '1 + 6T + 29T^{2}' in L.data
-        assert '1.68486586956382681209348921118' in L.data
-        assert '3.10207045712088492456262227600' in L.data
+        assert '\chi_{350} (51, \cdot )' in L.get_data(as_text=True)
+        assert '(2,\ 350,\ (\ :1/2),\ 0.991 + 0.126i)' in L.get_data(as_text=True)
+        assert '2.00692' in L.get_data(as_text=True)
+        assert '0.127359' in L.get_data(as_text=True)
+        assert '1 + 6T + 29T^{2}' in L.get_data(as_text=True)
+        assert '1.68486586956382681209348921118' in L.get_data(as_text=True)
+        assert '3.10207045712088492456262227600' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/350/2/e/k/151/1/')
-        assert 'Modular form 350.2.e.k.151.1' in L.data
-        assert 'Dual L-function' in L.data
+        assert 'Modular form 350.2.e.k.151.1' in L.get_data(as_text=True)
+        assert 'Dual L-function' in L.get_data(as_text=True)
         assert '/L/ModularForm/GL2/Q/holomorphic/350/2/e/k/51/1/'
-        assert '\chi_{350} (151, \cdot )' in L.data
-        assert '(2,\ 350,\ (\ :1/2),\ 0.991 - 0.126i)' in L.data
-        assert '2.00692' in L.data
-        assert '0.127359' in L.data
-        assert '1 + 6T + 29T^{2}' in L.data
-        assert '1.68486586956382681209348921118' in L.data
-        assert '3.10207045712088492456262227600' in L.data
+        assert '\chi_{350} (151, \cdot )' in L.get_data(as_text=True)
+        assert '(2,\ 350,\ (\ :1/2),\ 0.991 - 0.126i)' in L.get_data(as_text=True)
+        assert '2.00692' in L.get_data(as_text=True)
+        assert '0.127359' in L.get_data(as_text=True)
+        assert '1 + 6T + 29T^{2}' in L.get_data(as_text=True)
+        assert '1.68486586956382681209348921118' in L.get_data(as_text=True)
+        assert '3.10207045712088492456262227600' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/350/2/e/k/')
-        assert 'Modular form 350.2.e.k.151.1' in L.data
-        assert 'Modular form 350.2.e.k.51.1' in L.data
-        assert 'Modular form 350.2.e.k' in L.data
-        assert '(4,\ 122500,\ (\ :1/2, 1/2),\ 1)' in L.data
-        assert '4.04397' in L.data
-        assert '1.68486586956382681209348921118' in L.data
-        assert '3.10207045712088492456262227600' in L.data
-        assert '( 1 + T + p T^{2} )( 1 + 7 T + p T^{2} )' in L.data
-        assert '( 1 - 2 T + p T^{2} )^{2}' in L.data
+        assert 'Modular form 350.2.e.k.151.1' in L.get_data(as_text=True)
+        assert 'Modular form 350.2.e.k.51.1' in L.get_data(as_text=True)
+        assert 'Modular form 350.2.e.k' in L.get_data(as_text=True)
+        assert '(4,\ 122500,\ (\ :1/2, 1/2),\ 1)' in L.get_data(as_text=True)
+        assert '4.04397' in L.get_data(as_text=True)
+        assert '1.68486586956382681209348921118' in L.get_data(as_text=True)
+        assert '3.10207045712088492456262227600' in L.get_data(as_text=True)
+        assert '( 1 + T + p T^{2} )( 1 + 7 T + p T^{2} )' in L.get_data(as_text=True)
+        assert '( 1 - 2 T + p T^{2} )^{2}' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/129/2/a/d/')
-        assert 'Modular form 129.2.a.d' in L.data
+        assert 'Modular form 129.2.a.d' in L.get_data(as_text=True)
         for i in range(1,4):
-            assert 'Modular form 129.2.a.d.1.%d' % i in L.data
+            assert 'Modular form 129.2.a.d.1.%d' % i in L.get_data(as_text=True)
 
-        assert '1.04395' in L.data
-        assert '( 1 + T )^{3}' in L.data
-        assert '1.55341889806322957326786121161' in L.data
-        assert r'S_4\times C_2' in L.data
+        assert '1.04395' in L.get_data(as_text=True)
+        assert '( 1 + T )^{3}' in L.get_data(as_text=True)
+        assert '1.55341889806322957326786121161' in L.get_data(as_text=True)
+        assert r'S_4\times C_2' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/60/2/i/a/')
-        assert 'Modular form 60.2.i.a' in L.data
+        assert 'Modular form 60.2.i.a' in L.get_data(as_text=True)
         for c in [17, 53]:
             for i in range(1,3):
-                assert 'Modular form 60.2.i.a.%d.%d' % (c,i) in L.data, 'Modular form 60.2.%d.a.%d' % (c,i)
-        assert '0.676894' in L.data
-        assert '2.15777231959226116393597609132' in L.data
-        assert '1 - 2 T + 2 T^{2} - 2 p T^{3} + p^{2} T^{4}' in L.data
-        assert '(8,\ 12960000,\ (\ :1/2, 1/2, 1/2, 1/2),\ 1)' in L.data
+                assert 'Modular form 60.2.i.a.%d.%d' % (c,i) in L.get_data(as_text=True), 'Modular form 60.2.%d.a.%d' % (c,i)
+        assert '0.676894' in L.get_data(as_text=True)
+        assert '2.15777231959226116393597609132' in L.get_data(as_text=True)
+        assert '1 - 2 T + 2 T^{2} - 2 p T^{3} + p^{2} T^{4}' in L.get_data(as_text=True)
+        assert '(8,\ 12960000,\ (\ :1/2, 1/2, 1/2, 1/2),\ 1)' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/207/2/i/b/')
         for c in [55,64,73,82,100,118,127,154,163,190]:
-            assert 'Modular form 207.2.i.b.%d.1' % c in L.data, 'Modular form 207.2.%d.d.1' % c
-        assert '0.233961' in L.data
-        assert '0.096070203083029088532433951629' in L.data
-        assert 'T + T^{2} + 21 T^{3} - 219 T^{4} - 1365 T^{5} - 219 p T^{6} + 21 p^{2} T^{7} + p^{3} T^{8}' in L.data
-        assert 'Plot not available' in L.data
+            assert 'Modular form 207.2.i.b.%d.1' % c in L.get_data(as_text=True), 'Modular form 207.2.%d.d.1' % c
+        assert '0.233961' in L.get_data(as_text=True)
+        assert '0.096070203083029088532433951629' in L.get_data(as_text=True)
+        assert 'T + T^{2} + 21 T^{3} - 219 T^{4} - 1365 T^{5} - 219 p T^{6} + 21 p^{2} T^{7} + p^{3} T^{8}' in L.get_data(as_text=True)
+        assert 'Plot not available' in L.get_data(as_text=True)
 
 
 
@@ -291,233 +291,233 @@ class LfunctionTest(LmfdbTest):
 
     def test_Lhmf(self):
         L = self.tc.get('/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/')
-        assert '0.3599289594' in L.data
+        assert '0.3599289594' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/0/0/')
-        assert '3.67899147579' in L.data
+        assert '3.67899147579' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-9.1-a/0/0/')
-        assert '0.22396252' in L.data
+        assert '0.22396252' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/TotallyReal/2.2.8.1/holomorphic/2.2.8.1-9.1-a/0/0/')
-        assert '3.03882077536' in L.data
+        assert '3.03882077536' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/TotallyReal/2.2.24.1/holomorphic/2.2.24.1-1.1-a/0/0/')
-        assert '0.28781' in L.data
+        assert '0.28781' in L.get_data(as_text=True)
 
     def test_Lgl2maass(self):
         L = self.tc.get('/L/ModularForm/GL2/Q/Maass/4f5695df88aece2afe000021/')
-        assert '1 + 4.54845492142i' in L.data
+        assert '1 + 4.54845492142i' in L.get_data(as_text=True)
         # FIXME
         # these zeros cannot be correct to this much precision
         # the eigenvalue was computed to lower precision
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/Maass/4f5695df88aece2afe000021/')
-        assert '7.8729423429' in L.data
+        assert '7.8729423429' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/Q/Maass/4f55571b88aece241f000013/')
-        assert '5.09874190873i' in L.data
+        assert '5.09874190873i' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL2/Q/Maass/4f55571b88aece241f000013/')
-        assert '11.614970337' in L.data
+        assert '11.614970337' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032/')
-        assert '1 + 9.53369526135i' in L.data
+        assert '1 + 9.53369526135i' in L.get_data(as_text=True)
 
     def test_Lgl3maass(self):
         L = self.tc.get('/L/ModularForm/GL3/Q/Maass/1/1/20.39039_14.06890/-0.0742719/')
-        assert '0.0742' in L.data
+        assert '0.0742' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL3/Q/Maass/1/1/20.39039_14.06890/-0.0742719/')
-        assert '0.9615558824' in L.data
+        assert '0.9615558824' in L.get_data(as_text=True)
 
     def test_Lgl4maass(self):
         L = self.tc.get('/L/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019/')
-        assert '0.556' in L.data
-        assert 'Graph' in L.data
+        assert '0.556' in L.get_data(as_text=True)
+        assert 'Graph' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019/')
-        assert '16.18901597' in L.data
+        assert '16.18901597' in L.get_data(as_text=True)
 
     def test_Lsym2EC(self):
         L = self.tc.get('/L/SymmetricPower/2/EllipticCurve/Q/11/a/')
-        assert '0.8933960461' in L.data
+        assert '0.8933960461' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/SymmetricPower/2/EllipticCurve/Q/11/a/')
-        assert '4.7345954' in L.data
+        assert '4.7345954' in L.get_data(as_text=True)
 
     def test_Lsym3EC(self):
         L = self.tc.get('/L/SymmetricPower/3/EllipticCurve/Q/11/a/')
-        assert '1.140230868' in L.data
+        assert '1.140230868' in L.get_data(as_text=True)
 
     def test_Lsym4EC(self):
         L = self.tc.get('/L/SymmetricPower/4/EllipticCurve/Q/11/a/')
-        assert '0.6058003920' in L.data
+        assert '0.6058003920' in L.get_data(as_text=True)
 
     def test_LsymHighEC(self):
         L = self.tc.get('/L/SymmetricPower/5/EllipticCurve/Q/11/a/')
-        assert '161051' in L.data
+        assert '161051' in L.get_data(as_text=True)
         L = self.tc.get('/L/SymmetricPower/6/EllipticCurve/Q/11/a/')
-        assert '1771561' in L.data
+        assert '1771561' in L.get_data(as_text=True)
         L = self.tc.get('/L/SymmetricPower/11/EllipticCurve/Q/11/a/')
-        assert '11^{11}' in L.data
+        assert '11^{11}' in L.get_data(as_text=True)
 
 
     def test_Ldedekind(self):
         L = self.tc.get('/L/NumberField/3.1.23.1/')
-        assert '0.2541547348' in L.data
+        assert '0.2541547348' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/NumberField/3.1.23.1/')
-        assert '5.1156833288' in L.data
+        assert '5.1156833288' in L.get_data(as_text=True)
         L = self.tc.get('/L/NumberField/5.5.2337227518904161.1/')
-        assert '3718837' in L.data
+        assert '3718837' in L.get_data(as_text=True)
         L = self.tc.get('L/NumberField/14.14.28152039412241052225421312.1/')
-        assert 'chi_{172}' in L.data and 'chi_{43}' in L.data
+        assert 'chi_{172}' in L.get_data(as_text=True) and 'chi_{43}' in L.data
 
     def test_Ldedekindabelian(self):
         L = self.tc.get('/L/NumberField/3.3.81.1/')
-        assert 'Graph' in L.data
+        assert 'Graph' in L.get_data(as_text=True)
 
     def test_Lartin(self):
         L = self.tc.get('/L/ArtinRepresentation/2.23.3t2.1c1/', follow_redirects=True)
-        assert '0.1740363269' in L.data
+        assert '0.1740363269' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ArtinRepresentation/2.23.3t2.1c1/')
-        assert '5.1156833288' in L.data
+        assert '5.1156833288' in L.get_data(as_text=True)
         L = self.tc.get('/L/ArtinRepresentation/4.1609.5t5.1c1/')
-        assert '0.0755586459' in L.data
+        assert '0.0755586459' in L.get_data(as_text=True)
         L = self.tc.get('/L/Zeros/ArtinRepresentation/4.1609.5t5.1c1/')
-        assert '3.504643404484' in L.data
+        assert '3.504643404484' in L.get_data(as_text=True)
 
     def test_Lmain(self):
         L = self.tc.get('/L/', follow_redirects=True)
-        assert 'Riemann' in L.data and 'modular form' in L.data
+        assert 'Riemann' in L.get_data(as_text=True) and 'modular form' in L.data
 
     def test_Ldegree1(self):
         L = self.tc.get('/L/degree1/')
-        assert 'Dirichlet L-function' in L.data and 'Conductor range' in L.data and 'Primitive Dirichlet character' in L.data
+        assert 'Dirichlet L-function' in L.get_data(as_text=True) and 'Conductor range' in L.data and 'Primitive Dirichlet character' in L.data
 
     def test_Ldegree2(self):
         L = self.tc.get('/L/degree2/')
-        assert '1.73353' in L.data and '/EllipticCurve/Q/234446/a' in L.data
-        assert '17.02494' in L.data and '/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032' in L.data
+        assert '1.73353' in L.get_data(as_text=True) and '/EllipticCurve/Q/234446/a' in L.data
+        assert '17.02494' in L.get_data(as_text=True) and '/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032' in L.data
 
     def test_Ldegree3(self):
         L = self.tc.get('/L/degree3/')
-        assert '6.42223' in L.data and '/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864' in L.data
+        assert '6.42223' in L.get_data(as_text=True) and '/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.4216864' in L.data
 
     def test_Ldegree4(self):
         L = self.tc.get('/L/degree4/')
-        assert '5.06823' in L.data and '/Genus2Curve/Q/169/a/' in L.data
-        assert '16.18901' in L.data and '2.272' in L.data and '/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019' in L.data
+        assert '5.06823' in L.get_data(as_text=True) and '/Genus2Curve/Q/169/a/' in L.data
+        assert '16.18901' in L.get_data(as_text=True) and '2.272' in L.data and '/ModularForm/GL4/Q/Maass/1/1/16.89972_2.272587_-6.03583/0.55659019' in L.data
 
     def test_LdegreeLarge(self):
         L = self.tc.get('L/degree1234567689/')
-        assert 'no L-function data available' in L.data
+        assert 'no L-function data available' in L.get_data(as_text=True)
 
     def test_Ldegree2CuspForm(self):
         L = self.tc.get('/L/degree2/CuspForm/')
-        assert 'trivial character' in L.data
+        assert 'trivial character' in L.get_data(as_text=True)
 
     def test_Ldegree2MaassForm(self):
         L = self.tc.get('/L/degree2/MaassForm/')
-        assert 'Maass' in L.data
+        assert 'Maass' in L.get_data(as_text=True)
 
     def test_Ldegree2EllipticCurve(self):
         L = self.tc.get('/L/degree2/EllipticCurve/')
-        assert 'Elliptic' in L.data
+        assert 'Elliptic' in L.get_data(as_text=True)
 
     def test_Ldegree3MaassForm(self):
         L = self.tc.get('/L/degree3/r0r0r0/')
-        assert 'equation' in L.data
+        assert 'equation' in L.get_data(as_text=True)
 
     def test_Ldegree3EllipticCurve(self):
         L = self.tc.get('/L/degree3/EllipticCurve/SymmetricSquare/')
-        assert 'Elliptic' in L.data
+        assert 'Elliptic' in L.get_data(as_text=True)
 
     def test_Ldegree4MaassForm(self):
         L = self.tc.get('/L/degree4/r0r0r0r0/')
-        assert 'functional' in L.data
+        assert 'functional' in L.get_data(as_text=True)
 
     def test_Ldegree4EllipticCurve(self):
         L = self.tc.get('/L/degree4/EllipticCurve/SymmetricCube/')
-        assert 'Elliptic' in L.data
+        assert 'Elliptic' in L.get_data(as_text=True)
 
     def test_Lhgm(self):
         L = self.tc.get('/L/Motive/Hypergeometric/Q/A4_B2.1/t-1.1')
-        assert 'Graph' in L.data
+        assert 'Graph' in L.get_data(as_text=True)
 
     def test_Lgenus2(self):
         L = self.tc.get('/L/Genus2Curve/Q/169/a/')
-        assert '0.0904903908' in L.data and 'E_6' in L.data
+        assert '0.0904903908' in L.get_data(as_text=True) and 'E_6' in L.data
 
         L = self.tc.get('/L/Zeros/Genus2Curve/Q/169/a/')
-        assert '5.06823463541' in L.data
+        assert '5.06823463541' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/15360/f/')
-        assert 'Isogeny class 15360.f' in L.data
+        assert 'Isogeny class 15360.f' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Zeros/Genus2Curve/Q/15360/f/')
-        assert '2.15654793578' in L.data
+        assert '2.15654793578' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/2457/b/')
-        assert 'Isogeny class 2.0.3.1-273.1-a' in L.data
-        assert 'Isogeny class 2.0.3.1-273.4-a' in L.data
-        assert 'Isogeny class 2457.b' in L.data
+        assert 'Isogeny class 2.0.3.1-273.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.3.1-273.4-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2457.b' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/363/a/')
-        assert 'Isogeny class 363.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 11.a' in L.data
-        assert 'Isogeny class 33.a' in L.data
+        assert 'Isogeny class 363.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 11.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 33.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/360/a/')
-        assert 'Isogeny class 360.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 15.a' in L.data
-        assert 'Isogeny class 24.a' in L.data
+        assert 'Isogeny class 360.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 15.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 24.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/336/a/')
-        assert 'Isogeny class 336.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 14.a' in L.data
-        assert 'Isogeny class 24.a' in L.data
+        assert 'Isogeny class 336.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 14.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 24.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/324/a/')
-        assert 'Isogeny class 324.a' in L.data
-        assert 'Modular form 18.2.c.a' in L.data
+        assert 'Isogeny class 324.a' in L.get_data(as_text=True)
+        assert 'Modular form 18.2.c.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/294/a/')
-        assert 'Isogeny class 294.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 14.a' in L.data
-        assert 'Isogeny class 21.' in L.data
+        assert 'Isogeny class 294.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 14.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 21.' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/256/a/')
-        assert 'Isogeny class 256.a' in L.data
-        assert 'Modular form 16.2.e.a' in L.data
+        assert 'Isogeny class 256.a' in L.get_data(as_text=True)
+        assert 'Modular form 16.2.e.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/169/a/')
-        assert 'Isogeny class 169.a' in L.data
-        assert 'Modular form 13.2.e.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Modular form 13.2.e.a.4.1' in L.data
-        assert 'Modular form 13.2.e.a.10.1' in L.data
+        assert 'Isogeny class 169.a' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a.4.1' in L.get_data(as_text=True)
+        assert 'Modular form 13.2.e.a.10.1' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/196/a/')
-        assert 'Isogeny class 196.a' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 14.a' in L.data
-        assert 'Modular form 14.2.a.a' in L.data
+        assert 'Isogeny class 196.a' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 14.a' in L.get_data(as_text=True)
+        assert 'Modular form 14.2.a.a' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/576/a/')
-        assert 'Hilbert modular form 2.2.8.1-9.1-a' in L.data
-        assert 'Isogeny class 2.2.8.1-9.1-a' in L.data
-        assert 'Isogeny class 576.a' in L.data
-        assert 'Modular form 24.2.d.a' in L.data
-        assert 'Modular form 24.2.d.a.13.1' in L.data
-        assert 'Modular form 24.2.d.a.13.2' in L.data
+        assert 'Hilbert modular form 2.2.8.1-9.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.8.1-9.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 576.a' in L.get_data(as_text=True)
+        assert 'Modular form 24.2.d.a' in L.get_data(as_text=True)
+        assert 'Modular form 24.2.d.a.13.1' in L.get_data(as_text=True)
+        assert 'Modular form 24.2.d.a.13.2' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/Genus2Curve/Q/20736/i/')
-        assert 'Bianchi modular form 2.0.8.1-324.3-a' in L.data
-        assert 'Hilbert modular form 2.2.24.1-36.1-a' in L.data
-        assert 'Isogeny class 2.0.8.1-324.3-a' in L.data
-        assert 'Isogeny class 2.2.24.1-36.1-a' in L.data
-        assert 'Isogeny class 20736.i' in L.data
-        assert 'Origins of factors' in L.data
-        assert 'Isogeny class 36.a' in L.data
-        assert 'Isogeny class 576.f' in L.data
-        assert 'Modular form 36.2.a.a' in L.data
-        assert 'Modular form 36.2.a.a.1.1' in L.data
-        assert 'Modular form 576.2.a.f' in L.data
-        assert 'Modular form 576.2.a.f.1.1' in L.data
+        assert 'Bianchi modular form 2.0.8.1-324.3-a' in L.get_data(as_text=True)
+        assert 'Hilbert modular form 2.2.24.1-36.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.0.8.1-324.3-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 2.2.24.1-36.1-a' in L.get_data(as_text=True)
+        assert 'Isogeny class 20736.i' in L.get_data(as_text=True)
+        assert 'Origins of factors' in L.get_data(as_text=True)
+        assert 'Isogeny class 36.a' in L.get_data(as_text=True)
+        assert 'Isogeny class 576.f' in L.get_data(as_text=True)
+        assert 'Modular form 36.2.a.a' in L.get_data(as_text=True)
+        assert 'Modular form 36.2.a.a.1.1' in L.get_data(as_text=True)
+        assert 'Modular form 576.2.a.f' in L.get_data(as_text=True)
+        assert 'Modular form 576.2.a.f.1.1' in L.get_data(as_text=True)
 
 
     def test_Llhash(self):
@@ -526,34 +526,34 @@ class LfunctionTest(LmfdbTest):
         """
         # The hash for /L/EllipticCurve/Q/324016/h
         L = self.tc.get('/L/lhash/1938322253992393114/')
-        assert '324016' in L.data, "Missing data in /L/lhash/1938322253992393114/"
-        assert 'Dual L-function' not in L.data
-        assert '/L/EllipticCurve/Q/324016/h' in L.data
+        assert '324016' in L.get_data(as_text=True), "Missing data in /L/lhash/1938322253992393114/"
+        assert 'Dual L-function' not in L.get_data(as_text=True)
+        assert '/L/EllipticCurve/Q/324016/h' in L.get_data(as_text=True)
 
         L = self.tc.get('/L/lhash/dirichlet_L_6253.458/')
-        assert '1.0612' in L.data, "Missing data in /L/lhash/dirichlet_L_6253.458/"
-        assert """Dirichlet Character \(\chi_{%s} (%s, \cdot) \)""" % (6253,458) in L.data,\
+        assert '1.0612' in L.get_data(as_text=True), "Missing data in /L/lhash/dirichlet_L_6253.458/"
+        assert """Dirichlet Character \(\chi_{%s} (%s, \cdot) \)""" % (6253,458) in L.get_data(as_text=True),\
                 "Missing origin in /L/lhash/dirichlet_L_6253.458/"
-        assert 'Dual L-function' in L.data
-        assert '/L/Character/Dirichlet/6253/2635' in L.data
-        assert '/L/Character/Dirichlet/6253/458' in L.data # self
+        assert 'Dual L-function' in L.get_data(as_text=True)
+        assert '/L/Character/Dirichlet/6253/2635' in L.get_data(as_text=True)
+        assert '/L/Character/Dirichlet/6253/458' in L.get_data(as_text=True) # self
 
         L = self.tc.get('/L/Lhash/7200459463482029776252499748763/')
-        assert 'Dual L-function' in L.data
-        assert 'Modular form 13.4.c.a.3.1' in L.data
-        assert '/L/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1' in L.data
+        assert 'Dual L-function' in L.get_data(as_text=True)
+        assert 'Modular form 13.4.c.a.3.1' in L.get_data(as_text=True)
+        assert '/L/ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1' in L.get_data(as_text=True)
 
     def test_tracehash(self):
         L = self.tc.get('/L/tracehash/7200459463482029776252499748763/')
-        assert 'trace_hash = 7200459463482029776252499748763 not in [0, 2^61]' in L.data
+        assert 'trace_hash = 7200459463482029776252499748763 not in [0, 2^61]' in L.get_data(as_text=True)
         L = self.tc.get('/L/tracehash/1938322253992393114/', follow_redirects = True)
-        assert '324016' in L.data, "Missing data in /L/tracehash/1938322253992393114/"
-        assert 'Dual L-function' not in L.data
+        assert '324016' in L.get_data(as_text=True), "Missing data in /L/tracehash/1938322253992393114/"
+        assert 'Dual L-function' not in L.get_data(as_text=True)
 
 
         L = self.tc.get('/L/tracehash/1127515239490717889/', follow_redirects = True)
-        assert 'Isogeny class 37.a' in L.data
-        assert 'Dual L-function' not in L.data
+        assert 'Isogeny class 37.a' in L.get_data(as_text=True)
+        assert 'Dual L-function' not in L.get_data(as_text=True)
 
 
     #------------------------------------------------------
@@ -566,11 +566,11 @@ class LfunctionTest(LmfdbTest):
 
     def test_LDirichletZeros(self):
         L = self.tc.get('/L/Zeros/Character/Dirichlet/5/2/')
-        assert '6.18357819' in L.data
+        assert '6.18357819' in L.get_data(as_text=True)
 
     def test_LecZeros(self):
         L = self.tc.get('/L/Zeros/EllipticCurve/Q/56/a/')
-        assert '2.791838' in L.data
+        assert '2.791838' in L.get_data(as_text=True)
 
     def test_LcmfPlot(self):
         L = self.tc.get('/L/Plot/ModularForm/GL2/Q/holomorphic/14/6/a/a/')
@@ -586,7 +586,7 @@ class LfunctionTest(LmfdbTest):
 
     def test_LHGMZeros(self):
         L = self.tc.get('/L/Zeros/Motive/Hypergeometric/Q/A2.2.2.2_B1.1.1.1/t-1.1/')
-        assert '4.497732273' in L.data
+        assert '4.497732273' in L.get_data(as_text=True)
 
 
     #------------------------------------------------------
@@ -595,29 +595,29 @@ class LfunctionTest(LmfdbTest):
 
     def test_errorMessages(self):
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/5/k/4/a/1/')
-        assert 'The requested URL was not found on the server' in L.data
+        assert 'The requested URL was not found on the server' in L.get_data(as_text=True)
         L = self.tc.get('/L/Character/Dirichlet/9/10/')
-        assert 'should not exceed the modulus ' in L.data
+        assert 'should not exceed the modulus ' in L.get_data(as_text=True)
         L = self.tc.get('/L/EllipticCurve/Q/11/b/')
-        assert 'No L-function instance data for' in L.data
+        assert 'No L-function instance data for' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/Q/holomorphic/5/6/d/c/')
-        assert 'No L-function instance data for "ModularForm/GL2/Q/holomorphic/5/6/d/c" was found in the database.' in L.data
+        assert 'No L-function instance data for "ModularForm/GL2/Q/holomorphic/5/6/d/c" was found in the database.' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL3/Q/Maass/1/1/16.40312_0.171121/-0.421999/')
-        assert 'No L-function instance data for' in L.data
+        assert 'No L-function instance data for' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.1-a/2/0/')
-        assert 'L-function of Hilbert form of non-trivial character not implemented yet' in L.data
+        assert 'L-function of Hilbert form of non-trivial character not implemented yet' in L.get_data(as_text=True)
         L = self.tc.get('/L/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-31.5-a/0/0/')
-        assert 'No Hilbert modular form with label' in L.data
+        assert 'No Hilbert modular form with label' in L.get_data(as_text=True)
         L = self.tc.get('/L/Genus2Curve/Q/247/a/')
-        assert 'No L-function instance data for' in L.data
+        assert 'No L-function instance data for' in L.get_data(as_text=True)
         L = self.tc.get('/L/NumberField/2.2.7.1/')
-        assert 'No data for the number field' in L.data
+        assert 'No data for the number field' in L.get_data(as_text=True)
         L = self.tc.get('/L/ArtinRepresentation/3.231.4t5.1c1/')
-        assert 'Error constructing Artin representation' in L.data
+        assert 'Error constructing Artin representation' in L.get_data(as_text=True)
         L = self.tc.get('/L/SymmetricPower/2/EllipticCurve/Q/37/d/')
-        assert 'No elliptic curve with label ' in L.data
+        assert 'No elliptic curve with label ' in L.get_data(as_text=True)
         L = self.tc.get('/L/SymmetricPower/2/EllipticCurve/Q/27/a/')
-        assert 'This Elliptic curve has complex multiplication and the symmetric power of its L-function is then not primitive.' in L.data
+        assert 'This Elliptic curve has complex multiplication and the symmetric power of its L-function is then not primitive.' in L.get_data(as_text=True)
 
 
     #------------------------------------------------------

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -8,24 +8,24 @@ class LocalFieldTest(LmfdbTest):
     #
     def test_search_ramif_cl_deg(self):
         L = self.tc.get('/LocalNumberField/?n=8&c=24&gal=8T5&p=2&e=8&count=20')
-        assert '4 matches' in L.data
+        assert '4 matches' in L.get_data(as_text=True)
 
     def test_search_top_slope(self):
         L = self.tc.get('/LocalNumberField/?p=2&topslope=3.5')
-        assert '81' in L.data # number of matches
+        assert '81' in L.get_data(as_text=True) # number of matches
         L = self.tc.get('/LocalNumberField/?p=2&topslope=topslope=3.4..3.55')
-        assert '81' in L.data # number of matches
+        assert '81' in L.get_data(as_text=True) # number of matches
         L = self.tc.get('/LocalNumberField/?p=2&topslope=topslope=7/2')
-        assert '81' in L.data # number of matches
+        assert '81' in L.get_data(as_text=True) # number of matches
 
     def test_field_page(self):
         L = self.tc.get('/LocalNumberField/11.6.4.2')
-        assert 'x^{2} - x + 7' in L.data # bad (not robust) test, but it's the best i was able to find...
-        assert 'x^{3} - 11 t' in L.data # bad (not robust) test, but it's the best i was able to find...
+        assert 'x^{2} - x + 7' in L.get_data(as_text=True) # bad (not robust) test, but it's the best i was able to find...
+        assert 'x^{3} - 11 t' in L.get_data(as_text=True) # bad (not robust) test, but it's the best i was able to find...
 
     def test_global_splitting_models(self):
         # The first one will have to change if we compute a GSM for it
         L = self.tc.get('/LocalNumberField/163.8.7.2')
-        assert 'Not computed' in L.data
+        assert 'Not computed' in L.get_data(as_text=True)
         L = self.tc.get('/LocalNumberField/2.8.0.1')
-        assert 'Does not exist' in L.data
+        assert 'Does not exist' in L.get_data(as_text=True)

--- a/lmfdb/modular_forms/maass_forms/maass_waveforms/test_mwf.py
+++ b/lmfdb/modular_forms/maass_forms/maass_waveforms/test_mwf.py
@@ -8,9 +8,9 @@ from lmfdb.tests import LmfdbTest
 class MwfTest(LmfdbTest):
     def test_sl2z(self):
         table = self.tc.get("/ModularForm/GL2/Q/Maass/?weight=0&level=&browse=1")
-        assert 'Eigenvalues of' in table.data, " The table of eigenvalues of the Laplacian is incomplete!"
-        # assert '9.53369526135' in table.data, " The table of eigenvalues of the Laplacian is incomplete!"
+        assert 'Eigenvalues of' in table.get_data(as_text=True), " The table of eigenvalues of the Laplacian is incomplete!"
+        # assert '9.53369526135' in table.get_data(as_text=True), " The table of eigenvalues of the Laplacian is incomplete!"
         # 
     def test_gamma_0_3maass(self):
         table = self.tc.get("/ModularForm/GL2/Q/Maass/4cb8503a58bca91458000032")
-        assert 'Fourier' in table.data, " The table of eigenvalues of the Laplacian is incomplete!"
+        assert 'Fourier' in table.get_data(as_text=True), " The table of eigenvalues of the Laplacian is incomplete!"

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -5,7 +5,7 @@ class NumberFieldTest(LmfdbTest):
 
     # All tests should pass
     def check_args(self, path, text):
-        assert text in self.tc.get(path, follow_redirects=True).data
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True)
 
     def test_Q(self):
         self.check_args('/NumberField/Q', '\chi_{1}')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -9,19 +9,19 @@ class SatoTateGroupTest(LmfdbTest):
     #
     def test_main(self):
         L = self.tc.get('/SatoTateGroup/')
-        assert 'Browse' in L.get_data(as_text=True) and 'SO(1)' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
+        assert 'Browse' in L.get_data(as_text=True) and 'SO(1)' in L.get_data(as_text=True) and 'U(1)_2' in L.get_data(as_text=True)  and 'SU(2)' in L.get_data(as_text=True) and 'Rational' in L.get_data(as_text=True)
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/?label=1.4.10.1.1a', follow_redirects=True)
-        assert 'USp(4)' in L.get_data(as_text=True) and '223412' in L.data
+        assert 'USp(4)' in L.get_data(as_text=True) and '223412' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)', follow_redirects=True)
-        assert '1.4.10.1.1a' in L.get_data(as_text=True) and '223412' in L.data
+        assert '1.4.10.1.1a' in L.get_data(as_text=True) and '223412' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))', follow_redirects=True)
-        assert '1.2.1.2.1a' in L.get_data(as_text=True) and '462' in L.data
+        assert '1.2.1.2.1a' in L.get_data(as_text=True) and '462' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?label=0.1.37', follow_redirects=True)
-        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.data
+        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)', follow_redirects=True)
-        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.data
+        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?label=0.1.mu(100000000000000000001)', follow_redirects=True)
         assert 'too large' in L.get_data(as_text=True)
 
@@ -59,7 +59,7 @@ class SatoTateGroupTest(LmfdbTest):
 
     def test_subgroups(self):
         L = self.tc.get('/SatoTateGroup/1.4.1.6.1a')
-        assert 'C_2' in L.get_data(as_text=True) and 'C_3' in L.data and 'D_{6,1}' in L.data and 'D_6' in L.data and 'J(D_3)' in L.data and 'O' in L.data
+        assert 'C_2' in L.get_data(as_text=True) and 'C_3' in L.get_data(as_text=True) and 'D_{6,1}' in L.get_data(as_text=True) and 'D_6' in L.get_data(as_text=True) and 'J(D_3)' in L.get_data(as_text=True) and 'O' in L.get_data(as_text=True)
 
     def test_event_probabilities(self):
         L = self.tc.get('/SatoTateGroup/1.4.1.48.48a')
@@ -76,7 +76,7 @@ class SatoTateGroupTest(LmfdbTest):
             sys.stdout.write("{}...".format(label))
             sys.stdout.flush()
             L = self.tc.get('/SatoTateGroup/' + label)
-            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.data
+            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=4')
         assert 'of 52' in L.get_data(as_text=True)
         data = list(db.gps_sato_tate.search({'weight':int(1),'degree':int(4)}, projection='label'))
@@ -86,9 +86,9 @@ class SatoTateGroupTest(LmfdbTest):
             sys.stdout.write("{}...".format(label))
             sys.stdout.flush()
             L = self.tc.get('/SatoTateGroup/' + label)
-            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.data
+            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?components=999999999&include_irrational=yes')
-        assert 'unique match'  in L.get_data(as_text=True) and 'mu(999999999)' in L.data
+        assert 'unique match'  in L.get_data(as_text=True) and 'mu(999999999)' in L.get_data(as_text=True)
 
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -9,66 +9,66 @@ class SatoTateGroupTest(LmfdbTest):
     #
     def test_main(self):
         L = self.tc.get('/SatoTateGroup/')
-        assert 'Browse' in L.data and 'SO(1)' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
+        assert 'Browse' in L.get_data(as_text=True) and 'SO(1)' in L.data and 'U(1)_2' in L.data  and 'SU(2)' in L.data and 'Rational' in L.data
         
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/?label=1.4.10.1.1a', follow_redirects=True)
-        assert 'USp(4)' in L.data and '223412' in L.data
+        assert 'USp(4)' in L.get_data(as_text=True) and '223412' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)', follow_redirects=True)
-        assert '1.4.10.1.1a' in L.data and '223412' in L.data
+        assert '1.4.10.1.1a' in L.get_data(as_text=True) and '223412' in L.data
         L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))', follow_redirects=True)
-        assert '1.2.1.2.1a' in L.data and '462' in L.data
+        assert '1.2.1.2.1a' in L.get_data(as_text=True) and '462' in L.data
         L = self.tc.get('/SatoTateGroup/?label=0.1.37', follow_redirects=True)
-        assert '0.1.37' in L.data and 'mu(185)' in L.data
+        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.data
         L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)', follow_redirects=True)
-        assert '0.1.37' in L.data and 'mu(185)' in L.data
+        assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.data
         L = self.tc.get('/SatoTateGroup/?label=0.1.mu(100000000000000000001)', follow_redirects=True)
-        assert 'too large' in L.data
+        assert 'too large' in L.get_data(as_text=True)
 
     def test_direct_access(self):
         L = self.tc.get('/SatoTateGroup/1.4.G_{3,3}', follow_redirects=True)
-        assert '1.4.6.1.1a' in L.data
+        assert '1.4.6.1.1a' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/G_{3,3}', follow_redirects=True)
-        assert '1.4.6.1.1a' in L.data
+        assert '1.4.6.1.1a' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/banana', follow_redirects=True)
-        assert 'The database currently contains' in L.data
+        assert 'The database currently contains' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
-        assert 'G_{3,3}' in L.data
+        assert 'G_{3,3}' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/0.1.mu(37)', follow_redirects=True)
-        assert '0.1.37' in L.data
+        assert '0.1.37' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/0.1.37')
-        assert 'mu(37)' in L.data
+        assert 'mu(37)' in L.get_data(as_text=True)
 
     def test_browse(self):
         L = self.tc.get('/SatoTateGroup/?identity_component=U(1)')
-        assert 'both matches' in L.data
+        assert 'both matches' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=4&include_irrational=yes&components=48')
-        assert 'unique match' in L.data
+        assert 'unique match' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?components=48&include_irrational=yes')
-        assert 'both matches' in L.data
+        assert 'both matches' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?degree=1&start=1000&count=25&include_irrational=yes')
-        assert 'matches 1001-1025' in L.data
+        assert 'matches 1001-1025' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?degree=1')
-        assert 'both matches' in L.data
+        assert 'both matches' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?count=47')
-        assert '1-47' in L.data
+        assert '1-47' in L.get_data(as_text=True)
 
     def test_moments(self):
         L = self.tc.get('/SatoTateGroup/1.4.6.1.1a')
-        assert '187348' in L.data
+        assert '187348' in L.get_data(as_text=True)
 
     def test_subgroups(self):
         L = self.tc.get('/SatoTateGroup/1.4.1.6.1a')
-        assert 'C_2' in L.data and 'C_3' in L.data and 'D_{6,1}' in L.data and 'D_6' in L.data and 'J(D_3)' in L.data and 'O' in L.data
+        assert 'C_2' in L.get_data(as_text=True) and 'C_3' in L.data and 'D_{6,1}' in L.data and 'D_6' in L.data and 'J(D_3)' in L.data and 'O' in L.data
 
     def test_event_probabilities(self):
         L = self.tc.get('/SatoTateGroup/1.4.1.48.48a')
-        assert '33' in L.data
+        assert '33' in L.get_data(as_text=True)
 
     def test_completeness(self):
         import sys
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=2')
-        assert '3 matches' in L.data
+        assert '3 matches' in L.get_data(as_text=True)
         data = list(db.gps_sato_tate.search({'weight':int(1),'degree':int(2)}, projection='label'))
         assert len(data) == 3
         print("")
@@ -76,9 +76,9 @@ class SatoTateGroupTest(LmfdbTest):
             sys.stdout.write("{}...".format(label))
             sys.stdout.flush()
             L = self.tc.get('/SatoTateGroup/' + label)
-            assert label in L.data and 'Moment Statistics' in L.data
+            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=4')
-        assert 'of 52' in L.data
+        assert 'of 52' in L.get_data(as_text=True)
         data = list(db.gps_sato_tate.search({'weight':int(1),'degree':int(4)}, projection='label'))
         assert len(data) == 52
 
@@ -86,20 +86,20 @@ class SatoTateGroupTest(LmfdbTest):
             sys.stdout.write("{}...".format(label))
             sys.stdout.flush()
             L = self.tc.get('/SatoTateGroup/' + label)
-            assert label in L.data and 'Moment Statistics' in L.data
+            assert label in L.get_data(as_text=True) and 'Moment Statistics' in L.data
         L = self.tc.get('/SatoTateGroup/?components=999999999&include_irrational=yes')
-        assert 'unique match'  in L.data and 'mu(999999999)' in L.data
+        assert 'unique match'  in L.get_data(as_text=True) and 'mu(999999999)' in L.data
 
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')
         assert '0 matches'
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1/4')
-        assert '1.4.3.4.1a' in L.data
+        assert '1.4.3.4.1a' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=19/24')
-        assert '1.4.1.24.14a' in L.data
+        assert '1.4.1.24.14a' in L.get_data(as_text=True)
         
     def test_favourites(self):
         for label in [ '1.2.1.2.1a','1.2.3.1.1a', '1.4.1.12.4d', '1.4.3.6.2a', '1.4.6.1.1a', '1.4.10.1.1a' ]:
             L = self.tc.get('/SatoTateGroup/'+label)
-            assert "Moment Statistics" in L.data
+            assert "Moment Statistics" in L.get_data(as_text=True)
 

--- a/lmfdb/siegel_modular_forms/smf_test_pages.py
+++ b/lmfdb/siegel_modular_forms/smf_test_pages.py
@@ -19,7 +19,7 @@ class SMFPageTest(LmfdbTest):
             print("Checking home page for SMF sample " + full_label)
             try:
                 n = n+1
-                pagedata = self.tc.get(url, follow_redirects=True).data
+                pagedata = self.tc.get(url, follow_redirects=True).get_data(as_text=True)
                 #print "Got %d bytes" % len(pagedata)
                 assert full_label in pagedata and "Hecke eigenform" in pagedata
             except:

--- a/lmfdb/siegel_modular_forms/test_siegel_modular_forms.py
+++ b/lmfdb/siegel_modular_forms/test_siegel_modular_forms.py
@@ -6,7 +6,7 @@ from lmfdb import db
 
 class HomePageTest(LmfdbTest):
     def check(self, url, text):
-        data = self.tc.get("/ModularForm/GSp/Q/" + url, follow_redirects=True).data
+        data = self.tc.get("/ModularForm/GSp/Q/" + url, follow_redirects=True).get_data(as_text=True)
         if isinstance(text, list):
             for t in text:
                 assert t in data, (

--- a/lmfdb/tests/test_acknowlegments.py
+++ b/lmfdb/tests/test_acknowlegments.py
@@ -24,18 +24,18 @@ class HomePageTest(LmfdbTest):
     #
     # The acknowledgments page
     def test_acknowledgements(self):
-        homepage = self.tc.get("/acknowledgment").data
+        homepage = self.tc.get("/acknowledgment").get_data(as_text=True)
         assert 'American Institute of Mathematics' in homepage
 
     #
     # Link to workshops page
     def test_workshops(self):
-        homepage = self.tc.get("/acknowledgment/activities").data
+        homepage = self.tc.get("/acknowledgment/activities").get_data(as_text=True)
         assert 'Computational Aspects of the Langlands Program' in homepage
     #
     # External Links on workshops page
     def test_workshoplinks(self):
-        homepage = self.tc.get("/acknowledgment/activities").data
+        homepage = self.tc.get("/acknowledgment/activities").get_data(as_text=True)
         self.check_external(homepage,
                 "http://people.oregonstate.edu/~swisherh/CRTNTconference/index.html",
                 'Galois')

--- a/lmfdb/tests/test_acknowlegments.py
+++ b/lmfdb/tests/test_acknowlegments.py
@@ -11,7 +11,7 @@ class HomePageTest(LmfdbTest):
 
     def check(self,homepage,path,text):
         assert path in homepage
-        assert text in self.tc.get(path).data
+        assert text in self.tc.get(path).get_data(as_text=True)
 
     def check_external(self, homepage, path, text):
         headers = {'User-Agent': 'Mozilla/5.0'}

--- a/lmfdb/tests/test_citations.py
+++ b/lmfdb/tests/test_citations.py
@@ -12,28 +12,28 @@ class CitationTest(LmfdbTest):
         Checking /citation page
         '''
         r = self.tc.get('/citation')
-        assert "A list of articles which cite the LMFDB" in r.data
+        assert "A list of articles which cite the LMFDB" in r.get_data(as_text=True)
 
     def test_how_to_cite(self):
         '''
         Checking "How to Cite" /citation/citing
         '''
         r = self.tc.get('/citation/citing')
-        assert "The BibTeX entry is" in r.data
-        assert "To cite a specific page in the LMFDB" in r.data
+        assert "The BibTeX entry is" in r.get_data(as_text=True)
+        assert "To cite a specific page in the LMFDB" in r.get_data(as_text=True)
 
     def test_citation_specific(self):
         '''
         Checking that a known citation appears in /citation/citations list
         '''
         r = self.tc.get('/citation/citations')
-        assert "Thomas&nbsp;A Hulse" in r.data
-        assert "Counting square discriminants" in r.data
+        assert "Thomas&nbsp;A Hulse" in r.get_data(as_text=True)
+        assert "Counting square discriminants" in r.get_data(as_text=True)
 
     def test_cite_bib(self):
         '''
         Checking that a known bib is in /citation/citations_bib bibliography
         '''
         r = self.tc.get('/citation/citations_bib')
-        assert "Hulse, Thomas A" in r.data
-        assert "Counting square discriminants" in r.data
+        assert "Hulse, Thomas A" in r.get_data(as_text=True)
+        assert "Counting square discriminants" in r.get_data(as_text=True)

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -9,33 +9,33 @@ class DynamicKnowlTest(LmfdbTest):
 
     def test_Galois_group_knowl(self):
         L = self.tc.get('/knowledge/show/nf.galois_group.data?n=5&t=5', follow_redirects=True)
-        assert 'Prime degree' in L.data
+        assert 'Prime degree' in L.get_data(as_text=True)
 
     def test_conjugacy_classes_knowl(self):
         L = self.tc.get('/knowledge/show/gg.conjugacy_classes.data?n=5&t=5', follow_redirects=True)
-        assert '1,2,3' in L.data
+        assert '1,2,3' in L.get_data(as_text=True)
 
     def test_character_table_knowl(self):
         L = self.tc.get('/knowledge/show/gg.character_table.data?n=5&t=5', follow_redirects=True)
         # character table order can vary, so use trivial character
-        assert '1  1  1  1  1  1  1' in L.data
+        assert '1  1  1  1  1  1  1' in L.get_data(as_text=True)
 
     def test_small_group_knowl(self):
         L = self.tc.get('/knowledge/show/group.small.data?gapid=2.1', follow_redirects=True)
-        assert 'Maximal subgroups' in L.data
+        assert 'Maximal subgroups' in L.get_data(as_text=True)
 
     def test_number_field_knowl(self):
         L = self.tc.get('/knowledge/show/nf.field.data?label=6.0.21296.1', follow_redirects=True)
-        assert '-21296' in L.data
+        assert '-21296' in L.get_data(as_text=True)
 
     def test_local_field_knowl(self):
         L = self.tc.get('/knowledge/show/lf.field.data?label=2.2.3.4', follow_redirects=True)
-        assert 'Residue field degree' in L.data
+        assert 'Residue field degree' in L.get_data(as_text=True)
 
     def test_galois_module_knowl(self):
         L = self.tc.get('/knowledge/show/nf.galois_group.gmodule?ind=3&n=6&t=2', follow_redirects=True)
-        assert 'Action' in L.data
+        assert 'Action' in L.get_data(as_text=True)
 
     def test_galois_alias_knowl(self):
         L = self.tc.get('/knowledge/show/nf.galois_group.name', follow_redirects=True)
-        assert '11T6' in L.data
+        assert '11T6' in L.get_data(as_text=True)

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -8,28 +8,28 @@ class DynamicKnowlTest(LmfdbTest):
     """
 
     def test_Galois_group_knowl(self):
-        L = self.tc.get('/knowledge/show/nf.galois_group.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/nf.galois_group.data?n=5&t=5', follow_redirects=True)
         assert 'Prime degree' in L.get_data(as_text=True)
 
     def test_conjugacy_classes_knowl(self):
-        L = self.tc.get('/knowledge/show/gg.conjugacy_classes.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/gg.conjugacy_classes.data?n=5&t=5', follow_redirects=True)
         assert '1,2,3' in L.get_data(as_text=True)
 
     def test_character_table_knowl(self):
-        L = self.tc.get('/knowledge/show/gg.character_table.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/gg.character_table.data?n=5&t=5', follow_redirects=True)
         # character table order can vary, so use trivial character
         assert '1  1  1  1  1  1  1' in L.get_data(as_text=True)
 
     def test_small_group_knowl(self):
-        L = self.tc.get('/knowledge/show/group.small.get_data(as_text=True)?gapid=2.1', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/group.small.data?gapid=2.1', follow_redirects=True)
         assert 'Maximal subgroups' in L.get_data(as_text=True)
 
     def test_number_field_knowl(self):
-        L = self.tc.get('/knowledge/show/nf.field.get_data(as_text=True)?label=6.0.21296.1', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/nf.field.data?label=6.0.21296.1', follow_redirects=True)
         assert '-21296' in L.get_data(as_text=True)
 
     def test_local_field_knowl(self):
-        L = self.tc.get('/knowledge/show/lf.field.get_data(as_text=True)?label=2.2.3.4', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/lf.field.data?label=2.2.3.4', follow_redirects=True)
         assert 'Residue field degree' in L.get_data(as_text=True)
 
     def test_galois_module_knowl(self):

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -8,28 +8,28 @@ class DynamicKnowlTest(LmfdbTest):
     """
 
     def test_Galois_group_knowl(self):
-        L = self.tc.get('/knowledge/show/nf.galois_group.data?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/nf.galois_group.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
         assert 'Prime degree' in L.get_data(as_text=True)
 
     def test_conjugacy_classes_knowl(self):
-        L = self.tc.get('/knowledge/show/gg.conjugacy_classes.data?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/gg.conjugacy_classes.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
         assert '1,2,3' in L.get_data(as_text=True)
 
     def test_character_table_knowl(self):
-        L = self.tc.get('/knowledge/show/gg.character_table.data?n=5&t=5', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/gg.character_table.get_data(as_text=True)?n=5&t=5', follow_redirects=True)
         # character table order can vary, so use trivial character
         assert '1  1  1  1  1  1  1' in L.get_data(as_text=True)
 
     def test_small_group_knowl(self):
-        L = self.tc.get('/knowledge/show/group.small.data?gapid=2.1', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/group.small.get_data(as_text=True)?gapid=2.1', follow_redirects=True)
         assert 'Maximal subgroups' in L.get_data(as_text=True)
 
     def test_number_field_knowl(self):
-        L = self.tc.get('/knowledge/show/nf.field.data?label=6.0.21296.1', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/nf.field.get_data(as_text=True)?label=6.0.21296.1', follow_redirects=True)
         assert '-21296' in L.get_data(as_text=True)
 
     def test_local_field_knowl(self):
-        L = self.tc.get('/knowledge/show/lf.field.data?label=2.2.3.4', follow_redirects=True)
+        L = self.tc.get('/knowledge/show/lf.field.get_data(as_text=True)?label=2.2.3.4', follow_redirects=True)
         assert 'Residue field degree' in L.get_data(as_text=True)
 
     def test_galois_module_knowl(self):

--- a/lmfdb/tests/test_homepage.py
+++ b/lmfdb/tests/test_homepage.py
@@ -6,7 +6,7 @@ class HomePageTest(LmfdbTest):
 
     def check(self,homepage,path,text):
         assert path in homepage, "%s not in the homepage" % path
-        assert text in self.tc.get(path, follow_redirects=True).data, "%s not in the %s" % (text, path)
+        assert text in self.tc.get(path, follow_redirects=True).get_data(as_text=True), "%s not in the %s" % (text, path)
 
     def check_external(self, homepage, path, text):
         from six.moves.urllib.request import urlopen

--- a/lmfdb/tests/test_homepage.py
+++ b/lmfdb/tests/test_homepage.py
@@ -20,7 +20,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 1 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check(homepage, "/L/degree2/", '9.53369')
         self.check(homepage, "/EllipticCurve/Q/?conductor=1-99", '[1, 0, 1, -11, 12]')
         # self.check(homepage, "/ModularForm/GL2/Q/Maass/",  'The database contains 16599 Maass forms')
@@ -33,7 +33,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 2 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check(homepage,"/L/Riemann/",  'Pole at \(s=1\)')
         self.check(homepage,"/ModularForm/GL2/Q/holomorphic/1/12/a/a/", '4830')
         self.check(homepage,"/ModularForm/GL2/Q/holomorphic/1/12/a/a/", '113643')
@@ -46,7 +46,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 3 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check(homepage, "/L/", 'Dirichlet')
         self.check(homepage, "/L/", 'Symmetric square')
         self.check(homepage, "/L/", 'Genus 2 curve')
@@ -59,7 +59,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 4 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check(homepage, "/L/degree4/MaassForm/", 'data on L-functions associated to Maass cusp forms for GSp(4) of level 1')
         self.check(homepage, "/EllipticCurve/Q/102/c/", r'1 &amp; 2 &amp; 4 &amp; 4 &amp; 8 &amp; 8')
 
@@ -68,7 +68,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 5 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check(homepage, "/universe", 'universe')
         # removed in PR #1167
         #self.check(homepage, "/knowledge/", 'Recently modified Knowls')
@@ -78,7 +78,7 @@ class HomePageTest(LmfdbTest):
         r"""
         Check that the links in Box 6 work.
         """
-        homepage = self.tc.get("/").data
+        homepage = self.tc.get("/").get_data(as_text=True)
         self.check_external(homepage, "https://github.com/LMFDB/lmfdb", 'Modular Forms Database')
         # I could not get this one to work - AVS
         #self.check_external(homepage, "http://www.sagemath.org/", 'mathematics software system')

--- a/lmfdb/tests/test_root.py
+++ b/lmfdb/tests/test_root.py
@@ -28,12 +28,12 @@ class RootTest(LmfdbTest):
         assert len(self.tc.get("/favicon.ico").get_data()) > 10
 
     def test_javscript(self):
-        js = self.tc.get("/static/lmfdb.js").data
+        js = self.tc.get("/static/lmfdb.js").get_data(as_text=True)
         # click handler def for knowls
         assert r"""$("body").on("click", "*[knowl]", debounce(knowl_handle,500, true));""" in js
 
     def test_css(self):
-        css = self.tc.get("/style.css").data
+        css = self.tc.get("/style.css").get_data(as_text=True)
         # def for knowls:
         assert '*[knowl]' in css
         assert 'border-bottom: 1px dotted' in css

--- a/lmfdb/tests/test_root.py
+++ b/lmfdb/tests/test_root.py
@@ -25,7 +25,7 @@ class RootTest(LmfdbTest):
         assert "Disallow: /static" in r.get_data(as_text=True)
 
     def test_favicon(self):
-        assert len(self.tc.get("/favicon.ico").get_data(as_text=True)) > 10
+        assert len(self.tc.get("/favicon.ico").get_data()) > 10
 
     def test_javscript(self):
         js = self.tc.get("/static/lmfdb.js").data

--- a/lmfdb/tests/test_root.py
+++ b/lmfdb/tests/test_root.py
@@ -18,14 +18,14 @@ class RootTest(LmfdbTest):
 
     def test_root(self):
         root = self.tc.get("/")
-        assert "database" in root.data
+        assert "database" in root.get_data(as_text=True)
 
     def test_robots(self):
         r = self.tc.get("/static/robots.txt")
-        assert "Disallow: /static" in r.data
+        assert "Disallow: /static" in r.get_data(as_text=True)
 
     def test_favicon(self):
-        assert len(self.tc.get("/favicon.ico").data) > 10
+        assert len(self.tc.get("/favicon.ico").get_data(as_text=True)) > 10
 
     def test_javscript(self):
         js = self.tc.get("/static/lmfdb.js").data
@@ -47,7 +47,7 @@ class RootTest(LmfdbTest):
             if "GET" in rule.methods:
                 tc = self.app.test_client()
                 res = tc.get(rule.rule)
-                assert "Database" in res.data, "rule %s failed " % rule
+                assert "Database" in res.get_data(as_text=True), "rule %s failed " % rule
 
     @unittest2.skip("Tests for latex errors, but fails at the moment because of other errors")
     def test_some_latex_error(self):
@@ -59,7 +59,7 @@ class RootTest(LmfdbTest):
                 try:
                     tc = self.app.test_client()
                     res = tc.get(rule.rule)
-                    assert not ("Undefined control sequence" in res.data), "rule %s failed" % rule
+                    assert not ("Undefined control sequence" in res.get_data(as_text=True)), "rule %s failed" % rule
                 except KeyError:
                     pass
 

--- a/lmfdb/tests/test_spelling.py
+++ b/lmfdb/tests/test_spelling.py
@@ -19,7 +19,7 @@ class SpellingTest(LmfdbTest):
                 try:
                     tc = self.app.test_client()
                     res = tc.get(rule.rule)
-                    assert not ("zeroes" in res.data), "rule %s failed " % rule
+                    assert not ("zeroes" in res.get_data(as_text=True)), "rule %s failed " % rule
                 except KeyError:
                     pass
 
@@ -37,9 +37,9 @@ class SpellingTest(LmfdbTest):
     #            try:
     #                tc = self.app.test_client()
     #                res = tc.get(rule.rule)
-    #                assert not ("maas" in res.data), "rule %s failed " % rule
-    #                assert not ("mass" in res.data), "rule %s failed " % rule
-    #                assert not ("Maas" in res.data), "rule %s failed " % rule
-    #                assert not ("Mass" in res.data), "rule %s failed " % rule
+    #                assert not ("maas" in res.get_data(as_text=True)), "rule %s failed " % rule
+    #                assert not ("mass" in res.get_data(as_text=True)), "rule %s failed " % rule
+    #                assert not ("Maas" in res.get_data(as_text=True)), "rule %s failed " % rule
+    #                assert not ("Mass" in res.get_data(as_text=True)), "rule %s failed " % rule
     #            except KeyError:
     #                pass

--- a/lmfdb/tests/test_tensor_products.py
+++ b/lmfdb/tests/test_tensor_products.py
@@ -14,15 +14,15 @@ class TensorProductTest(LmfdbTest):
     @unittest2.skip("Tests tensor product of elliptic curve and Dirchlet L-functions -- skipping all tensor product tests ")
     def test_ellcurve_dirichletchar(self):
         L = self.tc.get("/TensorProducts/show/?obj1=Character%2FDirichlet%2F13%2F2&obj2=EllipticCurve%2FQ%2F11.a2")
-        assert '1859' in L.data
+        assert '1859' in L.get_data(as_text=True)
 
     @unittest2.skip("Tests tensor product of artin rep and modular form L-functions -- skipping all tensor product tests ")
     def test_modform_artinrep(self):
         L1 = self.tc.get("ModularForm/GL2/Q/holomorphic/1/12/1/a/")
-        assert "6048q^{6}" in L1.data
+        assert "6048q^{6}" in L1.get_data(as_text=True)
         # the following lines need changing after Artin rep
         # relabelling.  Perhaps "ArtinRepresentation/2.31.3t2.1c1"
         L2 = self.tc.get("ArtinRepresentation/2/31/1/")
-        assert "(1,2,3)" in L2.data
+        assert "(1,2,3)" in L2.get_data(as_text=True)
         L = self.tc.get("TensorProducts/show/?obj1=ModularForm%2FGL2%2FQ%2Fholomorphic%2F1%2F12%2F0%2Fa%2F0&obj2=ArtinRepresentation%2F2%2F31%2F1%2F")
-        assert '961' in L.data
+        assert '961' in L.get_data(as_text=True)

--- a/lmfdb/users/test_users.py
+++ b/lmfdb/users/test_users.py
@@ -20,4 +20,4 @@ class UsersTestCase(LmfdbTest):
 
     def test_user(self, id='cremona'):
         p = self.tc.get("/users/profile/%s" % id)
-        assert id in p.data
+        assert id in p.get_data(as_text=True)


### PR DESCRIPTION
This gets us ready for Sage 9.0, as `tc.get(foo).data` returns a byte string, thus all of our tests fail
This PR was generated with:
```
find lmfdb -name "test_*.py" | xargs sed -ie '/assert/s/\.data/.get_data(as_text=True)/'
```