### PR TITLE
Fix python3 bytes not str errors

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -446,9 +446,9 @@ class KnowlBackend(PostgresBase):
         for kid in kids:
             try:
                 if sys.version_info[0] == 3:
-                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],encoding='utf-8').decode('utf-8').split(u'\n--\n'))
+                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],encoding='utf-8').split(u'\n--\n'))
                 else:
-                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))]).decode('utf-8').split(u'\n--\n'))
+                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))]).split(u'\n--\n'))
             except subprocess.CalledProcessError: # no matches
                 pass
         return [self._process_git_grep(match) for match in matches]

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -445,7 +445,7 @@ class KnowlBackend(PostgresBase):
         matches = []
         for kid in kids:
             try:
-                matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],,encoding='utf8').decode('utf-8').split(u'\n--\n'))
+                matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],encoding='utf8').decode('utf-8').split(u'\n--\n'))
             except subprocess.CalledProcessError: # no matches
                 pass
         return [self._process_git_grep(match) for match in matches]

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from collections import defaultdict
 import time
 import subprocess
-import os
+import os, sys
 
 from lmfdb.backend.base import PostgresBase
 from lmfdb.backend import db, DelayCommit
@@ -445,7 +445,10 @@ class KnowlBackend(PostgresBase):
         matches = []
         for kid in kids:
             try:
-                matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],encoding='utf8').decode('utf-8').split(u'\n--\n'))
+                if sys.version_info[0] == 3:
+                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],encoding='utf-8').decode('utf-8').split(u'\n--\n'))
+                else:
+                    matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))]).decode('utf-8').split(u'\n--\n'))
             except subprocess.CalledProcessError: # no matches
                 pass
         return [self._process_git_grep(match) for match in matches]
@@ -460,10 +463,14 @@ class KnowlBackend(PostgresBase):
         - -1 if the knowl is referenced but cannot be safely replaced.
         """
         try:
-            matches = subprocess.check_output(['git', 'grep', """['"]%s['"]"""%(knowlid.replace('.',r'\.'))],encoding='utf8').split('\n')
+            if sys.version_info[0] == 3:
+                matches = subprocess.check_output(['git', 'grep', """['"]%s['"]"""%(knowlid.replace('.',r'\.'))],encoding='utf-8').split('\n')
+            else:
+                matches = subprocess.check_output(['git', 'grep', """['"]%s['"]"""%(knowlid.replace('.',r'\.'))]).split('\n')
         except subprocess.CalledProcessError: # no matches
             return 0
-        easy_matches = subprocess.check_output(['git', 'grep', knowlid.replace('.',r'\.')],encoding='utf8').split('\n')
+
+        easy_matches = subprocess.check_output(['git', 'grep', knowlid.replace('.',r'\.')],encoding='utf-8').split('\n')
         return 1 if (len(matches) == len(easy_matches)) else -1
 
     def start_rename(self, knowl, new_name, who):
@@ -561,7 +568,10 @@ class KnowlBackend(PostgresBase):
         ids that show up in an expression of the form ``KNOWL('BAD_ID')``.
         """
         all_kids = set(k['id'] for k in self.get_all_knowls(['id']))
-        matches = subprocess.check_output(['git', 'grep', '-E', '--full-name', '--line-number', '--context', '2', r"""KNOWL(_INC)?[(]\s*['"]"""],encoding='utf8').split('\n--\n')
+        if sys.version_info[0] == 3:
+            matches = subprocess.check_output(['git', 'grep', '-E', '--full-name', '--line-number', '--context', '2', r"""KNOWL(_INC)?[(]\s*['"]"""],encoding='utf-8').split('\n--\n')
+        else:
+            matches = subprocess.check_output(['git', 'grep', '-E', '--full-name', '--line-number', '--context', '2', r"""KNOWL(_INC)?[(]\s*['"]"""]).split('\n--\n')
         results = []
         for match in matches:
             lines = match.split('\n')

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -445,7 +445,7 @@ class KnowlBackend(PostgresBase):
         matches = []
         for kid in kids:
             try:
-                matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))]).decode('utf-8').split(u'\n--\n'))
+                matches.extend(subprocess.check_output(['git', 'grep', '--full-name', '--line-number', '--context', '2', """['"]%s['"]"""%(kid.replace('.',r'\.'))],,encoding='utf8').decode('utf-8').split(u'\n--\n'))
             except subprocess.CalledProcessError: # no matches
                 pass
         return [self._process_git_grep(match) for match in matches]
@@ -460,10 +460,10 @@ class KnowlBackend(PostgresBase):
         - -1 if the knowl is referenced but cannot be safely replaced.
         """
         try:
-            matches = subprocess.check_output(['git', 'grep', """['"]%s['"]"""%(knowlid.replace('.',r'\.'))]).split('\n')
+            matches = subprocess.check_output(['git', 'grep', """['"]%s['"]"""%(knowlid.replace('.',r'\.'))],encoding='utf8').split('\n')
         except subprocess.CalledProcessError: # no matches
             return 0
-        easy_matches = subprocess.check_output(['git', 'grep', knowlid.replace('.',r'\.')]).split('\n')
+        easy_matches = subprocess.check_output(['git', 'grep', knowlid.replace('.',r'\.')],encoding='utf8').split('\n')
         return 1 if (len(matches) == len(easy_matches)) else -1
 
     def start_rename(self, knowl, new_name, who):
@@ -561,7 +561,7 @@ class KnowlBackend(PostgresBase):
         ids that show up in an expression of the form ``KNOWL('BAD_ID')``.
         """
         all_kids = set(k['id'] for k in self.get_all_knowls(['id']))
-        matches = subprocess.check_output(['git', 'grep', '-E', '--full-name', '--line-number', '--context', '2', r"""KNOWL(_INC)?[(]\s*['"]"""]).split('\n--\n')
+        matches = subprocess.check_output(['git', 'grep', '-E', '--full-name', '--line-number', '--context', '2', r"""KNOWL(_INC)?[(]\s*['"]"""],encoding='utf8').split('\n--\n')
         results = []
         for match in matches:
             lines = match.split('\n')

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -333,7 +333,7 @@ def restart():
     else:
         command = None
     if command:
-        out = Popen(command, stdout=PIPE).communicate()[0]
+        out = Popen(command, stdout=PIPE, encoding='utf8').communicate()[0]
         return out.replace('\n', '<br>')
     else:
         return "Only supported in beta.lmfdb.org, prodweb1.lmfdb.xyz, and prodweb2.lmfdb.xyz"

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -334,7 +334,10 @@ def restart():
     else:
         command = None
     if command:
-        out = Popen(command, stdout=PIPE, encoding='utf-8').communicate()[0] if sys.version_info[0] == 3 else Popen(command, stdout=PIPE).communicate()[0]
+        if sys.version_info[0] == 3:
+            out = Popen(command, stdout=PIPE, encoding='utf-8').communicate()[0]
+        else:
+            Popen(command, stdout=PIPE).communicate()[0]
         return out.replace('\n', '<br>')
     else:
         return "Only supported in beta.lmfdb.org, prodweb1.lmfdb.xyz, and prodweb2.lmfdb.xyz"

--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -323,6 +323,7 @@ def admin():
 @app.route("/restartserver")
 @admin_required
 def restart():
+    import sys
     from subprocess import Popen, PIPE
     from six.moves.urllib.parse import urlparse
     urlparts = urlparse(request.url)
@@ -333,7 +334,7 @@ def restart():
     else:
         command = None
     if command:
-        out = Popen(command, stdout=PIPE, encoding='utf8').communicate()[0]
+        out = Popen(command, stdout=PIPE, encoding='utf-8').communicate()[0] if sys.version_info[0] == 3 else Popen(command, stdout=PIPE).communicate()[0]
         return out.replace('\n', '<br>')
     else:
         return "Only supported in beta.lmfdb.org, prodweb1.lmfdb.xyz, and prodweb2.lmfdb.xyz"


### PR DESCRIPTION
This should address #3866 and #3867 and make it possible to address #3864 by adding encode='utf-8' in several places where it is needed.

To ensure backward compatibility I added an explicit version check.  If someone knows a cleaner way to do this using six, please let me know and I will change it.