### PR TITLE
Random link in sidebar

### DIFF
--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -7,7 +7,7 @@
     - title: Overview
       url_for: "introduction"
     - title: Random
-      url_for: "random"
+      url_for: "go_random"
     - title: Universe
       url_for: "universe"
     - title: Knowledge

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -6,8 +6,8 @@
   parts:
     - title: Overview
       url_for: "introduction"
-    - title: Features
-      url_for: "introduction_features"
+    - title: Random
+      url_for: "random"
     - title: Universe
       url_for: "universe"
     - title: Knowledge


### PR DESCRIPTION
This PR adds a "Random" link to the top of the sidebar that takes you to a random object anywhere in the LMFDB.  This makes it easier to visit a sequence of random objects and highlights the availability of this feature.

To make room for the new link, the content of the Overview and Features knowls have been merged into a single Overview link.