### PR TITLE
Widened CMF Search Quantifier Boxes

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1271,7 +1271,8 @@ class CMFSearchArray(SearchArray):
 
         weight_quantifier = ParityMod(
             name='weight_parity',
-            extra=['class="simult_select"', 'onchange="simult_change(event);"'])
+            extra=['class="simult_select"', 'onchange="simult_change(event);"'],
+            width = 105)
 
         weight = TextBoxWithSelect(
             name='weight',
@@ -1283,7 +1284,8 @@ class CMFSearchArray(SearchArray):
 
         character_quantifier = ParityMod(
             name='char_parity',
-            extra=['class="simult_select"', 'onchange="simult_change(event);"'])
+            extra=['class="simult_select"', 'onchange="simult_change(event);"'],
+            width = 105)
 
         character = TextBoxWithSelect(
             name='char_label',
@@ -1295,7 +1297,8 @@ class CMFSearchArray(SearchArray):
             select_box=character_quantifier)
 
         prime_quantifier = SubsetBox(
-            name="prime_quantifier")
+            name="prime_quantifier",
+            width = 105)
         level_primes = TextBoxWithSelect(
             name='level_primes',
             knowl='cmf.bad_prime',

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1260,7 +1260,7 @@ class CMFSearchArray(SearchArray):
                      ('square', 'square'),
                      ('squarefree', 'squarefree')
                      ],
-            width=105)
+            width=115)
         level = TextBoxWithSelect(
             name='level',
             label='Level',
@@ -1272,7 +1272,7 @@ class CMFSearchArray(SearchArray):
         weight_quantifier = ParityMod(
             name='weight_parity',
             extra=['class="simult_select"', 'onchange="simult_change(event);"'],
-            width = 105)
+            width = 115)
 
         weight = TextBoxWithSelect(
             name='weight',
@@ -1285,7 +1285,7 @@ class CMFSearchArray(SearchArray):
         character_quantifier = ParityMod(
             name='char_parity',
             extra=['class="simult_select"', 'onchange="simult_change(event);"'],
-            width = 105)
+            width = 115)
 
         character = TextBoxWithSelect(
             name='char_label',
@@ -1298,7 +1298,7 @@ class CMFSearchArray(SearchArray):
 
         prime_quantifier = SubsetBox(
             name="prime_quantifier",
-            width = 105)
+            width = 115)
         level_primes = TextBoxWithSelect(
             name='level_primes',
             knowl='cmf.bad_prime',
@@ -1323,7 +1323,7 @@ class CMFSearchArray(SearchArray):
         dim_quantifier = SelectBox(
             name='dim_type',
             options=[('', 'absolute'), ('rel', 'relative')],
-            width=105)
+            width=115)
 
         dim = TextBoxWithSelect(
             name='dim',


### PR DESCRIPTION
Addresses issue #3863 ; widened drop down quantifier boxes for Classical Modular Forms so that every option would display fully in the box with no cutoff (in addition to the issues raised in 3863, the "Level" box was too narrow for "prime power"). Decided to make all such boxes a uniform width (115 px), as opposed to each having it's own, as it looks nicer to me; happy to revert to each box having it's own optimized width if desired. 