### PR TITLE
New artin representation labels

### DIFF
--- a/lmfdb/artin_representations/__init__.py
+++ b/lmfdb/artin_representations/__init__.py
@@ -25,5 +25,5 @@ register_search_function(
     "artin_representations",
     "Artin representations",
     "Search over Artin representations",
-    auto_search = 'artin_reps'
+    auto_search = 'artin_reps_new'
 )

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -82,6 +82,9 @@ def parse_artin_label(label, safe=False):
             return ''
     raise ValueError
 
+def both_labels(label):
+    return list(db.artin_old2new_labels.lucky({'$or': [{'old':label}, {'new': label}]}).values())
+
 # Is it a rep'n or an orbit, supporting old and new styles
 def parse_any(label):
     try:
@@ -96,15 +99,16 @@ def parse_any(label):
 
 
 def add_lfunction_friends(friends, label):
-    rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
-    if rec:
-        num = 10 if 'c' in label.split('.')[-1] else 8 # number of components of CMF lable based on artin label (rep or orbit)
-        for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
-            s = r['url'].split('/')
-            if r['type'] == 'CMF' and len(s) == num:
-                cmf_label = '.'.join(s[4:])
-                url = r['url'] if r['url'][0] == '/' else '/' + r['url']
-                friends.append(("Modular form " + cmf_label, url))
+    for label in both_labels(label):
+        rec = db.lfunc_instances.lucky({'type':'Artin','url':'ArtinRepresentation/'+label})
+        if rec:
+            num = 10 if 'c' in label.split('.')[-1] else 8 # number of components of CMF lable based on artin label (rep or orbit)
+            for r in db.lfunc_instances.search({'Lhash':rec["Lhash"]}):
+                s = r['url'].split('/')
+                if r['type'] == 'CMF' and len(s) == num:
+                    cmf_label = '.'.join(s[4:])
+                    url = r['url'] if r['url'][0] == '/' else '/' + r['url']
+                    friends.append(("Modular form " + cmf_label, url))
     return friends
 
 @artin_representations_page.route("/")

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -52,24 +52,32 @@ def make_cond_key(D):
     return '%04d%s' % (D1, str(D))
 
 
-def parse_artin_orbit_label(label):
-    label = clean_input(label)
-    if ORBIT_RE.match(label):
-        return label
-    if OLD_ORBIT_RE.match(label):
-        newlabel = db.artin_old2new_labels.lookup(label)['new']
-        if newlabel:
-            return newlabel
+def parse_artin_orbit_label(label, safe=False):
+    try:
+        label = clean_input(label)
+        if ORBIT_RE.match(label):
+            return label
+        if OLD_ORBIT_RE.match(label):
+            newlabel = db.artin_old2new_labels.lookup(label)['new']
+            if newlabel:
+                return newlabel
+    except:
+        if safe:
+            return ''
     raise ValueError
 
-def parse_artin_label(label):
-    label = clean_input(label)
-    if LABEL_RE.match(label):
-        return label
-    if OLD_LABEL_RE.match(label):
-        newlabel = db.artin_old2new_labels.lookup(label)['new']
+def parse_artin_label(label, safe=False):
+    try:
+        label = clean_input(label)
+        if LABEL_RE.match(label):
+            return label
+        if OLD_LABEL_RE.match(label):
+            newlabel = db.artin_old2new_labels.lookup(label)['new']
         if newlabel:
             return newlabel
+    except:
+        if safe:
+            return ''
     raise ValueError
 
 # Is it a rep'n or an orbit, supporting old and new styles
@@ -161,8 +169,6 @@ def render_artin_representation_webpage(label):
     if re.compile(r'^\d+$').match(label):
         return artin_representation_search(**{'dimension': label})
 
-    bread = get_bread([(label, ' ')])
-
     # label=dim.cond.nTt.indexcj, c is literal, j is index in conj class
     # Should we have a big try around this to catch bad labels?
     clean_label = clean_input(label)
@@ -198,6 +204,8 @@ def render_artin_representation_webpage(label):
         allchars = [ ArtinRepresentation(label+'.'+num2letters(j)).character_formatted() for j in range(1,num_conj+1)]
 
     label = newlabel
+    bread = get_bread([(label, ' ')])
+
     #artin_logger.info("Found %s" % (the_rep._data))
 
     if case=='rep':

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -13,8 +13,10 @@ from lmfdb.utils import (
     parse_ints, parse_container, parse_bool, clean_input, flash_error,
     search_wrap)
 from lmfdb.artin_representations import artin_representations_page
+#from lmfdb.artin_representations import artin_logger
 from lmfdb.artin_representations.math_classes import (
     ArtinRepresentation, num2letters)
+
 
 LABEL_RE = re.compile(r'^\d+\.\d+\.\d+(t\d+)?\.[a-z]+\.[a-z]+$')
 ORBIT_RE = re.compile(r'^\d+\.\d+\.\d+(t\d+)?\.[a-z]+$')
@@ -194,14 +196,14 @@ def render_artin_representation_webpage(label):
             return redirect(url_for(".index"))
     else: # it is an orbit
         try:
-            the_rep = ArtinRepresentation(label+'.a')
+            the_rep = ArtinRepresentation(newlabel+'.a')
         except:
             newlabel = parse_artin_orbit_label(newlabel)
             flash_error("Galois orbit of Artin representations %s is not in database", label)
             return redirect(url_for(".index"))
         # in this case we want all characters
         num_conj = the_rep.galois_conjugacy_size()
-        allchars = [ ArtinRepresentation(label+'.'+num2letters(j)).character_formatted() for j in range(1,num_conj+1)]
+        allchars = [ ArtinRepresentation(newlabel+'.'+num2letters(j)).character_formatted() for j in range(1,num_conj+1)]
 
     label = newlabel
     bread = get_bread([(label, ' ')])

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -12,7 +12,7 @@ from lmfdb.utils import (
     parse_primes, parse_restricted, parse_element_of, parse_galgrp,
     parse_ints, parse_container, parse_bool, clean_input, flash_error,
     search_wrap)
-from lmfdb.artin_representations import artin_representations_page, artin_logger
+from lmfdb.artin_representations import artin_representations_page
 from lmfdb.artin_representations.math_classes import (
     ArtinRepresentation, num2letters)
 

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -73,6 +73,19 @@ def process_polynomial_over_algebraic_integer(seq, field, root_of_unity):
     PP = PolynomialRing(field, "x")
     return PP([process_algebraic_integer(x, root_of_unity) for x in seq])
 
+# Conversion from numbers to letters and back
+def letters2num(s):
+    letters = [ord(z)-96 for z in list(s)]
+    ssum = 0
+    for j in range(len(letters)):
+        ssum = ssum*26+letters[j]
+    return ssum
+
+def num2letters(n):
+    if n <= 26:
+        return chr(96+n)
+    else:
+        return num2letters(int((n-1)/26))+chr(97+(n-1)%26)
 
 class ArtinRepresentation(object):
     def __init__(self, *x, **data_dict):
@@ -84,12 +97,15 @@ class ArtinRepresentation(object):
             if len(x) == 1: # Assume we got a label
                 label = x[0]
                 parts = x[0].split(".")
-                base = parts[0]
-                conjindex = int(parts[1])
+                base = "%s.%s.%s.%s"% tuple(parts[j] for j in (0,1,2,3))
+                if len(parts)<5: # Galois orbit
+                    conjindex=1
+                else:
+                    conjindex = letters2num(parts[4])
             elif len(x) == 2: # base and gorb index
                 base = x[0]
                 conjindex = x[1]
-                label = "%s.%s"%(str(x[0]),str(x[1]))
+                label = "%s.%s"%(str(x[0]),num2letters(x[1]))
             else:
                 raise ValueError("Invalid number of positional arguments")
             self._data = db.artin_reps_new.lucky({'Baselabel':str(base)})
@@ -122,6 +138,9 @@ class ArtinRepresentation(object):
 
     def conductor(self):
         return int(self._data["Conductor"])
+
+    def galorbindex(self):
+        return int(self._data['GalOrbIndex'])
 
     def NFGal(self):
         return [int(n) for n in self._data["NFGal"]]
@@ -266,6 +285,7 @@ class ArtinRepresentation(object):
             return self
         if 'central_character_as_artin_rep' in self._data:
             return self._data['central_character_as_artin_rep']
+        return ArtinRepresentation(self._data['Dets'][self.galorbindex()-1])
         myfunc = self.central_char_function()
         # Get the Artin field
         nfgg = self.number_field_galois_group()
@@ -644,18 +664,18 @@ class NumberFieldGaloisGroup(object):
             else:
                 coeffs = x[0]
             coeffs = [int(c) for c in coeffs]
-            self._data = db.artin_field_data.lucky({'Polynomial':coeffs})
+            self._data = db.artin_field_data_new.lucky({'Polynomial':coeffs})
             if self._data is None:
                 # This should probably be a ValueError, but we use an AttributeError for backward compatibility
                 raise AttributeError("No Galois group data for polynonial %s"%(coeffs))
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_field_data.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_field_data_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
-        result = db.artin_field_data.lucky(*args, **kwds)
+        result = db.artin_field_data_new.lucky(*args, **kwds)
         if result is not None:
             return cls(data=result)
 

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -83,16 +83,16 @@ class ArtinRepresentation(object):
         else:
             if len(x) == 1: # Assume we got a label
                 label = x[0]
-                parts = x[0].split("c")
+                parts = x[0].split(".")
                 base = parts[0]
                 conjindex = int(parts[1])
             elif len(x) == 2: # base and gorb index
                 base = x[0]
                 conjindex = x[1]
-                label = "%sc%s"%(str(x[0]),str(x[1]))
+                label = "%s.%s"%(str(x[0]),str(x[1]))
             else:
                 raise ValueError("Invalid number of positional arguments")
-            self._data = db.artin_reps.lucky({'Baselabel':str(base)})
+            self._data = db.artin_reps_new.lucky({'Baselabel':str(base)})
             conjs = self._data["GaloisConjugates"]
             conj = [xx for xx in conjs if xx['GalOrbIndex'] == conjindex]
             self._data['label'] = label
@@ -100,12 +100,12 @@ class ArtinRepresentation(object):
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_reps.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_reps_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
         # What about label?
-        return cls(data=db.artin_reps.lucky(*args, **kwds))
+        return cls(data=db.artin_reps_new.lucky(*args, **kwds))
 
     @classmethod
     def find_one_in_galorbit(cls, baselabel):

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -46,7 +46,7 @@ A <a href={{url_for('.random_representation')}}>random Artin representation</a> 
 <h2>Go to a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
 
 <div><form>
-Artin representation: <input type='text' name='natural' size='50' example='3.2e3_7e5.7t3.1c1'> <button type='submit' name='search' value='Go'>label</button> <span class="formexample">e.g., 3.2e3_7e5.7t3.1c1</span></form></div>
+Artin representation: <input type='text' name='natural' size='50' example='4.5648.6t13.b.a'> <button type='submit' name='search' value='Go'>label</button> <span class="formexample">e.g., 4.5648.6t13.b.a</span></form></div>
 
 
 <h2> Search for an Artin representation </h2>

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -69,7 +69,7 @@
           {% for cnt in range(galccsize) %}
         {% set artx = initfunc(artin['Baselabel'],cnt+1) %}
         {% if info.sign_code == 0 or info.sign_code == art.sign() %}
-            <a href = "{{artx.url_for()}}">{{art.baselabel()}}c{{cnt+1}}</a>
+            <a href = "{{artx.url_for()}}">{{artx.label()}}</a>
         {% endif %}
           {% endfor %}
             </td>

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -393,7 +393,9 @@ def l_function_nf_page(label):
 # L-function of Artin representation    ########################################
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
-    label = parse_artin_label(label)
+    newlabel = parse_artin_label(label, safe=True)
+    if newlabel != label:
+        return redirect(url_for(".l_function_artin_page", label=newlabel), 301)
     instance = db.lfunc_instances.lucky({'url': artin_url(label)})
     return render_single_Lfunction(ArtinLfunctionDB if instance else ArtinLfunction, {'label': label}, request)
 
@@ -985,7 +987,7 @@ def generateLfunctionFromUrl(*args, **kwds):
         return DedekindZeta(label=str(args[1]))
 
     elif args[0] == "ArtinRepresentation":
-        label = parse_artin_label(args[1])
+        label = parse_artin_label(args[1], safe=True)
         instance = db.lfunc_instances.lucky({'url': artin_url(label)})
         return ArtinLfunctionDB(label=label) if instance else ArtinLfunction(label=label)
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -27,6 +27,7 @@ from lmfdb.characters.web_character import WebDirichlet
 from lmfdb.lfunctions import l_function_page
 from lmfdb.modular_forms.maass_forms.maass_waveforms.views.mwf_plot import paintSvgMaass
 from lmfdb.classical_modular_forms.web_newform import convert_newformlabel_from_conrey
+from lmfdb.artin_representations.main import parse_artin_label
 from lmfdb.utils import to_dict, signtocolour, rgbtohex, key_for_numerically_sort, display_float
 from lmfdb.app import is_debug_mode
 from lmfdb import db
@@ -392,6 +393,7 @@ def l_function_nf_page(label):
 # L-function of Artin representation    ########################################
 @l_function_page.route("/ArtinRepresentation/<label>/")
 def l_function_artin_page(label):
+    label = parse_artin_label(label)
     instance = db.lfunc_instances.lucky({'url': artin_url(label)})
     return render_single_Lfunction(ArtinLfunctionDB if instance else ArtinLfunction, {'label': label}, request)
 
@@ -983,8 +985,9 @@ def generateLfunctionFromUrl(*args, **kwds):
         return DedekindZeta(label=str(args[1]))
 
     elif args[0] == "ArtinRepresentation":
-        instance = db.lfunc_instances.lucky({'url': artin_url(args[1])})
-        return ArtinLfunctionDB(label=str(args[1])) if instance else ArtinLfunction(label=str(args[1]))
+        label = parse_artin_label(args[1])
+        instance = db.lfunc_instances.lucky({'url': artin_url(label)})
+        return ArtinLfunctionDB(label=label) if instance else ArtinLfunction(label=label)
 
     elif args[0] == "SymmetricPower":
         return SymmetricPowerLfunction(power=args[1], underlying_type=args[2], field=args[3],

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -369,11 +369,11 @@ class LfunctionTest(LmfdbTest):
     def test_Lartin(self):
         L = self.tc.get('/L/ArtinRepresentation/2.23.3t2.1c1/', follow_redirects=True)
         assert '0.1740363269' in L.get_data(as_text=True)
-        L = self.tc.get('/L/Zeros/ArtinRepresentation/2.23.3t2.1c1/')
+        L = self.tc.get('/L/Zeros/ArtinRepresentation/2.23.3t2.1c1/', follow_redirects=True)
         assert '5.1156833288' in L.get_data(as_text=True)
-        L = self.tc.get('/L/ArtinRepresentation/4.1609.5t5.1c1/')
+        L = self.tc.get('/L/ArtinRepresentation/4.1609.5t5.1c1/', follow_redirects=True)
         assert '0.0755586459' in L.get_data(as_text=True)
-        L = self.tc.get('/L/Zeros/ArtinRepresentation/4.1609.5t5.1c1/')
+        L = self.tc.get('/L/Zeros/ArtinRepresentation/4.1609.5t5.1c1/', follow_redirects=True)
         assert '3.50464340448' in L.get_data(as_text=True)
 
     def test_Lmain(self):
@@ -612,7 +612,7 @@ class LfunctionTest(LmfdbTest):
         assert 'No L-function instance data for' in L.get_data(as_text=True)
         L = self.tc.get('/L/NumberField/2.2.7.1/')
         assert 'No data for the number field' in L.get_data(as_text=True)
-        L = self.tc.get('/L/ArtinRepresentation/3.231.4t5.1c1/')
+        L = self.tc.get('/L/ArtinRepresentation/3.231.4t5.a.a/')
         assert 'Error constructing Artin representation' in L.get_data(as_text=True)
         L = self.tc.get('/L/SymmetricPower/2/EllipticCurve/Q/37/d/')
         assert 'No elliptic curve with label ' in L.get_data(as_text=True)


### PR DESCRIPTION
This implements code to deal with the new labels for Artin representations and their orbits.

First, one should upload the postgres tables artin_field_data_new, artin_reps_new, and artin_old2new_labels to the cloud so that whenever this gets pushed to production down the road, the data is there.

To test, search for Artin reps, go to the home page for one, use friends to visit its determinant and Galois orbit (Galois group A5 or cyclic will give examples with conjugate representations).  Then go to the Artin field (from friends), scroll to the bottom to see that the representations are there, and click to go back.

You can go directly to a repn by entering its label on the index page.  This accepts both old and new labels, and converts to new.

The link to L-functions still works, as do friend links from weight 1 modular forms.

That said, I probably missed some things; just let me know what they are.