### PR TITLE
Fixed tiny bug in sibling display

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -540,8 +540,9 @@ def render_field_webpage(args):
             if not sibdeg[2]:
                 sibdeg[2] = dnc
             else:
+                nsibs = len(sibdeg[2])
                 sibdeg[2] = ', '.join(sibdeg[2])
-                if len(sibdeg[2])<sibdeg[1]:
+                if nsibs<sibdeg[1]:
                     sibdeg[2] += ', some '+dnc
 
         resinfo.append(('sib', siblings[0]))


### PR DESCRIPTION
On

http://beta.lmfdb.org/NumberField/6.0.908827479.1
http://127.0.0.1:37777/NumberField/6.0.908827479.1

some, but not all, siblings of the degree 24 number field have been computed.  This fixes the display of the information that it is listing only some of them.
