### PR TITLE
ecnf: code changes to display BSD data

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -107,7 +107,7 @@ def ideal_from_string(K,s, IQF_format=False):
         return "wrong" ## caller must check
 
 def pretty_ideal(I):
-    easy = I.number_field().degree()==2 or I.norm()==1
+    easy = True#I.number_field().degree()==2 or I.norm()==1
     gens = I.gens_reduced() if easy else I.gens()
     return r"\((" + ",".join([latex(g) for g in gens]) + r")\)"
 
@@ -441,51 +441,119 @@ class ECNF(object):
         self.ntors = web_latex(self.torsion_order)
         self.tr = len(self.torsion_structure)
         if self.tr == 0:
-            self.tor_struct_pretty = "Trivial"
+            self.tor_struct_pretty = "trivial"
         if self.tr == 1:
             self.tor_struct_pretty = r"\(\Z/%s\Z\)" % self.torsion_structure[0]
         if self.tr == 2:
             self.tor_struct_pretty = r"\(\Z/%s\Z\times\Z/%s\Z\)" % tuple(self.torsion_structure)
 
-        torsion_gens = [parse_point(K,P) for P in self.torsion_gens]
-        self.torsion_gens = ",".join([web_point(P) for P in torsion_gens])
+        self.torsion_gens = [web_point(parse_point(K,P)) for P in self.torsion_gens]
 
-        # Rank or bounds
+        # BSD data
+        #
+        # We divide into 3 cases, based on rank_bounds [lb,ub],
+        # analytic_rank ar, (lb=ngens always).  The flag
+        # self.bsd_status is set to one of the following:
+        #
+        # "unconditional"
+        #     lb=ar=ub: we always have reg but in some cases over sextic fields we do not have omega, Lvalue, sha.
+        #     i.e. [lb,ar,ub] = [r,r,r]
+        #
+        # "conditional"
+        #     lb=ar<ub: we always have reg but in some cases over sextic fields we do not have omega, Lvalue, sha.
+        #     e.g. [lb,ar,ub] = [0,0,2], [1,1,3]
+        #
+        # "missing_gens"
+        #     lb<ar<=ub
+        #     e.g. [lb,ar,ub] = [0,1,1], [0,2,2], [1,2,2], [0,1,3]
+        #
+        # "incomplete"
+        #     ar not computed.  (We can always set lb=0, ub=Infinity.)
+
+        # Rank and bounds
         try:
             self.rk = web_latex(self.rank)
         except AttributeError:
-            self.rk = "?"
+            self.rank = None
+            self.rk = "not available"
+
         try:
-            self.rk_bnds = "%s...%s" % tuple(self.rank_bounds)
+            self.rk_lb, self.rk_ub = self.rank_bounds
         except AttributeError:
-            self.rank_bounds = [0, Infinity]
-            self.rk_bnds = "not available"
+            self.rk_lb = 0
+            self.rk_ub = Infinity
+            self.rank_bounds = "not available"
+
+        # Analytic rank
+        try:
+            self.ar = web_latex(self.analytic_rank)
+        except AttributeError:
+            self.analytic_rank = None
+            self.ar = "not available"
+
+        # for debugging:
+        assert self.rk=="not available" or (self.rk_lb==self.rank          and self.rank         ==self.rk_ub)
+        assert self.ar=="not available" or (self.rk_lb<=self.analytic_rank and self.analytic_rank<=self.rk_ub)
+
+        self.bsd_status = "incomplete"
+        if self.analytic_rank != None:
+            if self.rk_lb==self.rk_ub:
+                self.bsd_status = "unconditional"
+            elif self.rk_lb==self.analytic_rank:
+                self.bsd_status = "conditional"
+            else:
+                self.bsd_status = "missing_gens"
+
+
+        # Regulator only in conditional/unconditional cases:
+        if self.bsd_status in ["conditional", "unconditional"]:
+            if self.ar == 0:
+                self.reg = web_latex(1)  # otherwise we only get 1.00000...
+            else:
+                try:
+                    self.reg = web_latex(self.reg)
+                except AttributeError:
+                    self.reg = "not available"
+        else:
+            self.reg = "not available"
 
         # Generators
         try:
-            gens = [parse_point(K, P) for P in self.gens]
-            self.gens = ", ".join(web_point(P) for P in gens)
-            if self.rk == "?":
-                self.reg = "not available"
-            else:
-                if gens:
-                    try:
-                        self.reg
-                    except AttributeError:
-                        self.reg = "not available"
-                    # self.reg already set
-                else:
-                    self.reg = 1  # otherwise we only get 1.00000...
-
+            self.gens = [web_point(parse_point(K, P)) for P in self.gens]
         except AttributeError:
-            self.gens = "not available"
-            self.reg = "not available"
-            try:
-                if self.rank == 0:
-                    self.reg = 1
-            except AttributeError:
-                pass
+            self.gens = []
 
+        # Global period
+        try:
+            self.omega = web_latex(self.omega)
+        except AttributeError:
+            self.omega = "not available"
+
+        # L-value
+        try:
+            r = int(self.analytic_rank)
+            lhs = "L(E,1) = " if r==0 else "L'(E,1) = " if r==1 else "L^{{({})}}(E,1)/{}! = ".format(r,r)
+            self.Lvalue = "\\(" + lhs + str(self.Lvalue) + "\\)" 
+        except (TypeError, AttributeError):
+            self.Lvalue = "not available"
+            
+        # Tamagawa product
+        tamagawa_numbers = [ZZ(_ld['cp']) for _ld in self.local_data]
+        cp_fac = [cp.factor() for cp in tamagawa_numbers]
+        cp_fac = [latex(cp) if len(cp)<2 else '('+latex(cp)+')' for cp in cp_fac]
+        if len(cp_fac)>1:
+            self.tamagawa_factors = r'\cdot'.join(cp_fac)
+        else:
+            self.tamagawa_factors = None
+        self.tamagawa_product = web_latex(prod(tamagawa_numbers,1))
+
+        # Analytic Sha
+        try:
+            self.sha = web_latex(self.sha)
+        except AttributeError:
+            self.sha = "not available"
+            
+        
         # Local data
 
         # Fix for Kodaira symbols, which in the database start and end

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -505,7 +505,7 @@ class ECNF(object):
                 self.bsd_status = "missing_gens"
 
 
-        # Regulator only in conditional/unconditional cases:
+        # Regulator only in conditional/unconditional cases, or when we know the rank:
         if self.bsd_status in ["conditional", "unconditional"]:
             if self.ar == 0:
                 self.reg = web_latex(1)  # otherwise we only get 1.00000...
@@ -514,6 +514,8 @@ class ECNF(object):
                     self.reg = web_latex(self.reg)
                 except AttributeError:
                     self.reg = "not available"
+        elif self.rk != "not available":
+            self.reg = web_latex(self.reg) if self.rank else web_latex(1)
         else:
             self.reg = "not available"
 
@@ -532,8 +534,8 @@ class ECNF(object):
         # L-value
         try:
             r = int(self.analytic_rank)
-            lhs = "L(E,1) = " if r==0 else "L'(E,1) = " if r==1 else "L^{{({})}}(E,1)/{}! = ".format(r,r)
-            self.Lvalue = "\\(" + lhs + str(self.Lvalue) + "\\)" 
+            # lhs = "L(E,1) = " if r==0 else "L'(E,1) = " if r==1 else "L^{{({})}}(E,1)/{}! = ".format(r,r)
+            self.Lvalue = "\\(" + str(self.Lvalue) + "\\)" 
         except (TypeError, AttributeError):
             self.Lvalue = "not available"
             
@@ -549,7 +551,7 @@ class ECNF(object):
 
         # Analytic Sha
         try:
-            self.sha = web_latex(self.sha)
+            self.sha = web_latex(self.sha) + " (rounded)"
         except AttributeError:
             self.sha = "not available"
             

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -195,13 +195,13 @@ def index():
     rqfs = ['2.2.{}.1'.format(d) for d in [5, 89, 229, 497]]
     niqfs = len(fields_by_sig[0,1])
     nrqfs = len(fields_by_sig[2,0])
-    info['fields'].append(['{} real <a href="{}">quadratic fields</a>, including'.format(nrqfs, url_for('.statistics_by_degree', d=2)),
+    info['fields'].append(['{} <a href="{}">real quadratic fields</a>, including'.format(nrqfs, url_for('.statistics_by_signature', d=2, r=2)),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in rqfs)])
 
     # Imaginary quadratics (sample)
     iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11]]
-    info['fields'].append(['{} imaginary <a href="{}">quadratic fields</a>, including'.format(niqfs, url_for('.statistics_by_degree', d=2)),
+    info['fields'].append(['{} <a href="{}">imaginary quadratic fields</a>, including'.format(niqfs, url_for('.statistics_by_signature', d=2, r=0)),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in iqfs)])
 

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -232,7 +232,7 @@ cellpadding="5";
     {% endif %}
   </th>
   {% for h in ec.heights %}
-  <td>{{ h }}</td>
+  <td>\({{ h }}\)</td>
   {% endfor %}
 </tr>
 {% endif %}
@@ -257,9 +257,16 @@ cellpadding="5";
 </div>
 
 <div>
-<h2> {{ KNOWL('ec.bsdconjecture', title='BSD') }} invariants</h2>
+<h2> {{ KNOWL('ec.bsdconjecture', title='BSD invariants') }}</h2>
 <p>
         <table>
+
+        <tr>
+        <th align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</th>
+        <td>
+	  {{ ec.ar }}
+        </td>
+        </tr>
 
         <tr>
         <td colspan="4">
@@ -268,7 +275,7 @@ cellpadding="5";
         </tr>
 
 	<tr>
-	  <th align='left'>{{ KNOWL('ec.rank', title="Rank")}}</th>
+	  <th align='left'>{{ KNOWL('ec.rank', title="Mordell-Weil rank")}}</th>
 	  {% if ec.rk == "not available" %}
 	  {% if ec.rank_bounds != "not available" %}
 	  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
@@ -279,14 +286,6 @@ cellpadding="5";
 	  <td>\({{ ec.rank }}\)</td>
 	  {% endif %}
 	</tr>
-
-        <tr>
-        <th align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</th>
-        <td>
-	  {{ ec.ar }}
-        </td>
-        </tr>
-
         <tr>
 	  <th align='left'>
 	    {% if ec.bsd_status == "conditional" %}
@@ -296,7 +295,7 @@ cellpadding="5";
 	    {% endif %}
 	  </th>
           <td>
-	  {% if ec.ar=='not available' %}
+	  {% if ec.reg=='not available' %}
 	  not available
 	  {% else %}
 	  {{ ec.reg }}
@@ -342,7 +341,7 @@ cellpadding="5";
     </p>
 {% if ec.bsd_status == "conditional" %}
 <p>
-  (*) Conditional on {{ KNOWL('ec.bsdconjecture', title='BSD') }}: assuming rank = analytic rank.
+  * Conditional on {{ KNOWL('ec.bsdconjecture', title='BSD') }}: assuming rank = analytic rank.
 </p>
 {% if ec.sha != "not available" and ec.sha!="1" %}
 <p>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -154,10 +154,12 @@ cellpadding="5";
         <td>
          \(j\)</td>
         <td>=</td>
-        <td>{{ ec.j }}</td>
         {% if ec.fact_j %}
+        <td>{{ ec.j }}</td>
         <td>=</td>
         <td>{{ ec.fact_j }}</td>
+        {% else %}
+        <td colspan=3>{{ ec.j }}</td>
         {% endif %}
         </tr>
         <tr><td colspan=5>     {{ place_code('jinv') }}</td></tr>
@@ -186,70 +188,173 @@ cellpadding="5";
 
 <div>
 <h2> {{ KNOWL('ec.mordell_weil_group', title="Mordell-Weil group") }} </h2>
-{% if ec.rk == "?" %}
-{% if ec.rk_bnds != "not available" %}
-<b>Rank</b> \(r\) satisfies \({{ ec.rank_bounds[0] }} \le r \)
-{% if ec.rank_bounds[1] != "Infinity" %}
- \(\le {{ec.rank_bounds[1]}}\)
-{% endif %}
-{% else %}
-Rank not available.
-{% endif %}
-{% else %}
-<b>Rank:</b> \( {{ ec.rank }} \)
-{% endif %}
-<p>{{ place_code('rank') }}</p>
-
-{% if ec.rank_bounds[0] %}
-{% if ec.gens == 'not available' %}
-<p>No generators available.</p>
-{% else %}
-<p><b>
-{% if ec.rank_bounds[0] == 1 %}
-Generator:
-{% else %}
-Generators:
-{% endif %}</b>
-{{ ec.gens }}
-{{ place_code('gens') }}
-</p>
-<p><b>
-{% if ec.rank_bounds[0] == 1 %}
-{{ KNOWL('ec.canonical_height', title="Height") }}:
-{% else %}
-{{ KNOWL('ec.canonical_height', title="Heights") }}:
-{% endif %}</b>
-{% for h in ec.heights %}{%-if loop.index0-%}, {% endif %}{{h}}{% endfor %}
-{{ place_code('heights') }}
-</p>
-{% endif %}
-{% endif %}
-
 <p>
-<b>{{ KNOWL('ec.regulator', title="Regulator") }}:</b>
-{{ ec.reg }}
-{% if not ec.rank_bounds[0] %} {{ place_code('gens') }} {% endif %}
- {{ place_code('reg') }}
-</p>
-</div>
-
-<div>
-<h2> {{ KNOWL('ec.torsion_subgroup', title="Torsion subgroup") }} </h2>
 <table>
 <tr>
-<th>Structure:</th>
+  <th align = 'left'>{{ KNOWL('ec.rank', title="Rank")}}</th>
+{% if ec.rk == "not available" %}
+{% if ec.rank_bounds != "not available" %}
+  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
+{% else %}
+  <td>not available</td>
+{% endif %}
+{% else %}
+  <td>\({{ ec.rank }}\)</td>
+{% endif %}
+</tr>
+
+{% if ec.ngens %}
+<tr>
+  <th align = 'left'>
+    {% if ec.ngens==1 %}
+    Generator
+    {% else %}
+    Generators
+    {% endif %}
+  </th>
+  {% if ec.gens == 'not available' %}
+  <td>not available</td>
+  {% else %}
+  {% for gen in ec.gens %}
+  <td>{{ gen }}</td>
+  {% endfor %}
+{% endif %}
+</tr>
+{% endif %}
+
+{% if ec.heights %}
+<tr>
+  <th align = 'left'>
+    {% if ec.ngens==1 %}
+    {{ KNOWL('ec.canonical_height', title="Height") }}
+    {% else %}
+    {{ KNOWL('ec.canonical_height', title="Heights") }}
+    {% endif %}
+  </th>
+  {% for h in ec.heights %}
+  <td>{{ h }}</td>
+  {% endfor %}
+</tr>
+{% endif %}
+
+<tr>
+<th align='left'>Torsion structure:</th>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
 <tr><td colspan=2> {{ place_code('tors') }}</td></tr>
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<th>{% if ec.tr==1 %}Generator{% else %}Generators{% endif %}:</th>
-<td>{{ ec.torsion_gens }}</td>
+<th align='left'>{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}:</th>
+{% for gen in ec.torsion_gens %}
+<td>{{ gen }}</td>
+{% endfor %}
 </tr>
 <tr><td colspan=2> {{ place_code('torgens') }}</td></tr>
     {% endif %}
 </table>
+</p>
+</div>
+
+<div>
+<h2> {{ KNOWL('ec.bsdconjecture', title='BSD') }} invariants</h2>
+<p>
+        <table>
+
+        <tr>
+        <td colspan="4">
+          {{ place_code('rank') }}
+        </td>
+        </tr>
+
+	<tr>
+	  <th align='left'>{{ KNOWL('ec.rank', title="Rank")}}</th>
+	  {% if ec.rk == "not available" %}
+	  {% if ec.rank_bounds != "not available" %}
+	  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
+	  {% else %}
+	  <td>not available</td>
+	  {% endif %}
+	  {% else %}
+	  <td>\({{ ec.rank }}\)</td>
+	  {% endif %}
+	</tr>
+
+        <tr>
+        <th align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</th>
+        <td>
+	  {{ ec.ar }}
+        </td>
+        </tr>
+
+        <tr>
+	  <th align='left'>
+	    {% if ec.bsd_status == "conditional" %}
+            {{ KNOWL('ec.regulator', title='Regulator*') }}:
+	    {% else %}
+	    {{ KNOWL('ec.regulator', title='Regulator') }}:
+	    {% endif %}
+	  </th>
+          <td>
+	  {% if ec.ar=='not available' %}
+	  not available
+	  {% else %}
+	  {{ ec.reg }}
+	  {% endif %}
+	</td>
+        </tr>
+
+        <tr>
+        <th align='left'>{{ KNOWL('ec.period', title='Period') }}:</th>
+        <td> {{ ec.omega }}</td>
+        </tr>
+
+        <tr>
+        <th align='left'>{{ KNOWL('ec.tamagawa_number', title='Tamagawa product') }}:</th>
+        <td> {{ ec.tamagawa_product }}
+          {% if ec.tamagawa_factors %}
+          &nbsp;=&nbsp; \({{ ec.tamagawa_factors }}\)
+          {% endif %}
+        </td>
+        </tr>
+
+        <tr>
+        <th align='left'>{{ KNOWL('ec.torsion_order', title='Torsion order') }}:</th>
+        <td>\({{ ec.torsion_order }}\)</td>
+        </tr>
+
+        <tr>
+        <th align='left'>{{ KNOWL('lfunction.leading_coeff', title='Leading coefficient') }}:</th>
+        <td> {{ ec.Lvalue }}</td>
+        </tr>
+
+        <tr>
+	  <th align='left'>
+	    {% if ec.bsd_status ==  "conditional" %}
+            {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;*') }}:
+	    {% else %}
+	    {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:
+	    {% endif %}
+	  </th>
+        <td> {{ ec.sha }} </td>
+        </tr>
+        </table>
+    </p>
+{% if ec.bsd_status == "conditional" %}
+<p>
+  (*) Conditional on {{ KNOWL('ec.bsdconjecture', title='BSD') }}: assuming rank = analytic rank.
+</p>
+{% if ec.sha != "not available" and ec.sha!="1" %}
+<p>
+  Note: We expect that the nontriviality of &#1064; explains the
+  discrepancy between the upper bound on the rank and the analytic
+  rank.  The application of further descents should suffice to
+  establish the weak BSD conjecture for this curve.
+</p>
+{% endif %}
+{% endif %}
+
+{# %%%%%%%%%%%%%%%% END OF TABLE %%%%%%%%%%%%%%%%%%% #}
 </div>
 
 <div>


### PR DESCRIPTION
After updating the ec_nfcurves table to include several extra columns, these code changes show full BSD data.  (Without this you can still see ranks a gens as those columns were there already).

This adresses Issue #3900 

There are many slightly different cases to be dealt with depending on whether we have missing data (e.g. over sextic fields) or when the lower and upper bounds on the rank are different. I tried to be very systematic about this, and display all useful information. Here are examples to look at:

http://localhost:37777/EllipticCurve/2.0.3.1/111972.3/d/3 rank 0 known
http://localhost:37777/EllipticCurve/3.3.1509.1/54.2/c/1 rank 1 known
http://localhost:37777/EllipticCurve/2.2.97.1/100.2/b/1 rank 2 known
http://localhost:37777/EllipticCurve/2.2.93.1/197.2/b/1 rank 3 known
http://localhost:37777/EllipticCurve/3.3.1101.1/64.4/c/1 bounds 0,2; analytic rank 0
http://localhost:37777/EllipticCurve/2.0.11.1/3100.5/c/1 bounds 0,1; analytic rank 1
http://localhost:37777/EllipticCurve/4.4.15317.1/94.3/c/1 bounds 0,3; analytic rank 1
http://localhost:37777/EllipticCurve/4.4.2225.1/1216.5/h/1 bounds 1,3; analytic rank 1
http://localhost:37777/EllipticCurve/6.6.592661.1/409.1/a/1 bounds 0,2; analytic rank 2
http://localhost:37777/EllipticCurve/6.6.453789.1/43.1/a/1 no rank bounds or analytic rank