### PR TITLE
Add class number formula to number field pages

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -497,6 +497,7 @@ def render_field_webpage(args):
         'unit_rank': nf.unit_rank(),
         'root_of_unity': rootofunity,
         'fund_units': nf.units_safe(),
+        'cnf': nf.cnf(),
         'grh_label': grh_label,
         'loc_alg': loc_alg
     })

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -106,6 +106,11 @@ table.ntdata a {
           </table>
         </p>
 
+        <p><h2> {{ KNOWL('nf.class_number_formula', title='Class number formula') }}</h2>
+ <table>
+   <tr><td>$\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) = {{ info.cnf|safe }}$
+                {{ info.grh_label|safe }}
+  </table>
 
         <p><h2> {{ KNOWL('nf.galois_group', title='Galois group') }}</h2>
         <p>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -108,7 +108,7 @@ table.ntdata a {
 
         <p><h2> {{ KNOWL('nf.class_number_formula', title='Class number formula') }}</h2>
  <table>
-   <tr><td>$\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) = {{ info.cnf|safe }}$
+   <tr><td>$\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) {{ info.cnf|safe }}
                 {{ info.grh_label|safe }}
   </table>
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -692,7 +692,7 @@ class WebNumberField:
 
     def cnf(self):
         if not self.haskey('class_group'):
-            return na_text()
+            return r'$<td>  '+na_text()
         # Otherwise we should have what we need
         [r1,r2] = self.signature()
         reg = self.regulator()
@@ -701,8 +701,8 @@ class WebNumberField:
         r1term= r'2^{%s}\cdot'% r1
         r2term= r'(2\pi)^{%s}\cdot'% r2
         disc = ZZ(self._data['disc_abs'])
-        ltx = r'\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
-        ltx += r'\approx %s'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
+        ltx = r'=\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
+        ltx += r'\approx %s$'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
         return ltx
 
     def is_cm_field(self):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -5,7 +5,7 @@ from six import text_type
 
 from flask import url_for
 from sage.all import (
-    Set, ZZ, euler_phi, CyclotomicField, gap, RealField,
+    Set, ZZ, RR, pi, euler_phi, CyclotomicField, gap, RealField, sqrt,
     QQ, NumberField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
@@ -689,6 +689,21 @@ class WebNumberField:
             res = res.replace('\\\\', '\\')
             return res
         return na_text()
+
+    def cnf(self):
+        if not self.haskey('class_group'):
+            return na_text()
+        # Otherwise we should have what we need
+        [r1,r2] = self.signature()
+        reg = self.regulator()
+        h = self.class_number()
+        w = self.root_of_1_order()
+        r1term= r'2^{%s}\cdot'% r1
+        r2term= r'(2\pi)^{%s}\cdot'% r2
+        disc = ZZ(self._data['disc_abs'])
+        ltx = r'\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
+        ltx += r'\approx %s'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
+        return ltx
 
     def is_cm_field(self):
         return self._data['cm']

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -701,8 +701,10 @@ class WebNumberField:
         r1term= r'2^{%s}\cdot'% r1
         r2term= r'(2\pi)^{%s}\cdot'% r2
         disc = ZZ(self._data['disc_abs'])
-        ltx = r'\approx\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
-        ltx += r'\approx %s$'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
+        approx1 = r'\approx' if self.unit_rank()>0 else r'='
+        approx2 = r'\approx' if self.degree()>1 else r'='
+        ltx = r'%s\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(approx1,r1term,r2term,str(reg),h,w,disc)
+        ltx += r'%s %s$'%(approx2,2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
         return ltx
 
     def is_cm_field(self):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -691,6 +691,8 @@ class WebNumberField:
         return na_text()
 
     def cnf(self):
+        if self.degree()==1:
+            return r'=\frac{2^1\cdot (2\pi)^0 \cdot 1\cdot 1}{2\sqrt 1}=1$'
         if not self.haskey('class_group'):
             return r'$<td>  '+na_text()
         # Otherwise we should have what we need
@@ -702,9 +704,8 @@ class WebNumberField:
         r2term= r'(2\pi)^{%s}\cdot'% r2
         disc = ZZ(self._data['disc_abs'])
         approx1 = r'\approx' if self.unit_rank()>0 else r'='
-        approx2 = r'\approx' if self.degree()>1 else r'='
         ltx = r'%s\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(approx1,r1term,r2term,str(reg),h,w,disc)
-        ltx += r'%s %s$'%(approx2,2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
+        ltx += r'\approx %s$'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
         return ltx
 
     def is_cm_field(self):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -701,7 +701,7 @@ class WebNumberField:
         r1term= r'2^{%s}\cdot'% r1
         r2term= r'(2\pi)^{%s}\cdot'% r2
         disc = ZZ(self._data['disc_abs'])
-        ltx = r'=\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
+        ltx = r'\approx\frac{%s%s %s \cdot %s}{%s\sqrt{%s}}'%(r1term,r2term,str(reg),h,w,disc)
         ltx += r'\approx %s$'%(2**r1*(2*RR(pi))**r2*reg*h/(w*sqrt(RR(disc))))
         return ltx
 


### PR DESCRIPTION
Just go to a number field page and scroll down below units.

Typical page (but no whining about Artin representation labels being long now that they are multiplied out):
http://127.0.0.1:37777/NumberField/7.1.193607.1
Assumes grh:
http://127.0.0.1:37777/NumberField/27.9.67585198634817523235520443624317923.1
Data not computed:
http://127.0.0.1:37777/NumberField/47.1.3847243917163654348435987752506690356998556730699127064362242968132131231881167.1 
Case where the first formula is exact (so there is an equals sign):
http://127.0.0.1:37777/NumberField/2.0.8.1
Only case where both values are exact (so no approximation symbols):
http://127.0.0.1:37777/NumberField/1.1.1.1

I chose to leave things in the form of the formula, including exponents of 0