### PR TITLE
Number fields search by subfield

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -764,6 +764,7 @@ def number_field_search(info, query):
                  qfield='ramps',mode='exclude')
     parse_primes(info,query,'ram_primes',name='Ramified primes',
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad')
+    parse_subfield(info, query, 'subfield', name='Subfield',mode='include')
     info['wnf'] = WebNumberField.from_data
     info['gg_display'] = group_pretty_and_nTj
 
@@ -1029,6 +1030,11 @@ class NFSearchArray(SearchArray):
             label="Unramified primes",
             knowl="nf.unramified_prime",
             example="2,3")
+        subfield = TextBox(
+            name="subfield",
+            label="Subfield",
+            knowl="nf.subfield_entry",
+            example="2.2.5.1 or x^2-5")
         count = CountBox()
 
         self.browse_array = [
@@ -1038,10 +1044,10 @@ class NFSearchArray(SearchArray):
             [class_number, class_group],
             [num_ram, cm_field],
             [ram_primes, ur_primes],
-            [regulator],
+            [regulator, subfield],
             [count]]
 
         self.refine_array = [
             [degree, signature, gal, class_number, class_group],
             [regulator, num_ram, ram_primes, ur_primes, cm_field],
-            [discriminant, rd]]
+            [discriminant, rd, subfield]]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -17,7 +17,7 @@ from lmfdb.utils import (
     SearchArray, TextBox, TextBoxNoEg, YesNoBox, SubsetNoExcludeBox, TextBoxWithSelect,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
-    parse_floats, search_wrap)
+    parse_floats, parse_subfield, search_wrap)
 from lmfdb.galois_groups.transitive_group import (
     cclasses_display_knowl,character_table_display_knowl,
     group_phrase, galois_group_data,
@@ -764,7 +764,7 @@ def number_field_search(info, query):
                  qfield='ramps',mode='exclude')
     parse_primes(info,query,'ram_primes',name='Ramified primes',
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad')
-    parse_subfield(info, query, 'subfield', name='Subfield',mode='include')
+    parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
     info['wnf'] = WebNumberField.from_data
     info['gg_display'] = group_pretty_and_nTj
 
@@ -1032,9 +1032,11 @@ class NFSearchArray(SearchArray):
             example="2,3")
         subfield = TextBox(
             name="subfield",
-            label="Subfield",
-            knowl="nf.subfield_entry",
-            example="2.2.5.1 or x^2-5")
+            label="Intermediate field",
+            knowl="nf.intermediate_fields",
+            example_span="2.2.5.1 or x^2-5 or a "+
+                display_knowl("nf.nickname", "field nickname"),
+            example="x^2-5")
         count = CountBox()
 
         self.browse_array = [

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -27,7 +27,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'parse_subset', 'parse_submultiset', 'parse_list',
            'parse_list_start', 'parse_string_start', 'parse_restricted',
            'parse_noop', 'parse_equality_constraints', 'parse_gap_id',
-           'parse_galgrp', 'parse_nf_string', 'parse_nf_elt',
+           'parse_galgrp', 'parse_nf_string', 'parse_subfield', 'parse_nf_elt',
            'parse_container', 'parse_hmf_weight', 'parse_count',
            'parse_start', 'parse_ints_to_list_flash', 'integer_options',
            'nf_string_to_label', 'SearchParsingError', 'clean_input', 'prep_ranges',
@@ -73,8 +73,8 @@ from .search_parsing import (
     parse_list_start, parse_string_start, parse_restricted, parse_noop,
     parse_equality_constraints, parse_gap_id, parse_galgrp, parse_nf_string,
     parse_nf_elt, parse_container, parse_hmf_weight, parse_count, parse_start,
-    parse_ints_to_list_flash, integer_options, nf_string_to_label,
-    SearchParsingError,
+    parse_ints_to_list_flash, integer_options, nf_string_to_label, 
+    parse_subfield, SearchParsingError,
     clean_input, prep_ranges)
 
 from .search_wrapper import search_wrap, count_wrap

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -771,6 +771,16 @@ def nf_string_to_label(FF):  # parse Q, Qsqrt2, Qsqrt-4, Qzeta5, etc
     parts[2] = str(prod(raise_power(c) for c in parts[2].split("_")))
     return ".".join(parts)
 
+def input_to_subfield(inp):
+    result = inp
+    result = '.'.join(result)
+    return return result
+
+@search_parser # see SearchParser.__call__ for actual arguments when calling
+def parse_subfield(inp, query, qfield):
+    query[qfield] = input_to_subfield(inp)
+
+
 @search_parser # see SearchParser.__call__ for actual arguments when calling
 def parse_nf_string(inp, query, qfield):
     query[qfield] = nf_string_to_label(inp)


### PR DESCRIPTION
This addresses issue #3306.  It adds a search box for a subfield when doing a number field search.  When testing, try fields given by labels, polynomials, and nicknames.  It will work with polynomials which are not polredabs'ed.

Bad inputs it will catch are reducible polynomials, labels not in the database, malformed nicknames, and variations which would effectively ask for Q (like Q(zeta_4+)), and general garbage (like banana).