### PR TITLE
Api 2 Fix part 1

### DIFF
--- a/lmfdb/api2/api2.py
+++ b/lmfdb/api2/api2.py
@@ -4,6 +4,7 @@ from flask import render_template, request, Response, make_response
 from lmfdb.api2.searchers import searchers, singletons
 from . import utils
 
+
 @api2_page.route("/api.css")
 def api_css():
     response = make_response(render_template("api.css"))
@@ -15,19 +16,23 @@ def api_css():
         response.headers['Cache-Control'] = 'public, max-age=600'
     return response
 
+
 @api2_page.route("/")
 def index():
     title = "API Description"
     return render_template("api2.html", **locals())
+
 
 @api2_page.route("/demo")
 def demo():
     title = "API Demo"
     return render_template("api_demo.html", **locals())
 
+
 @api2_page.route("/<other>")
 def other(other):
     return Response(utils.build_api_error(other), mimetype='application/json')
+
 
 @api2_page.route("/livepg/<db>")
 def live_page_pg(db):
@@ -40,10 +45,12 @@ def live_page_pg(db):
     search_tuple = utils.simple_search(search)
     return Response(utils.build_api_search(db, search_tuple, request = request), mimetype='application/json')
 
+
 @api2_page.route("/pretty/<path:path_var>")
 def prettify_live(path_var):
     bread = []
     return render_template('view.html', data_url=path_var, bread=bread)
+
 
 @api2_page.route("/singletons/<path:path_var>")
 def handle_singletons(path_var):
@@ -69,6 +76,7 @@ def handle_singletons(path_var):
         return Response(utils.build_api_search(path_var, search_tuple, request = request), mimetype='application/json')
     return Response(utils.build_api_error(path_var), mimetype='application/json')
 
+
 @api2_page.route("/description/searchers")
 def list_searchers():
     names=[]
@@ -78,7 +86,10 @@ def list_searchers():
         names.append(el)
         h_names.append(searchers[el].get_name())
         descs.append(searchers[el].get_description())
-    return Response(utils.build_api_searchers(names, h_names, descs, request=request), mimetype='application/json')
+    return Response(
+        utils.build_api_searchers(names, h_names, descs, request=request),
+        mimetype='application/json'
+    )
 
 
 @api2_page.route("/description/<searcher>")
@@ -97,7 +108,11 @@ def list_descriptions(searcher):
     else:
         return Response(utils.build_api_error(searcher), mimetype='application/json')
     if lst:
-        return Response(utils.build_api_descriptions(searcher, lst, request=request), mimetype='application/json')
+        return Response(
+            utils.build_api_descriptions(searcher, lst, request=request),
+            mimetype='application/json'
+        )
+
 
 @api2_page.route("/inventory/<searcher>")
 def list_responses(searcher):
@@ -115,7 +130,10 @@ def list_responses(searcher):
     else:
         return Response(utils.build_api_error(searcher), mimetype='application/json')
     if lst:
-        return Response(utils.build_api_inventory(searcher, lst, request=request), mimetype='application/json')
+        return Response(
+            utils.build_api_inventory(searcher, lst, request=request),
+            mimetype='application/json'
+        )
 
 
 @api2_page.route("/data/<searcher>")
@@ -129,8 +147,12 @@ def get_data(searcher):
     except KeyError:
         val = None
 
-    if not val: return Response(utils.build_api_error(searcher), mimetype='application/json')
+    if not val:
+        return Response(utils.build_api_error(searcher), mimetype='application/json')
 
     search = val.auto_search(request)
 
-    return Response(utils.build_api_search('/data/'+searcher, search, request=request), mimetype='application/json')
+    return Response(
+        utils.build_api_search('/data/'+searcher, search, request=request),
+        mimetype='application/json'
+    )

--- a/lmfdb/api2/api2.py
+++ b/lmfdb/api2/api2.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from unicodedata import normalize
 from lmfdb.api2 import api2_page
 from flask import render_template, request, Response, make_response
 from lmfdb.api2.searchers import searchers, singletons
@@ -28,7 +27,7 @@ def demo():
 
 @api2_page.route("/<other>")
 def other(other):
-    return Response(utils.build_api_error(other), mimetype='application/json')    
+    return Response(utils.build_api_error(other), mimetype='application/json')
 
 @api2_page.route("/livepg/<db>")
 def live_page_pg(db):
@@ -84,14 +83,12 @@ def list_searchers():
 
 @api2_page.route("/description/<searcher>")
 def list_descriptions(searcher):
-    dbstr = normalize('NFKD', searcher).encode('ascii','ignore')
-
-    if (searcher.startswith("<") and searcher.endswith(">")): 
+    if (searcher.startswith("<") and searcher.endswith(">")):
         title = "API Description"
         return render_template("example.html", **locals())
 
     try:
-        val = searchers[dbstr]
+        val = searchers[searcher]
     except KeyError:
         val = None
 
@@ -100,18 +97,16 @@ def list_descriptions(searcher):
     else:
         return Response(utils.build_api_error(searcher), mimetype='application/json')
     if lst:
-        return Response(utils.build_api_descriptions(dbstr, lst, request=request), mimetype='application/json')
+        return Response(utils.build_api_descriptions(searcher, lst, request=request), mimetype='application/json')
 
 @api2_page.route("/inventory/<searcher>")
 def list_responses(searcher):
-    dbstr = normalize('NFKD', searcher).encode('ascii','ignore')
-
-    if (searcher.startswith("<") and searcher.endswith(">")):     
+    if (searcher.startswith("<") and searcher.endswith(">")):
         title = "API Description"
         return render_template("example.html", **locals())
 
     try:
-        val = searchers[dbstr]
+        val = searchers[searcher]
     except KeyError:
         val = None
 
@@ -120,22 +115,21 @@ def list_responses(searcher):
     else:
         return Response(utils.build_api_error(searcher), mimetype='application/json')
     if lst:
-        return Response(utils.build_api_inventory(dbstr, lst, request=request), mimetype='application/json')
+        return Response(utils.build_api_inventory(searcher, lst, request=request), mimetype='application/json')
+
 
 @api2_page.route("/data/<searcher>")
 def get_data(searcher):
-    dbstr = normalize('NFKD', searcher).encode('ascii','ignore')
-
-    if (searcher.startswith("<") and searcher.endswith(">")):     
+    if (searcher.startswith("<") and searcher.endswith(">")):
         title = "API Description"
         return render_template("example.html", **locals())
 
     try:
-        val = searchers[dbstr]
+        val = searchers[searcher]
     except KeyError:
         val = None
 
-    if not val : return Response(utils.build_api_error(searcher), mimetype='application/json')
+    if not val: return Response(utils.build_api_error(searcher), mimetype='application/json')
 
     search = val.auto_search(request)
 

--- a/lmfdb/api2/templates/api2.html
+++ b/lmfdb/api2/templates/api2.html
@@ -188,7 +188,10 @@ records:{...}
 }</code></pre>
 <p>client is interested in returning the key with canonical name <code>2ADIC_INDEX</code>. It can express this as <code>_fields=&quot;2ADIC_INDEX&quot;</code> .</p>
 <h2 id="get-results">Get results</h2>
-<p>Knowing what it wants to search on and what it wants returned the client connects to <a href="/api2/data/elliptic_curve_q?label=&quot;100a3&quot;&amp;_fields=&quot;2adic_index&quot;" class="uri">/api2/data/elliptical_curve_q?label=&quot;100a3&quot;&amp;_fields=&quot;2ADIC_INDEX&quot;</a>. Result is</p>
+<p>Knowing what it wants to search on and what it wants returned the client
+connects to <a
+  href="/api2/data/elliptic_curves_q?label=&quot;100a3&quot;&amp;_fields=&quot;2adic_index&quot;"
+  class="uri">/api2/data/elliptic_curves_q?label=&quot;100a3&quot;&amp;_fields=&quot;2ADIC_INDEX&quot;</a>. Result is</p>
 <pre language="json" startFrom="1"><code>{&quot;api_version&quot;:&quot;1.0.0&quot;,
 &quot;type&quot;:&quot;API_INVENTORY&quot;,
 &quot;key&quot;: &quot;inventory/elliptic_curves_q&quot;,


### PR DESCRIPTION
This is a partial resolution to the issue in #3911. After this, almost all examples on the api2 page now work.

This was caused by a string-to-bytes issue and presumably hasn't worked since we updated to python3.

This also updates the html in the page to make the last example (for returning certain fields) of the correct form, even though this functionality does not yet actually work. I will post more on that in issue #3911.