### PR TITLE
Display Hecke charpolys. Add test. PEP8 blank lines

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
@@ -179,8 +179,4 @@ function show_qexp(qstyle) {
 </div>
 {% endif %}
 
-<h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
-
-{{ space.display_hecke_char_polys() | safe }}
-
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
@@ -179,9 +179,8 @@ function show_qexp(qstyle) {
 </div>
 {% endif %}
 
-{#
 <h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
 
 {{ space.display_hecke_char_polys() | safe }}
-#}
+
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -223,9 +223,8 @@ function get_all_embeddings(num_embeddings) {
 {{ newform.display_hecke_cutters() | safe }}
 {% endif %}
 
-{#
 <h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
 
 {{ newform.display_hecke_char_polys() | safe }}
-#}
+
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_space.html
@@ -191,9 +191,8 @@ function show_qexp(qstyle) {
 </div>
 {% endif %}
 
-{#
 <h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
 
 {{ space.display_hecke_char_polys() | safe }}
-#}
+
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_space.html
@@ -191,8 +191,4 @@ function show_qexp(qstyle) {
 </div>
 {% endif %}
 
-<h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
-
-{{ space.display_hecke_char_polys() | safe }}
-
 {% endblock %}

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -422,7 +422,6 @@ class CmfTest(LmfdbTest):
             assert r'0.990338' in page.get_data(as_text=True)
             assert r'0.550990' in page.get_data(as_text=True)
 
-
         for url in ['/ModularForm/GL2/Q/holomorphic/5/9/c/a/?n=2-10&m=1-6&prec=6&format=satake',
                 '/ModularForm/GL2/Q/holomorphic/5/9/c/a/2/1/',
                 '/ModularForm/GL2/Q/holomorphic/5/9/c/a/3/1/',
@@ -437,7 +436,6 @@ class CmfTest(LmfdbTest):
                 ]:
             page = self.tc.get(url)
             assert '0.00593626' in page.get_data(as_text=True)
-
 
         for url in ['/ModularForm/GL2/Q/holomorphic/31/2/c/a/?m=1-4&n=2-10&prec=6&format=satake',
                 '/ModularForm/GL2/Q/holomorphic/31/2/c/a/5/1/',
@@ -615,7 +613,6 @@ class CmfTest(LmfdbTest):
         assert '-0.498394' in page.get_data(as_text=True)
         assert '0.406839418685' in page.get_data(as_text=True)
         assert '1.2.3.c9' in page.get_data(as_text=True) # Sato-Tate group
-
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_full_space/20.5', follow_redirects = True)
         assert r"""["20.5.b.a", "20.5.d.a", "20.5.d.b", "20.5.d.c", "20.5.f.a"]""" in page.get_data(as_text=True)
@@ -891,7 +888,7 @@ class CmfTest(LmfdbTest):
 
     def test_Fricke_signs_search(self):
         r"""
-        Test that we display Fricke sings
+        Test that we display Fricke signs
         """
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15%2C20&weight=2&dim=1&search_type=List',  follow_redirects=True)
         assert 'Fricke sign' in page.get_data(as_text=True)
@@ -930,13 +927,30 @@ class CmfTest(LmfdbTest):
                                   97: r'\( 7938 + 126 T + T^{2} \)'},
 
                     '/294/5/b/f' : {2: r'\( ( 8 + T^{2} )^{5} \)',
-                                    7: r'\( ( T )^{10} \)'},
+                                    # The following test checks that monomials do not have superfluous parentheses
+                                    7: r'\( T^{10} \)'},
 
-                    # The following is a newspace with 5 newforms, hence the more verbose polynomials
+                    # The following is a newspace with 5 newforms, hence the more verbose polynomials.
+                    # These newspace examples have historically also been prone to superfluous parentheses
+                    # (e.g. LMFDB Issue #4117)
 
-                    '255/1/h/' : {2: r'(\( 1 + T \))(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( ( T )^{2} \))',
+                    '255/1/h/' : {2: r'(\( 1 + T \))(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( T^{2} \))',
                                   3: r'(\( 1 + T \))(\( -1 + T \))(\( 1 + T \))(\( -1 + T \))(\( 1 + T^{2} \))',
-                                  5: r'(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( 1 + T \))(\( 1 + T^{2} \))'}
+                                  5: r'(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( 1 + T \))(\( 1 + T^{2} \))'},
+
+                    # The following is a newspace with 9 newforms, but only 7 have been computed exactly.
+                    # This also checks correct parentheses
+
+                    '4866/2/a/' : {2: r'\( ( 1 + T )^{2} \)\( ( -1 + T )^{11} \)\( ( 1 + T )^{13} \)\( ( 1 + T )^{14} \)\( ( -1 + T )^{14} \)\( ( 1 + T )^{17} \)\( ( -1 + T )^{20} \)',
+                                   3: r'\( ( -1 + T )^{2} \)\( ( -1 + T )^{11} \)\( ( 1 + T )^{13} \)\( ( -1 + T )^{14} \)\( ( 1 + T )^{14} \)\( ( -1 + T )^{17} \)\( ( 1 + T )^{20} \)'},
+
+                    # The last one is the original issue highlighted in #4117
+
+                    '81/2/c/' : {# We want to put brackets around each monomial power for newspaces, to make it clear that we are taking a product over multiple distinct newforms
+                                 3: r'(\( T^{2} \))(\( T^{4} \))',
+                                 5: r'(\( T^{2} \))(\( 9 + 3 T^{2} + T^{4} \))',
+                                 # We *DO NOT* want extra parentheses around powers of non-monomial polynomials
+                                 7: r'(\( 1 - T + T^{2} \))\( ( 4 + 2 T + T^{2} )^{2} \)'}
                     }
 
         charpoly_test_string = "<td>${}$</th>\n<td>{}</th>"

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -6,6 +6,7 @@ import unittest2, socket
 from . import cmf_logger
 cmf_logger.setLevel(100)
 
+
 class CmfTest(LmfdbTest):
     def runTest():
         pass
@@ -160,7 +161,7 @@ class CmfTest(LmfdbTest):
         assert "No matches" in page.get_data(as_text=True)
         assert "Only for weight 1" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/maria/', follow_redirects=True)
-        assert 'maria' in page.get_data(as_text=True) and "is not a valid newform" in page.get_data(as_text=True)   
+        assert 'maria' in page.get_data(as_text=True) and "is not a valid newform" in page.get_data(as_text=True)
 
     def test_delta(self):
         r"""
@@ -236,7 +237,6 @@ class CmfTest(LmfdbTest):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/12/6/a/")
         for elt in ['Decomposition', r'S_{6}^{\mathrm{old}}(\Gamma_0(12))', 'lower level spaces']:
             assert elt in page.get_data(as_text=True)
-
 
     def test_not_in_db(self):
         # The following redirects to "ModularForm/GL2/Q/holomorphic/12000/12/"
@@ -385,7 +385,6 @@ class CmfTest(LmfdbTest):
 
             assert '13.2.e.a.4.1' in page.get_data(as_text=True)
             assert '13.2.e.a.10.1' in page.get_data(as_text=True)
-
 
     def test_satake(self):
         for url in ['/ModularForm/GL2/Q/holomorphic/11/2/a/a/?format=satake',
@@ -549,10 +548,6 @@ class CmfTest(LmfdbTest):
         assert 'up to 1000 are available' in page.get_data(as_text=True)
         assert 'a_{1000}' in page.get_data(as_text=True)
 
-
-
-
-
     def test_download_qexp(self):
         for label, exp in [
                 ['11.7.b.a'
@@ -630,7 +625,6 @@ class CmfTest(LmfdbTest):
         assert "244.4.w" in page.get_data(as_text=True)
 
     def test_download_magma(self):
-
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newform_to_magma/23.1.b.a.z')
         assert 'Label not found' in page.get_data(as_text=True)
 
@@ -682,9 +676,6 @@ class CmfTest(LmfdbTest):
             print("Connecting with magma.maths.usyd.edu.au timed out")
             print(err)
 
-
-
-
     def test_download_search(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=Traces', follow_redirects = True)
         assert '5.10.a.a' in page.get_data(as_text=True)
@@ -702,8 +693,6 @@ class CmfTest(LmfdbTest):
         assert 'Error: We limit downloads of traces to' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+30000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
         assert '863.2.c' in page.get_data(as_text=True)
-
-
 
     def test_random(self):
         r"""
@@ -731,7 +720,6 @@ class CmfTest(LmfdbTest):
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/random?level=%s' % l, follow_redirects = True)
             check(page)
 
-
     def test_dimension(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=10&weight=1-14&dim=1&search_type=List', follow_redirects = True)
         assert "14 matches" in page.get_data(as_text=True)
@@ -751,9 +739,6 @@ class CmfTest(LmfdbTest):
         assert "Results (4 matches)" in page.get_data(as_text=True)
         for elt in map(str,[17,0,-80,60,3780,-1200]):
             assert elt in page.get_data(as_text=True)
-
-
-
 
     def test_trivial_searches(self):
         from sage.all import Subsets
@@ -792,7 +777,6 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=even&char_parity=even&weight=3&search_type=List')
         assert "No matches" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?weight_parity=even&char_parity=odd&search_type=List')
-
 
     def test_coefficient_fields(self):
         r"""
@@ -848,7 +832,6 @@ class CmfTest(LmfdbTest):
         assert "nontrivial" in page.get_data(as_text=True)
         assert "inner twist" in page.get_data(as_text=True)
 
-
     def test_self_twist(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
         for elt in [r'\Q(\sqrt{-591})', r'\Q(\sqrt{-15})', r'\Q(\sqrt{985})']:
@@ -856,7 +839,6 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/1124/1/d/a/')
         for elt in [r'\Q(\sqrt{-281})', r'\Q(\sqrt{-1})', r'\Q(\sqrt{281})']:
             assert elt in page.get_data(as_text=True)
-
 
     def test_selft_twist_disc(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-40&weight=1-6&self_twist_discs=-3&search_type=List')
@@ -871,7 +853,6 @@ class CmfTest(LmfdbTest):
         for d in [3,-5]:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=1-100&self_twist_discs=%d&search_type=List' % d)
             assert 'is not a valid input for' in page.get_data(as_text=True)
-
 
     def test_projective(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/2955/1/c/e/')
@@ -908,10 +889,6 @@ class CmfTest(LmfdbTest):
         assert 'AL-dims.' in page.get_data(as_text=True)
         assert r'\(0\)+\(1\)+\(0\)+\(0\)' in page.get_data(as_text=True)
 
-
-
-
-
     def test_Fricke_signs_search(self):
         r"""
         Test that we display Fricke sings
@@ -921,13 +898,11 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?char_order=1&search_type=List',  follow_redirects=True)
         assert 'Fricke sign' in page.get_data(as_text=True)
 
-
     def displaying_weight1_search(self):
         for typ in ['List', 'Traces', 'Dimensions']:
             for search in ['weight=1', 'rm_discs=5','has_self_twist=rm','cm_discs=-3%2C+-39']:
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?%s&search_type=%s' % (search, typ),  follow_redirects=True)
                 assert 'Only for weight 1:' in page.get_data(as_text=True)
-
 
     def test_is_self_dual(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?is_self_dual=yes&search_type=List' ,  follow_redirects=True)
@@ -937,4 +912,36 @@ class CmfTest(LmfdbTest):
         for elt in ['52.1.j.a', '57.1.h.a', '111.1.h.a']:
             assert elt in page.get_data(as_text=True)
 
+    def test_hecke_charpolys(self):
+        """Test that the Hecke charpolys are correct.
 
+        Some expected Hecke charpolys are stored in the dict test_data,
+        which are then checked to be in the relevant page. These examples
+        have been chosen to be readily verifiable from the displayed
+        Fourier coefficients of each respective homepage."""
+
+        test_data = {
+                    '11/2/a/a' : {2: '\( 2 + T \)',
+                                 17: '\( 2 + T \)',
+                                 29: '\( T \)'},
+
+                    '10/3/c/a' :  {5: r'\( 25 + T^{2} \)',
+                                  11: r'\( ( 8 + T )^{2} \)',
+                                  97: r'\( 7938 + 126 T + T^{2} \)'},
+
+                    '/294/5/b/f' : {2: r'\( ( 8 + T^{2} )^{5} \)',
+                                    7: r'\( ( T )^{10} \)'},
+
+                    # The following is a newspace with 5 newforms, hence the more verbose polynomials
+
+                    '255/1/h/' : {2: r'(\( 1 + T \))(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( ( T )^{2} \))',
+                                  3: r'(\( 1 + T \))(\( -1 + T \))(\( 1 + T \))(\( -1 + T \))(\( 1 + T^{2} \))',
+                                  5: r'(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( 1 + T \))(\( 1 + T^{2} \))'}
+                    }
+
+        charpoly_test_string = "<td>${}$</th>\n<td>{}</th>"
+
+        for label, some_expected_charpolys in test_data.items():
+            page_as_text = self.tc.get('/ModularForm/GL2/Q/holomorphic/{}/'.format(label), follow_redirects=True).get_data(as_text=True)
+            for p, expected_pth_charpoly in some_expected_charpolys.items():
+                assert charpoly_test_string.format(p, expected_pth_charpoly) in page_as_text

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -917,40 +917,20 @@ class CmfTest(LmfdbTest):
         have been chosen to be readily verifiable from the displayed
         Fourier coefficients of each respective homepage."""
 
-        test_data = {
+        test_data = {# Dimension 1
                     '11/2/a/a' : {2: '\( 2 + T \)',
                                  17: '\( 2 + T \)',
                                  29: '\( T \)'},
 
+                    # Dimension 2
                     '10/3/c/a' :  {5: r'\( 25 + T^{2} \)',
                                   11: r'\( ( 8 + T )^{2} \)',
                                   97: r'\( 7938 + 126 T + T^{2} \)'},
 
+                    # Dimension 5
                     '/294/5/b/f' : {2: r'\( ( 8 + T^{2} )^{5} \)',
                                     # The following test checks that monomials do not have superfluous parentheses
                                     7: r'\( T^{10} \)'},
-
-                    # The following is a newspace with 5 newforms, hence the more verbose polynomials.
-                    # These newspace examples have historically also been prone to superfluous parentheses
-                    # (e.g. LMFDB Issue #4117)
-
-                    '255/1/h/' : {2: r'(\( 1 + T \))(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( T^{2} \))',
-                                  3: r'(\( 1 + T \))(\( -1 + T \))(\( 1 + T \))(\( -1 + T \))(\( 1 + T^{2} \))',
-                                  5: r'(\( 1 + T \))(\( -1 + T \))(\( -1 + T \))(\( 1 + T \))(\( 1 + T^{2} \))'},
-
-                    # The following is a newspace with 9 newforms, but only 7 have been computed exactly.
-                    # This also checks correct parentheses
-
-                    '4866/2/a/' : {2: r'\( ( 1 + T )^{2} \)\( ( -1 + T )^{11} \)\( ( 1 + T )^{13} \)\( ( 1 + T )^{14} \)\( ( -1 + T )^{14} \)\( ( 1 + T )^{17} \)\( ( -1 + T )^{20} \)',
-                                   3: r'\( ( -1 + T )^{2} \)\( ( -1 + T )^{11} \)\( ( 1 + T )^{13} \)\( ( -1 + T )^{14} \)\( ( 1 + T )^{14} \)\( ( -1 + T )^{17} \)\( ( 1 + T )^{20} \)'},
-
-                    # The last one is the original issue highlighted in #4117
-
-                    '81/2/c/' : {# We want to put brackets around each monomial power for newspaces, to make it clear that we are taking a product over multiple distinct newforms
-                                 3: r'(\( T^{2} \))(\( T^{4} \))',
-                                 5: r'(\( T^{2} \))(\( 9 + 3 T^{2} + T^{4} \))',
-                                 # We *DO NOT* want extra parentheses around powers of non-monomial polynomials
-                                 7: r'(\( 1 - T + T^{2} \))\( ( 4 + 2 T + T^{2} )^{2} \)'}
                     }
 
         charpoly_test_string = "<td>${}$</th>\n<td>{}</th>"
@@ -959,3 +939,8 @@ class CmfTest(LmfdbTest):
             page_as_text = self.tc.get('/ModularForm/GL2/Q/holomorphic/{}/'.format(label), follow_redirects=True).get_data(as_text=True)
             for p, expected_pth_charpoly in some_expected_charpolys.items():
                 assert charpoly_test_string.format(p, expected_pth_charpoly) in page_as_text
+
+        # Check large dimensions behave as we expect. The following is a form of dimension 108
+
+        large_dimension_page_as_text = self.tc.get('/ModularForm/GL2/Q/holomorphic/671/2/i/a/', follow_redirects=True).get_data(as_text=True)
+        assert "There are no characteristic polynomials of Hecke operators in the database" in large_dimension_page_as_text

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -933,7 +933,7 @@ class CmfTest(LmfdbTest):
                                     7: r'\( T^{10} \)'},
                     }
 
-        charpoly_test_string = "<td>${}$</th>\n<td>{}</th>"
+        charpoly_test_string = '<td align="left">${}$</td>\n<td>{}</td>'
 
         for label, some_expected_charpolys in test_data.items():
             page_as_text = self.tc.get('/ModularForm/GL2/Q/holomorphic/{}/'.format(label), follow_redirects=True).get_data(as_text=True)

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -134,28 +134,18 @@ def display_hecke_polys(form_label, num_disp = 5):
     - ``form_label`` - a string, the label of the newform
     - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
     """
-    #from time import clock
-    def th_wrap(kwl, title):
-        return '    <th>%s</th>' % display_knowl(kwl, title=title)
-    def td_wrap(val):
-        return '    <td>$%s$</th>' % val
 
     data = db.mf_newforms.lookup(form_label, ['hecke_orbit_code'])
     orbit_code = data['hecke_orbit_code']
     hecke_polys_orbits = {}
-    #factor_time = 0
     for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : orbit_code}):
         coeffs = poly_item['charpoly_factorization']
-        #t2 = clock()
         F_p = list_factored_to_factored_poly_otherorder(coeffs)
-        #t3 = clock()
-        #factor_time += (t3-t2)
         F_p = make_bigint(r'\( %s \)' % F_p)
         if (F_p != r"\( 1 \)") and (len(F_p) > 6):
             hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
         else:
             hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "")
-    #print "factoring took " + str(factor_time)
     if not hecke_polys_orbits:
         return "There are no characteristic polynomials of Hecke operators in the database"
     polys = ['<div style="max-width: 100%; overflow-x: auto;">',
@@ -171,7 +161,7 @@ def display_hecke_polys(form_label, num_disp = 5):
             polys.append('  <tr>')
         else:
             polys.append('  <tr class="more nodisplay">')
-        polys.extend([td_wrap(p), '<td>' + charpoly + '</th>'])
+        polys.extend([td_wrapl('${}$'.format(p)), '<td>' + charpoly + '</td>'])
         polys.append('  </tr>')
         loop_count += 1
     if loop_count > num_disp:

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -17,12 +17,13 @@ from lmfdb.utils import (
     web_latex_poly, bigint_knowl, bigpoly_knowl, too_big, make_bigint,
     display_float, display_complex, round_CBF_to_half_int, polyquo_knowl,
     display_knowl, factor_base_factorization_latex,
-    integer_options, names_and_urls, web_latex_factored_integer, prop_int_pretty)
+    integer_options, names_and_urls, web_latex_factored_integer, prop_int_pretty,
+    list_factored_to_factored_poly_otherorder)
 from lmfdb.number_fields.web_number_field import nf_display_knowl
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.galois_groups.transitive_group import small_group_label_display_knowl
 from lmfdb.sato_tate_groups.main import st_link, get_name
-from .web_space import convert_spacelabel_from_conrey, get_bread, cyc_display, display_hecke_polys
+from .web_space import convert_spacelabel_from_conrey, get_bread, cyc_display
 
 LABEL_RE = re.compile(r"^[0-9]+\.[0-9]+\.[a-z]+\.[a-z]+$")
 EMB_LABEL_RE = re.compile(r"^[0-9]+\.[0-9]+\.[a-z]+\.[a-z]+\.[0-9]+\.[0-9]+$")
@@ -118,6 +119,77 @@ def td_wrapr(val):
 
 def parity_text(val):
     return 'odd' if val == -1 else 'even'
+
+def display_hecke_polys(form_label, num_disp = 5):
+    """
+    Display a table of the characteristic polynomials of the Hecke operators
+    for small primes. The number of primes presented by default is 5, although
+    there is a "show more" / "show less" button to display all primes up to 97.
+    The code for the table wrapping, scrolling etc. is common with many others
+    and should be eventually replaced by a call to a single class/function with
+    some parameters.
+
+    INPUT:
+
+    - ``form_label`` - a string, the label of the newform
+    - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
+    """
+    #from time import clock
+    def th_wrap(kwl, title):
+        return '    <th>%s</th>' % display_knowl(kwl, title=title)
+    def td_wrap(val):
+        return '    <td>$%s$</th>' % val
+
+    data = db.mf_newforms.lookup(form_label, ['hecke_orbit_code'])
+    orbit_code = data['hecke_orbit_code']
+    hecke_polys_orbits = {}
+    #factor_time = 0
+    for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : orbit_code}):
+        coeffs = poly_item['charpoly_factorization']
+        #t2 = clock()
+        F_p = list_factored_to_factored_poly_otherorder(coeffs)
+        #t3 = clock()
+        #factor_time += (t3-t2)
+        F_p = make_bigint(r'\( %s \)' % F_p)
+        if (F_p != r"\( 1 \)") and (len(F_p) > 6):
+            hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
+        else:
+            hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "")
+    #print "factoring took " + str(factor_time)
+    if not hecke_polys_orbits:
+        return "There are no characteristic polynomials of Hecke operators in the database"
+    polys = ['<div style="max-width: 100%; overflow-x: auto;">',
+             '<table class="ntdata">', '<thead>', '  <tr>',
+             th_wrap('p', '$p$'),
+             th_wrap('charpoly', '$F_p(T)$'),
+             '  </tr>', '</thead>', '<tbody>']
+    loop_count = 0
+    for p, charpoly in hecke_polys_orbits.items():
+        if charpoly.strip() == "":
+            charpoly = "1"
+        if loop_count < num_disp:
+            polys.append('  <tr>')
+        else:
+            polys.append('  <tr class="more nodisplay">')
+        polys.extend([td_wrap(p), '<td>' + charpoly + '</th>'])
+        polys.append('  </tr>')
+        loop_count += 1
+    if loop_count > num_disp:
+        polys.append('''
+            <tr class="less toggle">
+                <td colspan="{{colspan}}">
+                  <a onclick="show_moreless(&quot;more&quot;); return true" href="#moreep">show more</a>
+                </td>
+            </tr>
+            <tr class="more toggle nodisplay">
+                <td colspan="{{colspan}}">
+                  <a onclick="show_moreless(&quot;less&quot;); return true" href="#eptable">show less</a>
+                </td>
+            </tr>
+            ''')
+        polys.extend(['</tbody>', '</table>', '</div>'])
+    return '\n'.join(polys)
+
 
 class WebNewform(object):
     def __init__(self, data, space=None, all_m = False, all_n = False, embedding_label = None):
@@ -979,8 +1051,8 @@ function switch_basis(btype) {
         return '\n'.join(twists)
 
     def display_hecke_char_polys(self, num_disp = 5):
-        return display_hecke_polys([self.label], num_disp)
-      
+        return display_hecke_polys(self.label, num_disp)
+
     def display_twists(self):
         if not self.twists:
             return '<p>Twists of this newform have not been computed.</p>'

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -166,12 +166,12 @@ def display_hecke_polys(form_labels, num_disp = 5):
     """
     Display a table of the characteristic polynomials of the Hecke operators for small primes
     Right now, the number of primes presented by default is 5, but that could be changed easily
-    The rest could be seen by using "show more" / "show less" - 
-    The code for the table wrapping, scrolling etc. is common with many others and should be eventually 
+    The rest could be seen by using "show more" / "show less" -
+    The code for the table wrapping, scrolling etc. is common with many others and should be eventually
     replaced by a call to a single class/function with some parameters.
-  
+
     INPUT:
- 
+
     - ``form_labels`` - a list of strings, the labels of the newforms in the space
     - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
     """
@@ -188,8 +188,8 @@ def display_hecke_polys(form_labels, num_disp = 5):
     hecke_polys_orbits = {}
     #factor_time = 0
     for orbit_code in orbit_codes:
-        for poly_item in db.mf_hecke_lpolys.search({'hecke_orbit_code' : orbit_code}):
-            coeffs = poly_item['lpoly_factorization']
+        for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : orbit_code}):
+            coeffs = poly_item['charpoly_factorization']
             #t2 = clock()
             F_p = list_factored_to_factored_poly_otherorder(coeffs)
             #t3 = clock()
@@ -207,17 +207,17 @@ def display_hecke_polys(form_labels, num_disp = 5):
     polys = ['<div style="max-width: 100%; overflow-x: auto;">',
              '<table class="ntdata">', '<thead>', '  <tr>',
              th_wrap('p', '$p$'),
-             th_wrap('lpoly', '$F_p(T)$'),
+             th_wrap('charpoly', '$F_p(T)$'),
              '  </tr>', '</thead>', '<tbody>']
     loop_count = 0
-    for p, lpoly in hecke_polys_orbits.items():
-        if lpoly.strip() == "":
-            lpoly = "1";
+    for p, charpoly in hecke_polys_orbits.items():
+        if charpoly.strip() == "":
+            charpoly = "1"
         if loop_count < num_disp:
             polys.append('  <tr>')
         else:
             polys.append('  <tr class="more nodisplay">')
-        polys.extend([td_wrap(p), '<td>' + lpoly + '</th>'])
+        polys.extend([td_wrap(p), '<td>' + charpoly + '</th>'])
         polys.append('  </tr>')
         loop_count += 1
     if loop_count > num_disp:
@@ -290,7 +290,7 @@ class DimGrid(object):
                      'new':data['eis_new_dim'],
                      'old':data['eis_dim']-data['eis_new_dim']}}
         return DimGrid(grid)
-    
+
 class WebNewformSpace(object):
     def __init__(self, data):
         # Need to set mf_dim, eis_dim, cusp_dim, new_dim, old_dim
@@ -386,7 +386,7 @@ class WebNewformSpace(object):
     def display_hecke_char_polys(self, num_disp = 5):
         form_labels = [nf['label'] for nf in self.newforms]
         return display_hecke_polys(form_labels, num_disp)
-    
+
     def _vec(self):
         return [self.level, self.weight, self.conrey_indexes[0]]
 
@@ -596,7 +596,7 @@ class WebGamma1Space(object):
 
     def trace_expansion(self, prec_max=10):
         return trace_expansion_generic(self, prec_max)
-    
+
     def display_hecke_char_polys(self, num_disp = 5):
         newforms = list(db.mf_newforms.search({'level':self.level, 'weight':self.weight}, ['label']));
         form_labels = [newform['label'] for newform in newforms]

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -196,7 +196,9 @@ def display_hecke_polys(form_labels, num_disp = 5):
             #factor_time += (t3-t2)
             F_p = make_bigint(r'\( %s \)' % F_p)
             if (F_p != r"\( 1 \)") and (len(F_p) > 6):
-                if (F_p[0] != '(') and (num_forms > 1):
+                starts_with_bracket = (coeffs[0][1] > 1) and (len(coeffs[0][0]) > 1)
+                is_monomial_power = len([x for x in coeffs[0][0] if x != 0]) == 1
+                if (not starts_with_bracket or is_monomial_power) and (num_forms > 1):
                     F_p = '(' + F_p + ')'
                 hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
             else:

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -6,8 +6,8 @@ from lmfdb import db
 from sage.databases.cremona import cremona_letter_code
 from lmfdb.number_fields.web_number_field import nf_display_knowl, cyclolookup, rcyclolookup
 from lmfdb.utils import (
-    display_knowl, web_latex, coeff_to_power_series, list_factored_to_factored_poly_otherorder,
-    make_bigint, web_latex_factored_integer, prop_int_pretty)
+    display_knowl, web_latex, coeff_to_power_series,
+    web_latex_factored_integer, prop_int_pretty)
 from flask import url_for
 import re
 NEWLABEL_RE = re.compile(r"^([0-9]+)\.([0-9]+)\.([a-z]+)$")
@@ -162,81 +162,6 @@ def trace_expansion_generic(space, prec_max=10):
     prec = min(len(space.traces)+1, prec_max)
     return web_latex(coeff_to_power_series([0] + space.traces[:prec-1],prec=prec),enclose=True)
 
-def display_hecke_polys(form_labels, num_disp = 5):
-    """
-    Display a table of the characteristic polynomials of the Hecke operators for small primes
-    Right now, the number of primes presented by default is 5, but that could be changed easily
-    The rest could be seen by using "show more" / "show less" -
-    The code for the table wrapping, scrolling etc. is common with many others and should be eventually
-    replaced by a call to a single class/function with some parameters.
-
-    INPUT:
-
-    - ``form_labels`` - a list of strings, the labels of the newforms in the space
-    - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
-    """
-    #from time import clock
-    def th_wrap(kwl, title):
-        return '    <th>%s</th>' % display_knowl(kwl, title=title)
-    def td_wrap(val):
-        return '    <td>$%s$</th>' % val
-    num_forms = len(form_labels)
-    orbit_codes = []
-    for label in form_labels:
-        data = db.mf_newforms.lookup(label, ['hecke_orbit_code'])
-        orbit_codes.append(data['hecke_orbit_code'])
-    hecke_polys_orbits = {}
-    #factor_time = 0
-    for orbit_code in orbit_codes:
-        for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : orbit_code}):
-            coeffs = poly_item['charpoly_factorization']
-            #t2 = clock()
-            F_p = list_factored_to_factored_poly_otherorder(coeffs)
-            #t3 = clock()
-            #factor_time += (t3-t2)
-            F_p = make_bigint(r'\( %s \)' % F_p)
-            if (F_p != r"\( 1 \)") and (len(F_p) > 6):
-                starts_with_bracket = (coeffs[0][1] > 1) and (len(coeffs[0][0]) > 1)
-                is_monomial_power = len([x for x in coeffs[0][0] if x != 0]) == 1
-                if (not starts_with_bracket or is_monomial_power) and (num_forms > 1):
-                    F_p = '(' + F_p + ')'
-                hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
-            else:
-                hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "")
-    #print "factoring took " + str(factor_time)
-    if not hecke_polys_orbits:
-        return "There are no characteristic polynomials of Hecke operators in the database"
-    polys = ['<div style="max-width: 100%; overflow-x: auto;">',
-             '<table class="ntdata">', '<thead>', '  <tr>',
-             th_wrap('p', '$p$'),
-             th_wrap('charpoly', '$F_p(T)$'),
-             '  </tr>', '</thead>', '<tbody>']
-    loop_count = 0
-    for p, charpoly in hecke_polys_orbits.items():
-        if charpoly.strip() == "":
-            charpoly = "1"
-        if loop_count < num_disp:
-            polys.append('  <tr>')
-        else:
-            polys.append('  <tr class="more nodisplay">')
-        polys.extend([td_wrap(p), '<td>' + charpoly + '</th>'])
-        polys.append('  </tr>')
-        loop_count += 1
-    if loop_count > num_disp:
-        polys.append('''
-            <tr class="less toggle">
-                <td colspan="{{colspan}}">
-                  <a onclick="show_moreless(&quot;more&quot;); return true" href="#moreep">show more</a>
-                </td>
-            </tr>
-            <tr class="more toggle nodisplay">
-                <td colspan="{{colspan}}">
-                  <a onclick="show_moreless(&quot;less&quot;); return true" href="#eptable">show less</a>
-                </td>
-            </tr>
-            ''')
-        polys.extend(['</tbody>', '</table>', '</div>'])
-    return '\n'.join(polys)
 
 class DimGrid(object):
     def __init__(self, grid=None):
@@ -384,10 +309,6 @@ class WebNewformSpace(object):
             deg_knowl = display_knowl('character.dirichlet.degree', title='degree')
             ord_deg = r" (of %s \(%d\) and %s \(%d\))" % (ord_knowl, self.char_order, deg_knowl, self.char_degree)
         return self.char_orbit_link + ord_deg
-
-    def display_hecke_char_polys(self, num_disp = 5):
-        form_labels = [nf['label'] for nf in self.newforms]
-        return display_hecke_polys(form_labels, num_disp)
 
     def _vec(self):
         return [self.level, self.weight, self.conrey_indexes[0]]
@@ -598,8 +519,3 @@ class WebGamma1Space(object):
 
     def trace_expansion(self, prec_max=10):
         return trace_expansion_generic(self, prec_max)
-
-    def display_hecke_char_polys(self, num_disp = 5):
-        newforms = list(db.mf_newforms.search({'level':self.level, 'weight':self.weight}, ['label']));
-        form_labels = [newform['label'] for newform in newforms]
-        return display_hecke_polys(form_labels, num_disp)

--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -44,7 +44,7 @@ links:
 ---
 title: Code and open software
 image: compute
-content: <p>Download the data, download the code, or see how the data was generate.</p><p><a href="https://github.com/LMFDB/lmfdb">GitHub</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.sagemath.org/">SageMath</a> &nbsp;&nbsp;&nbsp;<a href="http://pari.math.u-bordeaux.fr/">Pari/GP</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://magma.maths.usyd.edu.au/magma/">Magma</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.python.org/">Python</a></p>
+content: <p>Download the data, download the code, or see how the data was generated.</p><p><a href="https://github.com/LMFDB/lmfdb">GitHub</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.sagemath.org/">SageMath</a> &nbsp;&nbsp;&nbsp;<a href="http://pari.math.u-bordeaux.fr/">Pari/GP</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="http://magma.maths.usyd.edu.au/magma/">Magma</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.python.org/">Python</a></p>
 control: 0
 links:
   - [ 0,0 ]

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -87,7 +87,10 @@ def list_factored_to_factored_poly_otherorder(sfacts_fc_list, galois=False, vari
                     gtoprint[(val, i)] = elt/p**val
         glatex = latex(ZZpT(gtoprint))
         if  e > 1:
-            outstr += '( %s )^{%d}' % (glatex, e)
+            if len(glatex) != 1:
+                outstr += '( %s )^{%d}' % (glatex, e)
+            else:
+                outstr += '%s^{%d}' % (glatex, e)
         elif len(sfacts_fc_list) > 1:
             outstr += '( %s )' % (glatex,)
         else:
@@ -294,7 +297,7 @@ def str_to_CBF(s):
             b = '1'
         else:
             b = b.rstrip(' ').rstrip('I').rstrip('*')
-        
+
         res = CBF(0)
         if a:
             res += CBF(a)


### PR DESCRIPTION
This PR addresses #4196, to add Hecke characteristic polynomials to newform and newspace homepages. Until recently these were showing L-polys instead.

One test method has been added to `test_cmf.py`, with checks on 3 newforms and one newspace, all of varying dimensions. Test passes locally.

Also one minor typo on the homepage fixed.