### PR TITLE
ecnf: change one word on main search page

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -43,7 +43,7 @@ Some <a href="{{url_for('.interesting')}}">interesting elliptic curves</a> or a 
   {% endif %}
 </form>
 
-<p>&nbsp;&nbsp;*The rank is not known for many curves in the database; curves with unknown rank will not appear in searches specifying a rank.</p>
+<p>&nbsp;&nbsp;*The rank is not known for all curves in the database; curves with unknown rank will not appear in searches specifying a rank.</p>
 
 {% if DEBUG %}
 <hr>


### PR DESCRIPTION
It's no longer true to say that the rank is not known for "many" curves!  Out of 661079 curves we now have rank (not just bounds) for all but 4647, and analytic ranks for all but 16413.  The first of these numbers will go down shortly as the last field's rank data is added.  Meanwhile this is a trivial. change.  to a template.

I see that genus 2 curves all search on analytic rank, but not on MW rank.  We could do the same too for ECNF, or have both.