### PR TITLE
Dirichlet character cleanup

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -69,7 +69,7 @@ def render_characterNavigation():
 
 class DirichSearchArray(SearchArray):
     jump_example = "13.2"
-    jump_egspan = "e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,·)\), or 13 for the group of characters modulo 13, or 13.f for characters in that Galois orbit."
+    jump_egspan = "e.g. 13.2 for the Dirichlet character \(\displaystyle\chi_{13}(2,·)\),or 13.f for its Galois orbit."
     jump_knowl="character.dirichlet.search_input"
     jump_prompt="Label"
     def __init__(self):
@@ -136,8 +136,8 @@ class DirichSearchArray(SearchArray):
 
     def search_types(self, info):
         return self._search_again(info, [
-            ('List', 'List of Dirichlet characters'),
-            ('Random', 'Random Dirichlet character')])
+            ('List', 'List of characters'),
+            ('Random', 'Random character')])
 
 def common_parse(info, query):
     parse_ints(info, query, "modulus", name="base field")

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -287,13 +287,17 @@ def render_DirichletNavigation():
         flash_error("Error raised in parsing: %s", err)
         return render_template('CharacterNavigate.html', title='Dirichlet characters')
 
-    info = to_dict(request.args, search_array=DirichSearchArray())
     if request.args:
         # hidden_search_type for prev/next buttons
+        info = to_dict(request.args, search_array=DirichSearchArray())
         info["search_type"] = search_type = info.get("search_type", info.get("hst", "List"))
         if search_type in ['List', 'Random']:
             return dirichlet_character_search(info)
         assert False
+    info = to_dict(request.args, search_array=DirichSearchArray(), stats=DirichStats())
+    info['title'] = 'Dirichlet characters'
+    return render_template('CharacterNavigate.html', info=info,**info)
+
 
 @characters_page.route("/Dirichlet/Labels")
 def labels_page():

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -2,10 +2,8 @@
 
 from __future__ import absolute_import
 from lmfdb.app import app
-import ast
 import re
-from six import BytesIO
-from flask import render_template, url_for, request, redirect, abort, send_file
+from flask import render_template, url_for, request, redirect, abort
 from sage.all import gcd, euler_phi
 from lmfdb.utils import (
     to_dict, flash_error, SearchArray, YesNoBox, display_knowl, ParityBox,
@@ -140,9 +138,9 @@ class DirichSearchArray(SearchArray):
             ('Random', 'Random character')])
 
 def common_parse(info, query):
-    parse_ints(info, query, "modulus", name="base field")
-    parse_ints(info, query, "conductor", name="base cardinality")
-    parse_ints(info, query, "order", name="dimension")
+    parse_ints(info, query, "modulus", name="modulus")
+    parse_ints(info, query, "conductor", name="conductor")
+    parse_ints(info, query, "order", name="order")
     if 'parity' in info:
         parity=info['parity']
         if parity == 'even':
@@ -189,49 +187,6 @@ def url_for_label(label):
     number = label_to_number(modulus, number)
     return url_for(".render_Dirichletwebpage", modulus=modulus, number=number)
 
-def download_search(info):
-    import time
-
-    dltype = info["Submit"]
-    #delim = "bracket"
-    com = r"\\"  # single line comment start
-    com1 = ""  # multiline comment start
-    com2 = ""  # multiline comment end
-    filename = "characters.gp"
-    mydate = time.strftime("%d %B %Y")
-    if dltype == "sage":
-        com = "#"
-        filename = "characters.sage"
-    if dltype == "magma":
-        com = ""
-        com1 = "/*"
-        com2 = "*/"
-        #delim = "magma"
-        filename = "characters.m"
-    s = com1 + "\n"
-    s += com + " Dirichlet character data downloaded from the LMFDB on %s.\n" % (mydate)
-    s += "\n" + com2
-    s += "\n"
-    #if dltype == "magma":
-    #    s += "P<x> := PolynomialRing(Integers()); \n"
-    #    s += "data := ["
-    #else:
-    #    if dltype == "sage":
-    #        s += "x = polygen(ZZ) \n"
-    #    s += "data = [ "
-    #s += "\\\n"
-    s= ""
-    for f in db.char_dir_orbits.search(ast.literal_eval(info["query"])):
-        s += str(f) + "\n"
-    #if delim == "magma":
-    #    s = s.replace("[", "[*")
-    #    s = s.replace("]", "*]")
-    #    s += ";"
-    strIO = BytesIO()
-    strIO.write(s.encode('utf-8'))
-    strIO.seek(0)
-    return send_file(strIO, attachment_filename=filename, as_attachment=True, add_etags=False)
-
 @search_wrap(
     template="character_search_results.html",
     table=db.char_dir_orbits,
@@ -239,7 +194,6 @@ def download_search(info):
     err_title="Dirichlet character search input error",
     shortcuts={
         "jump": jump,
-        "download": download_search
     },
     url_for_label=url_for_label,
     learnmore=learnmore_list,

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -20,7 +20,7 @@ from lmfdb.characters.web_character import (
         WebDBDirichletGroup,
 )
 from lmfdb.characters.web_character import WebHeckeExamples, WebHeckeFamily, WebHeckeGroup, WebHeckeCharacter
-from lmfdb.characters.ListCharacters import get_character_modulus, get_character_conductor, get_character_order, CharacterSearch
+from lmfdb.characters.ListCharacters import get_character_modulus, get_character_conductor, get_character_order
 from lmfdb.number_fields.web_number_field import WebNumberField
 from lmfdb.characters import characters_page
 from sage.databases.cremona import class_to_int
@@ -236,26 +236,15 @@ def label_to_number(modulus, number, all=False):
 @characters_page.route("/Dirichlet")
 @characters_page.route("/Dirichlet/")
 def render_DirichletNavigation():
-    info = to_dict(request.args, search_array=DirichSearchArray())
-    if request.args:
-        # hidden_search_type for prev/next buttons
-        info["search_type"] = search_type = info.get("search_type", info.get("hst", "List"))
-        if search_type in ['List', 'Random']:
-            return dirichlet_character_search(info)
-        assert False
-    #else:
-        #return dirichlet_character_browse(info)
-    args = to_dict(request.args)
-    info = {'args': request.args}
-    info['bread'] = get_bread()
-    info['learnmore'] = learn()
-
     try:
-        if 'modbrowse' in args:
-            arg = args['modbrowse']
+        if 'modbrowse' in request.args:
+            arg = request.args['modbrowse']
             arg = arg.split('-')
             modulus_start = int(arg[0])
             modulus_end = int(arg[1])
+            info = {'args': request.args}
+            info['bread'] = get_bread()
+            info['learnmore'] = learn()
             info['title'] = 'Dirichlet characters of modulus ' + str(modulus_start) + '-' + str(modulus_end)
             info['credit'] = 'Sage'
             h, c, rows, cols = get_character_modulus(modulus_start, modulus_end)
@@ -265,11 +254,14 @@ def render_DirichletNavigation():
             info['cols'] = cols
             return render_template("ModulusList.html", **info)
 
-        elif 'condbrowse' in args:
-            arg = args['condbrowse']
+        elif 'condbrowse' in request.args:
+            arg = request.args['condbrowse']
             arg = arg.split('-')
             conductor_start = int(arg[0])
             conductor_end = int(arg[1])
+            info = {'args': request.args}
+            info['bread'] = get_bread()
+            info['learnmore'] = learn()
             info['conductor_start'] = conductor_start
             info['conductor_end'] = conductor_end
             info['title'] = 'Dirichlet characters of conductor ' + str(conductor_start) + '-' + str(conductor_end)
@@ -277,56 +269,31 @@ def render_DirichletNavigation():
             info['contents'] = get_character_conductor(conductor_start, conductor_end + 1)
             return render_template("ConductorList.html", **info)
 
-        elif 'ordbrowse' in args:
-            arg = args['ordbrowse']
+        elif 'ordbrowse' in request.args:
+            arg = request.args['ordbrowse']
             arg = arg.split('-')
             order_start = int(arg[0])
             order_end = int(arg[1])
+            info = {'args': request.args}
+            info['bread'] = get_bread()
+            info['learnmore'] = learn()
             info['order_start'] = order_start
             info['order_end'] = order_end
             info['title'] = 'Dirichlet characters of orders ' + str(order_start) + '-' + str(order_end)
             info['credit'] = 'SageMath'
             info['contents'] = get_character_order(order_start, order_end + 1)
             return render_template("OrderList.html", **info)
-
-        elif 'label' in args:
-            label = args['label'].replace(' ','')
-            if re.match(r'^[1-9][0-9]*\.[1-9][0-9]*$', label):
-                slabel = label.split('.')
-                m,n = int(slabel[0]), int(slabel[1])
-                if m==n==1 or n < m and gcd(m,n) == 1:
-                    return redirect(url_for(".render_Dirichletwebpage", modulus=slabel[0], number=slabel[1]))
-            if re.match(r'^[1-9][0-9]*\.[a-z]+$', label):
-                slabel = label.split('.')
-                return redirect(url_for(".render_Dirichletwebpage", modulus=int(slabel[0]), number=slabel[1]))
-            if re.match(r'^[1-9][0-9]*$', label):
-                return redirect(url_for(".render_Dirichletwebpage", modulus=label), 301)
-
-            flash_error("%s is not a valid label for a Dirichlet character.  It should be of the form <span style='color:black'>q.n</span>, where q and n are coprime positive integers with n < q, or q=n=1.", label)
-            return render_template('CharacterNavigate.html', **info)
     except ValueError as err:
         flash_error("Error raised in parsing: %s", err)
         return render_template('CharacterNavigate.html', title='Dirichlet characters')
 
-    if args:
-        # if user clicked refine search, reset start to 0
-        if args.get('refine'):
-            args['start'] = '0'
-        try:
-            search = CharacterSearch(args)
-        except ValueError as err:
-            info['err'] = str(err)
-            return render_template("CharacterNavigate.html" if "search" in args else "character_search_results.html" , **info)
-        info['info'] = search.results()
-        info['title'] = 'Dirichlet character search results'
-        info['bread'] = get_bread(('Search results'))
-        info['credit'] = 'SageMath'
-        return render_template("character_search_results.html", **info)
-    else:
-        info = to_dict(request.args, search_array=DirichSearchArray(), stats=DirichStats())
-        info['title'] = 'Dirichlet characters'
-        return render_template('CharacterNavigate.html', info=info,**info)
-
+    info = to_dict(request.args, search_array=DirichSearchArray())
+    if request.args:
+        # hidden_search_type for prev/next buttons
+        info["search_type"] = search_type = info.get("search_type", info.get("hst", "List"))
+        if search_type in ['List', 'Random']:
+            return dirichlet_character_search(info)
+        assert False
 
 @characters_page.route("/Dirichlet/Labels")
 def labels_page():

--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -135,11 +135,7 @@
   {% if valuefield %}
   <tr>
     <td> {{KNOWL('character.dirichlet.value_field',title='Field of values')}}:</td>
-    {% if vflabel %}
-    <td> <a href="/NumberField/{{vflabel}}">{{ valuefield }}</a> </td>
-    {% else %}
     <td> {{ valuefield | safe }} </td>
-    {% endif %}
   </tr>
   {% endif %}
   {% if kerfield %}

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -32,9 +32,9 @@ table td.params {
   {% if n <= 5 %}
     {% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}
   {% else %}
-    <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
+    <a href="{{char.modulus}}/{{char.galois_orbit[0]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
     &nbsp;$\vdots$&nbsp;
-    <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
+    <a href="{{char.modulus}}/{{char.galois_orbit[n-1]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
   {% endif %}
 </td>
 <td class="center">{{char.label}}</a></td>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -27,7 +27,16 @@ table td.params {
 </thead>
 {% for char in info.results: %}
 <tr>
-    <td class="center">{% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}</td>
+<td class="center">
+  {% set n = char.galois_orbit | length %}
+  {% if n <= 5 %}
+    {% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}
+  {% else %}
+    <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
+    "&nbsp;$\vdots$&nbsp;"
+    <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
+  {% endif %}
+</td>
 <td class="center">{{char.label}}</a></td>
 <td class="center">{{char.modulus}}</td>
 <td class="center">{{char.conductor}}</td>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -33,7 +33,7 @@ table td.params {
     {% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}
   {% else %}
     <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
-    "&nbsp;$\vdots$&nbsp;"
+    &nbsp;$\vdots$&nbsp;
     <a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
   {% endif %}
 </td>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -33,7 +33,7 @@ table td.params {
     {% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}
   {% else %}
     <a href="{{char.modulus}}/{{char.galois_orbit[0]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
-    &nbsp;$\vdots$&nbsp;
+    &nbsp;$\vdots {{n-2}}$&nbsp;
     <a href="{{char.modulus}}/{{char.galois_orbit[n-1]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
   {% endif %}
 </td>

--- a/lmfdb/characters/templates/character_search_results.html
+++ b/lmfdb/characters/templates/character_search_results.html
@@ -33,7 +33,7 @@ table td.params {
     {% for num in char.galois_orbit %}<a href="{{char.modulus}}/{{num}}">\(\chi_{ {{char.modulus}} }({{num}}, \cdot)\)</a>{% endfor %}
   {% else %}
     <a href="{{char.modulus}}/{{char.galois_orbit[0]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[0]}}, \cdot)\)</a>
-    &nbsp;$\vdots {{n-2}}$&nbsp;
+    &nbsp;$\vdots$&nbsp;
     <a href="{{char.modulus}}/{{char.galois_orbit[n-1]}}">\(\chi_{ {{char.modulus}} }({{char.galois_orbit[n-1]}}, \cdot)\)</a>
   {% endif %}
 </td>

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -50,11 +50,11 @@ class DirichletSearchTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4')
         assert r'15.e' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7')
-        assert r'25.d,' in W.get_data(as_text=True)
+        assert r'25.d' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes')
-        assert r'25.d,' in W.get_data(as_text=True)
+        assert r'25.d' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No')
-        assert r'50.d,' in W.get_data(as_text=True)
+        assert r'50.d' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd')
         assert r'56.n' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even')
@@ -66,9 +66,9 @@ class DirichletSearchTest(LmfdbTest):
 
     def test_nextprev(self):
         W = self.tc.get('/Character/Dirichlet/?start=200&count=25&order=3')
-        assert r'288.i' in W.get_data(as_text=True) and r'\chi_{182}(113,' in W.get_data(as_text=True)
+        assert r'288.i' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?start=100&count=25&order=3')
-        assert r'169.c' in W.get_data(as_text=True) and r'\chi_{117}(40,' in W.get_data(as_text=True)
+        assert r'169.c' in W.get_data(as_text=True)
 
 class DirichletTableTest(LmfdbTest):
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -30,7 +30,7 @@ class DirichletSearchTest(LmfdbTest):
 
     def test_order(self):
         W = self.tc.get('/Character/Dirichlet/?order=19-23')
-        assert r'\chi_{25}(2' in W.get_data(as_text=True)
+        assert r'25.f' in W.get_data(as_text=True)
 
     def test_even_odd(self):
         W = self.tc.get('/Character/Dirichlet/?modulus=35')
@@ -47,28 +47,28 @@ class DirichletSearchTest(LmfdbTest):
         assert len(re.findall('Dirichlet/[0-9][0-9]/27',W.get_data(as_text=True))) == 20
 
     def test_search(self):
-        W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4&limit=25')
-        assert r'\chi_{15}(2,' in W.get_data(as_text=True) and r'\chi_{195}(53,' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&limit=25')
-        assert r'\chi_{25}(6,' in W.get_data(as_text=True) and r'\chi_{36}(7,' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes&limit=25')
-        assert r'\chi_{25}(6,' in W.get_data(as_text=True) and r'\chi_{36}(7,' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&limit=25')
-        assert r'\chi_{50}(11,' in W.get_data(as_text=True) and r'\chi_{72}(7,' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd&limit=25')
-        assert r'\chi_{56}(23,' in W.get_data(as_text=True) and r'\chi_{112}(79,' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even&limit=25')
-        assert r'\chi_{50}(11,' in W.get_data(as_text=True) and r'\chi_{75}(46,' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4')
+        assert r'15.e' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7')
+        assert r'25.d,' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes')
+        assert r'25.d,' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No')
+        assert r'50.d,' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd')
+        assert r'56.n' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even')
+        assert r'50.d' in W.get_data(as_text=True)
 
     def test_condsearch(self):
-        W = self.tc.get('/Character/Dirichlet/?conductor=111&limit=100')
-        assert '111/17' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/?conductor=111')
+        assert '111.m' in W.get_data(as_text=True)
 
     def test_nextprev(self):
         W = self.tc.get('/Character/Dirichlet/?start=200&count=25&order=3')
-        assert r'\chi_{169}(22,' in W.get_data(as_text=True) and r'\chi_{182}(113,' in W.get_data(as_text=True)
+        assert r'288.i' in W.get_data(as_text=True) and r'\chi_{182}(113,' in W.get_data(as_text=True)
         W = self.tc.get('/Character/Dirichlet/?start=100&count=25&order=3')
-        assert r'\chi_{97}(35,' in W.get_data(as_text=True) and r'\chi_{117}(40,' in W.get_data(as_text=True)
+        assert r'169.c' in W.get_data(as_text=True) and r'\chi_{117}(40,' in W.get_data(as_text=True)
 
 class DirichletTableTest(LmfdbTest):
 
@@ -86,7 +86,7 @@ class DirichletCharactersTest(LmfdbTest):
     def test_dirichletfamily(self):
         W = self.tc.get('/Character/Dirichlet/')
         assert 'Find' in W.get_data(as_text=True)
-        assert r'Dirichlet character \(\displaystyle\chi_{13}(2,&middot;)\)' in W.get_data(as_text=True)
+        assert r'13.2' in W.get_data(as_text=True)
 
     def test_dirichletgroup(self):
         W = self.tc.get('/Character/Dirichlet/23', follow_redirects=True)

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -69,7 +69,7 @@ from lmfdb.utils import web_latex
 from lmfdb.utils.utilities import num2letters
 from lmfdb.logger import make_logger
 from lmfdb.nfutils.psort import ideal_label, ideal_from_label
-from lmfdb.number_fields.web_number_field import WebNumberField, formatfield
+from lmfdb.number_fields.web_number_field import WebNumberField, formatfield, nf_display_knowl
 from lmfdb.characters.HeckeCharacters import HeckeChar, RayClassGroup
 from lmfdb.characters.TinyConrey import ConreyCharacter, kronecker_symbol, symbol_numerator
 from lmfdb.characters.utils import url_character, complex2str, evalpolelt

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -740,31 +740,26 @@ class WebChar(WebCharObject):
         return self.char2tex(self.conductor, self.indlabel)
 
     @lazy_attribute
-    def valuefield(self):
-        """ compute order """
-        order2 = self.order
-        if order2 % 4 == 2:
-            order2 = order2 / 2
-        if order2 == 1:
-            vf = r'\(\Q\)'
-        elif order2 == 4:
-            vf = r'\(\Q(i)\)'
-        else:
-            vf = r'\(\Q(\zeta_{%d})\)' % order2
-        return vf
-
-    @lazy_attribute
     def vflabel(self):
       order2 = self.order if self.order % 4 != 2 else self.order / 2
-      if order2 == 1:
-          return '1.1.1.1'
-      elif order2 == 4:
-          return '2.0.4.1'
-      valuewnf =  WebNumberField.from_cyclo(order2)
-      if not valuewnf.is_null():
-          return valuewnf.label
+      #if order2 == 1:
+      #    return '1.1.1.1'
+      #elif order2 == 4:
+      #    return '2.0.4.1'
+      nf =  WebNumberField.from_cyclo(order2)
+      if not nf.is_null():
+          return nf.label
       else:
           return ''
+
+    @lazy_attribute
+    def valuefield(self):
+        order2 = self.order if self.order % 4 != 2 else self.order / 2
+        nf =  WebNumberField.from_cyclo(order2)
+        if not nf.is_null():
+            return nf_display_knowl(nf.get_label(),nf.field_pretty())
+        else:
+            return r'$\Q(\zeta_{%d})$' % order2
 
     @lazy_attribute
     def kerfield(self):


### PR DESCRIPTION
Fixes pyflakes errors, minor formatting issues, value field number field display, and modifies search results to abbreviate rows for large Galois oribits.  

These are all straight forward fixes to minor problems caused by the last 3 PRs that were merged related ot Dirichlet characters.  I will merge this once tests pass then push to beta.

Download search results has been removed since we don't yet support downloads for Dirichlet characters in any form (there was code copied from abvars that I deleted).  Once we add downloads to Dirichlet character pages we can add them to search results (this mostly amounts to deciding how we want to handle Dirichlet characters in Sage and Magma where there is a dependency on code to handle Conrey characters that is not  built-in to Sage and Magma, Pari/GP does provide built-in support for Conrey characters.  In any case, I think it makes sense to defer dealing with downloads for Dirichlet characters to a separate PR, and I don't think we want to try and address this in 1.1.2 (which is almost done, only one more PR is pending!)
