### PR TITLE
ECs over Q: Show both endomorphism rings and introduce "potential Complex Multiplication"

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -154,15 +154,15 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism Ring') }}:</td>
         <td>\(\Z\)</td>
-        <td rowspan=2>&nbsp;</td>
-        <td rowspan=2>({%if data.data.CMD %}potential {%else %}no {%endif %}
-	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
-        </td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
+        <td>&nbsp;</td>
+        <td>({%if data.data.CMD %}potential {%else %}no {%endif %}
+	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
+        </td>
         </tr>
 
         <tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -152,7 +152,7 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
+        <td>{{ KNOWL('ec.endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
         <td>&nbsp;</td>
         <td>({%if not data.data.CMD %}no {%endif %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -152,12 +152,17 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
-        <td>{{ data.data.EndE }}</td>
+        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism Ring') }}:</td>
+        <td>{{ \(\Z\) }}</td>
         <td>&nbsp;</td>
         <td>({%if not data.data.CMD %}no {%endif %}
 	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
         </td>
+        </tr>
+
+        <tr>
+        <td>{{ KNOWL('ec.geometric_endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
+        <td>{{ data.data.EndE }}</td>
         </tr>
 
         <tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -154,8 +154,8 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism Ring') }}:</td>
         <td>\(\Z\)</td>
-        <td>&nbsp;</td>
-        <td>({%if data.data.CMD %}potential {%else %}no {%endif %}
+        <td rowspan=2>&nbsp;</td>
+        <td rowspan=2>({%if data.data.CMD %}potential {%else %}no {%endif %}
 	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
         </td>
         </tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -153,15 +153,15 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism Ring') }}:</td>
-        <td>{{ \(\Z\) }}</td>
+        <td>\(\Z\)</td>
         <td>&nbsp;</td>
-        <td>({%if not data.data.CMD %}no {%endif %}
+        <td>({%if data.data.CMD %}potential {%else %}no {%endif %}
 	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
         </td>
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.geometric_endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
+        <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
         </tr>
 


### PR DESCRIPTION
This works towards finishing off issue #3683 

This builds on and includes the first commit of #4075. This is somewhat redundant information for ECs over Q, but if we like this presentation then I can also do this for ECs over number fields, where the data will be more interesting.