### PR TITLE
Fix issue #4248

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -4,7 +4,7 @@
 
 from flask import render_template, request, url_for, redirect
 from sage.all import (
-    PolynomialRing, QQ, RR, latex, cached_function, Primes, kronecker, ZZ)
+    PolynomialRing, QQ, RR, latex, cached_function, Integers)
 
 from lmfdb import db
 from lmfdb.app import app
@@ -351,11 +351,7 @@ def prettyname(ent):
 def getu(p):
     if p == 2:
         return 5
-    P = Primes()
-    k = 2
-    while kronecker(k, p)==1:
-        k = P.next(ZZ(k))
-    return k
+    return int(Integers(p).quadratic_nonresidue())
 
 def printquad(code, p):
     if code == [1, 0]:

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -3,7 +3,8 @@
 # Author: John Jones
 
 from flask import render_template, request, url_for, redirect
-from sage.all import PolynomialRing, QQ, RR, latex, cached_function
+from sage.all import (
+    PolynomialRing, QQ, RR, latex, cached_function, Primes, kronecker, ZZ)
 
 from lmfdb import db
 from lmfdb.app import app
@@ -346,16 +347,27 @@ def prettyname(ent):
         return printquad(ent['rf'], ent['p'])
     return ent['label']
 
+@cached_function
+def getu(p):
+    if p == 2:
+        return 5
+    P = Primes()
+    k = 2
+    while kronecker(k, p)==1:
+        k = P.next(ZZ(k))
+    return k
+
 def printquad(code, p):
     if code == [1, 0]:
         return(r'$\Q_{%s}$' % p)
+    u = getu(p)
     if code == [1, 1]:
-        return(r'$\Q_{%s}(\sqrt{*})$' % p)
+        return(r'$\Q_{%s}(\sqrt{%s})$' % (p,u))
     if code == [-1, 1]:
-        return(r'$\Q_{%s}(\sqrt{-*})$' % p)
+        return(r'$\Q_{%s}(\sqrt{-%s})$' % (p,u))
     s = code[0]
     if code[1] == 1:
-        s = str(s) + '*'
+        s = str(s) + r'\cdot '+str(u)
     return(r'$\Q_{' + str(p) + r'}(\sqrt{' + str(s) + '})$')
 
 


### PR DESCRIPTION
On local field pages, this replaces the use of * with an integer when describing a quadratic extension of Qp.

From
  http://127.0.0.1:37777/LocalNumberField/?hst=List&n=2&p=2&search_type=List
and
  http://127.0.0.1:37777/LocalNumberField/?hst=List&n=2&p=7&search_type=List
you can click on the fields to see p=2 and p>2.
