### PR TITLE
small bread fix on hgcwa

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -136,7 +136,7 @@ def label_to_breadcrumbs(L):
             newsig += ","
         elif (L[i] == '.'):
             newsig += ';'
-        elif (L[i] == '0'):  # The case where there is no ramification gives a 0 in signature
+        elif (L[i] == '0' and L[i-1] == '.'):  # The case where there is no ramification gives a 0 in signature
             newsig += '-'
         else:
             newsig += L[i]


### PR DESCRIPTION
The bread display (not the bread link itself) on a few HGCWA pages had a small error. Basically "0" were replaced with "-" in too many places.  See:
https://beta.lmfdb.org/HigherGenus/C/Aut/2.10-2.0.2-5-10.1
https://beta.lmfdb.org/HigherGenus/C/Aut/5.20-2.0.2-20-20.4

We do want some 0 replaced, see
https://beta.lmfdb.org/HigherGenus/C/Aut/3.2-1.2.0.1 
where the "-" displayed on the bread link is replacing the "0" in the label.

The new PR keeps the 0's we want
http://localhost:37777/HigherGenus/C/Aut/2.10-2.0.2-5-10.1
http://localhost:37777/HigherGenus/C/Aut/5.20-2.0.2-20-20.4

and still replaces the 0s we don't want
http://localhost:37777/HigherGenus/C/Aut/3.2-1.2.0.1 

