### PR TITLE
Only display CMF coefficient ring index if it is computed

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -77,10 +77,12 @@
     <td> \(\mathbb{Z}\)</td>
   </tr>
   {% endif %}
+  {% if newform.hecke_ring_index_factored %}
   <tr>
     <td> {{ KNOWL('cmf.coefficient_ring',title='Coefficient ring index') }}: </td>
     <td> {{ newform.ring_index_display() | safe }}</td>
   </tr>
+  {% endif %}
   <tr>
     <td> {{ KNOWL('cmf.twist_minimal',title='Twist minimal') }}: </td>
     <td> {{ newform.twist_minimal_display() | safe }}</td>


### PR DESCRIPTION
Deals with issue #3914. Only displays CMF coefficient ring index if it is computed, by adding the appropriate "if" statement around the print line. 