### PR TITLE
Geometric endomorphism ring and reformatting of EC/NF pages

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -335,7 +335,7 @@ class ECNF(object):
             self.mindisc_norm = web_latex(Dmin_norm)
             if Dmin_norm == 1:  # since the factorization of (1) displays as "1"
                 self.fact_mindisc = self.mindisc
-                self.fact_mindisc_norm = self.mindisc
+                self.fact_mindisc_norm = self.mindisc_norm
             else:
                 Dminfac = Factorization(list(zip(badprimes,mindisc_ords)))
                 self.fact_mindisc = web_latex_ideal_fact(Dminfac)

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -529,7 +529,6 @@ def elliptic_curve_search(info, query):
             query['q_curve'] = True
 
     if 'include_cm' in info:
-    if 'include_cm' in info:
         if info['include_cm'] == 'PCM':
             query['cm'] = {'$ne' : 0}
         elif info['include_cm'] == 'PCMnoCM':
@@ -538,6 +537,7 @@ def elliptic_curve_search(info, query):
             query['cm'] = {'$gt' : 0}
         elif info['include_cm'] == 'noPCM':
             query['cm'] = 0
+
     parse_ints(info,query,field='cm_disc',qfield='cm')
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -529,10 +529,15 @@ def elliptic_curve_search(info, query):
             query['q_curve'] = True
 
     if 'include_cm' in info:
-        if info['include_cm'] == 'exclude':
-            query['cm'] = 0
-        elif info['include_cm'] == 'only':
+    if 'include_cm' in info:
+        if info['include_cm'] == 'PCM':
             query['cm'] = {'$ne' : 0}
+        elif info['include_cm'] == 'PCMnoCM':
+            query['cm'] = {'$lt' : 0}
+        elif info['include_cm'] == 'CM':
+            query['cm'] = {'$gt' : 0}
+        elif info['include_cm'] == 'noPCM':
+            query['cm'] = 0
     parse_ints(info,query,field='cm_disc',qfield='cm')
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs
@@ -758,10 +763,11 @@ class ECNFSearchArray(SearchArray):
             knowl="ec.isogeny_class",
             options=[("", ""),
                      ("yes", "one")])
-        include_cm = ExcludeOnlyBox(
+        include_cm = SelectBox(
             name="include_cm",
             label="CM",
-            knowl="ec.complex_multiplication")
+            knowl="ec.complex_multiplication",
+            options=[('', ''), ('PCM', 'potential CM'), ('PCMnoCM', 'potential CM but no CM'), ('CM', 'CM'), ('noPCM', 'no potential CM')])
         cm_disc = TextBox(
             name="cm_disc",
             label= "CM discriminant",

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -735,7 +735,7 @@ class ECNFSearchArray(SearchArray):
         field = TextBox(
             name="field",
             label="Base field",
-            knowl="nf",
+            knowl="ag.base_field",
             example="2.2.5.1",
             example_span="2.2.5.1 or Qsqrt5")
         include_base_change = ExcludeOnlyBox(

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -78,9 +78,6 @@ cellpadding="5";
       <table id="invariants">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
-        <td>
-         \(\mathfrak{N} \)</td>
-        <td>=</td>
         <td>{{ ec.cond }}</td>
         <td>=</td>
         <td>{{ ec.fact_cond }}</td>
@@ -144,9 +141,9 @@ cellpadding="5";
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
-        <td>{% if ec.rational_cm %}{{ ec.End }}{% else %}\(\Z\)</td>
+        <td>{% if ec.rational_cm %} {{ ec.End }} {% else %} \(\Z\) {% endif %}</td>
         <td>&nbsp;</td>
-        <td>({% if ec.rational_cm %}{{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}){% endif %}</td>
+        <td>{% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}</td>
         </tr>
         
         <tr>
@@ -155,9 +152,9 @@ cellpadding="5";
         <td>&nbsp;</td>
         <td>
         {%if not ec.cm %}
-        (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
+          (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
         {% elif not ec.rational_cm %}
-        ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+          ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% endif %}
         </td>
         </tr>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -227,7 +227,7 @@ cellpadding="5";
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<td align='left'>{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}:</td>
+<td align='left'>{{KNOWL('ec.mw_generators','{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}')}}:</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>
 {% endfor %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -44,7 +44,7 @@
 
 <style type="text/css">
 #invariants th, #invariants  td {
-padding : 4px;
+padding : 1px, 10px;
 text-align: left;
 cellpadding="5";
 }

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -227,7 +227,7 @@ cellpadding="5";
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<td align='left'>{{KNOWL('ec.mw_generators','{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}')}}:</td>
+<td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}')}}:</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>
 {% endfor %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -174,7 +174,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.End }}</td>
         <td>&nbsp;</td>
-        <td>({% if ec.rational_cm %}{{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})</td>
+        <td>({% if ec.rational_cm %}{{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}){% endif %}</td>
         </tr>
         
         <tr>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -74,8 +74,7 @@ cellpadding="5";
 
 <h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
-    <div style='overflow:auto; margin-left:1ch;'>
-      <table id="invariants">
+      <table id="invariants" style="overflow:auto;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
         <td>{{ ec.cond }}</td>
@@ -101,14 +100,14 @@ cellpadding="5";
         {% endif %}
         </tr>
 
-          <tr><td colspan=5> {{ place_code('disc') }}</td></tr>
+        <tr><td colspan=4> {{ place_code('disc') }}</td></tr>
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
         </tr>
-        <tr><td colspan=5> {{ place_code('disc_norm') }}</td></tr>
+        <tr><td colspan=4> {{ place_code('disc_norm') }}</td></tr>
 
 {% if not ec.is_minimal %}
         <tr>
@@ -128,7 +127,7 @@ cellpadding="5";
 {% endif %}
 
         <tr>
-        <td>{{ KNOWL('ec.j_invariant','j-invariant')}}"</td>
+        <td>{{ KNOWL('ec.j_invariant','j-invariant')}}:</td>
         {% if ec.fact_j %}
         <td>{{ ec.j }}</td>
         <td>=</td>
@@ -137,7 +136,7 @@ cellpadding="5";
         <td colspan=3>{{ ec.j }}</td>
         {% endif %}
         </tr>
-        <tr><td colspan=5>     {{ place_code('jinv') }}</td></tr>
+        <tr><td colspan=4>     {{ place_code('jinv') }}</td></tr>
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
@@ -159,23 +158,21 @@ cellpadding="5";
         </td>
         </tr>
 
-        <tr><td colspan=5>     {{ place_code('cm') }}</td></tr>
+        <tr><td colspan=4>     {{ place_code('cm') }}</td></tr>
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
-        <td>=</td>
         <td>{{ ec.ST|safe }}</td>
         </td>
         </tr>
 
 </table>
-</div>
 
 <div>
 <h2> {{ KNOWL('ec.mordell_weil_group', title="Mordell-Weil group") }} </h2>
 <p>
 <table>
 <tr>
-  <th align = 'left'>{{ KNOWL('ec.rank', title="Rank")}}:</th>
+  <td align = 'left'>{{ KNOWL('ec.rank', title="Rank")}}:</td>
 {% if ec.rk == "not available" %}
 {% if ec.rank_bounds != "not available" %}
   <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
@@ -189,13 +186,13 @@ cellpadding="5";
 
 {% if ec.ngens %}
 <tr>
-  <th align = 'left'>
+  <td align = 'left'>
     {% if ec.ngens==1 %}
     Generator
     {% else %}
     Generators
     {% endif %}
-  </th>
+  </td>
   {% if ec.gens == 'not available' %}
   <td>not available</td>
   {% else %}
@@ -208,13 +205,13 @@ cellpadding="5";
 
 {% if ec.heights %}
 <tr>
-  <th align = 'left'>
+  <td align = 'left'>
     {% if ec.ngens==1 %}
     {{ KNOWL('ec.canonical_height', title="Height") }}
     {% else %}
     {{ KNOWL('ec.canonical_height', title="Heights") }}
     {% endif %}
-  </th>
+  </td>
   {% for h in ec.heights %}
   <td>\({{ h }}\)</td>
   {% endfor %}
@@ -222,14 +219,14 @@ cellpadding="5";
 {% endif %}
 
 <tr>
-<th align='left'>Torsion structure:</th>
+<td align='left'>Torsion structure:</td>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
 <tr><td colspan=2> {{ place_code('tors') }}</td></tr>
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<th align='left'>{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}:</th>
+<td align='left'>{% if ec.tr==1 %}Torsion generator{% else %}Torsion generators{% endif %}:</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>
 {% endfor %}
@@ -246,7 +243,7 @@ cellpadding="5";
         <table>
 
         <tr>
-        <th align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</th>
+        <td align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</td>
         <td>
 	  {{ ec.ar }}
         </td>
@@ -259,7 +256,7 @@ cellpadding="5";
         </tr>
 
 	<tr>
-	  <th align='left'>{{ KNOWL('ec.rank', title="Mordell-Weil rank")}}</th>
+	  <td align='left'>{{ KNOWL('ec.rank', title="Mordell-Weil rank")}}</td>
 	  {% if ec.rk == "not available" %}
 	  {% if ec.rank_bounds != "not available" %}
 	  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
@@ -271,13 +268,13 @@ cellpadding="5";
 	  {% endif %}
 	</tr>
         <tr>
-	  <th align='left'>
+	  <td align='left'>
 	    {% if ec.bsd_status == "conditional" %}
             {{ KNOWL('ec.regulator', title='Regulator*') }}:
 	    {% else %}
 	    {{ KNOWL('ec.regulator', title='Regulator') }}:
 	    {% endif %}
-	  </th>
+	  </td>
           <td>
 	  {% if ec.reg=='not available' %}
 	  not available
@@ -288,12 +285,12 @@ cellpadding="5";
         </tr>
 
         <tr>
-        <th align='left'>{{ KNOWL('ec.period', title='Period') }}:</th>
+        <td align='left'>{{ KNOWL('ec.period', title='Period') }}:</td>
         <td> {{ ec.omega }}</td>
         </tr>
 
         <tr>
-        <th align='left'>{{ KNOWL('ec.tamagawa_number', title='Tamagawa product') }}:</th>
+        <td align='left'>{{ KNOWL('ec.tamagawa_number', title='Tamagawa product') }}:</td>
         <td> {{ ec.tamagawa_product }}
           {% if ec.tamagawa_factors %}
           &nbsp;=&nbsp; \({{ ec.tamagawa_factors }}\)
@@ -302,23 +299,23 @@ cellpadding="5";
         </tr>
 
         <tr>
-        <th align='left'>{{ KNOWL('ec.torsion_order', title='Torsion order') }}:</th>
+        <td align='left'>{{ KNOWL('ec.torsion_order', title='Torsion order') }}:</td>
         <td>\({{ ec.torsion_order }}\)</td>
         </tr>
 
         <tr>
-        <th align='left'>{{ KNOWL('lfunction.leading_coeff', title='Leading coefficient') }}:</th>
+        <td align='left'>{{ KNOWL('lfunction.leading_coeff', title='Leading coefficient') }}:</td>
         <td> {{ ec.Lvalue }}</td>
         </tr>
 
         <tr>
-	  <th align='left'>
+	  <td align='left'>
 	    {% if ec.bsd_status ==  "conditional" %}
             {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;*') }}:
 	    {% else %}
 	    {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:
 	    {% endif %}
-	  </th>
+	  </td>
         <td> {{ ec.sha }} </td>
         </tr>
         </table>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -31,7 +31,7 @@
 #}
 
 <div>
-  <h2>  Base field   {{ ec.field.knowl()|safe }} </h2>
+  <h2> {{KNOWL('ag.base field','Base field')}} {{ ec.field.knowl()|safe }} </h2>
 <p>
  {{ KNOWL('nf.generator', 'Generator') }} \({{
  ec.field.generator_name() }}\), with {{
@@ -51,7 +51,7 @@ cellpadding="5";
 </style>
 
 <h2>{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass equation') }}</h2>
-<div style='overflow-x:auto; overflow-y:hidden'>
+<div style='overflow-x:auto; overflow-y:hidden; margin-left:1ch;'>
 \({{ ec.equation }}\)
 </div>
     {{ place_code('curve') }}
@@ -74,9 +74,10 @@ cellpadding="5";
 
 <h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
-    <div style='overflow:auto'>
+    <div style='overflow:auto; margin-left:1ch;'>
       <table id="invariants">
         <tr>
+        <td>{{KNOWL('ec.conductor', title='Conductor')}}</td>
         <td>
          \(\mathfrak{N} \)</td>
         <td>=</td>
@@ -87,6 +88,7 @@ cellpadding="5";
         <tr><td colspan=5>    {{ place_code('cond') }}</td></tr>
 
         <tr>
+        <td>{{KNOWL('ec.conductor', title='Conductor norm')}}</td>
         <td>
          \(N(\mathfrak{N}) \)</td>
         <td>=</td>
@@ -97,6 +99,7 @@ cellpadding="5";
         <tr><td colspan=5>    {{ place_code('cond_norm') }}</td></tr>
 
         <tr>
+        <td>{{KNOWL('ec.discriminant', title='Discriminant')}}</td>
         <td>
           {% if ec.is_minimal %}
           \(\mathfrak{D}\)
@@ -114,6 +117,7 @@ cellpadding="5";
 
           <tr><td colspan=5> {{ place_code('disc') }}</td></tr>
         <tr>
+        <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}</td>
         <td>
           {% if ec.is_minimal %}
           \(N(\mathfrak{D})\)
@@ -165,18 +169,32 @@ cellpadding="5";
         <tr><td colspan=5>     {{ place_code('jinv') }}</td></tr>
 
         <tr>
+        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
         <td> \( \text{End} (E) \)</td>
         <td>=</td>
         <td>{{ ec.End }}</td>
         <td>&nbsp;</td>
-        <td>({%if not ec.cm %}no {%endif %}
-   {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication')}}
-            )
+        <td>({% if ec.rational_cm %}{{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})</td>
+        </tr>
+        
+        <tr>
+        <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
+        <td> \( \text{End} (E) \)</td>
+        <td>=</td>
+        <td>{{ ec.End }}</td>
+        <td>&nbsp;</td>
+        <td>
+        {%if not ec.cm %}
+        (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
+        {% elif not ec.rational_cm %}
+        ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+        {% endif %}
         </td>
         </tr>
-        <tr><td colspan=5>     {{ place_code('cm') }}</td></tr>
 
+        <tr><td colspan=5>     {{ place_code('cm') }}</td></tr>
         <tr>
+        <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
         <td> \( \text{ST} (E) \)</td>
         <td>=</td>
         <td>{{ ec.ST|safe }}</td>
@@ -513,6 +531,7 @@ Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>   con
 
 <div>
 <h2> {{KNOWL('ec.base_change','Base change')}} </h2>
+<p>
 This curve {% if ec.base_change %} is the
 {{KNOWL('ec.base_change','base-change')}} of elliptic curves
 {% for E0 in ec.base_change%}
@@ -529,6 +548,7 @@ It is not a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 It has not yet been determined whether or not it is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 {% endif %}
 {% endif %}
+</p>
 </div>
 
 {% if DEBUG %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -74,7 +74,7 @@ cellpadding="5";
 
 <h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
-      <table id="invariants" style="overflow:auto; padding:1px;">
+      <table id="invariants" style="overflow:auto;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
         <td>{{ ec.cond }}</td>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -31,7 +31,7 @@
 #}
 
 <div>
-  <h2> {{KNOWL('ag.base field','Base field')}} {{ ec.field.knowl()|safe }} </h2>
+  <h2> {{KNOWL('ag.base_field','Base field')}} {{ ec.field.knowl()|safe }} </h2>
 <p>
  {{ KNOWL('nf.generator', 'Generator') }} \({{
  ec.field.generator_name() }}\), with {{

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -74,7 +74,7 @@ cellpadding="5";
 
 <h2>{{ KNOWL('ec.invariants', title='Invariants')}}</h2>
 
-      <table id="invariants" style="overflow:auto;">
+      <table id="invariants" style="overflow:auto; padding:1px;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
         <td>{{ ec.cond }}</td>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -152,7 +152,7 @@ cellpadding="5";
         <td>&nbsp;</td>
         <td>
         {%if not ec.cm %}
-          (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
+          (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% elif not ec.rational_cm %}
           ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% endif %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -227,7 +227,7 @@ cellpadding="5";
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}')}}:</td>
+<td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}:</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>
 {% endfor %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -111,6 +111,7 @@ cellpadding="5";
 
 {% if not ec.is_minimal %}
         <tr>
+        <td>{{KNOWL('ec.minimal_discriminant', title='Minimal discriminant')}}:</td>
         <td>{{ ec.mindisc }}</td>
         {% if ec.fact_mindisc %}
         <td>=</td>
@@ -119,7 +120,7 @@ cellpadding="5";
         </tr>
 
         <tr>
-        <td>
+        <td>{{KNOWL('ec.minimal_discriminant', title='Minimal discriminant norm')}}:</td>
         <td>{{ ec.mindisc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_mindisc_norm }}</td>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -188,9 +188,9 @@ cellpadding="5";
 <tr>
   <td align = 'left'>
     {% if ec.ngens==1 %}
-    Generator
+    {{KNOWL('ec.mw_generators','Generator')}}
     {% else %}
-    Generators
+    {{KNOWL('ec'mw_generators','Generators')}}
     {% endif %}
   </td>
   {% if ec.gens == 'not available' %}
@@ -219,7 +219,7 @@ cellpadding="5";
 {% endif %}
 
 <tr>
-<td align='left'>Torsion structure:</td>
+<td align='left'>{{KNOWL('ec.torsion_subgroup','Torsion structure')}}:</td>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
 <tr><td colspan=2> {{ place_code('tors') }}</td></tr>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -81,7 +81,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_cond }}</td>
         </tr>
-        <tr><td colspan=5>    {{ place_code('cond') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('cond') }}</td></tr>
 
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor norm')}}:</td>
@@ -89,7 +89,7 @@ cellpadding="5";
         <td>=</td>
         <td>{{ ec.fact_cond_norm }}</td>
         </tr>
-        <tr><td colspan=5>    {{ place_code('cond_norm') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('cond_norm') }}</td></tr>
 
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant')}}:</td>
@@ -100,14 +100,14 @@ cellpadding="5";
         {% endif %}
         </tr>
 
-        <tr><td colspan=4> {{ place_code('disc') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('disc') }}</td></tr>
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
         </tr>
-        <tr><td colspan=4> {{ place_code('disc_norm') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('disc_norm') }}</td></tr>
 
 {% if not ec.is_minimal %}
         <tr>
@@ -136,7 +136,7 @@ cellpadding="5";
         <td colspan=3>{{ ec.j }}</td>
         {% endif %}
         </tr>
-        <tr><td colspan=4>     {{ place_code('jinv') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('jinv') }}</td></tr>
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
@@ -158,7 +158,7 @@ cellpadding="5";
         </td>
         </tr>
 
-        <tr><td colspan=4>     {{ place_code('cm') }}</td></tr>
+        <tr><td colspan=4 style="padding:0;">{{ place_code('cm') }}</td></tr>
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
         <td>{{ ec.ST|safe }}</td>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -190,7 +190,7 @@ cellpadding="5";
     {% if ec.ngens==1 %}
     {{KNOWL('ec.mw_generators','Generator')}}
     {% else %}
-    {{KNOWL('ec'mw_generators','Generators')}}
+    {{KNOWL('ec.mw_generators','Generators')}}
     {% endif %}
   </td>
   {% if ec.gens == 'not available' %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -142,15 +142,13 @@ cellpadding="5";
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
         <td>{% if ec.rational_cm %} {{ ec.End }} {% else %} \(\Z\) {% endif %}</td>
-        <td>&nbsp;</td>
-        <td>{% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}</td>
+        <td colspan="2">{% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}</td>
         </tr>
         
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
         <td>{{ ec.End }}</td>
-        <td>&nbsp;</td>
-        <td>
+        <td colspan="2">
         {%if not ec.cm %}
           (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% elif not ec.rational_cm %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -77,7 +77,7 @@ cellpadding="5";
     <div style='overflow:auto; margin-left:1ch;'>
       <table id="invariants">
         <tr>
-        <td>{{KNOWL('ec.conductor', title='Conductor')}}</td>
+        <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
         <td>
          \(\mathfrak{N} \)</td>
         <td>=</td>
@@ -88,10 +88,7 @@ cellpadding="5";
         <tr><td colspan=5>    {{ place_code('cond') }}</td></tr>
 
         <tr>
-        <td>{{KNOWL('ec.conductor', title='Conductor norm')}}</td>
-        <td>
-         \(N(\mathfrak{N}) \)</td>
-        <td>=</td>
+        <td>{{KNOWL('ec.conductor', title='Conductor norm')}}:</td>
         <td>{{ ec.cond_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_cond_norm }}</td>
@@ -99,15 +96,7 @@ cellpadding="5";
         <tr><td colspan=5>    {{ place_code('cond_norm') }}</td></tr>
 
         <tr>
-        <td>{{KNOWL('ec.discriminant', title='Discriminant')}}</td>
-        <td>
-          {% if ec.is_minimal %}
-          \(\mathfrak{D}\)
-          {% else %}
-          \((\Delta)\)
-          {% endif %}
-        </td>
-        <td>=</td>
+        <td>{{KNOWL('ec.discriminant', title='Discriminant')}}:</td>
         <td>{{ ec.disc }}</td>
         {% if ec.fact_disc %}
         <td>=</td>
@@ -117,15 +106,7 @@ cellpadding="5";
 
           <tr><td colspan=5> {{ place_code('disc') }}</td></tr>
         <tr>
-        <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}</td>
-        <td>
-          {% if ec.is_minimal %}
-          \(N(\mathfrak{D})\)
-          {% else %}
-          \(N(\Delta)\)
-          {% endif %}
-         </td>
-        <td>=</td>
+        <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
@@ -134,9 +115,6 @@ cellpadding="5";
 
 {% if not ec.is_minimal %}
         <tr>
-        <td>
-         \(\mathfrak{D}\)</td>
-        <td>=</td>
         <td>{{ ec.mindisc }}</td>
         {% if ec.fact_mindisc %}
         <td>=</td>
@@ -146,8 +124,6 @@ cellpadding="5";
 
         <tr>
         <td>
-         \(N(\mathfrak{D})\)</td>
-        <td>=</td>
         <td>{{ ec.mindisc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_mindisc_norm }}</td>
@@ -155,9 +131,7 @@ cellpadding="5";
 {% endif %}
 
         <tr>
-        <td>
-         \(j\)</td>
-        <td>=</td>
+        <td>{{ KNOWL('ec.j_invariant','j-invariant')}}"</td>
         {% if ec.fact_j %}
         <td>{{ ec.j }}</td>
         <td>=</td>
@@ -170,17 +144,13 @@ cellpadding="5";
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
-        <td> \( \text{End} (E) \)</td>
-        <td>=</td>
-        <td>{{ ec.End }}</td>
+        <td>{% if ec.rational_cm %}{{ ec.End }}{% else %}\(\Z\)</td>
         <td>&nbsp;</td>
         <td>({% if ec.rational_cm %}{{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}){% endif %}</td>
         </tr>
         
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
-        <td> \( \text{End} (E) \)</td>
-        <td>=</td>
         <td>{{ ec.End }}</td>
         <td>&nbsp;</td>
         <td>
@@ -195,7 +165,6 @@ cellpadding="5";
         <tr><td colspan=5>     {{ place_code('cm') }}</td></tr>
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
-        <td> \( \text{ST} (E) \)</td>
         <td>=</td>
         <td>{{ ec.ST|safe }}</td>
         </td>
@@ -209,7 +178,7 @@ cellpadding="5";
 <p>
 <table>
 <tr>
-  <th align = 'left'>{{ KNOWL('ec.rank', title="Rank")}}</th>
+  <th align = 'left'>{{ KNOWL('ec.rank', title="Rank")}}:</th>
 {% if ec.rk == "not available" %}
 {% if ec.rank_bounds != "not available" %}
   <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -686,7 +686,7 @@ class ECSearchArray(SearchArray):
             name="include_cm",
             label="CM",
             knowl="ec.complex_multiplication",
-            options=[('', ''), ('exclude', 'no potential CM'), ('only', 'potential CM')])
+            options=[('', ''), ('only', 'potential CM'), ('exclude', 'no potential CM')])
         tor_opts = ([("", ""),
                      ("[]", "trivial")] +
                     [("[%s]"%n, "C%s"%n) for n in range(2, 13) if n != 11] +

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -16,7 +16,7 @@ from lmfdb.backend.encoding import Json
 from lmfdb.utils import (
     web_latex, to_dict, flash_error, display_knowl,
     parse_rational, parse_ints, parse_floats, parse_bracketed_posints, parse_primes,
-    SearchArray, TextBox, SelectBox, SubsetBox, SubsetNoExcludeBox, TextBoxWithSelect, ExcludeOnlyBox, CountBox,
+    SearchArray, TextBox, SelectBox, SubsetBox, SubsetNoExcludeBox, TextBoxWithSelect, CountBox,
     YesNoBox, parse_element_of, parse_bool, search_wrap)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.elliptic_curves import ec_page, ec_logger

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -686,7 +686,7 @@ class ECSearchArray(SearchArray):
             name="include_cm",
             label="CM",
             knowl="ec.complex_multiplication",
-            options=[('', ''), ('no CM', 'exclude'), ('potential CM', 'only')])
+            options=[('', ''), ('exclude', 'no potential CM'), ('only', 'potential CM')])
         tor_opts = ([("", ""),
                      ("[]", "trivial")] +
                     [("[%s]"%n, "C%s"%n) for n in range(2, 13) if n != 11] +

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -682,10 +682,11 @@ class ECSearchArray(SearchArray):
             knowl="ec.q.j_invariant",
             example="1728",
             example_span="1728 or -4096/11")
-        cm = ExcludeOnlyBox(
+        cm = SelectBox(
             name="include_cm",
             label="CM",
-            knowl="ec.complex_multiplication")
+            knowl="ec.complex_multiplication",
+            options=[('', ''), ('no CM', 'exclude'), ('potential CM', 'only')])
         tor_opts = ([("", ""),
                      ("[]", "trivial")] +
                     [("[%s]"%n, "C%s"%n) for n in range(2, 13) if n != 11] +

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -174,7 +174,7 @@ white-space: pre in order to keep line breaks! #}
         <td>&nbsp;</td>
         <td>
         {%if not data.data.CMD %}
-        (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
+        (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% else %}
         ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -63,15 +63,27 @@ white-space: pre in order to keep line breaks! #}
 
 
     <h2> {{ KNOWL('ec.mordell_weil_group', title='Mordell-Weil group') }} structure</h2>
-   <div>{% if data.mw.rank==1 %}{% if data.mw.tor_order!=1 %} \(\Z\times {{data.mw.tor_struct}}\)
-    {%endif%}  {%endif%}     </div>
-
-    <div>{% if data.mw.rank==1 %}{% if data.mw.tor_order==1 %}\(\Z\) {%endif%}  {%endif%} </div>
-    <div> {% if data.mw.rank !=0 and data.mw.rank!=1 %} {% if data.mw.tor_order!=1 %}\(\Z^{{data.mw.rank}} \times {{data.mw.tor_struct}}\) {%endif%}  {%endif%} </div>
-    <div> {% if data.mw.rank !=0 and data.mw.rank!=1%} {% if data.mw.tor_order==1 %} \(\Z^{{data.mw.rank}}\){%endif%}  {%endif%} </div>
-    <div> {% if data.mw.rank ==0 %} {% if data.mw.tor_order!=1 %} \({{data.mw.tor_struct}}\){%endif%}  {%endif%} </div>
-    <div> {% if data.mw.rank ==0 %} {% if data.mw.tor_order==1 %}
-    Trivial {%endif%}  {%endif%} </div>
+    <p>
+    {% if data.mw.rank == 0 %}
+      {% if data.mw.tor_order == 1 %}
+        Trivial
+      {% else %}
+        \({{data.mw.tor_struct}}\)
+      {%endif%}
+    {% elif data.mw.rank==1 %}
+      {% if data.mw.tor_order == 1 %}
+        \(\Z\)
+      {% else %}
+        \(\Z\times {{data.mw.tor_struct}}\)
+      {%endif%}
+    {% else %}
+      {% if data.mw.tor_order == 1 %}
+        \(\Z^{{data.mw.rank}}\)
+      {% else %}
+        \(\Z^{{data.mw.rank}} \times {{data.mw.tor_struct}}\)
+      {% endif %}
+    {%endif%}
+    </p>
 
     {% if data.mw.rank!=0 %}
     {% if data.mw.rank==1 %}
@@ -275,7 +287,7 @@ white-space: pre in order to keep line breaks! #}
 {#
     <form>
 #}
-        <div class="output"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
+        <div class="output" style="margin-left:1ch;"><span id="modform_output">{{ data.data.newform | safe }}</span></div>
         <div class="emptyspace"><br></div>
 {#
         <button id="morebutton">More coefficients</button>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -171,8 +171,7 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
-        <td>&nbsp;</td>
-        <td>
+        <td colspan="2">
         {%if not data.data.CMD %}
         (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% else %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -152,21 +152,25 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism Ring') }}:</td>
+        <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
         <td>\(\Z\)</td>
         </tr>
 
         <tr>
-        <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric Endomorphism Ring') }}:</td>
+        <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
         <td>{{ data.data.EndE }}</td>
         <td>&nbsp;</td>
-        <td>({%if data.data.CMD %}potential {%else %}no {%endif %}
-	  {{ KNOWL('ec.complex_multiplication', title='Complex Multiplication') }})
+        <td>
+        {%if not data.data.CMD %}
+        (no {{ KNOWL('ec.complex_multiplication', title='complex multiplication')}})
+        {% else %}
+        ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+        {% endif %}
         </td>
         </tr>
 
         <tr>
-        <td>{{ KNOWL('st_group.definition', title='Sato-Tate Group') }}:</td>
+        <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
         <td>{{ data.data.ST|safe }}</td>
         </tr>
 

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -128,7 +128,7 @@ white-space: pre in order to keep line breaks! #}
         <table>
 
         <tr>
-        <td colspan="6">
+        <td colspan="4">
           {{ place_code('cond') }}
         </td>
         </tr>
@@ -140,7 +140,7 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td colspan="6">
+        <td colspan="4">
           {{ place_code('disc') }}
         </td>
         </tr>
@@ -152,7 +152,7 @@ white-space: pre in order to keep line breaks! #}
         </tr>
 
         <tr>
-        <td colspan="6">
+        <td colspan="4">
           {{ place_code('jinv') }}
         </td>
         </tr>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -397,7 +397,7 @@ class WebEC(object):
                            ('j-invariant', '%s' % data['j_inv_latex']),
                            ('CM', '%s' % data['CM']),
                            ('Rank', '%s' % self.mw['rank']),
-                           ('Torsion Structure', r'\(%s\)' % self.mw['tor_struct'])
+                           ('Torsion structure', r'\(%s\)' % self.mw['tor_struct'])
                            ]
 
         if self.label_type == 'Cremona':


### PR DESCRIPTION
This PR is the final step in resolving #3683.  The geometric endomorphism ring is now displayed on all elliptic curve pages and we distinguish between "potential CM" (geometric endomorphism ring != Z) and "CM" (endomorphism ring != Z).  The re are now more search options in the CM dropdown when searching for elliptic curves over number fields to reflect various combinations.  You can see this on https://blue.lmfdb.xyz. Examples include:

https://blue.lmfdb.xyz/EllipticCurve/2.0.8.1/33561.10/c/3 (no potential CM)
https://blue.lmfdb.xyz/EllipticCurve/3.3.1524.1/9.3/a/3 (potential CM but no CM)
https://blue.lmfdb.xyz/EllipticCurve/2.0.8.1/9.3/CMa/1 (CM)

The CM knowl has been changed to include a definition of potential CM and to explain that over Q one can only ever have potential CM.  This more precise terminology is important in the number field setting (where the distinction between CM and potential CM really matters), and to keep things consistent we want to use the same terminology for elliptic curves over Q, o the CM dropdown over Q has also been changed.

The layout of the EC/NF pages has been changed to make it more consistent with the EC/Q and genus 2 curve pages.