### PR TITLE
Add number of auts to NF pages

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -394,6 +394,7 @@ def render_field_webpage(args):
     t = nf.galois_t()
     n = nf.degree()
     data['is_galois'] = nf.is_galois()
+    data['autstring'] = r'\Gal' if data['is_galois'] else r'\Aut'
     data['is_abelian'] = nf.is_abelian()
     if nf.is_abelian():
         conductor = nf.conductor()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -409,6 +409,7 @@ def render_field_webpage(args):
             factored_conductor = factor_base_factorization_latex(factored_conductor)
             data['conductor'] = r"\(%s=%s\)" % (str(data['conductor']), factored_conductor)
     data['galois_group'] = group_pretty_and_nTj(n,t,True)
+    data['auts'] = db.gps_transitive.lookup(r'{}T{}'.format(n,t))['auts']
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
     data['class_group'] = nf.class_group()

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -49,7 +49,7 @@ table.ntdata a {
   {% elif info.is_galois %}
             <tr><td colspan="3">This field is Galois over $\Q$.</tr>
   {% else %}
-            <tr><td colspan="3">This field is not Galois over $\Q$</tr>
+            <tr><td colspan="3">This field is not Galois over $\Q$.</tr>
   {% endif %}
   {% if nf.is_cm_field() %}
   <tr><td colspan="3">This is a {{ KNOWL('nf.cm_field', title="CM field") }}.</tr>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -34,6 +34,8 @@ table.ntdata a {
              <tr><td>{{ KNOWL('nf.discriminant', title="Discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.discriminant}}<td>{{ place_code('discriminant') }}
              <tr><td>{{ KNOWL('nf.root_discriminant', title="Root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.rd}}<td>{{ place_code('rd') }}
             <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
+            <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
+            <tr><td> $|{{ info.autstring|safe }}(K/\Q)|$:<td>&nbsp;&nbsp;<td>${{info.auts}}$</td></tr>
   {% if info.is_abelian %}
             <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>
                 <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>
@@ -48,13 +50,7 @@ table.ntdata a {
   {% elif info.is_galois %}
             <tr><td colspan="3">This field is Galois over $\Q$.</tr>
   {% else %}
-            <tr><td colspan="3">This field is not Galois over $\Q$ and has
-              {% if info.auts == 1 %}
-                only one automorphism.
-              {% else %}
-                {{info.auts}} automorphisms.
-              {% endif %}
-            </tr>
+            <tr><td colspan="3">This field is not Galois over $\Q$</tr>
   {% endif %}
   {% if nf.is_cm_field() %}
   <tr><td colspan="3">This is a {{ KNOWL('nf.cm_field', title="CM field") }}.</tr>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -34,7 +34,6 @@ table.ntdata a {
              <tr><td>{{ KNOWL('nf.discriminant', title="Discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.discriminant}}<td>{{ place_code('discriminant') }}
              <tr><td>{{ KNOWL('nf.root_discriminant', title="Root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.rd}}<td>{{ place_code('rd') }}
             <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
-            <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
             <tr><td> $|{{ info.autstring|safe }}(K/\Q)|$:<td>&nbsp;&nbsp;<td>${{info.auts}}$</td></tr>
   {% if info.is_abelian %}
             <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -48,7 +48,13 @@ table.ntdata a {
   {% elif info.is_galois %}
             <tr><td colspan="3">This field is Galois over $\Q$.</tr>
   {% else %}
-            <tr><td colspan="3">This field is not Galois over $\Q$.</tr>
+            <tr><td colspan="3">This field is not Galois over $\Q$ and has
+              {% if info.auts == 1 %}
+                only one automorphism.
+              {% else %}
+                {{info.auts}} automorphisms.
+              {% endif %}
+            </tr>
   {% endif %}
   {% if nf.is_cm_field() %}
   <tr><td colspan="3">This is a {{ KNOWL('nf.cm_field', title="CM field") }}.</tr>


### PR DESCRIPTION
This does issue #3648 listing the number of automorphisms of a number field.  I decided to do the same for local fields and discovered they already listed the number of automorphisms.  So, this make global fields behave like local fields.

If a field is Galois, it gives |Gal(K/Q)|, otherwise |Aut(K/Q)| in the table at the top just above the sentence saying whether the field is Galois or not.

Sample pages

Galois:
 http://127.0.0.1:37777/NumberField/8.0.4194304.1
 http://beta.lmfdb.org/NumberField/8.0.4194304.1

Not Galois:
 http://127.0.0.1:37777/NumberField/6.6.4647635253.1
 http://beta.lmfdb.org/NumberField/6.6.4647635253.1