### PR TITLE
Handling long Artin labels, resolves #4108

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -369,8 +369,8 @@ def render_artin_representation_webpage(label):
         elif int(the_rep.conductor())**the_rep.dimension() <= 729000000000000:
             friends.append(("L-function", url_for("l_functions.l_function_artin_page",
                                               label=the_rep.label())))
-        orblabel = artin_label_pretty(re.sub(r'\.[a-z]+$', '', label))
-        friends.append(("Galois orbit "+orblabel,
+        orblabel = re.sub(r'\.[a-z]+$', '', label)
+        friends.append(("Galois orbit " + artin_label_pretty(orblabel),
             url_for(".render_artin_representation_webpage", label=orblabel)))
     else:
         add_lfunction_friends(friends,label)

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -25,7 +25,7 @@ from lmfdb.galois_groups.transitive_group import (
 from lmfdb.artin_representations import artin_representations_page
 #from lmfdb.artin_representations import artin_logger
 from lmfdb.artin_representations.math_classes import (
-    ArtinRepresentation, num2letters)
+    ArtinRepresentation, num2letters, artin_label_pretty)
 
 
 LABEL_RE = re.compile(r'^\d+\.\d+\.\d+(t\d+)?\.[a-z]+\.[a-z]+$')
@@ -320,7 +320,7 @@ def render_artin_representation_webpage(label):
         processed_root_number = "not computed"
     else:
         processed_root_number = str(the_rep.sign())
-    properties = [("Label", label),
+    properties = [("Label", artin_label_pretty(label)),
                   ("Dimension", str(the_rep.dimension())),
                   ("Group", the_rep.group()),
                   ("Conductor", "$" + the_rep.factored_conductor_latex() + "$")]
@@ -369,7 +369,7 @@ def render_artin_representation_webpage(label):
         elif int(the_rep.conductor())**the_rep.dimension() <= 729000000000000:
             friends.append(("L-function", url_for("l_functions.l_function_artin_page",
                                               label=the_rep.label())))
-        orblabel = re.sub(r'\.[a-z]+$', '', label)
+        orblabel = artin_label_pretty(re.sub(r'\.[a-z]+$', '', label))
         friends.append(("Galois orbit "+orblabel,
             url_for(".render_artin_representation_webpage", label=orblabel)))
     else:

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -307,7 +307,7 @@ def render_artin_representation_webpage(label):
         allchars = [ ArtinRepresentation(newlabel+'.'+num2letters(j)).character_formatted() for j in range(1,num_conj+1)]
 
     label = newlabel
-    bread = get_bread([(label, ' ')])
+    bread = get_bread([(artin_label_pretty(label), ' ')])
 
     #artin_logger.info("Found %s" % (the_rep._data))
 

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -377,7 +377,7 @@ def render_artin_representation_webpage(label):
         friends.append(("L-function", url_for("l_functions.l_function_artin_page", label=the_rep.label())))
         for j in range(1,1+the_rep.galois_conjugacy_size()):
             newlabel = label+'.'+num2letters(j)
-            friends.append(("Artin representation "+newlabel,
+            friends.append(("Artin representation " + artin_label_pretty(newlabel),
                 url_for(".render_artin_representation_webpage", label=newlabel)))
 
     info={} # for testing

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -166,9 +166,9 @@ class ArtinRepresentation(object):
         if self.conductor() == 1:
             return "1"
         if len(factors) == 1 and factors[0][1] == 1:
-            return bigint_knowl(self.conductor())
+            return bigint_knowl(self.conductor(),sides=3)
         else:
-            return bigint_knowl(self.conductor()) + "=" + self.factored_conductor_latex()
+            return bigint_knowl(self.conductor(),sides=3) + r"\(= " + self.factored_conductor_latex() + r"\)"
 
     def factored_conductor(self):
         return [(p, valuation(Integer(self.conductor()), p)) for p in self.bad_primes()]

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -11,6 +11,12 @@ from lmfdb.number_fields.web_number_field import WebNumberField, formatfield
 from lmfdb.characters.web_character import WebSmallDirichletCharacter
 import re
 
+# abbreviate labels with large conductors for display purposes
+def artin_label_pretty(label):
+    s = label.split('.')
+    if len(s[1]) > 20:
+        s[1] = s[1][:3] + "..." + s[1][-3:]
+    return '.'.join(s)
 
 # fun is the function, N the modulus, and n the denominator
 # for values (value a means e(a/n))
@@ -120,6 +126,9 @@ class ArtinRepresentation(object):
     def label(self):
         return str(self._data['label'])
 
+    def label_pretty(self):
+        return artin_label_pretty(self._data['label'])
+
     def dimension(self):
         return int(self._data["Dim"])
 
@@ -151,14 +160,15 @@ class ArtinRepresentation(object):
         return self.central_character_as_artin_rep().label()
 
     def conductor_equation(self):
+        from lmfdb.utils import bigint_knowl
         # Returns things of the type "1", "7", "49 = 7^{2}"
         factors = self.factored_conductor()
         if self.conductor() == 1:
             return "1"
         if len(factors) == 1 and factors[0][1] == 1:
-            return str(self.conductor())
+            return bigint_knowl(self.conductor())
         else:
-            return str(self.conductor()) + "=" + self.factored_conductor_latex()
+            return bigint_knowl(self.conductor()) + "=" + self.factored_conductor_latex()
 
     def factored_conductor(self):
         return [(p, valuation(Integer(self.conductor()), p)) for p in self.bad_primes()]

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -168,7 +168,7 @@ class ArtinRepresentation(object):
         if len(factors) == 1 and factors[0][1] == 1:
             return bigint_knowl(self.conductor(),sides=3)
         else:
-            return bigint_knowl(self.conductor(),sides=3) + r"\(= " + self.factored_conductor_latex() + r"\)"
+            return bigint_knowl(self.conductor(),sides=3) + r"\(\medspace = " + self.factored_conductor_latex() + r"\)"
 
     def factored_conductor(self):
         return [(p, valuation(Integer(self.conductor()), p)) for p in self.bad_primes()]

--- a/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
+++ b/lmfdb/artin_representations/templates/artin-representation-galois-orbit.html
@@ -6,7 +6,7 @@
     <table>
         <tr><td>{{ KNOWL('artin.dimension', title='Dimension') }}:<td>${{ object.dimension() }}$ </tr>
         <tr><td>{{ KNOWL('artin.gg_quotient', title='Group') }}:<td>{{ object.pretty_galois_knowl() | safe }}</td>
-        <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>${{ object.conductor_equation() }} $</tr>
+        <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>{{ object.conductor_equation() | safe }}</tr>
         <tr><td> {{ KNOWL('artin.number_field', title='Artin number field') }}: <td>Splitting field of
                 $f={{ object.number_field_galois_group().polynomial_latex()}}$ over $\Q$</tr>
         <tr><td> Size of {{ KNOWL('artin.galois_orbit', title='Galois orbit') }}: <td> {{object.galois_conjugacy_size()}}

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -31,7 +31,7 @@
           {% for cnt in range(galccsize) %}
         {% set artx = initfunc(artin['Baselabel'],cnt+1) %}
         {% if info.sign_code == 0 or info.sign_code == art.sign() %}
-            <a href = "{{artx.url_for()}}">{{artx.label()}}</a>
+            <a href = "{{artx.url_for()}}">{{artx.label_pretty()}}</a>
         {% endif %}
           {% endfor %}
             </td>

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -6,7 +6,7 @@
     <table>
         <tr><td>{{ KNOWL('artin.dimension', title='Dimension') }}:<td>${{ object.dimension() }}$ </tr>
         <tr><td>{{ KNOWL('artin.gg_quotient', title='Group') }}:<td>{{ object.pretty_galois_knowl() | safe }}</td>
-        <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>${{ object.conductor_equation() }} $</tr>
+        <tr><td>{{ KNOWL('artin.conductor', title='Conductor') }}:<td>{{ object.conductor_equation() | safe }}</tr>
         <tr><td> {{ KNOWL('artin.number_field', title='Artin number field') }}: <td>Splitting field of
                 {% if wnf %}
                 {{wnf.knowl()|safe}} defined by

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -592,12 +592,13 @@ def render_field_webpage(args):
         downloads.append(('Download {} code'.format(lang[0]),
                           url_for(".nf_download", nf=label_orig, download_type=lang[1])))
     from lmfdb.artin_representations.math_classes import NumberFieldGaloisGroup
+    from lmfdb.artin_representations.math_classes import artin_label_pretty
     try:
         info["tim_number_field"] = NumberFieldGaloisGroup(nf._data['coeffs'])
         arts = [z.label() for z in info["tim_number_field"].artin_representations()]
         #print arts
         for ar in arts:
-            info['friends'].append(('Artin representation '+str(ar),
+            info['friends'].append(('Artin representation '+artin_label_pretty(ar),
                 url_for("artin_representations.render_artin_representation_webpage", label=ar)))
         v = nf.factor_perm_repn(info["tim_number_field"])
 

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -278,7 +278,7 @@ table.ntdata a {
         {% for artin in info["tim_number_field"].artin_representations()%}
           <tr> <td align="left">
               {{info.mydecomp[loop.index-1]|safe}}
-              <td align="left"><a href = "{{artin.url_for()}}">{{artin.label()}}</a></td><td align="center">${{artin.dimension()}}$</td>
+              <td align="left"><a href = "{{artin.url_for()}}">{{artin.label_pretty()}}</a></td><td align="center">${{artin.dimension()}}$</td>
 {#    <td align="center">${{artin.conductor_equation()}}$</td> #}
       <td align="center">${{artin.factored_conductor_latex()}}$</td>
       {% if artin.number_field_galois_group().url_for() %}


### PR DESCRIPTION
This is running on https://blue.lmfdb.xyz.  A good place to start is

[old large conductor search results](https://beta.lmfdb.org/ArtinRepresentation/?Hide=0&dimension=40-70&conductor=10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000-)
[new large conductor search results](https://blue.lmfdb.xyz/ArtinRepresentation/?Hide=0&dimension=40-70&conductor=10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000-)

The changes are visible on the search pages, the object pages for artin reps and their Galois orbits, and also on the number field pages.  Some examples:

[old artin rep page](https://beta.lmfdb.org/ArtinRepresentation/70.515032279716534633102079631518330199783418041514749767510985855869341934761392210495237217330955785246179923266129287533183612995632780458627572856510443047134047818251730643809097369404567433725336703991055588343559968131942505027958961921166781166866931564372307126496377543256137691901011658304407993998315326936170603506781758080021346693412756396337287262843898068900680029281949265589057636602511343997921012622601820956634919199639399925438562008265433303784885955726356758628022564672406163550515930753379843702784.120.a.a)
[new artin rep page](https://blue.lmfdb.xyz/ArtinRepresentation/70.515032279716534633102079631518330199783418041514749767510985855869341934761392210495237217330955785246179923266129287533183612995632780458627572856510443047134047818251730643809097369404567433725336703991055588343559968131942505027958961921166781166866931564372307126496377543256137691901011658304407993998315326936170603506781758080021346693412756396337287262843898068900680029281949265589057636602511343997921012622601820956634919199639399925438562008265433303784885955726356758628022564672406163550515930753379843702784.120.a.a)

[old Galois orbit page](https://beta.lmfdb.org/ArtinRepresentation/70.515032279716534633102079631518330199783418041514749767510985855869341934761392210495237217330955785246179923266129287533183612995632780458627572856510443047134047818251730643809097369404567433725336703991055588343559968131942505027958961921166781166866931564372307126496377543256137691901011658304407993998315326936170603506781758080021346693412756396337287262843898068900680029281949265589057636602511343997921012622601820956634919199639399925438562008265433303784885955726356758628022564672406163550515930753379843702784.120.a)
[new Galois orbit page](https://blue.lmfdb.xyz/ArtinRepresentation/70.515032279716534633102079631518330199783418041514749767510985855869341934761392210495237217330955785246179923266129287533183612995632780458627572856510443047134047818251730643809097369404567433725336703991055588343559968131942505027958961921166781166866931564372307126496377543256137691901011658304407993998315326936170603506781758080021346693412756396337287262843898068900680029281949265589057636602511343997921012622601820956634919199639399925438562008265433303784885955726356758628022564672406163550515930753379843702784.120.a)

[old number field page](https://beta.lmfdb.org/NumberField/8.0.5620066455663197695561554590870531303687507769819136.1)
[new number field page](https://blue.lmfdb.xyz/NumberField/8.0.5620066455663197695561554590870531303687507769819136.1)