### PR TITLE
Change database field being accessed for subfields of a number field

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -563,8 +563,11 @@ class WebNumberField:
         return [cnt, [], []]
 
     def subfields(self):
-        if not self.haskey('subs'):
+        if not self.haskey('subfields'):
             return []
+        sf = [z.replace('.',',') for z in self._data['subfields']]
+        sfm = self._data['subfield_mults']
+        return [[sf[j],sfm[j]] for j in range(len(sf))]
         return self._data['subs']
 
     def subfields_show(self):


### PR DESCRIPTION
This is a step in a bigger process.  There was a feature request to be able to search for number fields based on subfields, i.e., get extensions of a given field with some properties.  To do that, subfield information had to move from the extras table to the main table, and its format changed a bit.

The database change was done months ago and is on prod and beta, although the new database fields are currently not being used.  This small change makes it so that the new fields are used rather than the old field "subs".  After this makes its way to prod, the old database field can be removed.

There should be no visible changes here.  Here is one sample page which shou

http://127.0.0.1:37777/NumberField/8.0.2313441.1
http://beta.lmfdb.org/NumberField/8.0.2313441.1

which should look the same.  (It is an octic D4 field, so lots of subfield structure.)
