### PR TITLE
BMF change display of a_P, and update import script

### DIFF
--- a/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
@@ -39,39 +39,6 @@
 </table>
 </p>
 
-<h2> {{ KNOWL('mf.bianchi.hecke_algebra', 'Hecke eigenvalues') }} </h2>
-
-  {#
-<p>
-  The database contains {{data.nap}} eigenvalues{% if data.nap0 <
-  data.nap %} of which we only show {{data.nap0}}{%endif%}.
-</p>
-#}
-
-{% if data.dimension > 1 %}
-<p>
-The Hecke eigenfield is \(\Q(z)\) where  $z$ is a root of the defining
-polynomial: {{data.hecke_poly}}.
-</p>
-{% else %}
-<p>The Hecke eigenvalue field is $\Q$</a>.</p>
-{% endif %}
-
-<table class="ntdata" cellpadding=5>
-<tr>
-<th>Norm</th>
-<th>Prime</th>
-<th>Eigenvalue</th>
-</tr>
-{% for entry in data.hecke_table: %}
-<tr>
-<td>{{entry[0]}}</td>
-<td>{{entry[1]}} = ({{entry[2]}})</td>
-<td align=right>{{entry[3]}}</td>
-</tr>
-{% endfor %}
-</table>
-
 <h2>  Atkin-Lehner eigenvalues  </h2>
 
 {% if data.have_AL %} 
@@ -94,6 +61,40 @@ polynomial: {{data.hecke_poly}}.
 {% else %}
 <p>Not known</P>
 {% endif %}
+
+<h2> {{ KNOWL('mf.bianchi.hecke_algebra', 'Hecke eigenvalues') }} </h2>
+
+
+{% if data.dimension > 1 %}
+<p>
+The Hecke eigenfield is \(\Q(z)\) where  $z$ is a root of the defining
+polynomial: {{data.hecke_poly}}.
+{% else %}
+<p>The Hecke eigenvalue field is $\Q$</a>.
+{% endif %}
+The eigenvalue of the {{ KNOWL('mf.bianchi.hecke_algebra', 'Hecke operator') }} $T_{\mathfrak{p}}$ is $a_{\mathfrak{p}}$.
+{% if data.nap0 < data.nap %}
+The database contains {{data.nap}} eigenvalues of which we only show {{data.nap0}}.
+{%else%}
+The database contains {{data.nap}} eigenvalues.
+{%endif%}
+We only show the eigenvalues $a_{\mathfrak{p}}$ for primes $\mathfrak{p}$ which do not divide the level.		  
+</p>
+
+<table class="ntdata" cellpadding=5>
+<tr>
+<th>$N(\mathfrak{p})$</th>
+<th>$\mathfrak{p}$</th>
+<th align=right>$a_{\mathfrak{p}}$</th>
+</tr>
+{% for entry in data.hecke_table: %}
+<tr>
+<td>{{entry[0]}}</td>
+<td>{{entry[1]}} = ({{entry[2]}})</td>
+<td align=right>{{entry[3]}}</td>
+</tr>
+{% endfor %}
+</table>
 
 
 

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -100,15 +100,17 @@ class WebBMF(object):
                     return F(str(ap))
             self.hecke_eigs = [conv(str(ap)) for ap in self.hecke_eigs]
 
-        self.nap = len(self.hecke_eigs)
-        self.nap0 = min(50, self.nap)
-        self.hecke_table = [[web_latex(p.norm()),
-                             ideal_label(p),
-                             web_latex(p.gens_reduced()[0]),
-                             web_latex(ap)] for p,ap in zip(primes_iter(K), self.hecke_eigs[:self.nap0])]
         level = ideal_from_label(K,self.level_label)
         self.level_ideal2 = web_latex(level)
         badp = level.prime_factors()
+
+        self.nap = len(self.hecke_eigs)
+        self.nap0 = min(50, self.nap)
+        self.neigs = self.nap0 + len(badp)
+        self.hecke_table = [[web_latex(p.norm()),
+                             ideal_label(p),
+                             web_latex(p.gens_reduced()[0]),
+                             web_latex(ap)] for p,ap in zip(primes_iter(K), self.hecke_eigs[:self.neigs]) if not p in badp]
         self.have_AL = self.AL_eigs[0]!='?'
         if self.have_AL:
             self.AL_table = [[web_latex(p.norm()),


### PR DESCRIPTION
The home page for a Bianchi form now
   - lists the Atkin-Lehner eigenvalues first (otherwise they might not be noticed at the bottom of the page);
   - lists the Hecke eigenvalues a_P for good prime P only (previously the number listed as a_P was not actually the Hecke eigenvalue for bad primes, it was the Fourier coefficient);
   - says how many a_P are on file and defined what they are (with knowl links).

Visit the page af a random BMF to see the difference.