### PR TITLE
Fix search for Artin reps of dihedral type

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -208,10 +208,12 @@ def parse_projective_type(inp, query, qfield):
         if current and current != query[qfield]:
             raise ValueError('Projective image and projective image type are inconsistent')
     elif inp == 'dn':
-        query[qfield] = {'$in': dihedrals}
+        dih_list = [{qfield: z} for z in dihedrals]
+        query[qfield] = {'$or': dih_list}
+        #query[qfield] = {'$in': dihedrals}
         if current and current not in dihedrals:
             raise ValueError('Projective image and projective image type are inconsistent')
-        else:
+        elif current:
             query[qfield] = current
 
 def url_for_label(label):


### PR DESCRIPTION
Fixes issue #4093 

To test, you can use

   https://beta.lmfdb.org/ArtinRepresentation/?projective_image_type=Dn&search_type=List
   https://http://127.0.0.1:37777//ArtinRepresentation/?projective_image_type=Dn&search_type=List

to test.  I switched it from using "any" to an or with a list of the options.