### PR TITLE
Galois group and local field formatting tweaks

### DIFF
--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -12,19 +12,19 @@ table.reptable td, table.reptable th {
 
   <p><h2>{{ KNOWL('gg.group_action_invariants', title='Group action invariants') }}</h2>
     <table>
-      <tr><td>{{KNOWL('gg.degree', 'Degree')}} $n$ :<td>&nbsp;&nbsp;<td>${{info.n}}$</tr>
-      <tr><td>{{KNOWL('gg.tnumber', 'Transitive number')}} $t$ :<td>&nbsp;&nbsp;<td>${{info.t}}$</tr>
+      <tr><td>{{KNOWL('gg.degree', 'Degree')}} $n$:<td>&nbsp;&nbsp;<td>${{info.n}}$</tr>
+      <tr><td>{{KNOWL('gg.tnumber', 'Transitive number')}} $t$:<td>&nbsp;&nbsp;<td>${{info.t}}$</tr>
       {% if info.pretty_name %}
-      <tr><td>{{KNOWL('gg.simple_name', title='Group')}} :<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
+      <tr><td>{{KNOWL('gg.simple_name', title='Group')}}:<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
       {% endif %}
       {% if info.n < 16 %}
-      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}} :<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
+      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
       {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}</tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</tr>
       <tr><td>{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</tr>
       <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}</tr>
-      <tr><td>{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
+      <tr><td class="nowrap">{{KNOWL('gg.field_automorphisms', '$|\Aut(F/K)|$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</tr>
     </table>
   </p>
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -228,7 +228,7 @@ def render_field_webpage(args):
         the_gal = WebGaloisGroup.from_nt(gn,gt)
         isgal = ' Galois' if the_gal.order() == gn else ' not Galois'
         abelian = ' and abelian' if the_gal.is_abelian() else ''
-        galphrase = 'This field is'+isgal+abelian+r' over $\Q_{%d}$.'%p
+        galphrase = 'This field is'+isgal+abelian+r' over $\Q_{%d}.$'%p
         autstring = r'\Gal' if the_gal.order() == gn else r'\Aut'
         prop2 = [
             ('Label', label),

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -15,10 +15,10 @@
   <p>
     <table>
       <tr><td>Base field:</td> <td> {{info.base|safe}}
-      <tr><td>{{ KNOWL('lf.degree', title='Degree') }} $d$ :</td> <td>${{info.n}}$</td></tr>
-      <tr><td>{{ KNOWL('lf.ramification_index', title='Ramification exponent') }} $e$ :</td> <td>${{info.e}}$</td></tr>
-      <tr><td>{{ KNOWL('lf.residue_field_degree', title='Residue field degree') }} $f$ :</td> <td>${{info.f}}$</td></tr>
-      <tr><td>{{ KNOWL('lf.discriminant_exponent', title='Discriminant exponent') }} $c$ :</td> <td>${{info.c}}$</td></tr>
+      <tr><td>{{ KNOWL('lf.degree', title='Degree') }} $d$:</td> <td>${{info.n}}$</td></tr>
+      <tr><td>{{ KNOWL('lf.ramification_index', title='Ramification exponent') }} $e$:</td> <td>${{info.e}}$</td></tr>
+      <tr><td>{{ KNOWL('lf.residue_field_degree', title='Residue field degree') }} $f$:</td> <td>${{info.f}}$</td></tr>
+      <tr><td>{{ KNOWL('lf.discriminant_exponent', title='Discriminant exponent') }} $c$:</td> <td>${{info.c}}$</td></tr>
       <tr><td>{{ KNOWL('lf.discriminant_root_field', title='Discriminant root field') }}:</td> <td>{{info.rf|safe}}</td></tr>
       <tr><td>{{ KNOWL('lf.root_number', title='Root number') }}:</td> <td>{{info.hw}}</td></tr>
       <tr><td> $|{{ info.autstring|safe }}(K/\Q_{ {{info.p}} })|$:</td> <td>${{info.aut}}$</td></tr>


### PR DESCRIPTION
There was inconsistent use of spaces before colons in the invariants
on the home pages of Galois groups and local fields.  Also two places
where a colon or period could appear by itself on the next line,
depending on the page width.  This addresses those anomalies.

See
/GaloisGroup/5T3
and
/LocalNumberField/3.12.23.65
for representative examples.

An alternative to the "nowrap" in the Galois group template is putting
the colon inside the math, as I did with the period in local_fields/main.py .
(But the reverse alternative is not good, because there are multiple
words in that entry for local fields, and they should be allowed to wrap.)