### PR TITLE
Allow multiplication and exponentiation in input boxes, 4268

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -661,6 +661,10 @@ class CmfTest(LmfdbTest):
             print("Connecting with magma.maths.usyd.edu.au timed out")
             print(err)
 
+    def test_expression_level(self):
+        # checks we can search on 2*7^2
+        page = self.check('/ModularForm/GL2/Q/holomorphic/?hst=List&level=2*7%5E2&search_type=List', '98.2.a.a')
+
     def test_download_search(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=Traces', follow_redirects = True)
         assert '5.10.a.a' in page.get_data(as_text=True)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -663,7 +663,7 @@ class CmfTest(LmfdbTest):
 
     def test_expression_level(self):
         # checks we can search on 2*7^2
-        self.check('/ModularForm/GL2/Q/holomorphic/?hst=List&level=2*7%5E2&search_type=List', '98.2.a.a')
+        self.check_args('/ModularForm/GL2/Q/holomorphic/?hst=List&level=2*7%5E2&search_type=List', '98.2.a.a')
 
     def test_download_search(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=Traces', follow_redirects = True)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -663,7 +663,7 @@ class CmfTest(LmfdbTest):
 
     def test_expression_level(self):
         # checks we can search on 2*7^2
-        page = self.check('/ModularForm/GL2/Q/holomorphic/?hst=List&level=2*7%5E2&search_type=List', '98.2.a.a')
+        self.check('/ModularForm/GL2/Q/holomorphic/?hst=List&level=2*7%5E2&search_type=List', '98.2.a.a')
 
     def test_download_search(self):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27level_radical%27%3A+5%2C+%27dim%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27weight%27%3A+10%7D&search_type=Traces', follow_redirects = True)

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -8,7 +8,7 @@ import re
 from collections import Counter
 
 from lmfdb.utils.utilities import flash_error
-from sage.all import ZZ, QQ, prod, PolynomialRing, pari, gp
+from sage.all import ZZ, QQ, prod, PolynomialRing, pari
 from sage.misc.decorators import decorator_keywords
 from sage.repl.preparse import implicit_mul
 from sage.misc.parser import Parser

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -5,6 +5,7 @@ from six.moves import range
 from six import string_types
 
 import re
+import sys
 from collections import Counter
 
 from lmfdb.utils.utilities import flash_error

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -42,11 +42,11 @@ import ast
 class PowMulNodeVisitor(ast.NodeTransformer):
     def visit_BinOp(self, node):
         if isinstance(node.op, ast.Pow):
-            if log2(self.visit(node.left)) * self.visit(node.right) > 100:
+            if log2(self.visit(node.left)) * self.visit(node.right) > 3000:
                 raise ValueError('output will be too large')
             return  self.visit(node.left) ** self.visit(node.right)
         elif isinstance(node.op, ast.Mult):
-            return  self.visit(node.left) * self.visit(node.right) 
+            return  self.visit(node.left) * self.visit(node.right)
     def visit_Constant(self, node):
         return ast.literal_eval(node)
 

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -8,7 +8,7 @@ import re
 from collections import Counter
 
 from lmfdb.utils.utilities import flash_error
-from sage.all import ZZ, QQ, prod, PolynomialRing, pari
+from sage.all import ZZ, QQ, prod, PolynomialRing, pari, sage_eval
 from sage.misc.decorators import decorator_keywords
 from sage.repl.preparse import implicit_mul
 from sage.misc.parser import Parser
@@ -27,6 +27,7 @@ QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
 QQ_DEC_RE = re.compile(r'^\d+((\.\d+)|(/\d+))?$')
 LIST_POSINT_RE = re.compile(r'^(\d+)(,\d+)*$')
 LIST_RAT_RE = re.compile(r'^((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-((\d+((\.\d+)|(/\d+))?))?))(,((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-(\d+((\.\d+)|(/\d+))?)?)))*$')
+MULT_PARSE= re.compile(r'^[0-9()*^]*$') # to check if a string is comprised of just multiplication and exponentiation symbols
 SIGNED_LIST_RE = re.compile(r'^(-?\d+|(-?\d+--?\d+))(,(-?\d+|(-?\d+--?\d+)))*$')
 ## RE from number_field.py
 #LIST_SIMPLE_RE = re.compile(r'^(-?\d+)(,-?\d+)*$'
@@ -82,7 +83,7 @@ class SearchParser(object):
             else:
                 flash_error("<span style='color:black'>%s</span> is not a valid input for <span style='color:black'>%s</span>. %s", inp, name, str(err))
             info['err'] = ''
-            raise
+            raise		
 
 @decorator_keywords
 def search_parser(f, clean_info=False, prep_ranges=False, prep_plus=False, pass_name=False,
@@ -344,8 +345,14 @@ def parse_rational(inp, query, qfield):
 def parse_ints(inp, query, qfield, parse_singleton=int):
     if LIST_RE.match(inp):
         collapse_ors(parse_range2(inp, qfield, parse_singleton), query)
+    elif MULT_PARSE.match(inp):
+    	try:
+            inp=str(int(sage_eval(str(inp))))
+            collapse_ors(parse_range2(inp, qfield, parse_singleton), query)
+    	except:
+            raise SearchParsingError("Sage is unable to evaluate that syntax.")
     else:
-        raise SearchParsingError("It needs to be an integer (such as 25), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
+        raise SearchParsingError("It needs to be an integer (such as 25), be a multiplicative expression that parses to an integer (such as 2^2*3), a range of integers (such as 2-10 or 2..10), or a comma-separated list of these (such as 4,9,16 or 4-25, 81-121).")
 
 @search_parser(clean_info=True, clean_spaces=False, prep_ranges=False) # see SearchParser.__call__ for actual arguments when calling
 def parse_ints_raw(inp, query, qfield, names={}):

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -8,7 +8,7 @@ import re
 from collections import Counter
 
 from lmfdb.utils.utilities import flash_error
-from sage.all import ZZ, QQ, prod, PolynomialRing, pari, sage_eval
+from sage.all import ZZ, QQ, prod, PolynomialRing, pari, gp
 from sage.misc.decorators import decorator_keywords
 from sage.repl.preparse import implicit_mul
 from sage.misc.parser import Parser
@@ -347,7 +347,7 @@ def parse_ints(inp, query, qfield, parse_singleton=int):
         collapse_ors(parse_range2(inp, qfield, parse_singleton), query)
     elif MULT_PARSE.match(inp):
     	try:
-            inp=str(int(sage_eval(str(inp))))
+            inp=str(int(ZZ(gp(inp))))
             collapse_ors(parse_range2(inp, qfield, parse_singleton), query)
     	except:
             raise SearchParsingError("Sage is unable to evaluate that syntax.")

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -49,6 +49,9 @@ class PowMulNodeVisitor(ast.NodeTransformer):
             return  self.visit(node.left) * self.visit(node.right)
     def visit_Constant(self, node):
         return ast.literal_eval(node)
+    if sys.version_info < (3,8):
+        def visit_Num(self, node): # deprecated for python >= 3.8
+            return self.visit_Constant(node)
 
 class SearchParser(object):
     def __init__(self, f, clean_info, prep_ranges, prep_plus, pass_name, default_field, default_name, default_qfield, error_is_safe, clean_spaces):


### PR DESCRIPTION
Modified search_parsing.py to allow inputs involving multiplication and exponentiation. This uses regex to verify the inputted text only uses [0-9], (),^,* symbols and then attempts a sage_eval(). If sage_eval() succeeds, the search is run with that, otherwise an error is displayed.

See issue #4268