### PR TITLE
Fixing a bug in set_sort

### DIFF
--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -2124,7 +2124,7 @@ class PostgresTable(PostgresBase):
         with DelayCommit(self, commit, silence=True):
             if sort:
                 updater = SQL("UPDATE meta_tables SET sort = %s WHERE name = %s")
-                values = [sort, self.search_table]
+                values = [Json(sort), self.search_table]
             else:
                 updater = SQL("UPDATE meta_tables SET sort = NULL WHERE name = %s")
                 values = [self.search_table]


### PR DESCRIPTION
It now works as expected
```
sage: db.maass_newforms.set_sort(['level','weight','conrey_index','spectral_parameter'])
resorting disabled
Index maass_newforms_le_we_co_sp created in 0.206 secs
```

This will be merged once tests pass.