### PR TITLE
fixing configuration and command line arguments

### DIFF
--- a/lmfdb/backend/config.py
+++ b/lmfdb/backend/config.py
@@ -127,11 +127,7 @@ class Configuration(object):
             return sec, opt
 
         # 1: parsing command-line arguments
-        if  writeargstofile:
-            args = parser.parse_args()
-        else:
-            # only read config file
-            args = parser.parse_args([])
+        args = parser.parse_args()
         args_dict = vars(args)
         default_arguments_dict = vars(parser.parse_args([]))
 
@@ -183,19 +179,19 @@ class Configuration(object):
             _cfgp.read(args.secrets_file)
 
         # 3: override specific settings
-        def all(sep="_"):
+        def file_to_args(sep="_"):
             ret = {}
             for s in _cfgp.sections():
                 for k, v in _cfgp.items(s):
                     ret["%s%s%s" % (s, sep, k)] = v
             return ret
 
-        all_set = all()
+        args_file = file_to_args()
 
         for key, val in default_arguments_dict.items():
             # if a nondefault value was passed through command line arguments set it
             # or if a default value was not set in the config file
-            if args_dict[key] != val or key not in all_set:
+            if args_dict[key] != val or key not in args_file:
                 sec, opt = sec_opt(key)
                 if sec not in _cfgp.sections():
                     _cfgp.add_section(sec)

--- a/lmfdb/backend/config.py
+++ b/lmfdb/backend/config.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import
 import os, argparse
 from six.moves.configparser import ConfigParser
 from collections import defaultdict
+from copy import deepcopy
 
 def strbool(s):
     """
@@ -34,6 +35,7 @@ class Configuration(object):
       - ``postgresql_port`` -- an integer, the port to use when connecting to the database
       - ``postgresql_user`` -- the username when connecting to the database
       - ``postgresql_password`` -- the password for connecting to the database
+      - ``writeargstofile`` - a boolean, if config file doesn't exist, it determines if command line arguments are written to the config file instead of the default arguments
     """
     def __init__(self, parser=None, defaults={}, writeargstofile=False):
         if parser is None:
@@ -116,6 +118,14 @@ class Configuration(object):
                 default="lmfdb",
             )
 
+        def sec_opt(key):
+            if "_" in key:
+                sec, opt = key.split("_", 1)
+            else:
+                sec = "misc"
+                opt = key
+            return sec, opt
+
         # 1: parsing command-line arguments
         if  writeargstofile:
             args = parser.parse_args()
@@ -124,22 +134,19 @@ class Configuration(object):
             args = parser.parse_args([])
         args_dict = vars(args)
         default_arguments_dict = vars(parser.parse_args([]))
-        if writeargstofile:
-            default_arguments_dict = dict(args_dict)
 
         del default_arguments_dict["config_file"]
         del default_arguments_dict["secrets_file"]
 
-        self.default_args = {}
+        self.default_args = defaultdict(dict)
         for key, val in default_arguments_dict.items():
-            sec, opt = key.split("_", 1)
-            if sec not in self.default_args:
-                self.default_args[sec] = {}
+            sec, opt = sec_opt(key)
             self.default_args[sec][opt] = str(val)
 
         # reading the config file, creating it if necessary
         # 2/1: does config file exist?
         if not os.path.exists(args.config_file):
+            write_args = deepcopy(self.default_args)
             if not writeargstofile:
                 print(
                     "Config file: %s not found, creating it with the default values"
@@ -150,10 +157,17 @@ class Configuration(object):
                     "Config file: %s not found, creating it with the passed values"
                     % args.config_file
                 )
-            _cfgp = ConfigParser()
+                # overwrite default arguments passed via command line args
+                for key, val in args_dict.items():
+                    if key in default_arguments_dict:
+                        sec, opt = sec_opt(key)
+                        write_args[sec][opt] = str(val)
 
+
+
+            _cfgp = ConfigParser()
             # create sections
-            for sec, options in self.default_args.items():
+            for sec, options in write_args.items():
                 _cfgp.add_section(sec)
                 for opt, val in options.items():
                     _cfgp.set(sec, opt, str(val))
@@ -182,11 +196,9 @@ class Configuration(object):
             # if a nondefault value was passed through command line arguments set it
             # or if a default value was not set in the config file
             if args_dict[key] != val or key not in all_set:
-                if "_" in key:
-                    sec, opt = key.split("_")
-                else:
-                    sec = "misc"
-                    opt = key
+                sec, opt = sec_opt(key)
+                if sec not in _cfgp.sections():
+                    _cfgp.add_section(sec)
                 _cfgp.set(sec, opt, str(args_dict[key]))
 
         # We can derive the types from the parser

--- a/lmfdb/backend/config.py
+++ b/lmfdb/backend/config.py
@@ -37,7 +37,7 @@ class Configuration(object):
       - ``postgresql_password`` -- the password for connecting to the database
       - ``writeargstofile`` - a boolean, if config file doesn't exist, it determines if command line arguments are written to the config file instead of the default arguments
     """
-    def __init__(self, parser=None, defaults={}, writeargstofile=False):
+    def __init__(self, parser=None, defaults={}, writeargstofile=False, readargs=True):
         if parser is None:
             parser = argparse.ArgumentParser(description="Default psycodict parser")
 
@@ -127,7 +127,12 @@ class Configuration(object):
             return sec, opt
 
         # 1: parsing command-line arguments
-        args = parser.parse_args()
+        if  readargs:
+            args = parser.parse_args()
+        else:
+            # only read config file
+            args = parser.parse_args([])
+
         args_dict = vars(args)
         default_arguments_dict = vars(parser.parse_args([]))
 

--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -82,13 +82,6 @@ class Configuration(_Configuration):
             dest="core_debug",
             help="enable debug mode",
         )
-        parser.add_argument(
-            "--disable-debug",
-            dest="core_debug",
-            help="disable debug mode",
-            action="store_false",
-            default=argparse.SUPPRESS,
-        )
 
         parser.add_argument(
             "--color",

--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -82,6 +82,13 @@ class Configuration(_Configuration):
             dest="core_debug",
             help="enable debug mode",
         )
+        parser.add_argument(
+            "--disable-debug",
+            dest="core_debug",
+            help="disable debug mode",
+            action="store_false",
+            default=argparse.SUPPRESS,
+        )
 
         parser.add_argument(
             "--color",

--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -50,7 +50,7 @@ def get_secret_key():
 
 
 class Configuration(_Configuration):
-    def __init__(self, writeargstofile=False):
+    def __init__(self, writeargstofile=False, readargs=False):
         default_config_file = abs_path_lmfdb("config.ini")
 
         # 1: parsing command-line arguments
@@ -230,8 +230,10 @@ class Configuration(_Configuration):
             action="store_false",
             default=argparse.SUPPRESS,
         )
-        writeargstofile = writeargstofile or os.path.split(sys.argv[0])[-1] == "start-lmfdb.py"
-        _Configuration.__init__(self, parser, writeargstofile=writeargstofile)
+        fnargv0 = os.path.split(sys.argv[0])[-1]
+        writeargstofile = writeargstofile or fnargv0 == "start-lmfdb.py"
+        readargs = readargs or writeargstofile
+        _Configuration.__init__(self, parser, writeargstofile=writeargstofile, readargs=readargs)
 
         opts = self.options
         extopts = self.extra_options
@@ -287,4 +289,4 @@ class Configuration(_Configuration):
 
 
 if __name__ == "__main__":
-    Configuration(writeargstofile=True)
+    Configuration(writeargstofile=True, readargs=True)

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -108,7 +108,7 @@ def main():
 
     if "profiler" in flask_options and flask_options["profiler"]:
         info("Profiling!")
-        from werkzeug.contrib.profiler import ProfilerMiddleware
+        from werkzeug.middleware.profiler import ProfilerMiddleware
 
         app.wsgi_app = ProfilerMiddleware(
             app.wsgi_app, restrictions=[30], sort_by=("cumulative", "time", "calls")


### PR DESCRIPTION
- one can again use optional command-line arguments `--enable-profiler`
- these that precedence on whatever is read from the config file
- added the option `--disable-debug` to disable debug mode
- if there is no config file, we create one with all the default options, but the values passed via the command line optional take precedence over the default ones.
For example, running `sage -python start-lmfdb.py --disable-debug --port 5555 --color=17` for the first time will result in
```
[core]
debug = False
color = 17

[web]
port = 5555
...
```
