### PR TITLE
Issue/3534

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -425,5 +425,6 @@ affil: The University of North Carolina Greensboro
 name: David Yuen
 affil: Lake Forest College
 url: http://www.lakeforest.edu/academics/faculty/yuen/
-
+---
+name: Samuel Rice
 

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -11,7 +11,8 @@ from lmfdb.utils import (
     nf_string_to_label, parse_nf_string, parse_noop, parse_start, parse_count, parse_ints,
     SearchArray, TextBox, SelectBox, ExcludeOnlyBox, CountBox,
     teXify_pol, search_wrap)
-from lmfdb.number_fields.web_number_field import field_pretty, WebNumberField, nf_display_knowl
+from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.number_fields.web_number_field import WebNumberField, nf_display_knowl
 from lmfdb.nfutils.psort import ideal_from_label
 from lmfdb.bianchi_modular_forms import bmf_page
 from lmfdb.bianchi_modular_forms.web_BMF import WebBMF
@@ -113,7 +114,8 @@ def bianchi_modular_form_postprocess(res, info, query):
                        "sfe": lambda v: "+1" if v.get('sfe',None)==1 else ("-1" if v.get('sfe',None)==-1 else "?"),
                        "url": lambda v: url_for('.render_bmf_webpage',field_label=v['field_label'], level_label=v['level_label'], label_suffix=v['label_suffix']),
                        "bc": lambda v: bc_info(v['bc']),
-                       "cm": lambda v: cm_info(v.pop('CM', '?'))},
+                       "cm": lambda v: cm_info(v.pop('CM', '?')),
+                       "field_knowl": lambda e: nf_display_knowl(e['field_label'], field_pretty(e['field_label']))},
              bread=lambda:[('Modular forms', url_for('modular_forms')), ('Bianchi', url_for(".index")),
                            ('Search results', '.')],
              url_for_label=lambda label: url_for(".render_bmf_webpage",

--- a/lmfdb/bianchi_modular_forms/templates/bmf-search_results.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-search_results.html
@@ -22,7 +22,7 @@
     <tbody>
 {% for form in info.results: %}
 <tr>
-<td>{{form.field_label}}</td>
+<td>{{form.field_knowl|safe}}</td>
 <td><a href={{url_for("bmf.render_bmf_space_webpage",field_label=form.field_label,
        level_label=form.level_label)}}>{{form.level_label}}</a> {#$={{form.level_ideal}}$#}</td>
 <td align='left'><a href="{{form.url}}">

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -10,7 +10,8 @@ from lmfdb.utils import (
     SearchArray, TextBox, ExcludeOnlyBox, CountBox,
     search_wrap)
 from lmfdb.ecnf.main import split_class_label
-from lmfdb.number_fields.web_number_field import WebNumberField
+from lmfdb.number_fields.number_field import field_pretty
+from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberField
 from lmfdb.hilbert_modular_forms import hmf_page
 from lmfdb.hilbert_modular_forms.hilbert_field import findvar
 from lmfdb.hilbert_modular_forms.hmf_stats import get_stats, get_counts, hmf_degree_summary
@@ -116,7 +117,8 @@ def hilbert_modular_form_jump(info):
              per_page=50,
              shortcuts={'jump':hilbert_modular_form_jump},
              projection=['field_label', 'short_label', 'label', 'level_ideal', 'dimension'],
-             cleaners={"level_ideal": lambda v: teXify_pol(v['level_ideal'])},
+             cleaners={"level_ideal": lambda v: teXify_pol(v['level_ideal']),
+                       "field_knowl": lambda e: nf_display_knowl(e['field_label'], field_pretty(e['field_label']))},
              bread=lambda:[("Modular forms", url_for('modular_forms')),
                            ('Hilbert', url_for(".hilbert_modular_form_render_webpage")),
                            ('Search results', '.')],

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_search.html
@@ -33,7 +33,7 @@ Either modify your search above or go <input type=button value="Back" onClick="h
 <tr>
 <td align='left'><a href="{{url_for('hmf.render_hmf_webpage',field_label=form.field_label,label=form.label)}}">
   {{form.short_label}} </a></td>
-<td>{{form.field_label}}</td>
+<td>{{form.field_knowl|safe}}</td>
 <td>${{form.level_ideal}}$</td>
 <td>{{form.dimension}}</td>
 </tr>


### PR DESCRIPTION
Addresses #3534

The number fields in the BMF and HMF search results should now all be knowls with pretty names where possible.

Note: I've had issues with `field_pretty` on my local build (I'm running in WSL at the moment and sage segfaults somewhere in there). However, replacing that function call with some other text displays the knowl and new text as expected, so this _should_ work in a better environment.
