### PR TITLE
avoid displaying "There are no characteristic polynomials of Hecke operators in the database"

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -223,8 +223,10 @@ function get_all_embeddings(num_embeddings) {
 {{ newform.display_hecke_cutters() | safe }}
 {% endif %}
 
+{% if newform.display_hecke_char_polys() is not None %}
 <h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
 
 {{ newform.display_hecke_char_polys() | safe }}
+{% endif %}
 
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -223,7 +223,7 @@ function get_all_embeddings(num_embeddings) {
 {{ newform.display_hecke_cutters() | safe }}
 {% endif %}
 
-{% if newform.display_hecke_char_polys() is not None %}
+{% if newform.display_hecke_char_polys() is not none %}
 <h2>{{KNOWL('cmf.heckecharpolys', title='Hecke characteristic polynomials')}}</h2>
 
 {{ newform.display_hecke_char_polys() | safe }}

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -931,4 +931,4 @@ class CmfTest(LmfdbTest):
         # Check large dimensions behave as we expect. The following is a form of dimension 108
 
         large_dimension_page_as_text = self.tc.get('/ModularForm/GL2/Q/holomorphic/671/2/i/a/', follow_redirects=True).get_data(as_text=True)
-        assert "There are no characteristic polynomials of Hecke operators in the database" in large_dimension_page_as_text
+        assert "Hecke characteristic polynomials" not in large_dimension_page_as_text

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -120,65 +120,7 @@ def td_wrapr(val):
 def parity_text(val):
     return 'odd' if val == -1 else 'even'
 
-def display_hecke_polys(form_label, num_disp = 5):
-    """
-    Display a table of the characteristic polynomials of the Hecke operators
-    for small primes. The number of primes presented by default is 5, although
-    there is a "show more" / "show less" button to display all primes up to 97.
-    The code for the table wrapping, scrolling etc. is common with many others
-    and should be eventually replaced by a call to a single class/function with
-    some parameters.
 
-    INPUT:
-
-    - ``form_label`` - a string, the label of the newform
-    - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
-    """
-
-    data = db.mf_newforms.lookup(form_label, ['hecke_orbit_code'])
-    orbit_code = data['hecke_orbit_code']
-    hecke_polys_orbits = {}
-    for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : orbit_code}):
-        coeffs = poly_item['charpoly_factorization']
-        F_p = list_factored_to_factored_poly_otherorder(coeffs)
-        F_p = make_bigint(r'\( %s \)' % F_p)
-        if (F_p != r"\( 1 \)") and (len(F_p) > 6):
-            hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
-        else:
-            hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "")
-    if not hecke_polys_orbits:
-        return "There are no characteristic polynomials of Hecke operators in the database"
-    polys = ['<div style="max-width: 100%; overflow-x: auto;">',
-             '<table class="ntdata">', '<thead>', '  <tr>',
-             th_wrap('p', '$p$'),
-             th_wrap('charpoly', '$F_p(T)$'),
-             '  </tr>', '</thead>', '<tbody>']
-    loop_count = 0
-    for p, charpoly in hecke_polys_orbits.items():
-        if charpoly.strip() == "":
-            charpoly = "1"
-        if loop_count < num_disp:
-            polys.append('  <tr>')
-        else:
-            polys.append('  <tr class="more nodisplay">')
-        polys.extend([td_wrapl('${}$'.format(p)), '<td>' + charpoly + '</td>'])
-        polys.append('  </tr>')
-        loop_count += 1
-    if loop_count > num_disp:
-        polys.append('''
-            <tr class="less toggle">
-                <td colspan="{{colspan}}">
-                  <a onclick="show_moreless(&quot;more&quot;); return true" href="#moreep">show more</a>
-                </td>
-            </tr>
-            <tr class="more toggle nodisplay">
-                <td colspan="{{colspan}}">
-                  <a onclick="show_moreless(&quot;less&quot;); return true" href="#eptable">show less</a>
-                </td>
-            </tr>
-            ''')
-        polys.extend(['</tbody>', '</table>', '</div>'])
-    return '\n'.join(polys)
 
 
 class WebNewform(object):
@@ -1039,8 +981,63 @@ function switch_basis(btype) {
         twists.extend(['</tbody>', '</table>'])
         return '\n'.join(twists)
 
+    @cached_method
     def display_hecke_char_polys(self, num_disp = 5):
-        return display_hecke_polys(self.label, num_disp)
+        """
+        Display a table of the characteristic polynomials of the Hecke operators
+        for small primes. The number of primes presented by default is 5, although
+        there is a "show more" / "show less" button to display all primes up to 97.
+        The code for the table wrapping, scrolling etc. is common with many others
+        and should be eventually replaced by a call to a single class/function with
+        some parameters.
+
+        INPUT:
+
+        - ``num_disp`` - an integer, the number of characteristic polynomials to display by default.
+        """
+
+        hecke_polys_orbits = {}
+        for poly_item in db.mf_hecke_charpolys.search({'hecke_orbit_code' : self.hecke_orbit_code}):
+            coeffs = poly_item['charpoly_factorization']
+            F_p = list_factored_to_factored_poly_otherorder(coeffs)
+            F_p = make_bigint(r'\( %s \)' % F_p)
+            if (F_p != r"\( 1 \)") and (len(F_p) > 6):
+                hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "") +  F_p
+            else:
+                hecke_polys_orbits[poly_item['p']] = hecke_polys_orbits.get(poly_item['p'], "")
+        if not hecke_polys_orbits:
+            return None
+        polys = ['<div style="max-width: 100%; overflow-x: auto;">',
+                 '<table class="ntdata">', '<thead>', '  <tr>',
+                 th_wrap('p', '$p$'),
+                 th_wrap('charpoly', '$F_p(T)$'),
+                 '  </tr>', '</thead>', '<tbody>']
+        loop_count = 0
+        for p, charpoly in hecke_polys_orbits.items():
+            if charpoly.strip() == "":
+                charpoly = "1"
+            if loop_count < num_disp:
+                polys.append('  <tr>')
+            else:
+                polys.append('  <tr class="more nodisplay">')
+            polys.extend([td_wrapl('${}$'.format(p)), '<td>' + charpoly + '</td>'])
+            polys.append('  </tr>')
+            loop_count += 1
+        if loop_count > num_disp:
+            polys.append('''
+                <tr class="less toggle">
+                    <td colspan="{{colspan}}">
+                      <a onclick="show_moreless(&quot;more&quot;); return true" href="#moreep">show more</a>
+                    </td>
+                </tr>
+                <tr class="more toggle nodisplay">
+                    <td colspan="{{colspan}}">
+                      <a onclick="show_moreless(&quot;less&quot;); return true" href="#eptable">show less</a>
+                    </td>
+                </tr>
+                ''')
+            polys.extend(['</tbody>', '</table>', '</div>'])
+        return '\n'.join(polys)
 
     def display_twists(self):
         if not self.twists:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import ast
-import os
 import re
 from six import BytesIO
-import tempfile
 import time
 
 from flask import render_template, url_for, request, redirect, make_response, send_file, abort


### PR DESCRIPTION
At the moment in CMF's when we don't have exact data we say at the end of the page:
"There are no characteristic polynomials of Hecke operators in the database", see for example, https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/671/2/i/a/

This PR removes that whole section if we don't have any data to display, as we do for Hecke cutters and twists.

I also moved the function inside the class