### PR TITLE
Change description of class group data

### DIFF
--- a/lmfdb/number_fields/templates/class_group_data.html
+++ b/lmfdb/number_fields/templates/class_group_data.html
@@ -7,25 +7,25 @@ of quadratic imaginary fields is available below.
 It is organized by fundamental discriminant $d$, and divided
 into four groups based on congruences:
 <ul>
-<li> $-d\equiv 3\pmod 8$
-<li> $-d\equiv 7\pmod 8$
-<li> $-d\equiv 4\pmod {16}$
-<li> $-d\equiv 8\pmod {16}$
+<li> $|d|\equiv 3\pmod 8$
+<li> $|d|\equiv 7\pmod 8$
+<li> $|d|\equiv 4\pmod {16}$
+<li> $|d|\equiv 8\pmod {16}$
 </ul>
 For each congruence class above, there are 4096 files, indexed from
 $k=0$ to $k=4095$.  The $k$th file contains data for
 $k\cdot 2^{28} \leq |d| \lt (k+1)\cdot 2^{28}$.  The files are named
-accordingly, so the $k=12$th file for $-d\equiv 7\pmod8$ is called
+accordingly, so the $k=12$th file for $|d|\equiv 7\pmod8$ is called
 <code>cl7mod8.12.gz</code>, the final extension because it has been
 compressed with <code>gzip</code>.  The compressed files range in size
 from 50 to 200 megabytes.
 
 <h3>File and data format</h3>
 <p>
-The $k$th file of data for $-d\equiv r\pmod{m}$ has filename of the form
+The $k$th file of data for $|d|\equiv r\pmod{m}$ has filename of the form
 <code>cl{</code>$r$<code>}mod{</code>$m$}.{$k$} after uncompressing
 with <code>gzip</code>
-(for example, file $12$ for $-d\equiv7\pmod8$ is <code>cl7mod8.12</code>).
+(for example, file $12$ for $|d|\equiv7\pmod8$ is <code>cl7mod8.12</code>).
 In this file there is one line per discriminant, with discriminants in order of their absolute
   value.  The discriminants and associated class group data may be extracted as
 follows, where  for $i\ge1$ we define $d_i$ to be the $i$th discriminant of the file:
@@ -66,7 +66,7 @@ and so on.
 <table>
 <tr>
 <td align="right">
-$-d \equiv $
+$|d| \equiv $
 <td align="left">
 <select name="filenamebase">
 <option value="cl3mod8">3 (mod 8)</option>

--- a/lmfdb/number_fields/templates/class_group_data.html
+++ b/lmfdb/number_fields/templates/class_group_data.html
@@ -14,19 +14,17 @@ into four groups based on congruences:
 </ul>
 For each congruence class above, there are 4096 files, indexed from
 $k=0$ to $k=4095$.  The $k$th file contains data for
-$k\cdot 2^{28} \leq |d| \lt (k+1)\cdot 2^{28}$.  The files are named
-accordingly, so the $k=12$th file for $|d|\equiv 7\pmod8$ is called
-<code>cl7mod8.12.gz</code>, the final extension because it has been
-compressed with <code>gzip</code>.  The compressed files range in size
-from 50 to 200 megabytes.
+$k\cdot 2^{28} \leq |d| \lt (k+1)\cdot 2^{28}$.  
 
 <h3>File and data format</h3>
 <p>
 The $k$th file of data for $|d|\equiv r\pmod{m}$ has filename of the form
-<code>cl{</code>$r$<code>}mod{</code>$m$}.{$k$} after uncompressing
-with <code>gzip</code>
-(for example, file $12$ for $|d|\equiv7\pmod8$ is <code>cl7mod8.12</code>).
-In this file there is one line per discriminant, with discriminants in order of their absolute
+<code>cl{</code>$r$<code>}mod{</code>$m$}.{$k$}<code>.gz</code>
+(for example, file $12$ for $|d|\equiv7\pmod8$ is <code>cl7mod8.12.gz</code>).
+Files range in size from 50 to 200 megabytes, and need to be uncompressed
+with <code>gzip</code>.
+After uncompressing,
+there is one line per discriminant, with discriminants in order of their absolute
   value.  The discriminants and associated class group data may be extracted as
 follows, where  for $i\ge1$ we define $d_i$ to be the $i$th discriminant of the file:
 <ul>

--- a/lmfdb/number_fields/templates/class_group_data.html
+++ b/lmfdb/number_fields/templates/class_group_data.html
@@ -4,33 +4,33 @@
 <p>Data from extensive computations on class groups
 of quadratic imaginary fields is available below.
 
-It is organized by fundamental discriminant $-d$, and divided
+It is organized by fundamental discriminant $d$, and divided
 into four groups based on congruences:
 <ul>
-<li> $d\equiv 3\pmod 8$
-<li> $d\equiv 7\pmod 8$
-<li> $d\equiv 4\pmod {16}$
-<li> $d\equiv 8\pmod {16}$
+<li> $-d\equiv 3\pmod 8$
+<li> $-d\equiv 7\pmod 8$
+<li> $-d\equiv 4\pmod {16}$
+<li> $-d\equiv 8\pmod {16}$
 </ul>
 For each congruence class above, there are 4096 files, indexed from
 $k=0$ to $k=4095$.  The $k$th file contains data for
 $k\cdot 2^{28} \leq |d| \lt (k+1)\cdot 2^{28}$.  The files are named
-accordingly, so the $k=12$th file for $d\equiv 7\pmod8$ is called
+accordingly, so the $k=12$th file for $-d\equiv 7\pmod8$ is called
 <code>cl7mod8.12.gz</code>, the final extension because it has been
 compressed with <code>gzip</code>.  The compressed files range in size
 from 50 to 200 megabytes.
 
 <h3>File and data format</h3>
 <p>
-The $k$th file of data for $d\equiv r\pmod{m}$ has filename of the form
+The $k$th file of data for $-d\equiv r\pmod{m}$ has filename of the form
 <code>cl{</code>$r$<code>}mod{</code>$m$}.{$k$} after uncompressing
 with <code>gzip</code>
-(for example, file $12$ for $d\equiv7\pmod8$ is <code>cl7mod8.12</code>).
+(for example, file $12$ for $-d\equiv7\pmod8$ is <code>cl7mod8.12</code>).
 In this file there is one line per discriminant, with discriminants in order of their absolute
   value.  The discriminants and associated class group data may be extracted as
-follows, where  for $i\ge1$ we define $-d_i$ to be the $i$th discriminant of the file:
+follows, where  for $i\ge1$ we define $d_i$ to be the $i$th discriminant of the file:
 <ul>
-<li>Initialise $-d_0=k\cdot2^{28}+r$.
+<li>Initialise $d_0=-k\cdot2^{28}-r$.
 <li>For $i\ge1$, let the data in line $i$ of the file be
 <table>
  <tr><td>$a$</td><td> $b$</td><td> $c_1\ c_2\ \ldots\ c_t$</td></tr>
@@ -38,8 +38,8 @@ follows, where  for $i\ge1$ we define $-d_i$ to be the $i$th discriminant of the
 <li>
 Then
 <ul>
- <li>$d_{i} = d_{i-1}+m\cdot a$,
- <li>$h(-d_{i}) = b$,
+ <li>$d_{i} = d_{i-1}-m\cdot a$,
+ <li>$h(d_{i}) = b$,
  <li>the invariant factors for the class group are $[c_1, c_2,\ldots, c_t]$.
 </ul>
 In particular, $b=\prod_{j=1}^t c_j$.
@@ -53,9 +53,9 @@ In particular, $b=\prod_{j=1}^t c_j$.
 </table>
 so
 <ul>
-<li> $-d_0=1\cdot2^{28}+4=268435460$, and then
-<li> $-d_1=-d_0+16\cdot0=268435460$, with class number $12160$,
-<li> $-d_2=-d_1+16\cdot2=268435492$, with class number $4392$,
+<li> $d_0=-1\cdot2^{28}-4=-268435460$, and then
+<li> $d_1=d_0-16\cdot0=-268435460$, with class number $12160$,
+<li> $d_2=d_1-16\cdot2=-268435492$, with class number $4392$,
 </ul>
 and so on.
 <p>
@@ -66,7 +66,7 @@ and so on.
 <table>
 <tr>
 <td align="right">
-$d \equiv $
+$-d \equiv $
 <td align="left">
 <select name="filenamebase">
 <option value="cl3mod8">3 (mod 8)</option>


### PR DESCRIPTION
This just changes text on

  http://localhost:37777/NumberField/QuadraticImaginaryClassGroups
  http://beta.lmfdb.org/NumberField/QuadraticImaginaryClassGroups

Now throughout, d<0 is the discriminant of a field.  It is still a bit awkward because the filenames are based on -d.