### PR TITLE
Fix bug in random_sample's CHOICE method

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -2294,7 +2294,7 @@ class PostgresTable(PostgresBase):
             count = int(len(results) * ratio)
             if repeatable is not None:
                 random.seed(repeatable)
-            return self._search_iterator(random.sample(results, count), search_cols, extra_cols, projection)
+            return random.sample(results, count)
         elif mode in ['SYSTEM', 'BERNOULLI']:
             if extra_cols:
                 raise ValueError("You cannot use the system or bernoulli modes with extra columns")


### PR DESCRIPTION
There was a bug in `random_sample`.  Since `random_sample` isn't currently used in the production site, this change should have no effect on the website.

To see the difference, compare the results of 
`db.ec_curves.random_sample(1/3000, mode='choice', projection=['num_int_pts', 'xcoord_integral_points', 'label', 'ainvs'])` before and after this change.