### PR TITLE
Correct sage code for torsion subgroup

### DIFF
--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -73,7 +73,7 @@ gens:
   magma: Generators(E); // includes torsion
 
 tors:
-  sage:  E.torsion_subgroup().gens()
+  sage:  E.torsion_subgroup()
   pari:  elltors(E)[2]
   magma: TorsionSubgroup(E);
 


### PR DESCRIPTION
for ecnf, see for example https://www.lmfdb.org/EllipticCurve/6.6.300125.1/1.1/a/2 and click sage code then  `sage: E.torsion_subgroup().gens()`  appears under structure and generators