### PR TITLE
EC/Q: added subsets option for bad primes search selector

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -276,6 +276,8 @@ def elliptic_curve_search(info, query):
         mode = 'exact'
     elif info.get('bad_quantifier') == 'exclude':
         mode = 'complement'
+    elif info.get('bad_quantifier') == 'subset':
+        mode = 'subsets'
     else:
         mode = 'append'
     parse_primes(info, query, 'bad_primes', name='bad primes',

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -192,8 +192,9 @@ A <a href={{url_for('.random_curve')}}>random elliptic curve</a> from the databa
 {{KNOWL('ec.q.reduction_type', title='Bad primes')}} 
     <select name='bad_quantifier'>
     <option value=''>include</option>
-    <option value="exclude">exclude</option>
+    <option value='exclude'>exclude</option>
     <option value='exactly'>exactly</option>
+    <option value='subset'>subset of</option>
     </select>
     </td>
     <td><input type='text' name='bad_primes' size=10 example='5,13'></td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -98,14 +98,22 @@
   <option value=''>include</option>
   <option value='exclude'>exclude</option>
   <option selected value='exactly'>exactly</option>
+  <option value='subset'>subset of</option>
 {% elif info.bad_quantifier=='exclude' %}
   <option value=''>include</option>
   <option selected value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
+  <option value='subset'>subset of</option>
+{% elif info.bad_quantifier=='subset' %}
+  <option value=''>include</option>
+  <option value='exclude'>exclude</option>
+  <option value='exactly'>exactly</option>
+  <option selected value='subset'>subset of</option>
 {% else %}
   <option selected value=''>include</option>
   <option value='exclude'>exclude</option>
   <option value='exactly'>exactly</option>
+  <option value='subset'>subset of</option>
 {% endif %}
   </select>
 <input type='text' name='bad_primes' placeholder="2,3" size=10  value={{info.bad_primes}}>


### PR DESCRIPTION
@jvoight asked 

>  How do I get the LMFDB to produce the list of elliptic curves with
good reduction away from 2,3?  In "bad primes", I have to choose from
'include', 'exclude', 'exactly', but then I guess I'd have to choose
'exactly' and merge 3 outputs?  And if I wanted to do this for
2,3,5,7, I need 15 outputs?

which raises a serious shortcoming, fixed by this PR.  Try selecting 'subset of' now with primes 2,3 and you should see all 752 curves listed here http://homepages.warwick.ac.uk/staff/J.E.Cremona/ftp/data/extra/E-2-3.txt