### PR TITLE
Bianchi download skeleton

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -317,6 +317,16 @@ def render_bmf_space_webpage(field_label, level_label):
 
     return render_template("bmf-space.html", info=info, credit=credit, title=t, bread=bread, properties=properties, friends=friends, learnmore=learnmore_list())
 
+@bmf_page.route('/<field_label>/<level_label>/<label_suffix>/download/<download_type>')
+def render_bmf_webpage_download(**args):
+    if args['download_type'] == 'sage':
+        pass # TODO
+
+def download_bmf_sage(**args):
+    label = "-".join([args['field_label'],args['level_label'],args['label_suffix']])
+    F = WebNumberField(args['field_label'])
+    data = WebBMF.by_label(label)
+
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/')
 def render_bmf_webpage(field_label, level_label, label_suffix):
     label = "-".join([field_label, level_label, label_suffix])

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -329,7 +329,7 @@ def download_bmf_sage(**args):
         data = WebBMF.by_label(label)
     except ValueError:
         flash_error("No Bianchi modular form in the database has label %s", label)
-        return "// No Bianchi modular form in the database has label %s"
+        return "// No Bianchi modular form in the database has label {}".format(label)
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/')
 def render_bmf_webpage(field_label, level_label, label_suffix):

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -325,7 +325,11 @@ def render_bmf_webpage_download(**args):
 def download_bmf_sage(**args):
     label = "-".join([args['field_label'],args['level_label'],args['label_suffix']])
     F = WebNumberField(args['field_label'])
-    data = WebBMF.by_label(label)
+    try:
+        data = WebBMF.by_label(label)
+    except ValueError:
+        flash_error("No Bianchi modular form in the database has label %s", label)
+        return "// No Bianchi modular form in the database has label %s"
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/')
 def render_bmf_webpage(field_label, level_label, label_suffix):


### PR DESCRIPTION
A tiny amount of skeleton code for downloading properties of Bianchi modular forms (Issue #4053 ). Based on the analogous code used for Hilbert modular forms. 