### PR TITLE
to_dict: do not overwrite keys passed as input

### DIFF
--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -330,6 +330,9 @@ def to_dict(args, exclude = [], **kwds):
     """
     d = dict(kwds)
     for key, values in args.items():
+        # do not overwrite keys passed as input
+        if key in d:
+            continue
         if isinstance(values, list) and key not in exclude:
             if values:
                 d[key] = values[-1]


### PR DESCRIPTION
this prevents users (and bots) to overwrite variables in the info dictionary that were supposed to be set by the code, for example:
https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/?search_array=foobar

@AndrewVSutherland and @roed314, this should stop most of flasklog errors coming from www.lmfdb.org