### PR TITLE
More genus 2 tweaks

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -322,6 +322,8 @@ def genus2_curve_search(info, query):
         mode = 'exact'
     elif info.get('bad_quantifier') == 'exclude':
         mode = 'complement'
+    elif info.get('bad_quantifier') == 'subset':
+        mode = 'subsets'
     else:
         mode = 'append'
     parse_primes(info, query, 'bad_primes', name='bad primes',qfield='bad_primes',mode=mode)

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -150,9 +150,9 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
 {{KNOWL('g2c.good_reduction', title='Bad primes')}}&nbsp;&thinsp;
   <select name='bad_quantifier'  style="width: 122px">
   <option value=''>include</option>
-  <option value="exclude">exclude</option>
+  <option value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
-  <option value='subset of'>subset</option>
+  <option value='subset'>subset of</option>
   </select>
 </td>
 <td><input type='text' name='bad_primes' size=10 example='5,13'></td>

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -152,6 +152,7 @@ A <a href={{url_for('.random_curve')}}>random genus 2 curve</a> from the databas
   <option value=''>include</option>
   <option value="exclude">exclude</option>
   <option value='exactly'>exactly</option>
+  <option value='subset of'>subset</option>
   </select>
 </td>
 <td><input type='text' name='bad_primes' size=10 example='5,13'></td>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -37,8 +37,6 @@ function show_eqns(invstyle) {
 <h2 class='min_eqn'>            {{ KNOWL('g2c.minimal_equation', title='Minimal equation') }} </h2>
 <h2 class='proj_eqn nodisplay'> {{ KNOWL('g2c.minimal_equation', title='Minimal equation') }} </h2>
 <h2 class='simp_eqn nodisplay'> {{ KNOWL('g2c.simple_equation',  title='Simplified equation') }} </h2>
-<p class='min_eqn proj_eqn'>{{place_code('curve')}}</p>
-<p class='simp_eqn nodisplay'>{{place_code('simplified_curve')}}</p>
 
 <table>
 <tr class='min_eqn'>
@@ -54,6 +52,7 @@ function show_eqns(invstyle) {
     <td>(<a onclick="show_eqns('min_eqn'); return false" href='#'>minimize</a>, <a onclick="show_eqns('proj_eqn'); return false" href='#'>homogenize</a>)</td>
 <tr>
 </table>
+<p>{{place_code('curve')}}</p>
 
 <h2> {{ KNOWL('g2c.invariants', title='Invariants') }} </h2>
 <table>
@@ -66,11 +65,8 @@ function show_eqns(invstyle) {
 </table>
 
 <h3 class='igusa_clebsch'>{{KNOWL("g2c.igusa_clebsch_invariants", title="Igusa-Clebsch invariants")}}</h3>
-<p class='igusa_clebsch'>{{place_code('igusa_clebsch')}}</p>
 <h3 class='igusa nodisplay'>{{KNOWL("g2c.igusa_invariants", title="Igusa invariants")}}</h3>
-<p class='igusa nodisplay'>{{place_code('igusa')}}</p>
 <h3 class='G2 nodisplay'>{{KNOWL("g2c.g2_invariants", title="G2 invariants")}}</h3>
-<p class='G2 nodisplay'>{{place_code('g2')}}</p>
 
 <table>
     <tr class='igusa_clebsch'>
@@ -126,30 +122,23 @@ function show_eqns(invstyle) {
     <span class='G2 nodisplay'><a onclick="show_invs('igusa'); return false" href='#'>Igusa invariants</a>)</span>
     <span class='igusa_clebsch igusa'><a onclick="show_invs('G2'); return false" href='#'>G2 invariants</a>)</span>
 </div>
+<p>{{place_code('geom_inv')}}</p>
 
 <h2> {{ KNOWL('g2c.aut_grp', title='Automorphism group') }} </h2>
 
 <table>
-    <tr>
-        <td colspan="5">
-            {{place_code('aut')}}
-        </td>
-    </tr>
     <tr>
         <td>\(\mathrm{Aut}(X)\)</td><td>\(\simeq\)</td>
         <td>{{ data['aut_grp'] | safe }}</td>
         <!-- a hack so that that the table doesn't expand with code blurbls -->
         <!-- TODO: use javascript to adapt the width -->
         <td style="width: 420px;"></td>
-    </tr>
-    <tr>
-        <td colspan="5">
-            {{place_code('autQbar')}}
-        </td>
+        <td>{{place_code('aut')}}</td>
     </tr>
     <tr>
         <td>\(\mathrm{Aut}(X_{\overline{\Q}})\)</td><td>\(\simeq\)</td>
         <td>{{ data['geom_aut_grp'] | safe }}</td>
+        <td>{{place_code('autQbar')}}</td>
     </tr>
 </table>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -52,7 +52,7 @@ function show_eqns(invstyle) {
     <td>(<a onclick="show_eqns('min_eqn'); return false" href='#'>minimize</a>, <a onclick="show_eqns('proj_eqn'); return false" href='#'>homogenize</a>)</td>
 <tr>
 </table>
-<p>{{place_code('curve')}}</p>
+<p>{{place_code('curve')}}{{place_code('simple_curve')</p>
 
 <h2> {{ KNOWL('g2c.invariants', title='Invariants') }} </h2>
 <table>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -52,7 +52,7 @@ function show_eqns(invstyle) {
     <td>(<a onclick="show_eqns('min_eqn'); return false" href='#'>minimize</a>, <a onclick="show_eqns('proj_eqn'); return false" href='#'>homogenize</a>)</td>
 <tr>
 </table>
-<p>{{place_code('curve')}}{{place_code('simple_curve')</p>
+<p>{{place_code('curve')}}{{place_code('simple_curve'}}</p>
 
 <h2> {{ KNOWL('g2c.invariants', title='Invariants') }} </h2>
 <table>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -184,8 +184,10 @@ function show_eqns(invstyle) {
 
 <p>
 <table>
+    <tr><td>{{ KNOWL('g2c.hasse_weil_conjecture', title='Hasse-Weil conjecture') }}:</td>
+        <td>{% if data.hasse_weil_proved  %} verified {%else %} unverified {% endif %}</td></tr>
     <tr><td>{{ KNOWL('g2c.analytic_rank', title='Analytic rank') }}:</td>
-        <td>\({{data.analytic_rank}}\) {% if data.analytic_rank > 0 %}&nbsp;&nbsp;(upper bound){% endif %}</td></tr> 
+        <td>\({{data.analytic_rank}}\) {% if data.analytic_rank > 2 and data.analytic_rank_proved != True %}&nbsp;&nbsp;(upper bound){% endif %}</td></tr> 
     <tr><td>{{ KNOWL('g2c.mordell_weil_rank', title='Mordell-Weil rank') }}:</td>
         <td>\({{data.mw_rank}}\) {% if not data.mw_rank_proved %}&nbsp;&nbsp;(lower bound){% endif %}</td></tr>    
     <tr><td>{{ KNOWL('g2c.two_selmer_rank', title='2-Selmer rank') }}:</td><td>\({{data.two_selmer_rank}}\)</td></tr>

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -132,7 +132,6 @@ function show_eqns(invstyle) {
         <td>{{ data['aut_grp'] | safe }}</td>
         <!-- a hack so that that the table doesn't expand with code blurbls -->
         <!-- TODO: use javascript to adapt the width -->
-        <td style="width: 420px;"></td>
         <td>{{place_code('aut')}}</td>
     </tr>
     <tr>
@@ -145,29 +144,29 @@ function show_eqns(invstyle) {
 
 <h2> {{ KNOWL('g2c.all_rational_points','Rational points') }} </h2>
 
-<p>{{place_code('rat_pts')}}</p>
 <p>{{ data.rat_pts_table | safe }}</p>
+<p>{{place_code('rat_pts')}}</p>
 
-<p>{{place_code('num_rat_wpts')}}</p>
 <p>Number of rational {{ KNOWL('g2c.num_rat_wpts', title='Weierstrass points') }}: \({{data.num_rat_wpts}}\)</p>
+<p>{{place_code('num_rat_wpts')}}</p>
 
-<p>{{place_code('locally_solvable')}}</p>
 <p>This curve is {{ KNOWL('g2c.locally_solvable', title='locally solvable') }} {{data.non_solvable_places}}.</p>
+<p>{{place_code('locally_solvable')}}</p>
 
 <h2> {{KNOWL('ag.mordell_weil', title='Mordell-Weil group of the Jacobian')}}: </h2>
 
-<p>{{place_code('mw_group')}}</p>
 <p>
 {{ KNOWL('ag.mordell_weil', title='Group structure') }}: {{data.mw_group}}
 {% if not data.mw_rank_proved %} ({{ KNOWL('g2c.conditional_mw_group','conditional')}}) {% endif %}
 </p>
+<p>{{place_code('mw_group')}}</p>
 
 {% if data.mw_gens_table %}
 <p>{{ data.mw_gens_table | safe }}</p>
 {% endif %}
 
-<p>{{place_code('two_torsion_field')}}</p>
 <p>{{ KNOWL('g2c.two_torsion_field', title='2-torsion field') }}: {{data.two_torsion_field_knowl|safe}}</p>
+<p>{{place_code('two_torsion_field')}}</p>
 
 <h2> {{KNOWL('g2c.bsd_invariants', title='BSD invariants')}} </h2>
 

--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -52,7 +52,7 @@ function show_eqns(invstyle) {
     <td>(<a onclick="show_eqns('min_eqn'); return false" href='#'>minimize</a>, <a onclick="show_eqns('proj_eqn'); return false" href='#'>homogenize</a>)</td>
 <tr>
 </table>
-<p>{{place_code('curve')}}{{place_code('simple_curve'}}</p>
+<p>{{place_code('curve')}}{{place_code('simple_curve')}}</p>
 
 <h2> {{ KNOWL('g2c.invariants', title='Invariants') }} </h2>
 <table>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -120,22 +120,22 @@
   <option value=''>include</option>
   <option value='exclude'>exclude</option>
   <option selected value='exactly'>exactly</option>
-  <option value='subset'>'subset of'</option>
+  <option value='subset'>subset of</option>
 {% elif info.bad_quantifier=='exclude' %}
   <option value=''>include</option>
   <option selected value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
-  <option value='subset'>'subset of'</option>
+  <option value='subset'>subset of</option>
 {% elif info.bad_quantifier=='subset' %}
   <option value=''>include</option>
   <option value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
-  <option selected value='subset'>'subset of'</option>
+  <option selected value='subset'>subset of</option>
 {% else %}
   <option selected value=''>include</option>
   <option value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
-  <option value='subset'>'subset of'</option>
+  <option value='subset'>subset of</option>
 {% endif %}
   </select>
 <input type='text' name='bad_primes' placeholder="2,3" size=10  value={{info.bad_primes}}>

--- a/lmfdb/genus2_curves/templates/g2c_search_results.html
+++ b/lmfdb/genus2_curves/templates/g2c_search_results.html
@@ -120,14 +120,22 @@
   <option value=''>include</option>
   <option value='exclude'>exclude</option>
   <option selected value='exactly'>exactly</option>
+  <option value='subset'>'subset of'</option>
 {% elif info.bad_quantifier=='exclude' %}
   <option value=''>include</option>
   <option selected value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
+  <option value='subset'>'subset of'</option>
+{% elif info.bad_quantifier=='subset' %}
+  <option value=''>include</option>
+  <option value='exclude'>exclude</option>
+  <option value='exactly'>exactly</option>
+  <option selected value='subset'>'subset of'</option>
 {% else %}
   <option selected value=''>include</option>
   <option value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
+  <option value='subset'>'subset of'</option>
 {% endif %}
   </select>
 <input type='text' name='bad_primes' placeholder="2,3" size=10  value={{info.bad_primes}}>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -500,18 +500,17 @@ def mw_gens_table(invs,gens,hts,pts):
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('g2c.mw_generator', 'Generator'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
-              th_wrap('g2c.mw_generator_support', 'Rational support'),
+              th_wrap('g2c.mw_generator_support', 'Divisor'),
               th_wrap('ag.canonical_height', 'Height'),
               th_wrap('g2c.mw_generator_order', 'Order'),
               '</tr>', '</thead>', '<tbody>']
     for i in range(len(invs)):
         gentab.append('<tr>')
         D,xD,yD = list_to_divisor(gens[i])
-        Daff = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
-        supp = '2*' + point_string(Daff[0]) if xD.is_square() else ' + '.join([point_string(P) for P in Daff])
-        if supp:
-            Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1])]
-            supp += (' - ' + ' - '.join([point_string(P) for P in Dinf])) if Dinf else ' - D_\\infty'
+        D0 = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
+        Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1])]
+        supp = ('2 \\cdot' + point_string(D0[0]) if xD.is_square() else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
+        supp += ' - ' + (' - '.join([point_string(P) for P in Dinf]) if Dinf else 'D_\\infty')
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
                        td_wrapc(supp),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -866,8 +866,7 @@ class WebG2C(object):
         g = simplify_hyperelliptic(fh)
         code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s));'%(f,h),
                          'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'%(f,h) }
-        code['simple_curve'] = {'sage':'X = HyperellipticCurve(R(%s))'%(g),
-                                'magma':'X,pi:= SimplifiedModel(C);'%(f,h) }
+        code['simple_curve'] = {'sage':'X = HyperellipticCurve(R(%s))'%(g), 'magma':'X,pi:= SimplifiedModel(C);' }
         if data['abs_disc'] % 4096 == 0:
             ind2 = [a[0] for a in data['bad_lfactors']].index(2)
             bad2 = data['bad_lfactors'][ind2][1]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -635,6 +635,8 @@ class WebG2C(object):
         data['analytic_rank'] = ZZ(curve['analytic_rank'])
         data['mw_rank'] = ZZ(0) if curve.get('mw_rank') is None else ZZ(curve['mw_rank']) # 0 will be marked as a lower bound
         data['mw_rank_proved'] = curve['mw_rank_proved']
+        data['analytic_rank_proved'] = curve['analytic_rank_proved']
+        data['hasse_weil_proved'] = curve['hasse_weil_proved']
         data['st_group'] = curve['st_group']
         data['st_group_link'] = st_link_by_name(1,4,data['st_group'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -508,7 +508,7 @@ def mw_gens_table(invs,gens,hts,pts):
         gentab.append('<tr>')
         D,xD,yD = list_to_divisor(gens[i])
         Daff = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
-        supp = '2*' cat point_string(D0[0]) if xD.is_square() else ' + '.join([point_string(P) for P in Daff])
+        supp = '2*' + point_string(Daff[0]) if xD.is_square() else ' + '.join([point_string(P) for P in Daff])
         if supp:
             Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1])]
             supp += (' - ' + ' - '.join([point_string(P) for P in Dinf])) if Dinf else ' - D_\\infty'

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -500,7 +500,7 @@ def mw_gens_table(invs,gens,hts,pts):
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('g2c.mw_generator', 'Generator'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
-              th_wrap('g2c.mw_generator_support', 'Divisor'),
+              th_wrap('g2c.mw_generator', 'Divisor'),
               th_wrap('ag.canonical_height', 'Height'),
               th_wrap('g2c.mw_generator_order', 'Order'),
               '</tr>', '</thead>', '<tbody>']
@@ -512,7 +512,7 @@ def mw_gens_table(invs,gens,hts,pts):
         supp = ('2 \\cdot' + point_string(D0[0]) if xD.is_square() else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
         supp += ' - ' + (' - '.join([point_string(P) for P in Dinf]) if Dinf else 'D_\\infty')
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
-                       td_wrapc(supp),
+                       td_wrapl(supp),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
                        td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -504,7 +504,7 @@ def mw_gens_table(invs,gens,hts,pts):
     for i in range(len(invs)):
         gentab.append('<tr>')
         D,xD,yD = list_to_divisor(gens[i])
-        supp = [P for P in pts if P[2] and xD(P[1],P[3]) == 0 and yD(P[2],P[3]) == 0]
+        supp = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[1],P[2]) == 0]
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
                        td_wrapc(', '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -703,7 +703,7 @@ class WebG2C(object):
             else:
                 data['mw_group'] = r'\(' + r' \times '.join([ (r'\Z' if n == 0 else r'\Z/{%s}\Z' % n) for n in invs]) + r'\)'
             if lower >= upper:
-                data['mw_gens_table'] = mw_gens_table (ratpts['mw_invs'], ratpts['mw_gens'], ratpts['mw_heights'])
+                data['mw_gens_table'] = mw_gens_table (ratpts['mw_invs'], ratpts['mw_gens'], ratpts['mw_heights'], ratpts['rat_pts'])
 
             if curve['two_torsion_field'][0]:
                 data['two_torsion_field_knowl'] = nf_display_knowl (curve['two_torsion_field'][0], field_pretty(curve['two_torsion_field'][0]))

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -483,7 +483,7 @@ def td_wrapr(val):
 def td_wrapc(val):
     return r' <td align="center">\(%s\)</td>' % val
 
-def mw_gens_table(invs,gens,hts):
+def mw_gens_table(invs,gens,hts,pts):
     def list_to_divisor(P):
         R = PolynomialRing(QQ,['x','z']); x = R('x');z = R('z')
         xP,yP = P[0],P[1]
@@ -492,18 +492,21 @@ def mw_gens_table(invs,gens,hts):
         if str(xD.factor())[:4] == "(-1)":
             xD = -xD
         yD = sum([ZZ(yden)*ZZ(yP[i][0])/ZZ(yP[i][1])*x**i*z**(len(yP)-i-1) for i in range(len(yP))])
-        return [str(xD.factor()).replace("**","^").replace("*",""), str(yden)+"y" if yden > 1 else "y", str(yD).replace("**","^").replace("*","")]
+        return [str(xD.factor()).replace("**","^").replace("*",""), str(yden)+"y" if yden > 1 else "y", str(yD).replace("**","^").replace("*","")], xD, yD
     if not invs:
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('g2c.mw_generator', 'Generator'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
+              th_wrap('g2c.mw_generator_support', 'Rational points'),
               th_wrap('ag.canonical_height', 'Height'),
               th_wrap('g2c.mw_generator_order', 'Order'),
               '</tr>', '</thead>', '<tbody>']
     for i in range(len(invs)):
         gentab.append('<tr>')
-        D = list_to_divisor(gens[i])
+        D,xD,yD = list_to_divisor(gens[i])
+        supp = [P for P in pts if P[2] and xD(P[1],P[3]) == 0 and yD(P[2],P[3]) == 0]
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
+                       td_wrapc(', '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
                        td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')
@@ -624,7 +627,6 @@ class WebG2C(object):
         # all information about the curve, its Jacobian, isogeny class, and endomorphisms goes in the data dictionary
         # most of the data from the database gets polished/formatted before we put it in the data dictionary
         data = self.data = {}
-        print "curve",curve
 
         data['label'] = curve['label'] if is_curve else curve['class']
         data['slabel'] = data['label'].split('.')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -504,9 +504,9 @@ def mw_gens_table(invs,gens,hts,pts):
     for i in range(len(invs)):
         gentab.append('<tr>')
         D,xD,yD = list_to_divisor(gens[i])
-        supp = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[1],P[2]) == 0]
+        supp = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
-                       td_wrapc(', '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])),
+                       td_wrapc(',\\ '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
                        td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -484,7 +484,7 @@ def td_wrapc(val):
     return r' <td align="center">\(%s\)</td>' % val
 
 def point_string(P):
-    '(' + ' : '.join(map(str, P)) + ')'
+    return '(' + ' : '.join(map(str, P)) + ')'
 
 def mw_gens_table(invs,gens,hts,pts):
     def list_to_divisor(P):

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -505,8 +505,13 @@ def mw_gens_table(invs,gens,hts,pts):
         gentab.append('<tr>')
         D,xD,yD = list_to_divisor(gens[i])
         supp = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
+        if xD.is_square():
+            assert len(sup) == 1
+            supp = '2*(' + join(map(str, supp[0])) + ')'
+        else:
+            supp = ' + '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
-                       td_wrapc(',\\ '.join(['(' + ' : '.join(map(str, P)) + ')' for P in supp])),
+                       td_wrapc(supp),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
                        td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -509,7 +509,7 @@ def mw_gens_table(invs,gens,hts,pts):
         D,xD,yD,yden = divisor_data(gens[i])
         D0 = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1]]
         Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1])]
-        supp = (r'2 \cdot' + point_string(D0[0]) if len(D0)==1 and len(D0)!=1 else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
+        supp = (r'2 \cdot' + point_string(D0[0]) if len(D0)==1 and len(Dinf)!=1 else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
         supp += ' - '
         supp += (r'2 \cdot' + point_string(Dinf[0]) if len(Dinf)==1 and len(D0)!=1 else ' + '.join([point_string(P) for P in Dinf])) if Dinf else r'D_\infty'
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -864,8 +864,10 @@ class WebG2C(object):
         code['show'] = {'sage':'','magma':''} # use default show names
         f,h = fh = data['min_eqn']
         g = simplify_hyperelliptic(fh)
-        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ)<br>C = HyperellipticCurve(R(%s), R(%s)); X = HyperellipticCurve(R(%s))'%(f,h,g),
-                         'magma':'R<x> := PolynomialRing(Rationals());<br>C := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
+        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s));'%(f,h),
+                         'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'%(f,h) }
+        code['simple_curve'] = {'sage':'X = HyperellipticCurve(R(%s))'%(g),
+                                'magma':'X,pi:= SimplifiedModel(C);'%(f,h) }
         if data['abs_disc'] % 4096 == 0:
             ind2 = [a[0] for a in data['bad_lfactors']].index(2)
             bad2 = data['bad_lfactors'][ind2][1]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -624,6 +624,7 @@ class WebG2C(object):
         # all information about the curve, its Jacobian, isogeny class, and endomorphisms goes in the data dictionary
         # most of the data from the database gets polished/formatted before we put it in the data dictionary
         data = self.data = {}
+        print "curve",curve
 
         data['label'] = curve['label'] if is_curve else curve['class']
         data['slabel'] = data['label'].split('.')
@@ -637,8 +638,6 @@ class WebG2C(object):
         data['mw_rank_proved'] = curve['mw_rank_proved']
         data['analytic_rank_proved'] = curve['analytic_rank_proved']
         data['hasse_weil_proved'] = curve['hasse_weil_proved']
-        print "curve",curve
-        print "data",data
         data['st_group'] = curve['st_group']
         data['st_group_link'] = st_link_by_name(1,4,data['st_group'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -500,7 +500,7 @@ def mw_gens_table(invs,gens,hts,pts):
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('g2c.mw_generator', 'Generator'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
-              th_wrap('g2c.mw_generator', 'Divisor'),
+              th_wrap('g2c.mw_generator', '$D_0$'),
               th_wrap('ag.canonical_height', 'Height'),
               th_wrap('g2c.mw_generator_order', 'Order'),
               '</tr>', '</thead>', '<tbody>']
@@ -509,13 +509,11 @@ def mw_gens_table(invs,gens,hts,pts):
         D,xD,yD,yden = divisor_data(gens[i])
         D0 = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1]]
         Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1])]
-        supp = (r'2 \cdot' + point_string(D0[0]) if len(D0)==1 and len(Dinf)!=1 else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
-        supp += ' - '
-        supp += (r'2 \cdot' + point_string(Dinf[0]) if len(Dinf)==1 and len(D0)!=1 else ' + '.join([point_string(P) for P in Dinf])) if Dinf else r'D_\infty'
-        gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
-                       td_wrapl(supp),
-                       td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),
-                       td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
+        div = (r'2 \cdot' + point_string(D0[0]) if len(D0)==1 and len(Dinf)!=1 else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
+        div += ' - '
+        div += (r'2 \cdot' + point_string(Dinf[0]) if len(Dinf)==1 and len(D0)!=1 else ' - '.join([point_string(P) for P in Dinf])) if Dinf else r'D_\infty'
+        gentab.extend([td_wrapl(div), td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
+                       td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'), td_wrapc(r'\infty') if invs[i]==0 else td_wrapc(invs[i])])
         gentab.append('</tr>')
     gentab.extend(['</tbody>', '</table>'])
     return '\n'.join(gentab)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -487,7 +487,7 @@ def point_string(P):
     return '(' + ' : '.join(map(str, P)) + ')'
 
 def mw_gens_table(invs,gens,hts,pts):
-    def list_to_divisor(P):
+    def divisor_data(P):
         R = PolynomialRing(QQ,['x','z']); x = R('x');z = R('z')
         xP,yP = P[0],P[1]
         xden,yden = lcm([r[1] for r in xP]), lcm([r[1] for r in yP])
@@ -495,7 +495,7 @@ def mw_gens_table(invs,gens,hts,pts):
         if str(xD.factor())[:4] == "(-1)":
             xD = -xD
         yD = sum([ZZ(yden)*ZZ(yP[i][0])/ZZ(yP[i][1])*x**i*z**(len(yP)-i-1) for i in range(len(yP))])
-        return [str(xD.factor()).replace("**","^").replace("*",""), str(yden)+"y" if yden > 1 else "y", str(yD).replace("**","^").replace("*","")], xD, yD
+        return [str(xD.factor()).replace("**","^").replace("*",""), str(yden)+"y" if yden > 1 else "y", str(yD).replace("**","^").replace("*","")], xD, yD, yden
     if not invs:
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
@@ -506,11 +506,12 @@ def mw_gens_table(invs,gens,hts,pts):
               '</tr>', '</thead>', '<tbody>']
     for i in range(len(invs)):
         gentab.append('<tr>')
-        D,xD,yD = list_to_divisor(gens[i])
-        D0 = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1]]
-        Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == P[1])]
-        supp = ('2 \\cdot' + point_string(D0[0]) if xD.is_square() else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
-        supp += ' - ' + (' - '.join([point_string(P) for P in Dinf]) if Dinf else 'D_\\infty')
+        D,xD,yD,yden = divisor_data(gens[i])
+        D0 = [P for P in pts if P[2] and xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1]]
+        Dinf = [P for P in pts if P[2] == 0 and not (xD(P[0],P[2]) == 0 and yD(P[0],P[2]) == yden*P[1])]
+        supp = (r'2 \cdot' + point_string(D0[0]) if len(D0)==1 and len(D0)!=1 else ' + '.join([point_string(P) for P in D0])) if D0 else 'D_0'
+        supp += ' - '
+        supp += (r'2 \cdot' + point_string(Dinf[0]) if len(Dinf)==1 and len(D0)!=1 else ' + '.join([point_string(P) for P in Dinf])) if Dinf else r'D_\infty'
         gentab.extend([td_wrapr(D[0]),td_wrapc('='),td_wrapl("0,"),td_wrapr(D[1]),td_wrapc("="),td_wrapl(D[2]),
                        td_wrapl(supp),
                        td_wrapc(decimal_pretty(str(hts[i]))) if invs[i] == 0 else td_wrapc('0'),

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -864,8 +864,8 @@ class WebG2C(object):
         code['show'] = {'sage':'','magma':''} # use default show names
         f,h = fh = data['min_eqn']
         g = simplify_hyperelliptic(fh)
-        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s)); X = Hyperellipticcurve(R(%s))'%(f,h,g),
-                         'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
+        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ)\nC = HyperellipticCurve(R(%s), R(%s)); X = HyperellipticCurve(R(%s))'%(f,h,g),
+                         'magma':'R<x> := PolynomialRing(Rationals());\nC := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
         if data['abs_disc'] % 4096 == 0:
             ind2 = [a[0] for a in data['bad_lfactors']].index(2)
             bad2 = data['bad_lfactors'][ind2][1]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -499,8 +499,8 @@ def mw_gens_table(invs,gens,hts,pts):
     if not invs:
         return ''
     gentab = ['<table class="ntdata">', '<thead>', '<tr>',
-              th_wrap('g2c.mw_generator', 'Generator'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
-              th_wrap('g2c.mw_generator', '$D_0$'),
+              th_wrap('g2c.mw_generator', 'Generator'),
+              th_wrap('g2c.mw_generator', '$D_0$'), '<th></th>', '<th></th>', '<th></th>', '<th></th>', '<th></th>',
               th_wrap('ag.canonical_height', 'Height'),
               th_wrap('g2c.mw_generator_order', 'Order'),
               '</tr>', '</thead>', '<tbody>']

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -864,8 +864,8 @@ class WebG2C(object):
         code['show'] = {'sage':'','magma':''} # use default show names
         f,h = fh = data['min_eqn']
         g = simplify_hyperelliptic(fh)
-        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ)\nC = HyperellipticCurve(R(%s), R(%s)); X = HyperellipticCurve(R(%s))'%(f,h,g),
-                         'magma':'R<x> := PolynomialRing(Rationals());\nC := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
+        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ)<br>C = HyperellipticCurve(R(%s), R(%s)); X = HyperellipticCurve(R(%s))'%(f,h,g),
+                         'magma':'R<x> := PolynomialRing(Rationals());<br>C := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
         if data['abs_disc'] % 4096 == 0:
             ind2 = [a[0] for a in data['bad_lfactors']].index(2)
             bad2 = data['bad_lfactors'][ind2][1]

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -547,7 +547,7 @@ def local_table(D,N,tama,bad_lpolys):
 
 def ratpts_table(pts,pts_v):
     def sorted_points(pts):
-        sorted(pts,key=lambda P:(max([abs(x) for x in P]),sum([abs(x) for x in P])))
+        return sorted(pts,key=lambda P:(max([abs(x) for x in P]),sum([abs(x) for x in P])))
     if len(pts) > 1:
         # always put points at infinity first, regardless of height
         pts = sorted_points([P for P in pts if P[2] == 0]) + sorted_points([P for P in pts if P[2] != 0])

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -864,10 +864,8 @@ class WebG2C(object):
         code['show'] = {'sage':'','magma':''} # use default show names
         f,h = fh = data['min_eqn']
         g = simplify_hyperelliptic(fh)
-        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s))'%(f,h),
-                         'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);'%(f,h) }
-        code['simplified_curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s))'%(g),
-                                    'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s);\n X,pi:= SimplifiedModel(C);'%(f,h) }
+        code['curve'] = {'sage':'R.<x> = PolynomialRing(QQ); C = HyperellipticCurve(R(%s), R(%s)); X = Hyperellipticcurve(R(%s))'%(f,h,g),
+                         'magma':'R<x> := PolynomialRing(Rationals()); C := HyperellipticCurve(R!%s, R!%s); X,pi:= SimplifiedModel(C);'%(f,h) }
         if data['abs_disc'] % 4096 == 0:
             ind2 = [a[0] for a in data['bad_lfactors']].index(2)
             bad2 = data['bad_lfactors'][ind2][1]
@@ -876,10 +874,8 @@ class WebG2C(object):
             magma_cond_option = ''
         code['cond'] = {'magma': 'Conductor(LSeries(C%s)); Factorization($1);'% magma_cond_option}
         code['disc'] = {'magma':'Discriminant(C); Factorization(Integers()!$1);'}
-        code['igusa_clebsch'] = {'sage':'C.igusa_clebsch_invariants(); [factor(a) for a in _]',
-                                      'magma':'IgusaClebschInvariants(C); [Factorization(Integers()!a): a in $1];'}
-        code['igusa'] = {'magma':'IgusaInvariants(C); [Factorization(Integers()!a): a in $1];'}
-        code['g2'] = {'magma':'G2Invariants(C);'}
+        code['geom_inv'] = {'sage':'C.igusa_clebsch_invariants(); [factor(a) for a in _]',
+                            'magma':'IgusaClebschInvariants(C); IgusaInvariants(C); G2Invariants(C);'}
         code['aut'] = {'magma':'AutomorphismGroup(C); IdentifyGroup($1);'}
         code['autQbar'] = {'magma':'AutomorphismGroup(ChangeRing(C,AlgebraicClosure(Rationals()))); IdentifyGroup($1);'}
         code['num_rat_wpts'] = {'magma':'#Roots(HyperellipticPolynomials(SimplifiedModel(C)));'}

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -637,6 +637,8 @@ class WebG2C(object):
         data['mw_rank_proved'] = curve['mw_rank_proved']
         data['analytic_rank_proved'] = curve['analytic_rank_proved']
         data['hasse_weil_proved'] = curve['hasse_weil_proved']
+        print "curve",curve
+        print "data",data
         data['st_group'] = curve['st_group']
         data['st_group_link'] = st_link_by_name(1,4,data['st_group'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])


### PR DESCRIPTION
This PR changes the display of Mordell-Weil generators to display divisors as sums of rational points when possible,   To see the difference go to

https://red.lmfdb.xyz/Genus2Curve/Q/

and click on each of the "interesting curves" (they all hit different cases, depending on whether divisors have rational affine/infinite parts and the degree of the affine part).

The is also a new row in the BSD invariants table that indicates whether the Hasse-Weil conjecture has been verified the the L-function of this curve (this currently applies only to cases where the Jacobian is of GL2-type or Q-isogenous to a product of elliptic curves over Q, or the paramodular conjecture is known).  More cases will be added in the future, but this will only involve data changes.  See

https://red.lmfdb.xyz/Genus2Curve/Q/169/a/169/1 (verified)
https://red.lmfdb.xyz/Genus2Curve/Q/277/a/277/1 (verified)
https://red.lmfdb.xyz/Genus2Curve/Q/563011/a/563011/1 (unverified)

The analytic rank display now checks the "analytic_rank_proved" flag and will not display upper bound when this is set (this applies, for example, to rank 2 Jacobians isogenous to a product of elliptic curves over Q), see

https://red.lmfdb.xyz/Genus2Curve/Q/3721/a/3721/1 (new)
https://beta.lmfdb.org/Genus2Curve/Q/3721/a/3721/1 (old)

I also changed the code snippets to get rid of some duplicates and moved them so they appear after the relevant entry on the page rather than before, which is consistent with elliptic curves.






