### PR TITLE
Improved HGM Circles a little bit

### DIFF
--- a/lmfdb/hypergm/plot.py
+++ b/lmfdb/hypergm/plot.py
@@ -48,8 +48,7 @@ def piecewise_linear_image(A,B):
 def circle_image(A,B):
     G = Graphics()
     G += circle((0,0), 1 , color = 'black',thickness = 3)
-    backgroundColor = (227/255,242/255,253/255) #This is the RGB color (in Sage format) of the properties bar (found in style.css). Making the framing circle this color makes it invisible on the page. 
-    G += circle((0,0), 1.4, color = backgroundColor) #This adds a framing circle to the plot, which protects the aspect ratio from being skewed. 
+    G += circle((0,0), 1.4, color = 'black',alpha = 0) #This adds an invisible framing circle to the plot, which protects the aspect ratio from being skewed. 
     from collections import defaultdict
     tmp = defaultdict(int)
     for a in A:

--- a/lmfdb/hypergm/plot.py
+++ b/lmfdb/hypergm/plot.py
@@ -47,7 +47,9 @@ def piecewise_linear_image(A,B):
     
 def circle_image(A,B):
     G = Graphics()
-    G += circle((0,0), 1 , color = 'grey')
+    G += circle((0,0), 1 , color = 'black',thickness = 3)
+    backgroundColor = (227/255,242/255,253/255) #This is the RGB color (in Sage format) of the properties bar (found in style.css). Making the framing circle this color makes it invisible on the page. 
+    G += circle((0,0), 1.4, color = backgroundColor) #This adds a framing circle to the plot, which protects the aspect ratio from being skewed. 
     from collections import defaultdict
     tmp = defaultdict(int)
     for a in A:
@@ -62,9 +64,11 @@ def circle_image(A,B):
                 rational = Rational(j)/Rational(b)
                 tmp[(rational.numerator(),rational.denominator())] -= 1
     C = ComplexField()
+    color1 = (41/255,95/255,45/255)
+    color2 = (0/255,0/255,150/255)
     for val in tmp:
         if tmp[val] > 0:
-            G += text(str(tmp[val]),exp(C(-.2+2*3.14159*I*val[0]/val[1])), fontsize = 30, axes = False, color = "green")
+            G += text(str(tmp[val]),exp(C(-.2+2*3.14159*I*val[0]/val[1])), fontsize = 30, axes = False, color = color1)
         if tmp[val] < 0:
-            G += text(str(abs(tmp[val])),exp(C(.2+2*3.14159*I*val[0]/val[1])), fontsize = 30, axes = False, color = "blue")
+            G += text(str(abs(tmp[val])),exp(C(.2+2*3.14159*I*val[0]/val[1])), fontsize = 30, axes = False, color = color2)
     return G

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -186,6 +186,7 @@ class WebHyperGeometricFamily(object):
                     pad=0,
                     pad_inches=0,
                     bbox_inches='tight',
+                    transparent = True,
                     remove_axes=True)
 
     @lazy_attribute


### PR DESCRIPTION
Deals with part of Issue #3406 . Added a frame around HGM circles to prevent skewing of the aspect ratio, thickened the circle, made the background transparent, and deepened the colors. Two examples below, left is new, right is old. It is easy to change color schemes if anyone has preferences:

![image](https://user-images.githubusercontent.com/53013402/88078954-ea1fa580-cb31-11ea-8d89-5f3e71b08fa8.png)

![image](https://user-images.githubusercontent.com/53013402/88078928-e0963d80-cb31-11ea-8013-1563da96148d.png)

