### PR TITLE
Fix random artin representation bug

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -297,7 +297,7 @@ def render_artin_representation_webpage(label):
 def random_representation():
     rep = db.artin_reps.random(projection=2)
     num = random.randrange(len(rep['GaloisConjugates']))
-    label = rep['Baselabel']+"c"+str(num+1)
+    label = rep['Baselabel']+"."+num2letters(num+1)
     return redirect(url_for(".render_artin_representation_webpage", label=label), 307)
 
 @artin_representations_page.route("/Labels")


### PR DESCRIPTION
This fixes issue #3827

To check, go to the Artin representation index page and click the link for a random representation.
