### PR TITLE
Remove unnecessary CMF knowls

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1141,8 +1141,6 @@ class CMF_stats(StatsDisplay):
     def summary(self):
         return r"The database currently contains %s (Galois orbits of) %s and %s nonzero %s, corresponding to %s modular forms over the complex numbers.  In addition to the statistics below, you can also <a href='%s'>create your own</a>." % (self.nforms, self.newform_knowl, self.nspaces, self.newspace_knowl, self.ndim, url_for(".dynamic_statistics"))
 
-    extent_knowl = 'cmf.statistics_extent'
-
     table = db.mf_newforms
     baseurl_func = ".index"
     buckets = {'level':['1','2-10','11-100','101-1000','1001-2000', '2001-4000','4001-6000','6001-8000','8001-%d'%level_bound()],

--- a/lmfdb/classical_modular_forms/templates/cmf_refine_search.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_refine_search.html
@@ -172,7 +172,7 @@ function set_buckets(col_selecter, bucket_id) {
     <td></td>
     {% endif %}
     {% endfor %}
-    <td>{{ KNOWL('cmf.sort_order', title='Sort order') }}</td>
+    <td>Sort order</td>
   </tr>
   {% else %}
   <tr style="height: 22px;"></tr>


### PR DESCRIPTION
Removes links to two CMF knowls that are potentially confusing and not really needed.  One is the qualifier on the stats page and the other is the "sort order" knowl on the refine search results page.

http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/stats
http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/?search_type=List&all=1

