### PR TITLE
Fix hardcoded PostgresTable in reload

### DIFF
--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -1823,7 +1823,7 @@ class PostgresTable(PostgresBase):
             ),
             [self.search_table],
         ).fetchone()
-        table = PostgresTable(self._db, *tabledata)
+        table = self._db._search_table_class_(self._db, *tabledata)
         self._db.__dict__[self.search_table] = table
 
     def drop_tmp(self):


### PR DESCRIPTION
This change just makes it so that you can immediately use a table after reloading (before this change some features would be broken since we were using the wrong class).