### PR TITLE
Catch errors in parsing a polynomial

### DIFF
--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -807,7 +807,12 @@ def input_to_subfield(inp):
     if 'x' in F:
         F1 = F.replace('^', '**')
         R = PolynomialRing(ZZ, 'x')
-        pol = PolynomialRing(QQ,'x')(str(F1))
+        if ',' in F:
+            raise SearchParsingError("You may only specify one subfield.")
+        try:
+            pol = PolynomialRing(QQ,'x')(str(F1))
+        except:
+            raise SearchParsingError("Subfield not entered properly.")
         pol *= pol.denominator()
         if not pol.is_irreducible():
             raise SearchParsingError("It is not an irreducible polynomial.")


### PR DESCRIPTION
This addresses issue #4221 

Go to the number field main page and search for two subfields:

http://127.0.0.1:37777/NumberField/?count=None&hst=List&subfield=x%5E2%2B1%2C+x%5E2-2&search_type=List

This gives a server error on beta, but should be fixed here.

There are in fact, two protections:
  - if there is a comma in the polynomial, then you get an error message saying that you can enter only one field.
  - if you enter an intermediate field like x^2 + banana then you get a message saying your input is not entered properly from a try/catch around the sage call to initialize the polynomial (so it should catch all bad polynomials).
