### PR TITLE
fix EC/Q completeness knowl display

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -215,6 +215,12 @@ class ECstats(StatsDisplay):
         cur = db._execute(SQL("SELECT UNIQ(SORT(ARRAY_AGG(elements ORDER BY elements))) FROM ec_curves, UNNEST(isodeg) as elements"))
         return cur.fetchone()[0]
 
+# NB the contex processor wants something callable and the summary is a *property*
+
+@app.context_processor
+def ctx_elliptic_curve_summary():
+    return {'elliptic_curve_summary': lambda: ECstats().summary}
+
 @ec_page.route("/stats")
 def statistics():
     title = r'Elliptic curves over $\Q$: Statistics'

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -145,3 +145,10 @@ class EllCurveTest(LmfdbTest):
         #print L.get_data(as_text=True)
         self.assertTrue(row in L.get_data(as_text=True),
                         "990h appears to have the wrong optimal curve.")
+
+    def test_completeness(self):
+        """
+        Test that the dynamic completeness knowl displays OK.
+        """
+        L = self.tc.get('/EllipticCurve/Q/Completeness')
+        assert 'The database currently contains' in L.get_data(as_text=True)


### PR DESCRIPTION
This fixes #4239.  Compare http://localhost:37777/EllipticCurve/Q/Completeness and http://localhost:37777/knowledge/show/dq.ec.extent with http://www.lmfdb.org/EllipticCurve/Q/Completeness and http://www.lmfdb.org/knowledge/show/dq.ec.extent