### PR TITLE
Fix link in number field knowls

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -301,7 +301,7 @@ def nf_knowl_guts(label):
         out += wnf.short_grh_string()
     out += '</div>'
     out += '<div align="right">'
-    out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.number_field_render_webpage", label=label)),label)
+    out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.by_label", label=label)),label)
     out += '</div>'
     return out
 


### PR DESCRIPTION
If you open a number field knowl, in the lower right is a link to the home page of that number field.  Changes since that was created now make it not work, and this fixes the situation (arguably this is what the code should have said all along).

To test, go to 

https://beta.lmfdb.org/knowledge/show/nf.field.data?label=6.0.12167.1
https://127.0.0.1:37777/knowledge/show/nf.field.data?label=6.0.12167.1

and click on "6.0.12167.1 home page" which is to the far right.  The first attempts a search, which fails, and the second takes you to the field's home page.

Or you can do this by going to
https://beta.lmfdb.org/NumberField/3.1.23.1
which has the above number field knowl on the page as the Galois closure, and then open it, then click on the link for the field's home page on the bottom right.