### PR TITLE
Tweak torsion subgroup snippets

### DIFF
--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -1,37 +1,33 @@
 prompt:
-  sage:   'sage'
-  pari:   'gp (2.8)'
-  magma:  'magma'
+  sage:  'sage'
+  pari:  'gp (2.8)'
+  magma: 'magma'
 
 logo:
-  sage: <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
+  sage:  <img src ="http://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
+  pari:  <img src = "http://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
   magma: <img src = "http://i.stack.imgur.com/0468s.png" width="50px">
 
 not-implemented:
-  sage: |
+  sage:  |
     # (not yet implemented)
-  pari: |
+  pari:  |
     \\\\ (not yet implemented)
   magma: |
     // (not yet implemented)
 
 field:
-  sage: x = polygen(QQ);  K.<a> = NumberField(%s)
-  pari: K = nfinit(%s);
+  sage:  x = polygen(QQ);  K.<a> = NumberField(%s)
+  pari:  K = nfinit(%s);
   magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(R!%s);
 
 curve:
-  sage: |
-    E = EllipticCurve(K, %s)
-  pari: |
-    E = ellinit(%s,K)
-  magma: |
-    E := ChangeRing(EllipticCurve(%s),K);
+  sage:  E = EllipticCurve(K, %s)
+  pari:  E = ellinit(%s,K)
+  magma: E := ChangeRing(EllipticCurve(%s),K);
 
 is_min:
-  sage: |
-    E.is_global_minimal_model()
+  sage:  E.is_global_minimal_model()
 
 cond:
   sage:  E.conductor()
@@ -73,24 +69,21 @@ gens:
   magma: Generators(E); // includes torsion
 
 tors:
-  sage:  E.torsion_subgroup()
-  pari:  elltors(E)[2]
-  magma: TorsionSubgroup(E);
+  sage:  T = E.torsion_subgroup(); T.invariants()
+  pari:  T = elltors(E); T[2]
+  magma: T,pi := TorsionSubgroup(E); Invariants(T);
 
 torgens:
-  sage:  E.torsion_subgroup().gens()
-  pari:  elltors(E)[3]
+  sage:  T.gens()
+  pari:  T[3]
   magma: |
-    [f(P): P in Generators(T)] where T,f:=TorsionSubgroup(E);
+         [pi(P) : P in Generators(T)];
 
 ntors:
-  sage:  E.torsion_order()
-  pari:  elltors(E)[1]
-  magma: Order(TorsionSubgroup(E));
-
+  sage:  T.order()
+  pari:  T[3]
+  magma: Order(T);
 
 localdata:
-  sage:
-    E.local_data()
-  magma:
-    LocalInformation(E);
+  sage:  E.local_data()
+  magma: LocalInformation(E);

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -60,24 +60,31 @@ rank:
   sage:  E.rank()
   magma: Rank(E);
 
-reg:
-  sage:  E.regulator_of_points(E.gens())
-  magma: Regulator(Generators(E));
-
 gens:
-  sage:  E.gens()
-  magma: Generators(E); // includes torsion
+  sage:  gens = E.gens(); gens
+  magma: |
+         gens := [P:P in Generators(E)|Order(P) eq 0]; gens;
+
+reg:
+  sage:  E.regulator_of_points(gens)
+  magma: Regulator(gens);
+
+heights:
+  sage:  |
+         [P.height():P in gens]
+  magma: |
+         [Height(P):P in gens];
 
 tors:
   sage:  T = E.torsion_subgroup(); T.invariants()
   pari:  T = elltors(E); T[2]
-  magma: T,pi := TorsionSubgroup(E); Invariants(T);
+  magma: T,piT := TorsionSubgroup(E); Invariants(T);
 
 torgens:
   sage:  T.gens()
   pari:  T[3]
   magma: |
-         [pi(P) : P in Generators(T)];
+         [piT(P) : P in Generators(T)];
 
 ntors:
   sage:  T.order()

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -71,7 +71,7 @@ reg:
 
 heights:
   sage:  |
-         [P.height():P in gens]
+         [P.height() for P in gens]
   magma: |
          [Height(P):P in gens];
 

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -1,6 +1,6 @@
 prompt:
   sage:  'sage'
-  pari:  'gp (2.8)'
+  pari:  'gp'
   magma: 'magma'
 
 logo:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -688,8 +688,8 @@ def ecnf_code_download(**args):
     return response
 
 sorted_code_names = ['field', 'curve', 'is_min', 'cond', 'cond_norm',
-                     'disc', 'disc_norm', 'jinv', 'cm', 'rank', 'ntors',
-                     'gens', 'reg', 'tors', 'torgens', 'localdata']
+                     'disc', 'disc_norm', 'jinv', 'cm', 'rank',
+                     'gens', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
 
 code_names = {'field': 'Define the base number field',
               'curve': 'Define the curve',

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -689,7 +689,7 @@ def ecnf_code_download(**args):
 
 sorted_code_names = ['field', 'curve', 'is_min', 'cond', 'cond_norm',
                      'disc', 'disc_norm', 'jinv', 'cm', 'rank',
-                     'gens', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
+                     'gens', 'heights', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
 
 code_names = {'field': 'Define the base number field',
               'curve': 'Define the curve',
@@ -703,6 +703,7 @@ code_names = {'field': 'Define the base number field',
               'rank': 'Compute the Mordell-Weil rank',
               'ntors': 'Compute the order of the torsion subgroup',
               'gens': 'Compute the generators (of infinite order)',
+              'heights': 'Compute the heights of the generators (of infinite order)',
               'reg': 'Compute the regulator',
               'tors': 'Compute the torsion subgroup',
               'torgens': 'Compute the generators of the torsion subgroup',

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -196,9 +196,9 @@ cellpadding="5";
 Rank not available.
 {% endif %}
 {% else %}
-<b>Rank:</b> \( {{ ec.rank }} \)<br>
+<b>Rank:</b> \( {{ ec.rank }} \)
 {% endif %}
- {{ place_code('rank') }}
+<p>{{ place_code('rank') }}</p>
 
 {% if ec.rank_bounds[0] %}
 {% if ec.gens == 'not available' %}
@@ -211,6 +211,7 @@ Generator:
 Generators:
 {% endif %}</b>
 {{ ec.gens }}
+{{ place_code('gens') }}
 </p>
 <p><b>
 {% if ec.rank_bounds[0] == 1 %}
@@ -219,9 +220,9 @@ Generators:
 {{ KNOWL('ec.canonical_height', title="Heights") }}:
 {% endif %}</b>
 {% for h in ec.heights %}{%-if loop.index0-%}, {% endif %}{{h}}{% endfor %}
+{{ place_code('heights') }}
 </p>
 {% endif %}
- {{ place_code('gens') }}
 {% endif %}
 
 <p>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -239,7 +239,7 @@ Generators:
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
 <tr><td colspan=2> {{ place_code('tors') }}</td></tr>
-<tr><td colspan=2> {{ place_code('ntors') }}</td></tr>
+<!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
 <th>{% if ec.tr==1 %}Generator{% else %}Generators{% endif %}:</th>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -196,7 +196,7 @@ cellpadding="5";
 Rank not available.
 {% endif %}
 {% else %}
-<b>Rank:</b> \( {{ ec.rank }} \)
+<b>Rank:</b> \( {{ ec.rank }} \)<br>
 {% endif %}
  {{ place_code('rank') }}
 
@@ -221,8 +221,8 @@ Generators:
 {% for h in ec.heights %}{%-if loop.index0-%}, {% endif %}{{h}}{% endfor %}
 </p>
 {% endif %}
-{% endif %}
  {{ place_code('gens') }}
+{% endif %}
 
 <p>
 <b>{{ KNOWL('ec.regulator', title="Regulator") }}:</b>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -228,6 +228,7 @@ Generators:
 <p>
 <b>{{ KNOWL('ec.regulator', title="Regulator") }}:</b>
 {{ ec.reg }}
+{% if not ec.rank_bounds[0] %} {{ place_code('gens') }} {% endif %}
  {{ place_code('reg') }}
 </p>
 </div>


### PR DESCRIPTION
This PR is meant to address the concerns raised after I prematurely committed #3642.  The changes all relate to the code snippets on torsion subgroups.  You can see the changes on https://red.lmfdb.xyz. 

Some pages to compare:

https://beta.lmfdb.org/EllipticCurve/2.2.5.1/76.1/b/2 (old)
https://red.lmfdb.xyz/EllipticCurve/2.2.5.1/76.1/b/2 (new)

https://beta.lmfdb.org/EllipticCurve/3.1.23.1/19379.1/A/1 (old)
https://red.lmfdb.xyz/EllipticCurve/3.1.23.1/19379.1/A/1 (new)

https://beta.lmfdb.org/EllipticCurve/2.2.40.1/142.1/b/1 (old)
https://red.lmfdb.xyz/EllipticCurve/2.2.40.1/142.1/b/1 (new)

https://beta.lmfdb.org/EllipticCurve/4.4.1125.1/45.1/b/8 (old)
https://red.lmfdb.xyz/EllipticCurve/4.4.1125.1/45.1/b/8 (new)

Try clicking on code snippets for Magma / PariGP / SageMath, and also the download all code options.  You will see that the torsion structure code snippets now actually display the structure (i.e. what you see on the page), rather than just computing the torsion subgroup and/or a list of generators for it and expecting the user to figure out what to do from there.

In addition to changing the torsion subgroup code snippets, I modified the (infinite order) generators snippet for magma to only take the generators of infinite order (to be consistent with Sage and what is displayed on the page) and modified the regulator snippet accordingly.

I also added a new code snippet for heights, which Sage and Magma are both happy to compute.

I changed the ecnf-curve.html template to only show the code snippet for the structure of the torsion subgroup, rather than structure and order, since the page doesn't display the order, but you still get the snippet for the torsion order in the download code options.  I also changed the display to only put code snippets for quantities that are actually displayed on the page (again the download code options will return everything), because otherwise it gets confusing.

Aside: on the second example page above the rank is marked as not available, but if you run the code snippets you will see that Magma and Sage are both able to compute it (and say it is zero).
