### PR TITLE
Add label to number field download

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -675,7 +675,7 @@ def download_search(info):
     s = com1 + "\n"
     s += com + ' Global number fields downloaded from the LMFDB downloaded %s\n'% mydate
     s += com + ' Below is a list called data. Each entry has the form:\n'
-    s += com + '   [polynomial, discriminant, t-number, class group]\n'
+    s += com + '   [label, polynomial, discriminant, t-number, class group]\n'
     s += com + ' Here the t-number is for the Galois group\n'
     s += com + ' If a class group was not computed, the entry is [-1]\n'
     s += '\n' + com2
@@ -696,7 +696,7 @@ def download_search(info):
             cl = f['class_group']
         else:
             cl = [-1]
-        entry = ', '.join([str(pol), str(D), str(gal_t), str(cl)])
+        entry = ', '.join(['\"'+str(f['label'])+'\"', str(pol), str(D), str(gal_t), str(cl)])
         s += '[' + entry + ']' + ',\\\n'
     s = s[:-3]
     if dltype == 'gp':


### PR DESCRIPTION
Addresses issue #3663, adding the label for a number fields when downloading search results.

You have to search, e.g.,
  http://127.0.0.1:37777/NumberField/?hst=List&degree=6&discriminant=1-100000

then click on one of the download buttons at the bottom.