### PR TITLE
Add optional argument to formatfield

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -249,13 +249,26 @@ def psum(val, li):
 def decodedisc(ads, s):
     return ZZ(ads[3:]) * s
 
-def formatfield(coef):
+def formatfield(coef, show_poly=False):
+    r"""
+      Take a list of coefficients (which can be a string like '1,3,1'
+      and either produce a number field knowl if the polynomial matches
+      a number field in the database, otherwise produce a knowl which
+      says say "Deg 15", which can be opened to show the degree 15
+      polynomial.  
+      
+      If show_poly is set to true and the polynomial is not in the
+      database, just display the polynomial (no knowl).
+    """
     if isinstance(coef, text_type):
         coef = string2list(coef)
     thefield = WebNumberField.from_coeffs(coef)
     if thefield._data is None:
         deg = len(coef) - 1
         mypol = latex(coeff_to_poly(coef))
+        if show_poly:
+            return '$'+mypol+'$'
+
         mypol = mypol.replace(' ','').replace('+','%2B').replace('{', '%7B').replace('}','%7d')
         mypol = '<a title = "Field missing" knowl="nf.field.missing" kwargs="poly=%s">Deg %d</a>' % (mypol,deg)
         return mypol


### PR DESCRIPTION
The function formatfield will look up a list of coefficients to see if the polynomial is in the number field database.  It then either produces a number field knowl if possible, or it produces something else.  By default, the something else is "Deg 24" for a degree 24 field as a knowl, and if you open the knowl, you get the polynomial.

This adds an option to the function show_poly.  If it is set to True and the field is not in the database, then just display the polynomial.

There is no place to see the new behavior without changing a current usage of formatfield.  It is added in anticipation of people using it.  You can see that the old behavior still works on say an S_5 field's page (lots of high degree siblings won't be in the database).