### PR TITLE
add missing comma in dirichlet group for number field

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -415,7 +415,7 @@ def render_field_webpage(args):
             if len(data['dirichlet_group']) == 1:
                 data['dirichlet_group'] = r'<span style="white-space:nowrap">$\lbrace$' + data['dirichlet_group'][0] + r'$\rbrace$</span>'
             else:
-                data['dirichlet_group'] = r'$\lbrace$' + ', '.join(data['dirichlet_group'][:-1]) + '<span style="white-space:nowrap">' + data['dirichlet_group'][-1] + r'$\rbrace$</span>'
+                data['dirichlet_group'] = r'$\lbrace$' + ', '.join(data['dirichlet_group'][:-1]) + ', <span style="white-space:nowrap">' + data['dirichlet_group'][-1] + r'$\rbrace$</span>'
         if data['conductor'].is_prime() or data['conductor'] == 1:
             data['conductor'] = r"\(%s\)" % str(data['conductor'])
         else:


### PR DESCRIPTION
See http://www.lmfdb.org/NumberField/6.6.69343957.1 the comma between the final two entries of the dirichlet character group is missing.