### PR TITLE
Clarify range of Galois image data for CM E/Q and E/K!=Q

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -329,7 +329,7 @@ The mod \( p \) Galois Representation data has not yet been computed for this cu
 <p>
 The mod \( p \) {{KNOWL('ec.galois_rep', title='Galois Representation')}}
 has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
-for all primes \( p \)
+for all primes \( p < 1000 \)
 {% if ec.galois_data %} {# there are non-maximal primes #}
 except those listed.
 </p>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -421,8 +421,10 @@ representation')}}
 has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
 {% if not data.data.CMD %}
 \(\GL(2,\F_p)\)
-{% endif %}
 for all primes \( p \)
+{% else %}
+for all primes \( p < 1000 \)
+{% endif %}
 {% if data.data.galois_data %} {# there are non-maximal primes #}
 except those listed.
 </p>


### PR DESCRIPTION
This PR clarifies the rigor of the mod-p Galois image data in the LMFDB.  For non-CM E/Q we provably know all p for which the mod-p rep is nonsurjective, but in all other cases we have only checked primes p < 1000.  It is in principle possible to rigorously extend these to all p, but this would require a non-trivial amount of (mathematical and computational) work and/or assuming GRH.

With this change on the home pages for E/Q with CM and E/K!=Q the statement  "for all primes p " now reads "for all prime p < 1000", see

http://127.0.0.1:37777/EllipticCurve/Q/27/a/1
http://127.0.0.1:37777/EllipticCurve/2.0.10691.1/1.0.1/a/1

for example.  There is no change on pages for E/Q without CM, see 

http://127.0.0.1:37777/EllipticCurve/Q/11/a/1

for example.
