### PR TITLE
Global random fix

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -721,6 +721,7 @@ WhiteListedRoutes = [
     'management',
     'news',
     'not_yet_implemented',
+    'random',
     'robots.txt',
     'search',
     'sitemap',


### PR DESCRIPTION
Currently the global random link https://www.lmfdb.org/random always redirects to beta. I added random to the white-listed routes, which should fix this.