### PR TITLE
Add searching by number of arithmetically equivalent fields.

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -152,6 +152,7 @@ def galois_group_search(info, query):
     parse_ints(info,query,'n','degree')
     parse_ints(info,query,'t')
     parse_ints(info,query,'order')
+    parse_ints(info,query,'arith_equiv')
     parse_ints(info,query,'nilpotency')
     parse_galgrp(info, query, qfield=['label','n'], name='Galois group', field='gal')
     for param in ('cyc', 'solv', 'prim'):
@@ -392,14 +393,24 @@ class GalSearchArray(SearchArray):
             knowl="group.nilpotent",
             example="1..100",
             example_span="-1, or 1..3")
+        arith_equiv = TextBox(
+            name="arith_equiv",
+            label="Arith. Equiv.",
+            knowl="gg.arithmetically_equiv_input",
+            example="1",
+            example_span="1 or 2,3 or 1..5 or 1,3..10")
         count = CountBox()
 
-        self.browse_array = [[n, parity], [t, cyc], [order, solv], [nilpotency, prim], [gal], [count]]
+        self.browse_array = [[n, parity], [t, cyc], [order, solv], [nilpotency, prim], [gal], [arith_equiv], [count]]
 
-        self.refine_array = [[parity, cyc, solv, prim], [n, t, order, gal, nilpotency]]
+        self.refine_array = [[parity, cyc, solv, prim, arith_equiv], [n, t, order, gal, nilpotency]]
 
 def yesone(s):
     return "yes" if s in ["yes", 1] else "no"
+
+def fixminus1(s):
+    return "not computed" if s == -1 else s
+
 def eqyesone(col):
     def inner(s):
         return "%s=%s" % (col, yesone(s))
@@ -418,6 +429,9 @@ class GaloisStats(StatsDisplay):
         {"cols": ["prim", "n"],
          "totaler": totaler(),
          "proportioner": proportioners.per_col_total},
+        {"cols": ["arith_equiv","n"],
+         "totaler": totaler(),
+         "proportioner": proportioners.per_row_total},
         {"cols": ["n", "nilpotency"],
          "totaler": totaler(),
          "proportioner": proportioners.per_row_total},
@@ -425,19 +439,23 @@ class GaloisStats(StatsDisplay):
     knowls = {"n": "gg.degree",
               "order": "group.order",
               "nilpotency": "group.nilpotent",
+              "arith_equiv": "gg.arithmetically_equivalent",
               "solv": "group.solvable",
               "prim": "gg.primitive",
     }
-    top_titles = {"nilpotency": "niplpotency classes",
+    top_titles = {"nilpotency": "nilpotency classes",
                   "solv": "solvability",
+                  "arith_equiv": "number of arithmetic equivalent siblings",
                   "prim": "primitivity"}
     short_display = {"n": "degree",
                      "nilpotency": "nilpotency class",
                      "solv": "solvable",
+                     "arith_equiv": "arithmetic equivalent count",
                      "prim": "primitive",
     }
     formatters = {"solv": yesone,
-                  "prim": yesone}
+                  "prim": yesone,
+                  "arith_equiv": fixminus1}
     query_formatters = {"solv": eqyesone("solv"),
                         "prim": eqyesone("prim")}
     buckets = {

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -415,6 +415,12 @@ def eqyesone(col):
     def inner(s):
         return "%s=%s" % (col, yesone(s))
     return inner
+
+def undominus1(s):
+    if isinstance(s,int):
+        return "arith_equiv=%s" % s
+    return "arith_equiv=-1"
+
 class GaloisStats(StatsDisplay):
     table = db.gps_transitive
     baseurl_func = ".index"
@@ -431,7 +437,7 @@ class GaloisStats(StatsDisplay):
          "proportioner": proportioners.per_col_total},
         {"cols": ["arith_equiv","n"],
          "totaler": totaler(),
-         "proportioner": proportioners.per_row_total},
+         "proportioner": proportioners.per_col_total},
         {"cols": ["n", "nilpotency"],
          "totaler": totaler(),
          "proportioner": proportioners.per_row_total},
@@ -457,7 +463,8 @@ class GaloisStats(StatsDisplay):
                   "prim": yesone,
                   "arith_equiv": fixminus1}
     query_formatters = {"solv": eqyesone("solv"),
-                        "prim": eqyesone("prim")}
+                        "prim": eqyesone("prim"),
+                        "arith_equiv": undominus1}
     buckets = {
         "n": ["1-3", "4-7", "8", "9-11", "12", "13-15", "16", "17-23", "24", "25-31", "32", "33-35", "36", "37-39", "40", "41-47"],
         "order": ["1-15", "16-31", "32-63", "64-127", "128-255", "256-511", "512-1023", "1024-2047", "2048-65535", "65536-40000000000", "40000000000-"]


### PR DESCRIPTION
As it says, if you go to the Galois groups index page, you can now search on the number of arithmetically equivalent fields a corresponding field would have.  It is also added to the stats page.  As a side note, the number of these which have not been computed yet is going down, computations are in progress.