### PR TITLE
text_type

### DIFF
--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 from __future__ import print_function
 from __future__ import absolute_import
-from six import string_types, text_type
+from six import string_types
 # store passwords, check users, ...
 # password hashing is done with fixed and variable salting
 # Author: Harald Schilly <harald.schilly@univie.ac.at>
@@ -74,7 +74,7 @@ class PostgresUserTable(PostgresBase):
         try:
             import bcrypt
             if not existing_hash:
-                existing_hash = text_type(bcrypt.gensalt())
+                existing_hash = bcrypt.gensalt().decode('utf-8')
             return bcrypt.hashpw(pwd.encode('utf-8'), existing_hash.encode('utf-8'))
         except Exception:
             logger.warning("Failed to return bchash, perhaps bcrypt is not installed");

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -73,6 +73,7 @@ class PostgresUserTable(PostgresBase):
         """
         try:
             import bcrypt
+            print(pwd)
             if not existing_hash:
                 existing_hash = bcrypt.gensalt().decode('utf-8')
             return bcrypt.hashpw(pwd.encode('utf-8'), existing_hash.encode('utf-8'))
@@ -143,7 +144,8 @@ class PostgresUserTable(PostgresBase):
             raise ValueError("User not present in database!")
         bcpass, oldpass = cur.fetchone()
         if bcpass:
-            if bcpass == self.bchash(pwd, existing_hash = bcpass):
+            print(bcpass, self.bchash(pwd, existing_hash = bcpass))
+            if bcpass.encode('utf-8') == self.bchash(pwd, existing_hash = bcpass):
                 return True
         else:
             for i in range(self.rmin, self.rmax + 1):

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -73,7 +73,6 @@ class PostgresUserTable(PostgresBase):
         """
         try:
             import bcrypt
-            print(pwd)
             if not existing_hash:
                 existing_hash = bcrypt.gensalt().decode('utf-8')
             return bcrypt.hashpw(pwd.encode('utf-8'), existing_hash.encode('utf-8'))


### PR DESCRIPTION
text_type was being incorrectly used in our password salts.
If you run the following in python3 
```
import bcrypt
from six import text_type
salt = bcrypt.gensalt()
current = text_type(salt)
print(current.encode('utf-8'))
want = salt.decode('utf-8')
print(want.encode('utf-8'))
```
you get something like
```
b"b'$2b$12$2NKDY/vHALiAJns7WraWg.'"
b'$2b$12$2NKDY/vHALiAJns7WraWg.'
```
while in python 2, salt is of string type, and both lines render the same
```
$2b$12$2NKDY/vHALiAJns7WraWg.
$2b$12$2NKDY/vHALiAJns7WraWg.
```
