### PR TITLE
Issue 3678: fix bread and link from EC/Q Reliability page

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -551,9 +551,9 @@ def reliability_page():
     t = r'Reliability of the Elliptic Curve data over $\Q$'
     bread = [('Elliptic Curves', url_for("ecnf.index")),
              (r'$\Q$', url_for("ec.rational_elliptic_curves")),
-             ('Source', '')]
+             ('Reliability', '')]
     return render_template("single.html", kid='dq.ec.reliability',
-                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @ec_page.route("/Labels")
 def labels_page():


### PR DESCRIPTION
This fixes issue #3678 

Go to http://localhost:37777/EllipticCurve/Q/Reliability, compare with https://beta.lmfdb.org/EllipticCurve/Q/Reliability and see that the breadcrumb has been corrected and there's now a link to the Source page but not to the same Reliability page.