### PR TITLE
ECNF stats fix

### DIFF
--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -94,8 +94,9 @@ class ECNF_stats(StatsDisplay):
         return int(nflabel.split('.',1)[0])
     def _fields_by(self, func):
         D = defaultdict(list)
-        for label in self.field_counts:
-            D[func(label)].append(label)
+        for label, count in self.field_counts.items():
+            if count:
+                D[func(label)].append(label)
         for fields in D.values():
             fields.sort(key=sort_field)
         return D


### PR DESCRIPTION
The `_fields_by` function should only return fields with nonzero counts.

For some reason, the label `3.1.972.2`, which we have 0 curves over, made into the counts table, and was breaking :
https://beta.lmfdb.org/EllipticCurve/browse/3/1/
https://beta.lmfdb.org/EllipticCurve/browse/3/