### PR TITLE
Jumpbox

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -180,6 +180,8 @@ def download_search(info):
 class AbvarSearchArray(SearchArray):
     jump_example = "2.16.am_cn"
     jump_egspan = "e.g. 2.16.am_cn or 1 - x + 2x^2 or x^2 - x + 2"
+    jump_knowl = "av.fq.search_input"
+    jump_prompt = "Label or polynomial"
     def __init__(self):
         qshort = display_knowl("ag.base_field", "Base field")
         q = TextBox(

--- a/lmfdb/abvar/fq/templates/abvarfq-index.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-index.html
@@ -41,7 +41,7 @@
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find }}</h2>
+<h2> Find </h2>
 <form>
   {{ info.search_array.jump_box(info) | safe }}
 </form>

--- a/lmfdb/abvar/fq/templates/abvarfq-index.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-index.html
@@ -34,15 +34,17 @@
   A <a href="?search_type=Counts">table</a> by dimension and base field
 </p>
 
-<h2> Find a specific {{KNOWL('av.isogeny_class',title="isogeny class") }} by {{ KNOWL('av.fq.lmfdb_label',title="label") }} or {{ KNOWL('av.fq.weil_polynomial',"Weil polynomial") }}</h2>
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
 <h2 id='search_h2'> Search
   <button id="advancedtoggle" href="#">Advanced search options</button>
 </h2>
 <form id='search' onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
+
+<h2> Find a specific {{KNOWL('av.isogeny_class',title="isogeny class") }} by {{ KNOWL('av.fq.lmfdb_label',title="label") }} or {{ KNOWL('av.fq.weil_polynomial',"Weil polynomial") }}</h2>
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
+
 <script> show_advancedQ(); </script>
 {% endblock %}

--- a/lmfdb/abvar/fq/templates/abvarfq-index.html
+++ b/lmfdb/abvar/fq/templates/abvarfq-index.html
@@ -14,7 +14,7 @@
 <div>
   {{ info.stats.short_summary | safe }}
 </div>
-<h2> Browse {{ KNOWL('av.isogeny_class',title='isogeny classes')}} of {{ KNOWL('ag.abelian_variety',title='abelian varieties')}} over finite fields</h2>
+<h2> Browse </h2>
 <p>
   By {{ KNOWL('ag.dimension', 'dimension') }}:
   {% for g in info.stats.gs %}
@@ -41,7 +41,7 @@
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific {{KNOWL('av.isogeny_class',title="isogeny class") }} by {{ KNOWL('av.fq.lmfdb_label',title="label") }} or {{ KNOWL('av.fq.weil_polynomial',"Weil polynomial") }}</h2>
+<h2> Find }}</h2>
 <form>
   {{ info.search_array.jump_box(info) | safe }}
 </form>

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -469,6 +469,8 @@ class ArtinSearchArray(SearchArray):
     plural_noun = "representations"
     jump_example = "4.5648.6t13.b.a"
     jump_egspan = "e.g. 4.5648.6t13.b.a"
+    jump_knowl = "artin.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         dimension = TextBox(
             name="dimension",

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -7,7 +7,7 @@
 {{KNOWL_INC("artin.extent", title = "")}}
 </div>
 
-<h2>Browse {{KNOWL('artin', title="Artin representations")}}</h2>
+<h2>Browse</h2>
 
 <p>
 By {{ KNOWL('artin.dimension',title="dimension") }}:

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -43,36 +43,16 @@ By {{ KNOWL('artin.gg_quotient',title="group") }}:
 Some <a href="{{url_for('.interesting')}}">interesting Artin representations</a> or a <a href="{{url_for('.random_representation')}}">random Artin representation</a>
 </p>
 
-<h2>Find a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
 <h2> Search for an Artin representation </h2>
 
 <form id="search" onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
-{# 
-    <br>
-    This index/search page is not done. The main reason is that it is not fully clear to me yet how people might want to search on Artin representations.
-    
-Meanwhile, here are some examples. You can browse more of them by directly changing the url, or by accessing them from the number field pages (bottom).
-However, the database only include a very thin slice of the data that will be available in the end, so it s likely you will follow broken links. 
 
-<table>
-    <tr><td><a href = {{url_for('.by_data', dim=1,conductor=1,index=1)}}>Artin representation of dimension 1, conductor 1 and index 1</a></td></tr>
-    <tr><td><a href = {{url_for('.by_data', dim=1,conductor=17,index=1)}}>Artin representation of dimension 1, conductor 17 and index 1</a></td></tr>
-    <tr><td><a href = {{url_for('.by_partial_data', dim=1,conductor=17)}}>Artin representations of dimension 1 and conductor 17 </a></td></tr>
-    <tr><td><a href = {{url_for('.by_data', dim = 3, conductor = 113337, index = 1 )}}>Artin representation of dimension 3, conductor 1133337 and index 1</a></td></tr>
-    <tr><td><a href = {{url_for('.by_partial_data', dim=1,conductor=1)}}>Artin representations of dimension 1 and conductor 1 </a></td></tr>
-    <tr><td><a href = {{url_for('.by_partial_data', dim=2,conductor=22356)}}>Artin representations of dimension 2 and conductor 22356 </a></td></tr>
-    <tr><td><a href = {{url_for('.by_partial_data', dim=4,conductor=136480336)}}>Artin representations of dimension 4 and conductor 136480336 </a></td></tr>
-    
-</table>
+<h2>Find a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
 
-#}
-
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {% endblock %}

--- a/lmfdb/artin_representations/templates/artin-representation-index.html
+++ b/lmfdb/artin_representations/templates/artin-representation-index.html
@@ -43,13 +43,13 @@ By {{ KNOWL('artin.gg_quotient',title="group") }}:
 Some <a href="{{url_for('.interesting')}}">interesting Artin representations</a> or a <a href="{{url_for('.random_representation')}}">random Artin representation</a>
 </p>
 
-<h2> Search for an Artin representation </h2>
+<h2> Search </h2>
 
 <form id="search" onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2>Find a specific Artin representation by {{KNOWL('artin.label',title='label')}}</h2>
+<h2>Find</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -720,6 +720,8 @@ class BelyiSearchArray(SearchArray):
     plural_noun = "maps"
     jump_example = "4T5-4_4_3.1-a"
     jump_egspan = "e.g. 4T5-4_4_3.1-a"
+    jump_knowl = "belyi.search_input"
+    jump_label = "Label"
     def __init__(self):
         deg = TextBox(
             name="deg",

--- a/lmfdb/belyi/templates/belyi_browse.html
+++ b/lmfdb/belyi/templates/belyi_browse.html
@@ -15,16 +15,16 @@ By {{ KNOWL('belyi.degree', title='degree')}}:
 <p>
 Some <a href="{{url_for('.interesting')}}">interesting Belyi maps</a> or a <a href={{url_for('.random_belyi_galmap')}}>random Belyi map</a>
 </p>
-<h2> Find a specific Belyi map or passport by {{ KNOWL('belyi.label', title='label')}} </h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
 
 <h2> Search </h2>
 <form id='search' onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
+</form>
+
+<h2> Find a specific Belyi map or passport by {{ KNOWL('belyi.label', title='label')}} </h2>
+
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
 </form>
 
 <!-- Debugging! -->

--- a/lmfdb/belyi/templates/belyi_browse.html
+++ b/lmfdb/belyi/templates/belyi_browse.html
@@ -5,7 +5,7 @@
 {{ info.stats.short_summary | safe}}
 </p>
 
-<h2> Browse {{ KNOWL('belyi.galmap', title='Belyi maps') }} </h2>
+<h2> Browse </h2>
 <p>
 By {{ KNOWL('belyi.degree', title='degree')}}:
 {% for rnge in info.degree_list %}
@@ -21,7 +21,7 @@ Some <a href="{{url_for('.interesting')}}">interesting Belyi maps</a> or a <a hr
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific Belyi map or passport by {{ KNOWL('belyi.label', title='label')}} </h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -409,6 +409,8 @@ class BMFSearchArray(SearchArray):
     plural_noun = "forms"
     jump_example = "2.0.4.1-65.2-a"
     jump_egspan = "e.g. 2.0.4.1-65.2-a (single form) or 2.0.4.1-65.2 (space of forms at a level)"
+    jump_prompt = "Label"
+    jump_knowl = "mf.bianchi.search_input"
     def __init__(self):
         field = TextBox(
             name='field_label',

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -6,8 +6,7 @@
 
 </div>
 
-<h2> Browse {{ KNOWL('mf.bianchi.bianchimodularforms', title='Bianchi
-  modular forms') }} </h2>
+<h2> Browse </h2>
 
 <p>
 Browse {{ KNOWL('mf.bianchi.newform', title='newforms')}} by {{ KNOWL('nf', title='base field')}}:
@@ -41,7 +40,7 @@ Browse {{ KNOWL('mf.bianchi.spaces', title='newform spaces')}} by  {{ KNOWL('nf'
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific form or space by  {{ KNOWL('mf.bianchi.labels', title='label')}} </h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -35,18 +35,16 @@ Browse {{ KNOWL('mf.bianchi.spaces', title='newform spaces')}} by  {{ KNOWL('nf'
 
 <p>Some <a href="{{url_for('.interesting')}}">interesting Bianchi modular forms</a> or a <a href={{url_for('.random_bmf')}}>random Bianchi modular form</a></p>
 
-
-<h2> Find a specific form or space by  {{ KNOWL('mf.bianchi.labels', title='label')}} </h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
 <h2> Search </h2>
 
 <form id='search' onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
 
+<h2> Find a specific form or space by  {{ KNOWL('mf.bianchi.labels', title='label')}} </h2>
+
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {% endblock %}

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -34,15 +34,6 @@
 &nbsp;&nbsp;Some <a href="{{url_for('.interesting')}}">interesting Dirichlet characters</a> or a <a href="random">random Dirichlet character</a></td>
 </p>
 
-<h2> Find a specific  {{KNOWL('character.dirichlet', title="Dirichlet character") }} or {{KNOWL('character.dirichlet.group', title="Dirichlet character group") }}  by
-  {{KNOWL('character.dirichlet.conrey', title="label") }}, {{KNOWL('character.dirichlet.modulus', title="modulus") }}, or {{KNOWL('character.dirichlet.galois_orbit_label', title="orbit label") }} </h2>
-<form>
-    <input type='text' name='label' style="width:320px;" value="{{args.label}}" placeholder="13.2" required>
-    <button type='submit' name='lookup' value='1'> Find  </button>
-    <br>
-    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit.</span>
-</form>
-
 <h2> Search for characters </h2>
 
 <form id='search' onsubmit="cleanSubmit(this.id)">
@@ -87,6 +78,15 @@
         </tr>
         <tr><td><button type='submit' > Search </button></td></tr>
     </table>
+</form>
+
+<h2> Find a specific  {{KNOWL('character.dirichlet', title="Dirichlet character") }} or {{KNOWL('character.dirichlet.group', title="Dirichlet character group") }}  by
+  {{KNOWL('character.dirichlet.conrey', title="label") }}, {{KNOWL('character.dirichlet.modulus', title="modulus") }}, or {{KNOWL('character.dirichlet.galois_orbit_label', title="orbit label") }} </h2>
+<form>
+    <input type='text' name='label' style="width:320px;" value="{{args.label}}" placeholder="13.2" required>
+    <button type='submit' name='lookup' value='1'> Find  </button>
+    <br>
+    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit.</span>
 </form>
 
 {#

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -7,7 +7,7 @@
 
 <h2> Browse </h2>
 <p>
-&nbsp;&nbsp;By {{ KNOWL('character.dirichlet.modulus', title="modulus") }}:
+By {{ KNOWL('character.dirichlet.modulus', title="modulus") }}:
 {% set step = 20 %}
 {% for c in range(1,101,step) %}
 &nbsp;&nbsp;<a href="?modbrowse={{c}}-{{c+step-1}}">{{c}}&mdash;{{c+step-1}}</a>
@@ -15,7 +15,7 @@
 </p>
 
 <p>
-&nbsp;&nbsp;By {{ KNOWL('character.dirichlet.conductor', title="conductor") }}:
+By {{ KNOWL('character.dirichlet.conductor', title="conductor") }}:
 {% set step = 20 %}
 {% for c in range(1,101,step) %}
 &nbsp;&nbsp;<a href="?condbrowse={{c}}-{{c+step-1}}">{{c}}&mdash;{{c+step-1}}</a>
@@ -23,7 +23,7 @@
 </p>
 
 <p>
-&nbsp;&nbsp;By {{ KNOWL('character.dirichlet.order', title="order") }}:</td>
+By {{ KNOWL('character.dirichlet.order', title="order") }}:</td>
 {% set step = 20 %}
 {% for c in range(1,101,step) %}
 &nbsp;&nbsp;<a href="?ordbrowse={{c}}-{{c+step-1}}">{{c}}&mdash;{{c+step-1}}</a>
@@ -31,7 +31,7 @@
 </p>
 
 <p>
-&nbsp;&nbsp;Some <a href="{{url_for('.interesting')}}">interesting Dirichlet characters</a> or a <a href="random">random Dirichlet character</a></td>
+Some <a href="{{url_for('.interesting')}}">interesting Dirichlet characters</a> or a <a href="random">random Dirichlet character</a></td>
 </p>
 
 <h2> Search </h2>

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -5,7 +5,7 @@
 
 {{ KNOWL_INC('dq.character.dirichlet.extent') }}
 
-<h2> Browse {{ KNOWL('character.dirichlet', title="Dirichlet characters") }}</h2>
+<h2> Browse </h2>
 <p>
 &nbsp;&nbsp;By {{ KNOWL('character.dirichlet.modulus', title="modulus") }}:
 {% set step = 20 %}
@@ -34,7 +34,7 @@
 &nbsp;&nbsp;Some <a href="{{url_for('.interesting')}}">interesting Dirichlet characters</a> or a <a href="random">random Dirichlet character</a></td>
 </p>
 
-<h2> Search for characters </h2>
+<h2> Search </h2>
 
 <form id='search' onsubmit="cleanSubmit(this.id)">
     <table>
@@ -80,13 +80,19 @@
     </table>
 </form>
 
-<h2> Find a specific  {{KNOWL('character.dirichlet', title="Dirichlet character") }} or {{KNOWL('character.dirichlet.group', title="Dirichlet character group") }}  by
-  {{KNOWL('character.dirichlet.conrey', title="label") }}, {{KNOWL('character.dirichlet.modulus', title="modulus") }}, or {{KNOWL('character.dirichlet.galois_orbit_label', title="orbit label") }} </h2>
+<h2> Find </h2>
 <form>
+<table>
+    <tr><td>
+    {{KNOWL({{'character.dirichlet.search_input','Label')}}
+    </td><td>
     <input type='text' name='label' style="width:320px;" value="{{args.label}}" placeholder="13.2" required>
+    </td><td>
     <button type='submit' name='lookup' value='1'> Find  </button>
-    <br>
+    </td></tr>
+    <tr><td></td><td colspan="2">
     <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit.</span>
+</td></tr></table>
 </form>
 
 {#

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -91,7 +91,7 @@
     <button type='submit' name='lookup' value='1'> Find  </button>
     </td></tr>
     <tr><td></td><td colspan="2">
-    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit.</span>
+    <span class="formexample"> e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\), or 13.f for its Galois orbit.</span>
 </td></tr></table>
 </form>
 

--- a/lmfdb/characters/templates/CharacterNavigate.html
+++ b/lmfdb/characters/templates/CharacterNavigate.html
@@ -84,7 +84,7 @@
 <form>
 <table>
     <tr><td>
-    {{KNOWL({{'character.dirichlet.search_input','Label')}}
+    {{KNOWL('character.dirichlet.search_input','Label')}}
     </td><td>
     <input type='text' name='label' style="width:320px;" value="{{args.label}}" placeholder="13.2" required>
     </td><td>

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1264,6 +1264,7 @@ class CMFSearchArray(SearchArray):
     jump_example="3.6.a.a"
     jump_egspan="e.g. 3.6.a.a, 55.3.d or 20.5"
     jump_knowl="cmf.search_input"
+    jump_prompt="Label"
     def __init__(self):
         level_quantifier = SelectBox(
             name='level_type',

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1265,6 +1265,7 @@ class CMFSearchArray(SearchArray):
     jump_egspan="e.g. 3.6.a.a, 55.3.d or 20.5"
     jump_knowl="cmf.search_input"
     jump_prompt="Label"
+    
     def __init__(self):
         level_quantifier = SelectBox(
             name='level_type',

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1263,6 +1263,7 @@ def dynamic_statistics():
 class CMFSearchArray(SearchArray):
     jump_example="3.6.a.a"
     jump_egspan="e.g. 3.6.a.a, 55.3.d or 20.5"
+    jump_knowl="cmf.search_input"
     def __init__(self):
         level_quantifier = SelectBox(
             name='level_type',

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1265,7 +1265,6 @@ class CMFSearchArray(SearchArray):
     jump_egspan="e.g. 3.6.a.a, 55.3.d or 20.5"
     jump_knowl="cmf.search_input"
     jump_prompt="Label"
-    
     def __init__(self):
         level_quantifier = SelectBox(
             name='level_type',

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,8 +63,7 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
-
+<h2 style="display:inline"> Find a newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
 <form>
   {{ info.search_array.jump_box(info) | safe }}
 </form>

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -56,12 +56,6 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
  a <a href="?search_type=SpaceDimensions">table of dimensions for \(\Gamma_1(N)\)</a>, or a <a href="?search_type=SpaceDimensions&char_order=1">table for \(\Gamma_0(N)\)</a> with trivial {{ KNOWL('cmf.character',title='character') }}
 </p>
 
-<h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
 {# SEARCHING #}
 
 <h2> Search </h2>
@@ -69,5 +63,10 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
+<h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
+
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,7 +63,7 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific newform or newspace </h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,9 +63,10 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2 style="display:inline"> Find a newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
+
 <form>
-  {{ info.search_array.jump_box(info) | safe }}
+<h2 style="display:inline"> Find a newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
+{{ info.search_array.jump_box(info) | safe }}
 </form>
 
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,7 +63,7 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
+<h2> Find a specific newform or newspace}} </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,7 +63,7 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific newform or newspace}} </h2>
+<h2> Find a specific newform or newspace </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/classical_modular_forms/templates/cmf_browse.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_browse.html
@@ -63,10 +63,10 @@ Create a <a href = "?search_type=Spaces">search</a> for newspaces,
   {{ info.search_array.html() | safe }}
 </form>
 
+<h2> Find a specific newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
 
 <form>
-<h2 style="display:inline"> Find a newform or newspace by {{ KNOWL('cmf.label', title='label')}} </h2>
-{{ info.search_array.jump_box(info) | safe }}
+  {{ info.search_array.jump_box(info) | safe }}
 </form>
 
 {% endblock %}

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -716,6 +716,8 @@ class ECNFSearchArray(SearchArray):
     plural_noun = "curves"
     jump_example = "2.2.5.1-31.1-a1"
     jump_egspan = "e.g. 2.2.5.1-31.1-a1 or 2.2.5.1-31.1-a"
+    jump_prompt = "Label"
+    jump_knowl = "ec.search_input"
     def __init__(self):
         field = TextBox(
             name="field",

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -716,8 +716,8 @@ class ECNFSearchArray(SearchArray):
     plural_noun = "curves"
     jump_example = "2.2.5.1-31.1-a1"
     jump_egspan = "e.g. 2.2.5.1-31.1-a1 or 2.2.5.1-31.1-a"
-    jump_prompt = "Label"
     jump_knowl = "ec.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         field = TextBox(
             name="field",

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -6,9 +6,7 @@
   {{ ecnf_summary()|safe}}
 </div>
 
-<h2> Browse {{ KNOWL('ec',title='elliptic curves')}} defined over:
-{# {{KNOWL('nf',title = "number fields")}} #}
-</h2>
+<h2> Browse </h2>
 
 <p>
 <ul>
@@ -35,7 +33,7 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific curve or {{ KNOWL('ec.isogeny_class',title="isogeny class") }}</h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -35,7 +35,7 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific curve or {{ KNOWL('ec.isogeny_class',title="isogeny class") }} by {{ KNOWL('ec.curve_label',title='label')}}</h2>
+<h2> Find a specific curve or {{ KNOWL('ec.isogeny_class',title="isogeny class") }}</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -28,6 +28,13 @@
 Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a <a href={{url_for('.random_curve')}}>random elliptic curve</a>
 </p>
 
+<h2> Search </h2>
+
+<p></p>
+<form id='search' onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
+
 <h2> Find a specific curve or {{ KNOWL('ec.isogeny_class',title="isogeny class") }} by {{ KNOWL('ec.curve_label',title='label')}}</h2>
 
 <form>
@@ -37,15 +44,6 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   <span class="errmsg">{{err_msg}}</span>
   {% endif %}
 </form>
-
-
-<h2> Search </h2>
-
-<p></p>
-<form id='search' onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
-</form>
-
 
 {% if DEBUG %}
 <hr>

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -636,6 +636,8 @@ class ECSearchArray(SearchArray):
     plural_noun = "curves"
     jump_example = "11.a2"
     jump_egspan = "e.g. 11.a2 or 389.a or 11a1 or 389a or [0,1,1,-2,0] or [-3024, 46224]"
+    jump_prompt = "Label or coefficients"
+    jump_knowl = "ec.q.search_input"
     def __init__(self):
         cond = TextBox(
             name="conductor",

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -58,6 +58,11 @@ By {{ KNOWL('ec.torsion_order', torsion=t,title="torsion order") }}:
 Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a <a href="{{url_for('.random_curve')}}"}>random elliptic curve</a>
 </p>
 
+<h2> Search </h2>
+<p></p>
+<form id='search' onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
 
 <h2> Find a specific curve or {{
   KNOWL('ec.isogeny_class',title="isogeny class") }} by coefficients,
@@ -71,13 +76,6 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {{ info.search_array.jump_box(info) | safe }}
 </form>
 
-<h2> Search </h2>
-<p></p>
-<form id='search' onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
-</form>
-
 {% endif %}
-
 
 {% endblock %}

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -30,7 +30,7 @@ An {{KNOWL("ec", title="elliptic curve")}} is a {{KNOWL("ag.curve.smooth",title=
 Here are some <a href={{ url_for('ec.statistics')}}>further statistics</a>.
 </div>
 
-<h2> Browse {{ KNOWL('ec',title='elliptic curves')}} over $\Q$</h2>
+<h2> Browse </h2>
 
 <p>
 By {{ KNOWL('ec.q.conductor',title = "conductor")}}:
@@ -64,7 +64,7 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific curve or {{KNOWL('ec.isogeny_class',title="isogeny class") }}</h2>
+<h2> Find </h2>
 {% if err_msg %}
 <form action={{url_for('ec.rational_elliptic_curves')}}>
 {% else %}

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -64,10 +64,7 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific curve or {{
-  KNOWL('ec.isogeny_class',title="isogeny class") }} by coefficients,
-  {{ KNOWL('ec.q.lmfdb_label',title="LMFDB label") }}, or 
-  {{ KNOWL('ec.q.cremona_label',title="Cremona label") }} </h2>
+<h2> Find a specific curve or {{KNOWL('ec.isogeny_class',title="isogeny class") }}</h2>
 {% if err_msg %}
 <form action={{url_for('ec.rational_elliptic_curves')}}>
 {% else %}

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -332,7 +332,7 @@ class GalSearchArray(SearchArray):
     jump_example = "8T14"
     jump_egspan = "e.g. 8T14"
     jump_knowl = "gg.search_input"
-    jump_prompt = "Label"
+    jump_prompt = "Label, name, or identifier"
     def __init__(self):
         parity = ParityBox(
             name="parity",

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -331,6 +331,8 @@ class GalSearchArray(SearchArray):
     plural_noun = "groups"
     jump_example = "8T14"
     jump_egspan = "e.g. 8T14"
+    jump_knowl = "gg.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         parity = ParityBox(
             name="parity",

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -51,15 +51,15 @@ Browse by abstract group:
 Some <a href="{{url_for('.interesting')}}">interesting Galois groups</a> or a <a href={{url_for('.random_group')}}>random Galois group</a>
 </p>
 
+<h2>Search</h2>
+<form id="search" onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
+
 <h2>Find a specific Galois group by {{KNOWL('gg.label',title="label")}}</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}
-</form>
-
-<h2>Search</h2>
-<form id="search" onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
 </form>
 
 {% endblock %}

--- a/lmfdb/galois_groups/templates/gg-index.html
+++ b/lmfdb/galois_groups/templates/gg-index.html
@@ -6,7 +6,7 @@
 {{ KNOWL_INC('gg.extent') }}
 </div>
 
-<h2>Browse {{KNOWL('gg.galois_group', title="Galois groups")}}</h2>
+<h2>Browse</h2>
 
 
 <p>
@@ -56,7 +56,7 @@ Some <a href="{{url_for('.interesting')}}">interesting Galois groups</a> or a <a
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2>Find a specific Galois group by {{KNOWL('gg.label',title="label")}}</h2>
+<h2>Find</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -748,7 +748,7 @@ class G2CSearchArray(SearchArray):
         info["jump_example"] = "169.a.169.1"
         info["jump_egspan"] = "e.g. 169.a.169.1 or 169.a or 1088.b"
         info["jump_knowl"] = "g2c.search_input"
-        info["jump_prompt"] = "Label or polynomial"
+        info["jump_prompt"] = "Label"
         if info.get("equation_search"):
             info["jump_egspan"] += " or x^5 + 1"
         return SearchArray.jump_box(self, info)

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -747,6 +747,8 @@ class G2CSearchArray(SearchArray):
     def jump_box(self, info):
         info["jump_example"] = "169.a.169.1"
         info["jump_egspan"] = "e.g. 169.a.169.1 or 169.a or 1088.b"
+        info["jump_knowl"] = "g2c.search_input"
+        info["jump_prompt"] = "Label or polynomial"
         if info.get("equation_search"):
             info["jump_egspan"] += " or x^5 + 1"
         return SearchArray.jump_box(self, info)

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -7,7 +7,7 @@ p {padding-left: 1ch;}
 
 {{ info.stats.short_summary | safe }}
 
-<h2> Browse {{ KNOWL('g2c.g2curve', title='genus 2 curves over $\Q$') }} </h2>
+<h2> Browse </h2>
 <p>
 By {{ KNOWL('ag.conductor', title='conductor')}}:
 {% for rnge in info.conductor_list %}
@@ -30,11 +30,7 @@ Some <a href="{{url_for('.interesting')}}">interesting genus 2 curves</a> or a <
 <p>&nbsp;&nbsp;*Items marked with an asterisk are only known conditionally (click captions for details).  Searches will match conditional values.</p>
 </form>
 
-{% if info['equation_search'] %}
-<h2>  Find a specific curve by equation or {{ KNOWL('g2c.label', title='label')}} </h2>
-{% else  %}
-<h2> Find a specific curve or isogeny class by {{ KNOWL('g2c.label', title='label')}} </h2>
-{% endif %}
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/genus2_curves/templates/g2c_browse.html
+++ b/lmfdb/genus2_curves/templates/g2c_browse.html
@@ -22,6 +22,14 @@ By {{ KNOWL('g2c.abs_discriminant', title='absolute discriminant')}}:
 Some <a href="{{url_for('.interesting')}}">interesting genus 2 curves</a> or a <a href={{url_for('.random_curve')}}>random genus 2 curve</a>
 </p>
 
+
+<h2> Search </h2>
+
+<form id='search' onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+<p>&nbsp;&nbsp;*Items marked with an asterisk are only known conditionally (click captions for details).  Searches will match conditional values.</p>
+</form>
+
 {% if info['equation_search'] %}
 <h2>  Find a specific curve by equation or {{ KNOWL('g2c.label', title='label')}} </h2>
 {% else  %}
@@ -30,14 +38,6 @@ Some <a href="{{url_for('.interesting')}}">interesting genus 2 curves</a> or a <
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}
-</form>
-
-
-<h2> Search </h2>
-
-<form id='search' onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
-<p>&nbsp;&nbsp;*Items marked with an asterisk are only known conditionally (click captions for details).  Searches will match conditional values.</p>
 </form>
 
 {% endblock %}

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -1225,6 +1225,8 @@ class HGCWASearchArray(SearchArray):
     plural_noun = "passports"
     jump_example = "2.12-4.0.2-2-2-3"
     jump_egspan = "e.g. 2.12-4.0.2-2-2-3 or 3.168-42.0.2-3-7.2"
+    jump_knowl = "curve.highergenus.aut.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         genus = TextBox(
             name="genus",

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -21,7 +21,7 @@ text-align:right;
 </div>
 
 
-      <h2>Browse {{KNOWL('g2c.aut_grp', title="automorphisms")}} of higher genus curves</h2>
+<h2>Browse</h2>
 
 <p>
 By  {{KNOWL('ag.curve.genus',title='genus')}}:
@@ -42,7 +42,7 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2>Find specific automorphisms of higher genus curves by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}</h2>
+<h2>Find</h2>
 
 <form name="search" method = "get" action="{{url_for('.index')}}">
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-index.html
@@ -35,20 +35,17 @@ By  {{KNOWL('ag.curve.genus',title='genus')}}:
 {% endfor %}
 </p>
 
-
 <p>Some <a href="{{url_for('.interesting')}}">interesting families</a> or a <a href="{{url_for('.random_passport')}}">random refined passport</a></p>
-
-
-<h2>Find specific automorphisms of higher genus curves by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}</h2>
-
-<form name="search" method = "get" action="{{url_for('.index')}}">
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
 
 <h2>Search</h2>
 <form id="re-search" name="search" method = "get" action={{url_for('.index')}} onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
 
+<h2>Find specific automorphisms of higher genus curves by {{KNOWL('dq.curve.highergenus.aut.label',title="label")}}</h2>
+
+<form name="search" method = "get" action="{{url_for('.index')}}">
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {% endblock %}

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -601,6 +601,8 @@ class HMFSearchArray(SearchArray):
     plural_noun = "forms"
     jump_example = "2.2.5.1-31.1-a"
     jump_egspan = "e.g. 2.2.5.1-31.1-a"
+    jump_knowl = "mf.hilbert.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         field = TextBox(
             name='field_label',

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -37,7 +37,7 @@ class HMFstats(StatsDisplay):
 
     @property
     def short_summary(self):
-        return "The database currently contains %s %s over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), self.counts()["maxdeg"], display_knowl('mf.hilbert','Hilbert modular forms'), url_for(".statistics"))
+        return "The database currently contains %s %s over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), display_knowl('mf.hilbert','Hilbert modular forms'), self.counts()["maxdeg"], url_for(".statistics"))
 
     @property
     def summary(self):

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -2,6 +2,7 @@
 from flask import url_for
 from lmfdb import db
 from lmfdb.utils import comma
+from lmfdb.utils.utilities import display_knowl
 from lmfdb.utils.display_stats import StatsDisplay, proportioners, totaler
 from lmfdb.logger import make_logger
 from lmfdb.number_fields.web_number_field import nf_display_knowl
@@ -36,7 +37,7 @@ class HMFstats(StatsDisplay):
 
     @property
     def short_summary(self):
-        return "The database currently contains %s {{KNOWL('mf.hilbert','Hilbert modular forms')}} over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), self.counts()["maxdeg"], url_for(".statistics"))
+        return "The database currently contains %s %s over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), self.counts()["maxdeg"], display_knowl('mf.hilbert','Hilbert modular forms'), url_for(".statistics"))
 
     @property
     def summary(self):

--- a/lmfdb/hilbert_modular_forms/hmf_stats.py
+++ b/lmfdb/hilbert_modular_forms/hmf_stats.py
@@ -36,7 +36,7 @@ class HMFstats(StatsDisplay):
 
     @property
     def short_summary(self):
-        return "The database currently contains %s Hilbert modular forms over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), self.counts()["maxdeg"], url_for(".statistics"))
+        return "The database currently contains %s {{KNOWL('mf.hilbert','Hilbert modular forms')}} over fields up to degree %s.  Here are some <a href='%s'>further statistics</a>." % (comma(self.nforms), self.counts()["maxdeg"], url_for(".statistics"))
 
     @property
     def summary(self):

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -5,7 +5,7 @@
   {{ info.stats.short_summary | safe }}
 </div>
 
-<h2> Browse {{ KNOWL('mf.hilbert', title='Hilbert cusp forms') }} </h2>
+<h2> Browse </h2>
 
 <p>
 By {{ KNOWL('nf', title='base field') }}:
@@ -49,7 +49,7 @@ including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific form</h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -43,20 +43,16 @@ including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
 
 <p>Some <a href="{{url_for('.interesting')}}">interesting Hilbert modular forms</a> or a <a href={{url_for('.random_hmf')}}>random Hilbert modular form</a></p>
 
-
-<h2> Find a specific form by {{ KNOWL('mf.hilbert.label', 'label') }} </h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
-
 <h2> Search </h2>
 
 <form id='search' onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
 
+<h2> Find a specific form by {{ KNOWL('mf.hilbert.label', 'label') }} </h2>
 
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {% endblock %}

--- a/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
+++ b/lmfdb/hilbert_modular_forms/templates/hilbert_modular_form_all.html
@@ -49,7 +49,7 @@ including <a href="?field_label=6.6.300125.1">6.6.300125.1</a>,
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific form by {{ KNOWL('mf.hilbert.label', 'label') }} </h2>
+<h2> Find a specific form</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -623,6 +623,8 @@ def labels_page():
 class HGMSearchArray(SearchArray):
     jump_example = "A2.2_B1.1_t1.2"
     jump_egspan = "an HGM label encoding the triple $(A, B, t)$"
+    jump_knowl = 'hgm.search_input'
+    jump_prompt = 'Label'
     def __init__(self):
         degree = TextBox(
             name="degree",

--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -179,7 +179,7 @@ Some <a href="{{url_for('.interesting_families')}}">interesting families of hype
   {{ info.search_array.motive_html() | safe }}
 </form>
 
-<h2>Find a specific HGM by {{KNOWL('hgm.field.label',title="label")}}</h2>
+<h2>Find</h2>
 
 <form name="search" method = "get" action="{{search}}">
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -164,13 +164,6 @@ are blank for combinations of weight and degree which cannot occur.
 Some <a href="{{url_for('.interesting_families')}}">interesting families of hypergeometric motives</a>, a <a href={{url_for('.random_family')}}>random family</a> or a <a href={{url_for('.random_motive')}}>random hypergeometric motive</a>.
 </p>
 
-<h2>Find a specific HGM by {{KNOWL('hgm.field.label',title="label")}}</h2>
-
-<form name="search" method = "get" action="{{search}}">
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
-
 <h3> Search for families of HGMs</h3>
 <form id="hgmsearch" onsubmit="cleanSubmit(this.id)">
   <p>
@@ -186,6 +179,11 @@ Some <a href="{{url_for('.interesting_families')}}">interesting families of hype
   {{ info.search_array.motive_html() | safe }}
 </form>
 
+<h2>Find a specific HGM by {{KNOWL('hgm.field.label',title="label")}}</h2>
+
+<form name="search" method = "get" action="{{search}}">
+  {{ info.search_array.jump_box(info) | safe }}
+</form>
 
 {# If the user hits enter while in a family input box, trigger
    family search instead of motive search #}

--- a/lmfdb/lattice/templates/lattice-index.html
+++ b/lmfdb/lattice/templates/lattice-index.html
@@ -22,7 +22,7 @@
 </p>
 {% endif %}
 
-<h2> Browse {{ KNOWL('lattice.definition', title='Integral Lattices') }}</h2>
+<h2> Browse </h2>
 
 <p>
 By {{ KNOWL('lattice.dimension', title='Dimension') }}: 
@@ -51,12 +51,13 @@ By {{ KNOWL('lattice.class_number', title='Class number') }}:
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific {{ KNOWL('lattice.definition', title='integral lattice') }} by {{KNOWL('lattice.label', title='label')}} or by {{KNOWL('lattice.name', title='name')}}</h2>
+<h2> Find </h2>
 
 <form>
-<input type='text' name='label' placeholder='3.4.8.1.2'>
-<button type='submit'>Label</button>
-<br><span class="formexample">e.g. 3.4.8.1.2, D3, E8, A14, Leech</span>
+<table><tr><td>{{KNOWL('lattice.search_input','Label or name')}}</td><td>
+<input type='text' name='label' placeholder='3.4.8.1.2'></td><td>
+<button type='submit'>Label</button></td></tr>
+<tr><td colspan="2"><span class="formexample">e.g. 3.4.8.1.2, D3, E8, A14, Leech</span></td></tr></table>
 </form>
 
 {% endblock %}

--- a/lmfdb/lattice/templates/lattice-index.html
+++ b/lmfdb/lattice/templates/lattice-index.html
@@ -45,7 +45,11 @@ By {{ KNOWL('lattice.class_number', title='Class number') }}:
 <p>Some <a href="{{url_for('.interesting')}}">interesting integral lattices</a> or a <a href={{url_for('.random_lattice')}}>random integral lattice</a>
 </p>
 
+<h2> Search </h2>
 
+<form id='search' onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
 
 <h2> Find a specific {{ KNOWL('lattice.definition', title='integral lattice') }} by {{KNOWL('lattice.label', title='label')}} or by {{KNOWL('lattice.name', title='name')}}</h2>
 
@@ -54,13 +58,5 @@ By {{ KNOWL('lattice.class_number', title='Class number') }}:
 <button type='submit'>Label</button>
 <br><span class="formexample">e.g. 3.4.8.1.2, D3, E8, A14, Leech</span>
 </form>
-
-<h2> Search </h2>
-
-
-<form id='search' onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
-</form>
-
 
 {% endblock %}

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -419,6 +419,8 @@ class LFSearchArray(SearchArray):
     plural_noun = "fields"
     jump_example = "2.4.6.7"
     jump_egspan = "e.g. 2.4.6.7"
+    jump_knowl = "lf.search_input"
+    jump_prompt = "Label"
     def __init__(self):
         degree = TextBox(
             name='n',

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -92,7 +92,7 @@ Some <a href="{{url_for('.interesting')}}">interesting $p$-adic fields</a> or a 
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2>Find a specific $p$-adic field by {{KNOWL('lf.field.label',title="label")}}</h2>
+<h2>Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -16,7 +16,7 @@ of $\Q_p$ up to isomorphism.
 </p>
 
 <p>
-<table class='ntdata'>
+<table class='number_table'>
   <thead>
 <tr>
 <th>$p$ \ $n$</th>

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -87,18 +87,15 @@ of $\Q_p$ up to isomorphism.
 Some <a href="{{url_for('.interesting')}}">interesting $p$-adic fields</a> or a <a href={{url_for('.random_field')}}>random $p$-adic field</a>
 </p>
 
+<h2>Search</h2>
+<form id="search"  onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
 
 <h2>Find a specific $p$-adic field by {{KNOWL('lf.field.label',title="label")}}</h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}
-</form>
-
-
-
-<h2>Search</h2>
-<form id="search"  onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
 </form>
 
 {% endblock %}

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -15,7 +15,8 @@ fields
 of $\Q_p$ up to isomorphism.
 </p>
 
-<table class='number_table'>
+<p>
+<table class='ntdata'>
   <thead>
 <tr>
 <th>$p$ \ $n$</th>
@@ -81,6 +82,7 @@ of $\Q_p$ up to isomorphism.
 </tr>
 </tbody>
 </table>
+</p>
 
 <p>
 Some <a href="{{url_for('.interesting')}}">interesting $p$-adic fields</a> or a <a href={{url_for('.random_field')}}>random $p$-adic field</a>

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -14,7 +14,7 @@ The table gives for each $p$ and $n$ shown, the number of degree $n$ extension
 fields
 of $\Q_p$ up to isomorphism.
 </p>
-<p>
+
 <table class='number_table'>
   <thead>
 <tr>
@@ -81,7 +81,6 @@ of $\Q_p$ up to isomorphism.
 </tr>
 </tbody>
 </table>
-</p>
 
 <p>
 Some <a href="{{url_for('.interesting')}}">interesting $p$-adic fields</a> or a <a href={{url_for('.random_field')}}>random $p$-adic field</a>

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -7,8 +7,7 @@
 {{ KNOWL_INC('lf.extent') }}
 </div>
 
-
-      <h2>Browse {{KNOWL('lf', title="$p$-adic fields")}}</h2>
+<h2>Browse</h2>
 
 <p>
 The table gives for each $p$ and $n$ shown, the number of degree $n$ extension

--- a/lmfdb/local_fields/templates/lf-index.html
+++ b/lmfdb/local_fields/templates/lf-index.html
@@ -13,6 +13,7 @@
 The table gives for each $p$ and $n$ shown, the number of degree $n$ extension
 fields
 of $\Q_p$ up to isomorphism.
+</p>
 <p>
 <table class='number_table'>
   <thead>
@@ -80,7 +81,7 @@ of $\Q_p$ up to isomorphism.
 </tr>
 </tbody>
 </table>
-<p>
+</p>
 
 <p>
 Some <a href="{{url_for('.interesting')}}">interesting $p$-adic fields</a> or a <a href={{url_for('.random_field')}}>random $p$-adic field</a>

--- a/lmfdb/maass_forms/templates/maass_browse.html
+++ b/lmfdb/maass_forms/templates/maass_browse.html
@@ -2,11 +2,7 @@
 {% block content %}
 
 <div>
-{{KNOWL_INC('mf.maass.mwf.weight0')}}
-</div>
-
-<div>
-The database contains {{dbcount}} Maass forms of weight 0 on $\Gamma_0(N)$ for $N$ in the range from 1 to 997.
+The database contains {{dbcount}} {{KNOWL('mf.maass.mwf.weight0','Maass forms')}} of weight 0 on $\Gamma_0(N)$ for $N$ in the range from 1 to 997.
 </div>
 
 <h2>Browse Maass forms of weight 0 on </h2>

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -971,6 +971,8 @@ class NFSearchArray(SearchArray):
     plural_noun = "fields"
     jump_example = "x^7 - x^6 - 3 x^5 + x^4 + 4 x^3 - x^2 - x + 1"
     jump_egspan = r"e.g. 2.2.5.1, Qsqrt5, x^2-5, or x^2-x-1 for \(\Q(\sqrt{5})\)"
+    jump_knowl = "nf.search_input"
+    jump_prompt = "Label, name, or polynomial"
     def __init__(self):
         degree = TextBox(
             name="degree",

--- a/lmfdb/number_fields/templates/nf-index.html
+++ b/lmfdb/number_fields/templates/nf-index.html
@@ -6,7 +6,7 @@
 {{ KNOWL_INC('nf.extent') }}
 </div>
 
-<h2> Browse {{KNOWL('nf', title='number fields')}} </h2>
+<h2> Browse </h2>
 
 <ul>
 <li>
@@ -35,14 +35,12 @@ By {{KNOWL('nf.class_number', title='class number')}}:
 Some <a href="{{url_for('.interesting')}}">interesting number fields</a> or a <a href={{url_for('.by_label', label='random')}}>random number field</a>
 </p>
 
-<h2> Search for fields </h2>
+<h2> Search </h2>
 <form id="search" onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2>Find a specific field by {{KNOWL('nf.label',title='label')}}, 
-  {{KNOWL('nf.nickname',title='nickname')}}, or 
-  {{KNOWL('nf.defining_polynomial',title='polynomial')}}</h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/number_fields/templates/nf-index.html
+++ b/lmfdb/number_fields/templates/nf-index.html
@@ -35,6 +35,10 @@ By {{KNOWL('nf.class_number', title='class number')}}:
 Some <a href="{{url_for('.interesting')}}">interesting number fields</a> or a <a href={{url_for('.by_label', label='random')}}>random number field</a>
 </p>
 
+<h2> Search for fields </h2>
+<form id="search" onsubmit="cleanSubmit(this.id)">
+  {{ info.search_array.html() | safe }}
+</form>
 
 <h2>Find a specific field by {{KNOWL('nf.label',title='label')}}, 
   {{KNOWL('nf.nickname',title='nickname')}}, or 
@@ -43,13 +47,5 @@ Some <a href="{{url_for('.interesting')}}">interesting number fields</a> or a <a
 <form>
   {{ info.search_array.jump_box(info) | safe }}
 </form>
-
-
-<h2> Search for fields </h2>
-<form id="search" onsubmit="cleanSubmit(this.id)">
-  {{ info.search_array.html() | safe }}
-</form>
-
-
 
 {% endblock %}

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -612,6 +612,8 @@ class STSearchArray(SearchArray):
     plural_noun = "groups"
     jump_example = "1.4.USp(4)"
     jump_egspan = "e.g. 0.1.3 or 0.1.mu(3), or 1.2.1.2.1a or N(U(1)), or 1.4.10.1.1a or 1.4.USp(4)"
+    jump_knowl = "st_group.search_input"
+    jump_prompt = "Label or name"
     def __init__(self):
         weight = TextBox(
             name="weight",

--- a/lmfdb/sato_tate_groups/templates/st_browse.html
+++ b/lmfdb/sato_tate_groups/templates/st_browse.html
@@ -4,7 +4,7 @@
 {{ KNOWL_INC('st_group.summary') }}
 </div>
 
-<h2> Browse {{ KNOWL('st_group.definition', title='Sato-Tate groups') }}</h2>
+<h2> Browse </h2>
 
 <p>
 By {{ KNOWL('st_group.weight', title='weight') }}
@@ -34,7 +34,7 @@ By {{ KNOWL('st_group.identity_component', title='identity component') }}
   {{ info.search_array.html() | safe }}
 </form>
 
-<h2> Find a specific {{ KNOWL('st_group.definition', title='Sato-Tate group') }} by {{KNOWL('st_group.label', title='label')}} or by {{KNOWL('st_group.name', title='name')}}</h2>
+<h2> Find </h2>
 
 <form>
   {{ info.search_array.jump_box(info) | safe }}

--- a/lmfdb/sato_tate_groups/templates/st_browse.html
+++ b/lmfdb/sato_tate_groups/templates/st_browse.html
@@ -7,19 +7,19 @@
 <h2> Browse </h2>
 
 <p>
-By {{ KNOWL('st_group.weight', title='weight') }}
+By {{ KNOWL('st_group.weight', title='weight') }}:
 {% for r in info.weight_list %}
     <a href="?weight={{r}}">{{r}}</a>
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('st_group.degree', title='degree') }}
+By {{ KNOWL('st_group.degree', title='degree') }}:
 {% for r in info.degree_list %}
     <a href="?degree={{r}}">{{r}}</a>
 {% endfor %}
 </p>
 <p>
-By {{ KNOWL('st_group.identity_component', title='identity component') }}
+By {{ KNOWL('st_group.identity_component', title='identity component') }}:
 {% for r in info.st0_list %}
     &nbsp;<a href="?identity_component={{r}}">${{info.st0_dict[r]}}$</a>
 {% endfor %}

--- a/lmfdb/sato_tate_groups/templates/st_browse.html
+++ b/lmfdb/sato_tate_groups/templates/st_browse.html
@@ -28,16 +28,16 @@ By {{ KNOWL('st_group.identity_component', title='identity component') }}
 <br>
 </p>
 
-<h2> Find a specific {{ KNOWL('st_group.definition', title='Sato-Tate group') }} by {{KNOWL('st_group.label', title='label')}} or by {{KNOWL('st_group.name', title='name')}}</h2>
-
-<form>
-  {{ info.search_array.jump_box(info) | safe }}
-</form>
-
 <h2> Search </h2>
 
 <form id='search' onsubmit="cleanSubmit(this.id)">
   {{ info.search_array.html() | safe }}
+</form>
+
+<h2> Find a specific {{ KNOWL('st_group.definition', title='Sato-Tate group') }} by {{KNOWL('st_group.label', title='label')}} or by {{KNOWL('st_group.name', title='name')}}</h2>
+
+<form>
+  {{ info.search_array.jump_box(info) | safe }}
 </form>
 
 {% endblock %}

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -767,7 +767,13 @@ cellpadding:3px;
 }
 
 
-table.number_table {border-collapse:collapse;}
+table.number_table {
+  border-collapse:collapse;
+  border: 3px;
+  margin-left: 7px;
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
 
 table.number_table tr:nth-child(even) {
     background: {{color.table_ntdata_background_cn}};

--- a/lmfdb/utils/interesting.py
+++ b/lmfdb/utils/interesting.py
@@ -23,12 +23,12 @@ def interesting_knowls(category, table, url_for_label, label_col="label", regex=
         k["link"] = url_for_label(label)
         unsorted[label] = k
     # Use the table for sorting
-    sorted_labels = {label: i for (i, label) in enumerate(table.search({label_col: {"$in": labels}}, label_col))}
+    sorted_labels = {lab: i for (i, lab) in enumerate(table.search({label_col: {"$in": labels}}, label_col))}
     # Some labels might not appear (e.g. if an isogeny class knowl was included)
     # and others might appear multiple times (higher genus families, where the "label" is for a family and isn't unique)
     if sorted_labels:
         M = max(sorted_labels.values()) + 1
     else:
         M = 1
-    knowls = [unsorted[label] for label in sorted(unsorted.keys(), key=lambda x: sorted_labels.get(x, M))]
+    knowls = [unsorted[lab] for lab in sorted(unsorted.keys(), key=lambda x: sorted_labels.get(x, M))]
     return render_template("interesting.html", knowls=knowls, **kwds)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -691,5 +691,5 @@ class SearchArray(UniqueRepresentation):
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
         return """<table><tr><td>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
-<button type='submit'>Find</button></td><td></tr><td><span class='formexample'>%s</span></td><td></td></tr></table>
+<button type='submit'>Find</button></td><td></tr><tr><td></td><td><span class='formexample'>%s</span></td><td></td></tr></table>
 """ % (display_knowl(jump_knowl, jump_prompt),jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -687,7 +687,7 @@ class SearchArray(UniqueRepresentation):
         jump_example = info.get("jump_example", getattr(self, "jump_example", ""))
         jump_width = info.get("jump_width", getattr(self, "jump_width", 320))
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
-        jump_prompt = info.get("jump_prompt", getattr(self, "jump_prompt", "Input"))
+        jump_prompt = info.get("jump_prompt", getattr(self, "jump_prompt", "Label"))
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
         return """<table><tr><td>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -687,8 +687,9 @@ class SearchArray(UniqueRepresentation):
         jump_example = info.get("jump_example", getattr(self, "jump_example", ""))
         jump_width = info.get("jump_width", getattr(self, "jump_width", 320))
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
+        jump_promput = info.get("jump_prompt", getattr(self, "jump_prompt", "Input"))
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
-        return """<table><tr><td>>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
+        return """<table><tr><td>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
 <button type='submit'>Find</button></td></tr></table>
-<br><span class='formexample'>%s</span></p>""" % (display_knowl(jump_knowl,'Input string'),jump_example, jump_width, info.get("jump", ""), jump_egspan)
+<br><span class='formexample'>%s</span></p>""" % (display_knowl(jump_knowl, jump_prompt),jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -689,6 +689,6 @@ class SearchArray(UniqueRepresentation):
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
-        return """<p><label>%s</label><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'>
-<button type='submit'>Find</button>
+        return """<table><tr><td>>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
+<button type='submit'>Find</button></td></tr></table>
 <br><span class='formexample'>%s</span></p>""" % (display_knowl(jump_knowl,'Input string'),jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -687,7 +687,8 @@ class SearchArray(UniqueRepresentation):
         jump_example = info.get("jump_example", getattr(self, "jump_example", ""))
         jump_width = info.get("jump_width", getattr(self, "jump_width", 320))
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
+        jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
-        return """<p><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'>
+        return """<p><label>{{KNOWL(jump_knowl,'Search input')}}</label><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'>
 <button type='submit'>Find</button>
 <br><span class='formexample'>%s</span></p>""" % (jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -691,5 +691,5 @@ class SearchArray(UniqueRepresentation):
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
         return """<table><tr><td>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
-<button type='submit'>Find</button></td><td></tr><tr><td></td><td><span class='formexample'>%s</span></td><td></td></tr></table>
+<button type='submit'>Find</button></td><td></tr><tr><td></td><td colspan="2"><span class='formexample'>%s</span></td></tr></table>
 """ % (display_knowl(jump_knowl, jump_prompt),jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -689,6 +689,6 @@ class SearchArray(UniqueRepresentation):
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
-        return """<p><label>{{KNOWL(jump_knowl,'Search input')}}</label><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'>
+        return """<p><label>%s</label><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'>
 <button type='submit'>Find</button>
-<br><span class='formexample'>%s</span></p>""" % (jump_example, jump_width, info.get("jump", ""), jump_egspan)
+<br><span class='formexample'>%s</span></p>""" % (display_knowl(jump_knowl,'Input string'),jump_example, jump_width, info.get("jump", ""), jump_egspan)

--- a/lmfdb/utils/search_boxes.py
+++ b/lmfdb/utils/search_boxes.py
@@ -687,9 +687,9 @@ class SearchArray(UniqueRepresentation):
         jump_example = info.get("jump_example", getattr(self, "jump_example", ""))
         jump_width = info.get("jump_width", getattr(self, "jump_width", 320))
         jump_egspan = info.get("jump_egspan", getattr(self, "jump_egspan", ""))
-        jump_promput = info.get("jump_prompt", getattr(self, "jump_prompt", "Input"))
+        jump_prompt = info.get("jump_prompt", getattr(self, "jump_prompt", "Input"))
         jump_knowl = info.get("jump_knowl", getattr(self, "jump_knowl", ""))
         # We don't use SearchBoxes since we want the example to be below, and the button directly to the right of the input (regardless of how big the example is)
         return """<table><tr><td>%s</td><td><input type='text' name='jump' placeholder='%s' style='width:%spx;' value='%s'></td><td>
-<button type='submit'>Find</button></td></tr></table>
-<br><span class='formexample'>%s</span></p>""" % (display_knowl(jump_knowl, jump_prompt),jump_example, jump_width, info.get("jump", ""), jump_egspan)
+<button type='submit'>Find</button></td><td></tr><td><span class='formexample'>%s</span></td><td></td></tr></table>
+""" % (display_knowl(jump_knowl, jump_prompt),jump_example, jump_width, info.get("jump", ""), jump_egspan)


### PR DESCRIPTION
If you visit https://blue.lmfdb.xyz/ and go to any of the main browse pages (e.g. elliptic curves or number fields), you will see that the headings have been streamlined to "Browse", "Search", "Find", and that "Find" has been moved below "Search".

The motivation for this change is that Search is more common than Find and requires less LMFDB specific knowledge.