### PR TITLE
fixing create_table_like

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -611,16 +611,19 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
             commit=commit,
         )
         if data:
+            cols = SQL(", ").join(map(Identifier, table.search_cols))
             self._execute(
-                SQL("INSERT INTO {0} SELECT * FROM {1}").format(
-                    Identifier(new_name), Identifier(table.search_table)
+                SQL("INSERT INTO {0} ( {1} ) SELECT {1} FROM {2}").format(
+                    Identifier(new_name), cols, Identifier(table.search_table)
                 ),
                 commit=commit,
             )
             if extra_columns:
+                extra_cols = SQL(", ").join(map(Identifier, table.extra_cols))
                 self._execute(
-                    SQL("INSERT INTO {0} SELECT * FROM {1}").format(
-                        Identifier(new_name + "_extras"), Identifier(table.extra_table)
+                    SQL("INSERT INTO {0} ( {1} ) SELECT {1} FROM {2}").format(
+                        Identifier(new_name + "_extras"), extra_cols,
+                        Identifier(table.extra_table)
                     ),
                     commit=commit,
                 )

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -196,7 +196,7 @@ class PostgresDatabase(PostgresBase):
 
         cur = self._execute(SQL(
             "SELECT table_name, column_name, udt_name::regtype "
-            "FROM information_schema.columns"
+            "FROM information_schema.columns ORDER BY table_name, ordinal_position"
         ))
         data_types = {}
         for table_name, column_name, regtype in cur:


### PR DESCRIPTION
Our `Insert to` command assumed columns would be in the same order in both tables.
This PR changes this behaviour to explicitly declaring the column names on the target and source tables.