### PR TITLE
Added "Learn more" to EC/Q, ECNF,AbVar, HGCWA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
     # what is the load on the server
     - uptime
       #- wget  --no-verbose http://grace.mit.edu/sage-lmfdb/sage-${SAGE_VERSION}-Ubuntu_14.04-x86_64.tar.bz2
-    - wget  --no-verbose https://math.mit.edu/~edgarc/sage-${SAGE_VERSION}-Ubuntu_14.04-x86_64.tar.bz2
+    - wget --progress=dot:giga https://math.mit.edu/~edgarc/sage-${SAGE_VERSION}-Ubuntu_14.04-x86_64.tar.bz2
     # what is the load on the server
     - uptime
     # travis_wait extends the default 10 minute timeout to 40 minutes

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -588,6 +588,7 @@ def jump(info):
     },
     postprocess=lambda res, info, query: [AbvarFq_isoclass(x) for x in res],
     url_for_label=url_for_label,
+    learnmore=learnmore_list,
     bread=lambda: get_bread(("Search Results", " ")),
     credit=lambda: abvarfq_credit,
 )
@@ -673,6 +674,7 @@ def search_input_error(info=None, bread=None):
         info=info,
         title="Abelian Variety Search Input Error",
         bread=bread,
+        learnmore=learnmore_list()
     )
 
 @abvarfq_page.route("/stats")

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -484,6 +484,7 @@ def url_for_label(label):
              cleaners={'numb':lambda e: str(e['number']),
                        'field_knowl':lambda e: nf_display_knowl(e['field_label'], field_pretty(e['field_label']))},
              url_for_label=url_for_label,
+             learnmore=learnmore_list,
              bread=lambda:[('Elliptic Curves', url_for(".index")), ('Search Results', '.')],
              credit=lambda:ecnf_credit)
 def elliptic_curve_search(info, query):
@@ -546,7 +547,7 @@ def elliptic_curve_search(info, query):
 def search_input_error(info=None, bread=None):
     if info is None: info = {'err':'','query':{}}
     if bread is None: bread = [('Elliptic Curves', url_for(".index")), ('Search Results', '.')]
-    return render_template("ecnf-search-results.html", info=info, title='Elliptic Curve Search Input Error', bread=bread)
+    return render_template("ecnf-search-results.html", info=info, title='Elliptic Curve Search Input Error', bread=bread, learnmore=learnmore_list())
 
 
 @ecnf_page.route("/browse/")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -245,6 +245,7 @@ def url_for_label(label):
              err_title='Elliptic Curve Search Input Error',
              per_page=50,
              url_for_label=url_for_label,
+             learnmore=learnmore_list,
              shortcuts={'jump':elliptic_curve_jump,
                         'download':download_search},
              bread=lambda:[('Elliptic Curves', url_for("ecnf.index")),

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -61,6 +61,17 @@ def get_bread(breads=[]):
         bc.append(b)
     return bc
 
+def learnmore_list():
+    return [('Completeness of the data', url_for(".completeness_page")),
+            ('Source of the data', url_for(".how_computed_page")),
+            ('Reliability of the data', url_for(".reliability_page")),
+            ('Labeling convention', url_for(".labels_page"))]
+
+# Return the learnmore list with the matchstring entry removed
+def learnmore_list_remove(matchstring):
+    return [t for t in learnmore_list() if t[0].find(matchstring) < 0]
+
+
 def tfTOyn(bool):
     if bool:
         return "Yes"
@@ -153,17 +164,12 @@ def index():
     info['genus_list'] = genus_list
     info['stats'] = HGCWAstats().stats()
 
-    learnmore = [('Completeness of the data', url_for(".completeness_page")),
-                 ('Source of the data', url_for(".how_computed_page")),
-                 ('Reliability of the data', url_for(".reliability_page")),
-                 ('Labeling convention', url_for(".labels_page"))]
-
     return render_template("hgcwa-index.html",
                            title="Families of Higher Genus Curves with Automorphisms",
                            bread=bread,
                            credit=credit,
                            info=info,
-                           learnmore=learnmore)
+                           learnmore=learnmore_list())
 
 
 @higher_genus_w_automorphisms_page.route("/random")
@@ -178,7 +184,8 @@ def statistics():
     }
     title = 'Families of Higher Genus Curves with Automorphisms: Statistics'
     bread = get_bread([('Statistics', ' ')])
-    return render_template("hgcwa-stats.html", info=info, credit=credit, title=title, bread=bread)
+   
+    return render_template("hgcwa-stats.html", info=info, credit=credit, title=title, learnmore=learnmore_list(), bread=bread)
 
 @higher_genus_w_automorphisms_page.route("/stats/groups_per_genus/<genus>")
 def groups_per_genus(genus):
@@ -209,10 +216,12 @@ def groups_per_genus(genus):
     bread = get_bread([('Statistics', url_for('.statistics')),
                        ('Groups per Genus', url_for('.statistics')),
                        (str(genus), ' ')])
+       
     return render_template("hgcwa-stats-groups-per-genus.html",
                            info=info,
                            credit=credit,
                            title=title,
+                           learnmore=learnmore_list(),
                            bread=bread)
 
 def url_for_label(label):
@@ -562,6 +571,7 @@ def parse_group_order(inp, query, qfield, parse_singleton=int):
             'download': hgcwa_code_download_search },
         cleaners={'signature': lambda field: ast.literal_eval(field['signature'])},
         bread=lambda: get_bread([("Search Results",'')]),
+        learnmore=learnmore_list,     
         credit=lambda: credit)
 def higher_genus_w_automorphisms_search(info, query):
     if info.get('signature'):
@@ -691,18 +701,14 @@ def render_family(args):
         bread_gp = label_to_breadcrumbs(br_gp)
 
         bread = get_bread([(br_g, './?genus='+br_g),('$'+pretty_group+'$','./?genus='+br_g + '&group='+bread_gp), (bread_sign,' ')])
-        learnmore =[('Completeness of the data', url_for(".completeness_page")),
-                ('Source of the data', url_for(".how_computed_page")),
-                    ('Reliability of the data', url_for(".reliability_page")),
-                ('Labeling convention', url_for(".labels_page"))]
-
+  
         downloads = [('Code to Magma', url_for(".hgcwa_code_download",  label=label, download_type='magma')),
                      ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
 
         return render_template("hgcwa-show-family.html",
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
-                               learnmore=learnmore, downloads=downloads, credit=credit)
+                               learnmore=learnmore_list(), downloads=downloads, credit=credit)
 
 
 def render_passport(args):
@@ -862,25 +868,21 @@ def render_passport(args):
             ('$'+pretty_group+'$', './?genus='+br_g + '&group='+bread_gp),
             (bread_sign, urlstrng),
             (data['cc'][0], ' ')])
-
-        learnmore = [('Completeness of the data', url_for(".completeness_page")),
-                     ('Source of the data', url_for(".how_computed_page")),
-                     ('Reliability of the data', url_for(".reliability_page")),
-                     ('Labeling convention', url_for(".labels_page"))]
-
+       
         downloads = [('Code to Magma', url_for(".hgcwa_code_download",  label=label, download_type='magma')),
                      ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
 
         return render_template("hgcwa-show-passport.html",
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
-                               learnmore=learnmore, downloads=downloads,
+                               learnmore=learnmore_list(), downloads=downloads,
                                credit=credit)
 
 
 
 def search_input_error(info, bread):
-    return render_template("hgcwa-search.html", info=info, title='Families of Higher Genus Curve Search Input Error', bread=bread, credit=credit)
+   
+    return render_template("hgcwa-search.html", info=info, title='Families of Higher Genus Curve Search Input Error', learnmore=learnmore_list(),bread=bread, credit=credit)
 
 
 
@@ -888,13 +890,10 @@ def search_input_error(info, bread):
 def completeness_page():
     t = 'Completeness of the Automorphisms of Curves Data'
     bread = get_bread([("Completeness", )])
-    learnmore = [('Source of the data', url_for(".how_computed_page")),
-                 ('Reliability of the data', url_for(".reliability_page")),
-                 ('Labeling convention', url_for(".labels_page"))]
     return render_template("single.html", kid='dq.curve.highergenus.aut.extent',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore,
+                           learnmore=learnmore_list_remove('Completeness'),
                            credit=credit)
 
 
@@ -902,11 +901,8 @@ def completeness_page():
 def labels_page():
     t = 'Label Scheme for the Data'
     bread = get_bread([("Labels", '')])
-    learnmore = [('Completeness of the data', url_for(".completeness_page")),
-                 ('Source of the data', url_for(".how_computed_page")),
-                 ('Reliability of the data', url_for(".reliability_page"))]
     return render_template("single.html", kid='dq.curve.highergenus.aut.label',
-                           learnmore=learnmore,
+                           learnmore=learnmore_list_remove('Label'),
                            title=t,
                            bread=bread,
                            credit=credit)
@@ -916,14 +912,11 @@ def labels_page():
 def reliability_page():
     t = 'Reliability of the Automorphisms of Curve Data'
     bread = get_bread([("Reliability", '')])
-    learnmore = [('Completeness of the data', url_for(".completeness_page")),
-                 ('Source of the data', url_for(".how_computed_page")),
-                 ('Labeling convention', url_for(".labels_page"))]
     return render_template("single.html",
                            kid='dq.curve.highergenus.aut.reliability',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore,
+                           learnmore=learnmore_list_remove('Reliability'),
                            credit=credit)
 
 
@@ -931,14 +924,11 @@ def reliability_page():
 def how_computed_page():
     t = 'Source of the Automorphisms of Curve Data'
     bread = get_bread([("Source", '')])
-    learnmore = [('Completeness of the data', url_for(".completeness_page")),
-                 ('Reliability of the data', url_for(".reliability_page")),
-                 ('Labeling convention', url_for(".labels_page"))]
     return render_template("single.html",
                            kid='dq.curve.highergenus.aut.source',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore,
+                           learnmore=learnmore_list_remove('Source'),
                            credit=credit)
 
 


### PR DESCRIPTION
This pull request fixes #3682 and puts the "Learn more about box" on some pages where it was missing.  

For HGCWA:   search page and stats page and  the unique groups pages off stats page were all missing the box.

http://localhost:37777/HigherGenus/C/Aut/?genus=3&search_type=List
vs
http://www.lmfdb.org/HigherGenus/C/Aut/?genus=3&search_type=List

http://localhost:37777/HigherGenus/C/Aut/stats
vs
http://www.lmfdb.org/HigherGenus/C/Aut/stats

http://localhost:37777/HigherGenus/C/Aut/stats/groups_per_genus/6
vs
http://www.lmfdb.org/HigherGenus/C/Aut/stats/groups_per_genus/6



For  ECNF, EC/Q, and AbVar: the search page  and some search error pages were the only pages I could find that didn't have it.  

http://localhost:37777/EllipticCurve/?torsion=2&search_type=List
vs
http://www.lmfdb.org/EllipticCurve/?torsion=2&search_type=List


http://localhost:37777/EllipticCurve/Q/?torsion=2&search_type=List
vs
http://www.lmfdb.org/EllipticCurve/Q/?torsion=2&search_type=List


https://localhost:37777/Variety/Abelian/Fq/?p=3&search_type=List
vs
https://www.lmfdb.org/Variety/Abelian/Fq/?p=3&search_type=List