### PR TITLE
BMFs: pass KNOWL_ID to template for top/bot knowls

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -17,7 +17,6 @@ from lmfdb.nfutils.psort import ideal_from_label
 from lmfdb.bianchi_modular_forms import bmf_page
 from lmfdb.bianchi_modular_forms.web_BMF import WebBMF
 
-
 bianchi_credit = 'John Cremona, Aurel Page, Alexander Rahm, Haluk Sengun'
 
 field_label_regex = re.compile(r'2\.0\.(\d+)\.1')
@@ -331,10 +330,20 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
                  (data.short_label, '')]
         properties = data.properties
         friends = data.friends
+        KNOWL_ID = "bmf.{}".format(label)
     except ValueError:
         raise
         info['err'] = "No Bianchi modular form in the database has label {}".format(label)
-    return render_template("bmf-newform.html", title=title, credit=credit, bread=bread, data=data, properties=properties, friends=friends, info=info, learnmore=learnmore_list())
+    return render_template("bmf-newform.html",
+                           title=title,
+                           credit=credit,
+                           bread=bread,
+                           data=data,
+                           properties=properties,
+                           friends=friends,
+                           info=info,
+                           KNOWL_ID = KNOWL_ID,
+                           learnmore=learnmore_list())
 
 def bianchi_modular_form_by_label(lab):
     if lab == '':


### PR DESCRIPTION
A small but necessary change so that BMF home pages can show top and bottom knowls.

So far these three forms have such knowls:
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/10000.1/b/
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/16384.1/d/
http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/6561.5/a/
