### PR TITLE
Fix issue 4010: use sage int for a big integer

### DIFF
--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -4,7 +4,7 @@ from six import string_types
 from lmfdb import db
 from lmfdb.utils import url_for, pol_to_html
 from lmfdb.utils.utilities import web_latex, coeff_to_poly, letters2num, num2letters
-from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField, RealField, log, I, factor, crt, euler_phi, primitive_root, mod, next_prime, PowerSeriesRing
+from sage.all import PolynomialRing, QQ, ComplexField, exp, pi, Integer, valuation, CyclotomicField, RealField, log, I, factor, crt, euler_phi, primitive_root, mod, next_prime, PowerSeriesRing, ZZ
 from lmfdb.galois_groups.transitive_group import (
     group_display_knowl, group_display_short, small_group_display_knowl)
 from lmfdb.number_fields.web_number_field import WebNumberField, formatfield
@@ -793,7 +793,7 @@ class NumberFieldGaloisGroup(object):
               Take an integer n, prime p, and precision prec, and return a 
               prec-tuple of the p-adic coefficients of j
             """
-            n = int(n)
+            n = ZZ(n)
             res = [0 for j in range(prec)]
             while n<0:
                 n += p**prec


### PR DESCRIPTION
The title pretty much describes it.  Some integer arithmetic used integers which were too large for python.

To test,

http://127.0.0.1:37777/ArtinRepresentation/16.74210483036805646041349463016441.24t2912.a.a
http://beta.lmfdb.org/ArtinRepresentation/16.74210483036805646041349463016441.24t2912.a.a