### PR TITLE
Remove references to galt from number field database

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -248,7 +248,7 @@ def render_group_webpage(args):
                 #print data['isoms']
 
         friends = []
-        if db.nf_fields.exists({'degree': n, 'galt': t}):
+        if db.nf_fields.exists({'galois_label': "%dT%d" % (n, t)}):
             friends.append(('Number fields with this Galois group', url_for('number_fields.number_field_render_webpage')+"?galois_group=%dT%d" % (n, t) ))
         prop2 = [('Label', label),
             ('Order', r'\(%s\)' % order),

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -234,7 +234,8 @@ def statistics():
     nsig = [[degree_r2_stats.get((deg+1, s), 0) for s in range((deg+3)//2)]
             for deg in range(23)]
     # Galois groups
-    nt_stats = nfstatdb.column_counts(['degree', 'galt'])
+    nt_stats = nfstatdb.column_counts(['degree', 'galois_label'])
+    nt_stats = {(key[0],int(key[1].split('T')[1])): value for (key,value) in nt_stats.items()}
     # if a count is missing it is because it is zero
     nt_all = [[nt_stats.get((deg+1, t+1), 0) for t in range(ntrans[deg+1])]
               for deg in range(23)]
@@ -689,7 +690,7 @@ def download_search(info):
     for f in res:
         pol = Qx(f['coeffs'])
         D = f['disc_abs'] * f['disc_sign']
-        gal_t = f['galt']
+        gal_t = int(f['galois_label'].split('T')[1])
         if 'class_group' in f:
             cl = f['class_group']
         else:
@@ -745,7 +746,6 @@ def number_field_jump(info):
              shortcuts={'jump':number_field_jump,
                         #'algebra':number_field_algebra,
                         'download':download_search},
-             split_ors=['galt'],
              url_for_label=url_for_label,
              bread=lambda:[('Global Number Fields', url_for(".number_field_render_webpage")),
                            ('Search Results', '.')],

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -404,7 +404,7 @@ class WebNumberField:
 
     # Return a nice string for the Galois group
     def galois_string(self):
-        if not self.haskey('galt'):
+        if not self.haskey('galois_label'):
             return 'Not computed'
         n = self._data['degree']
         t = int(self._data['galois_label'].split('T')[1])


### PR DESCRIPTION
Housecleaning for the number field database.  We switched from having a field for the t-number of the Galois group to one for the label of the Galois group which simplified searching.  The removes all code references to the field galt.

Nothing special to check, but places where the fix took into account:
 - the number field stats page should still work
 - from the page for a Galois group like 4T3, there is a related objects link to search for number fields with the same group
