### PR TITLE
fixing login issues without the remember

### DIFF
--- a/lmfdb/users/main.py
+++ b/lmfdb/users/main.py
@@ -169,7 +169,7 @@ def login(**kwargs):
     name = request.form["name"]
     password = request.form["password"]
     next = request.form["next"]
-    remember = True if request.form["remember"] == "on" else False
+    remember = request.form.get("remember") == "on"
     user = LmfdbUser(name)
     if user and user.authenticate(password):
         login_user(user, remember=remember)


### PR DESCRIPTION
If you try to log in without ticking the "remember" box you get a page error.
This patch fixes that.