### PR TITLE
ECs over Q: rename Endomorphism Ring to Geometric Endomorphism Ring

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -152,7 +152,7 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
+        <td>{{ KNOWL('ec.endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
         <td>&nbsp;</td>
         <td>({%if not data.data.CMD %}no {%endif %}


### PR DESCRIPTION
The first (hopefully uncontroversial) part of issue #3683 for elliptic curves over Q