### PR TITLE
Fix bug in local algebra display

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -465,6 +465,7 @@ def render_field_webpage(args):
                 loc_alg += '<td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
                 for mm in mydat[1:]:
                     lab = mm[0]
+                    myurl = url_for('local_fields.by_label', label=lab)
                     if mm[3]*mm[2] == 1:
                         lab = r'$\Q_{%s}$'%str(p)
                     loc_alg += '<tr><td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))


### PR DESCRIPTION
Go to

  http://www.lmfdb.org/NumberField/3.1.23.1
  http://127.0.0.1:37777/NumberField/3.1.23.1

At the bottom is the local algebra for p=23.  The labels for the local fields are correct, but they currently both link to Q_23 (and this will happen for every prime, all urls will be the first one).  This fixes it so that they point to the correct places.