### PR TITLE
Update development docs

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -1,62 +1,335 @@
+LMFDB Developer's Guide
+=======================
+
+This document describes the development process of the LMFDB. In addition, it
+describes the principles behind the pages in the LMFDB, the writing style, the
+use of knowls, and the URLs of the home pages of mathematical objects. This
+document is not meant as a rigid set of rules. Rather, it is intended to help
+speed the creation and adoption of new material, and to help maintain a unified
+design as the website grows.
+
+If you are interested in developing the LMFDB, it would be a very good idea to
+introduce yourself to the current developers, who can then help you get
+involved in current development meetings.
+
+
 Setup
 =====
-To set up your system for development see [Code development and sharing your work](https://github.com/LMFDB/lmfdb/blob/master/GettingStarted.md#running).
 
-Conventions
-===========
+To set up your system for development see [Code development and sharing your
+work](https://github.com/LMFDB/lmfdb/blob/master/GettingStarted.md#running).
 
-Template
---------
 
-A template has several variables:
+Adding material to the LMFDB
+============================
+
+New pages are developed through an iterative process that involves input from
+both experts and nonexperts. The goal is to make everyone happy.
+
+A principle to keep in mind is that a novice must be able to click their way
+around the site, exploring objects about which they might know very little;
+at the same time, an expert has to be able to quickly find what they are
+looking for.
+
+
+
+
+Structural Conventions
+======================
+
+Below, we describe several of the structural conventions used in the LMFDB. Note
+that we also have styling conventions for the content of individual pages. These
+styling conventions are described in
+[StyleSheet.md](https://github.com/LMFDB/lmfdb/blob/master/StyleSheet.md).
+
+Pages in the LMFDB
+------------------
+
+- Each mathematical object in the LMFDB has a "home page".
+- This home page should have a mathematically meaningful URL.
+- The home pages can be reached by browse pages and search pages.
+- On both the "home page" for an object and on the browse pages and search
+  pages, knowls provide information about technical terms.
+
+We elaborate on these four points.
+
+### Homepages
+
+Every object in the LMFDB has a "home page". The home page of a
+mathematical object is based on the idea of a home page of an individual
+mathematician, or the wikipedia article of someone famous.
+
+An object's home page should provide a wide variety of information about the
+object. Basic information, of interest to both experts and non-experts,
+should appear ear the top. More specialized information should appear
+near the bottom.
+
+In the upper right corner of each home page should be the "properties" box,
+summarizing the most basic facts about the object. The information in the
+properties box should also appear in the body of the page.
+
+Below the properties box is the "Related objects" box, containing links to
+the home pages of related objects. Below the related objects box is the
+"Downloads box", containing links to data and code. And below the downloads
+box is the "Learn more about" box, containing information about the
+completeness and source of the shown data.
+
+Standard practice for creating the home page for a new object is to copy the
+template for an existing object with a good home page. *(This has often been
+elliptic curves or global number fields in the past --- classical modular
+forms have some newer features and might be copied now too)*. The "Properties
+box" and other features will already be there, and you can use them without
+necessarily knowing all the details of how the templates work.
+
+Descriptions of the terminology on the home page for an object should be put in
+knowls. This allows nonexperts to find basic information without
+forcing experts to skim through documentation. The links to the knowls should
+be the words being defined. **Don't add extraneous words like "click here"**.
+
+When creating a new home page for an object, get feedback from both experts
+and nonexperts about the order in which the information appears on the
+home page, and the categories in which to group the material. If there is a
+question about whether something should go on a home page, frequently the
+answer is "yes"; the main exception is when the information is not of wide interest or if it more properly belongs on the home page of a related object.
+
+In practice, it is a good idea to get feedback from the current group of
+established LMFDB developers frequently.
+
+*Historical note*: the properties box is also known as the "Lady Gaga" box, or
+the "Gaga box". The name comes from John Voight's presentation at an LMFDB
+workshop, where he used Lady Gaga's Wikipedia article as an illustration
+of the value of gathering basic information in the upper-right corner of a
+home page.
+
+
+### Browse and search pages
+
+The entry point to most mathematical objects in the LMFDB is through browse
+and search pages. The upper portion of these pages (the part that is visible
+in a typical browser when first visiting the page) should contain two things:
+
+1. At the top should be a variety of links to specific objects, and to
+   search pages where reasonable search parameters have already been
+   selected. The point is that a novice should be able to click around with
+   their mouse and explore the topic, without needing to fill out a form
+   or even know anything about the topic to proceed.
+
+2. Below the top section, but still visible without scrolling far, should be a
+   search form which is suitable for use by experts.
+
+Other material can appear in the lower portion of browse and search pages.
+
+
+### Knowls
+
+In order to be able to write or edit knowls, it is necessary to contact the
+current developers of the LMFDB.
+
+#### Anatomy of a knowl
+
+There are three components to a knowl.
+
+1. Identifier: this indicates where the knowl fits into the hierarchy of
+   information in the LMFDB, but the scheme is not as elaborate or as rigid as
+   URLs.
+
+   Example: ec.q.conductor has `ec.q` as hierarchies.
+
+   Consult with experts before trying to introduce new first or second-level
+   identifiers. It is tedious to alter identifiers and change the places they
+   are used afterwards.
+
+2. Description/title: this consists of several words that describes the knowl
+   and helps distinguish it among knowls on similar topics.
+
+   Example: "Conductor of an elliptic curve over Q". Notice that this
+   description would be inadequate if it were any shorter.
+
+3. Content: this is the text that appears when someone clicks on the knowl.
+
+  As originally envisioned by Harald Schilly, knowls should contain a
+  relatively small amount of information (because it is better to have
+  knowls-within-knowls so the reader can determine what additional
+  information is needed), and the content of a knowl is *context
+  independent*. This means that the information should make sense wherever it
+  might appear.
+
+  In the example of "Conductor of an elliptic curve over Q", the definitions
+  in most textbooks may not be suitable for the content of the knowl,
+  because the phrasing may not make sense unless the reader has read previous
+  content in the text.
+
+  Note that years of schooling have trained people to write in a linear
+  fashion where each idea flows into the next. This training might not be
+  helpful in writing knowls, as they should be *context independent*.
+  Try not to think about the specific situation in which you want to use
+  the knowl: write something that makes sense in all other places where
+  others might use it.
+
+
+#### Using knowls
+
+Knowls are used in several ways:
+
+1. To provide supplementary information (such as a definition) on a web
+   page.
+
+2. To provide all the material on a webpage in a way that can be easily
+   edited. (Though this is relatively rare).
+
+The above is a list of how knowls are *currently* being used in the LMFDB.
+This might change over time.
+
+
+### URLs
+
+One of the fundamental principles of the LMFDB is that mathematical objects
+should have a "home page" (described above).
+
+As much as possible, the URLs for home pages of objects in the LMFDB
+should be
+
+1. mathematically meaningful
+2. human readable
+3. permanent
+4. suitable for inclusion in a bibliography
+
+Here and throughout this document, we say "should" instead of "must", with
+the understanding that some compromises will be inevitable.
+
+Here are some principles:
+
+1. If X is the URL of an object, then L/X is the URL of its standard
+   L-function. According to the Langlands program, other L-functions
+   associated to X have the form L(s, X, rho). Examples include
+
+   - L(s, f, sym^2)
+   - L(s, f, spin)
+
+   These should then have URLs, respectively,
+
+   - `L/SymmetricPower/2/<url_for_f>`
+   - `L/spin/<url_for_f>`
+
+2. The group comes before the field. For example, GL2/Q could occur in the URL
+   of some object.
+
+3. The "type of object" should come first. For example, some top level
+   URLs for home pages include
+
+   - /ArtinRepresentation
+   - /Character
+   - /EllipticCurve
+   - /L
+   - /ModularForm
+
+   There are other top level URLs, and not all top level URLs have
+   home pages for mathematical objects below them.
+
+4. "Nicknames" can sometimes be used for popular number fields. These include
+   - QsqrtN: where N can be a positive or negative integer. For example,
+     Qsqrt7 or Qsqrt-5
+   - Q: the rationals
+   - Qi: `Q(\sqrt{-1})`
+   - QzetaN: the Nth cyclotomic field
+
+   For example, the search page
+   https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/ allows
+   Qsqrt5 as a search parameter for the coefficient field.
+
+   Note that number fields like Qsqrt5 has an "official name" as well as a
+   nickname. Many discussions have occurred for what appropriate labels for
+   objects should be. Examine the structure of existing objects in the
+   LMFDB very closely to maintain correct labels and relationships.
+
+5. The URL of an object provides successively narrower descriptions of the
+   object. After some number of levels (depending on the object), one is
+   faced with the issue of naming a specific object. This final specification
+   can be done with a label, or with a hierarchy/directory-style
+   specification.
+
+   For example, the following examples are currently in use, and these URLs
+   should be considered permanent:
+
+   - `/ArtinRepresentation/\<dim>/\<conductor>/\<label>`
+   - `/Character/Dirichlet/\<modulus>/\<number>`
+   - `/Character/Hecke/\<number_field>/\<modulus>/\<number>`
+   - `/EllipticCurve/Q/\<label>`
+   - `/GaloisGroup/\<label>`
+   - `/LocalNumberField/\<label>`
+   - `/ModularForm/GL2/Q/holomorphic/\<label>`
+   - `/ModularForm/GL2/Q/Maass/\<label>`
+   - `/Motive/Hypergeometric/Q/\<label>`
+   - `/NumberField/\<label>`
+
+In practice, prior to deciding on a labelling scheme for new objects, one
+should talk to the current LMFDB developers (who now have a lot of experience
+in considering labelling schemes).
+
+
+Templates
+---------
+
+Pages are displayed through flask+jinja templates. A template has several
+typical variables:
+
  * title - that appears on several places
  * properties - right hand bar, see below
- * bread - breadcumb hierarchy, i.e. [ ('name', 'url'), ... ]
- * sidebar - additional sidebar entries, datastructure is
-   [ ('topic', [ ('text', 'url'), ...]), ... ]
-   ** info.downloads, info.friends, info.learnmore have the same strucutre,
-      names might change sometimes.
+ * bread - breadcrumb hierarchy, i.e. [ ('name', 'url'), ... ]
+ * sidebar - additional sidebar entries. The data structure is
+   `[ ('topic', [ ('text', 'url'), ...]), ... ]`.
+
+   - Note that `info.downloads`, `info.friends`, and `info.learnmore` have the
+     same structure, though the names might differ from page to page.
+
  * credit - small credits note at the bottom
- * support - either a default or a line that says who has supported this. 
+ * support - either a default or a line that says who has supported this.
 
 For more details read templates/homepage.html
 
 
 The idea is to extend "homepage.html" and replace the content block:
+
+```
 {% block content %}
    ... your stuff ...
 {% endblock %}
+```
+
 
 CSS
 ---
+
 The css should be kept in the .css files in lmfdb/templates/ and loaded into
 homepage.html.  Preferably, new css should be added to:
- * style.css - contains the majority of the css, for exmaple, for the
+
+ * style.css - contains the majority of the css, for example, for the
    properties and sidebar variables.
 
 The colors are defined in `lmfdb.utils.color`, and are available in
 Jinja as `color.header_background` for example.  Please use the colors
-defined there rather than specific colors so that the user can change
-the color theme.
+defined there rather than specific colors to facilitate future changes.
+
 
 Code Organization / Blueprints
 ------------------------------
 
-Each part of the website should be a Python module [1] and a
-proper flask Blueprint [2]. Look at how /knowledge/ is done,
-especially knowledge/__init__.py and knowledge/main.py. 
-Also, templates and static files specific to the module
-should be in their respective "templates" and "static"
-folders, e.g. /knowledge/templates/. 
+Each part of the website should be a Python module [1] and a proper flask
+Blueprint [2]. Look at how /knowledge/ is done, especially knowledge/__init__.py
+and knowledge/main.py. Also, templates and static files specific to the module
+should be in their respective "templates" and "static" folders, e.g.
+/knowledge/templates/.
 
 [1] http://docs.python.org/tutorial/modules.html
 [2] http://flask.pocoo.org/docs/blueprints/
 
+
 Code Attribution
 ----------------
-Each file should begin with a short copyright information,
-mentioning the people who are mainly involved in coding
-this particular python file. 
+
+Each file should begin with a short copyright information, mentioning the people
+who are mainly involved in coding this particular python file. In practice, 
+
 
 Testing
 -------
@@ -80,6 +353,7 @@ Testing
 
 Pro Tip: Debugging
 -------------------
+
 Just add
 ```
   import pdb; pdb.set_trace()
@@ -88,7 +362,7 @@ somewhere (e.g. protected inside a sensible if) this magic
 line and you will end up inside the interactive python
 debugger. there, you can check for the local variables with dir()
 you can execute python code (e.g. to introspect objects)
-and use "pp <var name>" to pretty print variables and 
+and use "pp <var name>" to pretty print variables and
 to continue executing code use the "n" command.
 When you get lost, the command "bt" shows you exactly where you
 are and "up" helps you to get on step up on the stack.
@@ -134,6 +408,7 @@ In your home directory, in the file ~/.gitconfig
 List-table should always be like
 --------------------------------
 
+```
 <table class="ntdata">
   <thead><tr><td>...</td></tr></thead>
 
@@ -144,25 +419,38 @@ List-table should always be like
    ...
   </tbody>
 </table>
+```
 
 ... we might also switch to CSS3's nth-element selector and forget about this.
 
+
 Properties
 ----------
-the table on the right renders Strings formatted in the following datastructure:
+
+The table on the right renders Strings formatted in the following datastructure:
+
+```
 prop = [ ( '<description>', [ '<value 1>', '<value 2>', ...] ), ... ]
+```
+
 or
+
+```
 prop = [ ( '<description>', '<value>'), ('<description>', '<value>'), ... ]
+```
+
 you can mix list or non-list.
+
 
 LaTeX Macros
 ------------
 
-Latex macros are documented in a knowl that will appear when you start editing one. 
+Latex macros are documented in a knowl that will appear when you start editing one.
 
 
 Server Hook
 -----------
+
 This is in the `hooks/post-receive` in the bare Git repo:
 
 ```
@@ -171,7 +459,7 @@ This is in the `hooks/post-receive` in the bare Git repo:
 # this is based on http://stackoverflow.com/a/13057643/54236
 
 restart() {
-    echo "updating $1" 
+    echo "updating $1"
     export GIT_WORK_TREE=/home/lmfdbweb/lmfdb-git-$1
     git checkout $1 -f
     echo 'git HEAD now at' `git rev-parse HEAD`

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -29,7 +29,7 @@ Installation
    Sage installation directory, so should be no problem on a personal
    machine, but if you are using a system-wide Sage install on a shared
    machine, you will need ask a system administrator to do this step.
-   
+
    ```
    sage -i gap_packages
    sage -i database_gap # only needed if sage version < 8.6
@@ -38,39 +38,39 @@ Installation
    # in the 'lmfdb/' directory:
    sage -pip install -r requirements.txt
    ```
-   
+
    ### Troubleshooting with packages.
-   
+
    - If you have not run the site for a while you might get an error
      with packages like
-     
+
      ```
      ImportError: cannot import name monitoring
      ```
-     
+
      In this case or if you need to upgrade for any reason run
-     
+
      ```
      sage -pip install -r requirements.txt --upgrade
      ```
-     
+
    - In case the last step fails by is Mac OSX with the error
-     
+
      ```
      Error: pg_config executable not found.
      ```
-     
+
      we recommend to installing PostgreSQL by doing
-     
+
      ```
      brew install postgresql
      ```
-     
+
      and performing the last step again.
-   
+
    - In case the last step fails due to some missing SSL library,
      (this may be the case on osX) follow these steps
-     
+
      ```
      sage -i openssl
      sage -f python2 # takes some time
@@ -78,7 +78,7 @@ Installation
      sage -pip install --upgrade pip
      sage -pip install -r requirements.txt
      ```
-  
+
    - [optional] Memcache.  *This step is not at all necessary and can
      safely be ignored!* Memcache speeds up recompilation of python
      modules during development.  Using it requires both installing the
@@ -86,9 +86,9 @@ Installation
      additional python module.  The first line below needs to be run in
      a Sage shell, and the for second you need to be a super-user to
      install memcached if your machine does not have it.
-     
+
      * `easy_install -U python-memcached`
-     
+
      or even better and only possible if you have the dev headers:
 
      * `easy_install -U pylibmc`
@@ -113,7 +113,7 @@ Running
    Without `--debug` what you see will be more like www.lmfdb.org.
 
  * Once the server is running, visit http://localhost:37777/
-   
+
    You should now have a fully functional LMFDB site through this server.
 
  * When running with `--debug`, whenever a python (*.py) file changes
@@ -147,9 +147,9 @@ CoCalc
 
  * You can run the LMFDB inside a [CoCalc](https://www.cocalc.com) project by doing
    following the above installation instructions on a terminal in your project (you may want to
-   install the requirements using the `--user` flag). 
+   install the requirements using the `--user` flag).
    Explicitly,
-   
+
    ```
    cd ~
    git clone https://github.com/LMFDB/lmfdb.git lmfdb
@@ -157,13 +157,13 @@ CoCalc
    sage -pip install --user -r requirements.txt
    sage -python start-lmfdb.py --debug
    ```
-   
+
    On the last step, when you start the server running,
    LMFDB will detect that it is running inside CoCalc and provide a URL through which the
    site can be accessed.
 
  * If you've changed static files, you will have to run LMFDB on a different port in order for the files to update. For instance, to run LMFDB on port 37778:
-   
+
    ```
    sage -python start-lmfdb.py --debug --port=37778
    ```
@@ -259,8 +259,8 @@ Code development and sharing your work
    git pull --rebase upstream master
    ```
 
- * Tell the [lmdb mailing list](https://groups.google.com/forum/#!forum/lmdb) 
-   that you have some new code!  
+ * Tell the [lmdb mailing list](https://groups.google.com/forum/#!forum/lmdb)
+   that you have some new code!
    You should also issue a pull request at github
    (from your feature branch `new_feature`) at the same time.  Make
    sure that your pull request is to the lmfdb `master` branch,

--- a/StyleSheet.md
+++ b/StyleSheet.md
@@ -1,19 +1,25 @@
-**General style conventions**
+# StyleSheet
+
+Below, we describe several styling conventions for the LMFDB. See also the
+[Developer's Guide](https://github.com/LMFDB/lmfdb/blob/master/Development.md)
+contains other conventions and information for the development process.
+
+## General style conventions
 
 - All titles, bread crumbs, captions, column headings should be left-aligned and use <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> (only first word and proper nouns capitalized).
-- Bread crumbs should avoid repetition (so "Modular forms -> Hilbert", not "Modular forms -> Hilber modular forms").
+- Bread crumbs should avoid repetition (so "Modular forms -> Hilbert", not "Modular forms -> Hilbert modular forms").
 - Section headings should be `<h2>`.
 - All content under section headings should be slightly indented (use a table or `<p>` to achieve this).
-- Whenever possible pages should be layed out to avoid horizontal scrolling on displays that are 1280 pixels or wider.
+- Whenever possible pages should be laid out to avoid horizontal scrolling on displays that are 1280 pixels or wider.
 
-**Learn more about box**
+## Learn more about box
 
 - This box should be present on all search/browse/object pages and include "Source of the data", "Completeness of the data", and "Reliability of the data" links to knowls of the form rcs.source.blah, rcs.cande.blah, rcs.rigor.blah (in that order).
 - Completeness page headings should have the form "Completeness of blah data" where blah is singular (e.g. "modular form" or "elliptic curve"), and similarly for Source and Reliability pages.
 - For sections where labels are relevant, there should also be "Labels of blah" links to knowls that explains the format of the labels for blah.
 - When a particular "Learn more about" page is displayed, the link to that page should not be removed from the "Learn more about" box.
 
-**Browse and search**
+## Browse and search
 
 - Colons should not follow captions on browse/search pages.
 - Jump box captions should have the form "Find a specific blah, or blah by blah" should have knowls on the blahs, the input box should be on the line below (no caption in front), and the button should say "Find".
@@ -28,7 +34,7 @@
 - Refine search page headings should have the form "Blah search results", where blah is singular.
 - Refine search pages should have captions above input boxes, no example to right, gray example inside input box.
 
-**Object pages**
+## Object pages
 
 - Object page templates should extend homepage.html and include a content block.
 - Every object page should have a properties box, and when relevant/available, a related objects box, and a downloads box.
@@ -38,16 +44,17 @@
 - Any invariant listed in the properties box should also appear in the body (or header) of the page -- all information should be visible even with the property box closed.
 - Factorizations of negative numbers should include only the sign, not -1 (use web_latex_factored_integer in utilities.py).
 
-**Properties box**
+## Properties box
 
 - Captions in the property box should be sentence case (like all captions) with no colon.
 - The first line of the properties box should be the label (if one exists) followed by a portrait (if available), followed by up to 8 standard invariants or properties of the object that can be displayed in a compact form (the properties box should never scroll).
 - Properties that are words (e.g yes/no, even/odd) or numbers (e.g. 42 or 1.2345), as well as labels, should be listed in standard font and not in math mode.
 - Integers in properties box should not be shown in factored form (when relevant the factorization should be in the body of the page).
 
-**Related objects box**
+## Related objects box
+
 - If an object has an L-function, all objects with the same L-function should appear (this will eventually be automated), as well as the L-function of the object itself, which should be the last entry in the related objxcts box.
 
-**Downloads box**
-- Links in the Downloads box should have the form "Download X to Y" where X is the thing being downloaded (e.g. "all data", "coefficients", "traces", ...) and Y is the format (e.g. "text", "Sage", "Magma", ...).
+## Downloads box
 
+- Links in the Downloads box should have the form "Download X to Y" where X is the thing being downloaded (e.g. "all data", "coefficients", "traces", ...) and Y is the format (e.g. "text", "Sage", "Magma", ...).


### PR DESCRIPTION
This updates the Developer's Guide, the StyleSheet, and the Developer's Guide (knowl). More precisely, this extracts the information from the knowl and inserts it into the Developer's Guide, and the StyleSheet and Developer's Guide now point to each other. I made a few other small updates that are fairly innocuous.

After this is merged, I recommend that the Developer's Guide knowl (which isn't currently linked to anywhere) be deleted.

This is to fix #3948.