### PR TITLE
Changing table names

### DIFF
--- a/lmfdb/artin_representations/__init__.py
+++ b/lmfdb/artin_representations/__init__.py
@@ -25,5 +25,5 @@ register_search_function(
     "artin_representations",
     "Artin representations",
     "Search over Artin representations",
-    auto_search = 'artin_reps_new'
+    auto_search = 'artin_reps'
 )

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -138,7 +138,7 @@ def artin_representation_jump(info):
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)
 
 @search_wrap(template="artin-representation-search.html",
-             table=db.artin_reps_new,
+             table=db.artin_reps,
              title='Artin Representation Search Results',
              err_title='Artin Representation Search Error',
              per_page=50,

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -108,7 +108,7 @@ class ArtinRepresentation(object):
                 label = "%s.%s"%(str(x[0]),num2letters(x[1]))
             else:
                 raise ValueError("Invalid number of positional arguments")
-            self._data = db.artin_reps_new.lucky({'Baselabel':str(base)})
+            self._data = db.artin_reps.lucky({'Baselabel':str(base)})
             conjs = self._data["GaloisConjugates"]
             conj = [xx for xx in conjs if xx['GalOrbIndex'] == conjindex]
             self._data['label'] = label
@@ -116,12 +116,12 @@ class ArtinRepresentation(object):
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_reps_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_reps.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
         # What about label?
-        return cls(data=db.artin_reps_new.lucky(*args, **kwds))
+        return cls(data=db.artin_reps.lucky(*args, **kwds))
 
     @classmethod
     def find_one_in_galorbit(cls, baselabel):
@@ -664,18 +664,18 @@ class NumberFieldGaloisGroup(object):
             else:
                 coeffs = x[0]
             coeffs = [int(c) for c in coeffs]
-            self._data = db.artin_field_data_new.lucky({'Polynomial':coeffs})
+            self._data = db.artin_field_data.lucky({'Polynomial':coeffs})
             if self._data is None:
                 # This should probably be a ValueError, but we use an AttributeError for backward compatibility
                 raise AttributeError("No Galois group data for polynonial %s"%(coeffs))
 
     @classmethod
     def search(cls, query={}, projection=1, limit=None, offset=0, sort=None, info=None):
-        return db.artin_field_data_new.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
+        return db.artin_field_data.search(query, projection, limit=limit, offset=offset, sort=sort, info=info)
 
     @classmethod
     def lucky(cls, *args, **kwds):
-        result = db.artin_field_data_new.lucky(*args, **kwds)
+        result = db.artin_field_data.lucky(*args, **kwds)
         if result is not None:
             return cls(data=result)
 


### PR DESCRIPTION
This removes "new" from the table names for Artin representations.  It restores the names to how they were before we changed the labels.

There are no special pages to check, but you could look at representations for the Galois group F_7, since the tables without _new have more examples in them.

First, the tables artin_data and artin_reps to production.  It currently doesn't reference those tables, but when this code change ultimately gets to prod, it will be ready.