### PR TITLE
Add download links to top of search results

### DIFF
--- a/lmfdb/templates/download_search_results.html
+++ b/lmfdb/templates/download_search_results.html
@@ -8,9 +8,8 @@
   {% set download_limit = 100000 %}
 {% endif %}
 
-<br>
-<br>
-<div id="download-area">
+
+&nbsp;
 {% if info.number > download_limit %}
   <span id="download-msg">
     There are too many search results 
@@ -19,16 +18,16 @@
   </span>
 {% else %}
   {% if info.exact_count %}
-    <form id="download-form">
+    <span id="download-form">
   {% else %}
     <span id="download-msg">
-      In order to download results, <a href="#" title="Get exact count" onclick="get_count_of_results({{ download_limit }}); return false;">determine the number of results</a>.
+      To download results, <a href="#" title="Get exact count" onclick="get_count_of_results({{ download_limit }}); return false;">determine the number of results</a>.
     </span>
-    <form id="download-form" style="display:none;">
+    <span id="download-form" style="display:none;">
   {% endif %}
   Download all
     <span id="result-count2">{% if info.exact_count %}{{ info.number }}{% endif %}</span>
-  search results for&nbsp;
+  results for&nbsp;
     {% for lang in languages %}
     {% if info.search_type %}
     <a class="like-button" href="{{modify_url(query='Submit='+lang+'&download=1&query='+(info.query|string))}}">{{lang_text[lang]}}</a>&nbsp;
@@ -36,6 +35,5 @@
     <a class="like-button" href="{{modify_url(query='Submit='+lang+'&download=1&query='+(info.query|string)+'&search_type='+info.search_type)}}">{{lang_text[lang]}}</a>&nbsp;
     {% endif %}
   {% endfor %}
-  </p>
+  </span>
 {% endif %}
-</div>

--- a/lmfdb/templates/download_search_results.html
+++ b/lmfdb/templates/download_search_results.html
@@ -8,7 +8,6 @@
   {% set download_limit = 100000 %}
 {% endif %}
 
-
 &nbsp;
 {% if info.number > download_limit %}
   <span id="download-msg">
@@ -25,9 +24,7 @@
     </span>
     <span id="download-form" style="display:none;">
   {% endif %}
-  Download all
-    <span id="result-count2">{% if info.exact_count %}{{ info.number }}{% endif %}</span>
-  results for&nbsp;
+  Download to &nbsp;
     {% for lang in languages %}
     {% if info.search_type %}
     <a class="like-button" href="{{modify_url(query='Submit='+lang+'&download=1&query='+(info.query|string))}}">{{lang_text[lang]}}</a>&nbsp;

--- a/lmfdb/templates/matches.html
+++ b/lmfdb/templates/matches.html
@@ -14,26 +14,27 @@
 {% if info.number == 0 %}
 <h2> No matches </h2>
 {% else %}
-<h2> Results ({% if info.number==1 -%}
-    unique match)
+<h2> Results {% if info.number==1 -%}
+    (unique match)
   {% elif info.number==2 -%}
-    displaying both matches)
+    (displaying both matches)
   {% elif info.number=='infinity' -%}
-    displaying matches {{ info.start + 1 }}-{{ upper_count }})
+    (matches {{ info.start + 1 }}-{{ upper_count }})
   {% elif info.number <= info.count and info.start == 0 -%}
-    displaying all {{ info.number }} matches)
+    ({{ info.number }} matches)
   {% elif info.exact_count -%}
-    displaying matches {{ info.start + 1 }}-{{ upper_count }} of {{ info.number }})
+    ({{ info.start + 1 }}-{{ upper_count }} of {{ info.number }} matches)
   {% else -%}
     {% if 'download_limit' in info %}
       {% set download_limit = info.download_limit %}
     {% else %}
       {% set download_limit = 100000 %}
     {% endif %}
-    displaying matches {{ info.start + 1 }}-{{ upper_count }} of
+    ({{ info.start + 1 }}-{{ upper_count }} of
     <span id="result-count"><a href="#" title="Get exact count" onclick="get_count_of_results({{ download_limit }}); return false;">at least {{ info.number }}</a></span>)
   {% endif %}
 {% include 'forward_back.html' %}
+{% include 'download_search_results.html' %}
 </h2>
 {% endif %}
 {% endif %}

--- a/lmfdb/templates/matches.html
+++ b/lmfdb/templates/matches.html
@@ -14,7 +14,10 @@
 {% if info.number == 0 %}
 <h2> No matches </h2>
 {% else %}
-<h2> Results {% if info.number==1 -%}
+<br>
+<div>
+  <h2 style="display: inline; color: #1565C0; font-weight: bold; font-family: sans-serif; text-decoration: none; font-size: 120%; text-align: left;">
+    Results {% if info.number==1 -%}
     (unique match)
   {% elif info.number==2 -%}
     (displaying both matches)
@@ -32,9 +35,10 @@
     {% endif %}
     ({{ info.start + 1 }}-{{ upper_count }} of
     <span id="result-count"><a href="#" title="Get exact count" onclick="get_count_of_results({{ download_limit }}); return false;">at least {{ info.number }}</a></span>)
-  {% endif %}
+    {% endif %}
+  </h2>
 {% include 'forward_back.html' %}
 {% include 'download_search_results.html' %}
-</h2>
+</div>  
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Addresses issue #3166. Main changes are: 

-Changed download_search_results to "span" instead of form to allow for inline formatting.
-Changed wording of matches/download_search_results for better spacing. 
-Manually styled a h2 header to allow for an inline header.