### PR TITLE
Two small fixes

### DIFF
--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -740,6 +740,8 @@ class WebCharGroup(WebCharObject):
 
     @cached_method
     def first_chars(self):
+        if self.modulus == 1:
+            return [1]
         r = []
         for i,c in enumerate(Integers(self.modulus).list_of_elements_of_multiplicative_group()):
             r.append(c)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -297,6 +297,8 @@ def l_function_cmf_old(level, weight, character, hecke_orbit, number):
 @l_function_page.route("/ModularForm/GL2/Q/holomorphic/<int:level>/<int:weight>/<int:character>/<hecke_orbit>/")
 def l_function_cmf_redirect_1(level, weight, character, hecke_orbit):
     char_orbit_label = db.mf_newspaces.lucky({'conrey_indexes': {'$contains': character}, 'level': level, 'weight': weight}, projection='char_orbit_label')
+    if char_orbit_label is None:
+        return abort(404, 'Invalid character label')
     return redirect(url_for('.l_function_cmf_page',
                                     level=level,
                                     weight=weight,


### PR DESCRIPTION
This PR fixes two small bugs that were causing server errors to show up in the flasklog.  The first is to correctly handle the Dirichlet group of modulus 1 and the second is to handle CMF L-function pages with invalid character orbit labels.  I'll merge this as soon as tests pass.