### PR TITLE
Download pages for local fields

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -10,7 +10,7 @@ from lmfdb.app import app
 from lmfdb.utils import (
     web_latex, coeff_to_poly, pol_to_html, display_multiset,
     parse_galgrp, parse_ints, clean_input, parse_rats, flash_error,
-    search_wrap)
+    search_wrap, Downloader)
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.galois_groups.transitive_group import (
     group_display_knowl, group_display_inertia,
@@ -160,12 +160,25 @@ def by_label(label):
 def local_field_jump(info):
     return redirect(url_for(".by_label",label=info['jump_to']), 301)
 
+class LF_download(Downloader):
+    table = db.lf_fields
+    title = 'Local Number Fields'
+    columns = ['p', 'coeffs']
+    data_format = ['p', '[coeffs]']
+    data_description = 'defining the local field over Qp by adjoining a root of f(x).'
+    function_body = {'magma':['Prec := 100; // Default precision of 100',
+                              'return [LocalField( pAdicField(r[1], Prec) , PolynomialRing(pAdicField(r[1], Prec))![c : c in r[2]] ) : r in data];'],
+                     'sage':['Prec = 100 # Default precision of 100',
+                             "return [pAdicExtension(Qp(r[0], Prec), PolynomialRing(Qp(r[0], Prec),'x')(r[1]), var_name='x') for r in data]"],
+                     'gp':['[[c[1], Polrev(c[2])]|c<-data];']}
+
+
 @search_wrap(template="lf-search.html",
              table=db.lf_fields,
              title='Local Number Field Search Results',
              err_title='Local Field Search Input Error',
              per_page=50,
-             shortcuts={'jump_to': local_field_jump},
+             shortcuts={'jump_to': local_field_jump, 'download': LF_download()},
              bread=lambda:get_bread([("Search Results", ' ')]),
              learnmore=learnmore_list,
              credit=lambda:LF_credit)


### PR DESCRIPTION
This should enable download pages for local fields. For Sage, some of the functionality is still to be implemented, but according to @roed314 this is in the pipeline. This hopefully solves issue #996.