### PR TITLE
Allow search on rational j-invariant for ecnf

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -17,7 +17,7 @@ from lmfdb.utils import (
     to_dict, flash_error,
     parse_ints, parse_noop, nf_string_to_label, parse_element_of,
     parse_nf_string, parse_nf_elt, parse_bracketed_posints,
-    search_wrap)
+    search_wrap, parse_rational)
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberField
 from lmfdb.ecnf import ecnf_page
@@ -499,9 +499,14 @@ def elliptic_curve_search(info, query):
             info['jinv'] = info['jinv'].replace('phi','a')
         if info.get('field','').strip() == '2.0.4.1':
             info['jinv'] = info['jinv'].replace('i','a')
-    parse_nf_elt(info,query,'jinv',name='j-invariant')
-    if query.get('jinv'):
-        query['jinv'] =','.join(query['jinv'])
+        if not 'a' in info['jinv'] and not info.get('field'): # rational j-invariant allowed for any field
+            parse_rational(info, query, 'jinv', name='j-invariant')
+            if query.get('jinv'):
+                query['jinv'] = {'$regex': '^' + query['jinv'] + '(,0)*$'} # nf elements like j,0,0,0
+        else: # j-invariant is a number field element
+            parse_nf_elt(info, query, 'jinv', name='j-invariant')
+            if query.get('jinv'):
+                query['jinv'] = ','.join(query['jinv'])
 
     if 'include_isogenous' in info and info['include_isogenous'] == 'off':
         info['number'] = 1

--- a/lmfdb/ecnf/templates/ecnf-search-results.html
+++ b/lmfdb/ecnf/templates/ecnf-search-results.html
@@ -29,7 +29,7 @@
 <td align=left><input type='text' name='conductor_norm' placeholder='31' size=10
                       value="{{info.conductor_norm}}"></td>
 <td>         <select name='include_isogenous'>
-{% if info.query.number %}
+{% if info.query and info.query.number %}
            <option value="off" selected="yes">exclude</option>
            <option value="">include</option>
 {% else %}


### PR DESCRIPTION
And fix a server error for the same pages. Fixes #3558

Compare the pages
https://beta.lmfdb.org/EllipticCurve/?start=50&hst=List&jinv=1728
after this change 
  /EllipticCurve/?start=50&hst=List&jinv=1728
will show a list of 911 curves with j-invariant 1728 defined over various fields, one can then exclude the base changed ones to get a list of all non-rational twists of these curves in the lmfdb.

