### PR TITLE
Fix issue #4137

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -335,7 +335,7 @@ def render_artin_representation_webpage(label):
         friends.append(("Artin field", nf_url))
         wnf = the_nf.wnf()
     proj_nf = WebNumberField.from_coeffs(the_rep._data['Proj_Polynomial'])
-    if proj_nf:
+    if proj_nf._data:
         friends.append(("Projective Artin field", 
             str(url_for("number_fields.by_label", label=proj_nf.get_label()))))
     if case == 'rep':

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -233,7 +233,7 @@ class ArtinRepresentation(object):
             return 'data not computed'
         if projfield == [0,1]:
             return formatfield(projfield)
-        return 'Galois closure of ' + formatfield(projfield)
+        return 'Galois closure of ' + formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
 
     def number_field_galois_group(self):
         try:


### PR DESCRIPTION
Fixes server error when projective field of an Artin representation is not in the database.

http://beta.lmfdb.org/ArtinRepresentation/4.46348864.8t32.f.a
http://127.0.0.1:37777/ArtinRepresentation/4.46348864.8t32.f.a

The issue was that if you initialize a web number field with coefficients still in the database, you still get an object -- we should test that it has no data.