### PR TITLE
No backslash in bigint knowls

### DIFF
--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -742,18 +742,7 @@ def bigint_knowl(n, cutoff=20, max_width=70, sides=2):
     if abs(n) >= 10**cutoff:
         short = str(n)
         short = short[:sides] + r'\!\cdots\!' + short[-sides:]
-        lng = str(n)
-        if len(lng) > max_width:
-            lines = 1 + (len(lng)-1) // (max_width-1)
-            width = 1 + (len(lng)-1) // lines
-            lng = [lng[i:i+width] for i in range(0,len(lng),width)]
-            for i in range(len(lng)-1):
-                lng[i] = r"<tr><td>%s\</td></tr>" % lng[i]
-            lng[-1] = r"<tr><td>%s</td></tr>" % lng[-1]
-            lng = "<table>" + "".join(lng) + "</table>"
-        else:
-            lng = r"\(%s\)" % lng
-        return r'<a title="[bigint]" knowl="dynamic_show" kwargs="%s">\(%s\)</a>'%(lng, short)
+        return r'<a title = "%s [lmfdb.bigint]" knowl="lmfdb.bigint" kwargs="n=%s">\(%s\)</a>'%(str(n), str(n), short)
     else:
         return r'\(%s\)'%n
 def too_big(L, threshold):

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -742,7 +742,8 @@ def bigint_knowl(n, cutoff=20, max_width=70, sides=2):
     if abs(n) >= 10**cutoff:
         short = str(n)
         short = short[:sides] + r'\!\cdots\!' + short[-sides:]
-        return r'<a title = "%s [lmfdb.bigint]" knowl="lmfdb.bigint" kwargs="n=%s">\(%s\)</a>'%(str(n), str(n), short)
+        lng = r"<div style='word-break: break-all'>%s</div>" % n
+        return r'<a title="[bigint]" knowl="dynamic_show" kwargs="%s">\(%s\)</a>'%(lng, short)
     else:
         return r'\(%s\)'%n
 def too_big(L, threshold):


### PR DESCRIPTION
The mechanism for really big integers are bigint knowls.  They show the first and last few digits of a long integer, and when you click on them, they show the whole integer.

Currently, the whole integer is chopped in to shorter segments which are displayed one per line with a backslash at the end of the line.  It looks a little odd since they are often making line breaks well before the right edge of the knowl.

This lets the number fill the full width of the knowl making line breaks as needed.  It does not have backslashes, but it should be clear from context that it is one number.  Copy/paste on my computer (a mac) from the knowl to gp worked -- a number came out as a single number with no spaces in it.

You find examples with any 70 dimensional Artin representation when it displays the conductor, such as

https://beta.lmfdb.org/ArtinRepresentation/70.1625012875268223522741925842919237945608418278728038019050407698613377540450476434262177005081112675355174880997614206454094148518111440366016816993675386871265126951159231315183723857114542315019948516990684524211350582386274256302319735286735377221032192623406120285134889286024542801896687264660667397927236930056749658430157515888210243211384210565144952426416319369731387633068614131902211436436420439984535966131444311824635794922026350522955632528005529986919971085407374210548824539136.120.a.a

http://127.0.0.1:37777//ArtinRepresentation/70.1625012875268223522741925842919237945608418278728038019050407698613377540450476434262177005081112675355174880997614206454094148518111440366016816993675386871265126951159231315183723857114542315019948516990684524211350582386274256302319735286735377221032192623406120285134889286024542801896687264660667397927236930056749658430157515888210243211384210565144952426416319369731387633068614131902211436436420439984535966131444311824635794922026350522955632528005529986919971085407374210548824539136.120.a.a
