### PR TITLE
Added Levelt matrices to HGM Families

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -166,6 +166,10 @@ name: Enrique González Jiménez
 affil: Universidad Auton&oacute;ma de Madrid
 url: http://www.uam.es/personal_pdi/ciencias/engonz/
 ---
+name: Thomas Grubb
+affil: University of California, San Diego
+url: https://www.math.ucsd.edu/~tgrubb/
+---
 name: Paul E. Gunnells
 affil: University of Massachusetts Amherst
 url: http://people.math.umass.edu/~gunnells/

--- a/lmfdb/hypergm/templates/hgm_family.html
+++ b/lmfdb/hypergm/templates/hgm_family.html
@@ -33,6 +33,8 @@
       <tr><td>{{KNOWL('hgm.bezout_matrix', title="Bezout matrix")}}:<td>${{family.bezout_latex}}$
       <tr><td>{{KNOWL('hgm.bezout_determinant', title="Bezout determinant")}}:<td>${{family.bezout_det}}$
       <tr><td>{{KNOWL('hgm.bezout_module', title="Bezout module")}}:<td>${{family.bezout_module}}$
+      <!--Levelt matrices purposefully tex'd slightly oddly for better viewing on narrow screens-->
+      <tr><td>{{KNOWL('hgm.levelt_matrices', title="Levelt matrices")}}:<td>${h_{\infty}={{family.hinf_latex}},\;}$ ${h_0={{family.h0_latex}},\;}$ $ {h_1={{family.h1_latex}}}$ 
     </table>
   <p>
 <p><h2> $p$-parts of defining parameters</h2>
@@ -160,3 +162,6 @@
 {% endif %}
 
 {% endblock %}
+
+
+

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -43,6 +43,9 @@ class WebHyperGeometricFamily(object):
         self.beta = cyc_to_QZ(self.B)
         self.hodge = data['famhodge']
         self.bezout = matrix(self.bezout)
+        self.hinf = matrix(self.hinf)
+        self.h0 = matrix(self.h0)
+        self.h1 = matrix(self.h1)
         #FIXME
         self.rotation_number = self.imprim
 
@@ -124,6 +127,18 @@ class WebHyperGeometricFamily(object):
     def bezout_det(self):
         return self.bezout.det()
 
+    @lazy_attribute
+    def hinf_latex(self):
+        return(latex(self.hinf))
+
+    @lazy_attribute
+    def h0_latex(self):
+        return(latex(self.h0))
+
+    @lazy_attribute
+    def h1_latex(self):
+        return(latex(self.h1))
+    
     @lazy_attribute
     def bezout_latex(self):
         return latex(self.bezout)


### PR DESCRIPTION
Edited lmfdb/hypergm/web_family.py to allow for tex formatting of Levelt matrices and edited lmfdb/hypergm/templates/hgm_family.html to display Levelt matrices on HGM family pages. 

This work was supported by a grant from the Simons Foundation (546235) for the collaboration `Arithmetic Geometry, Number Theory, and Computation', through a workshop held at ICERM.