### PR TITLE
Add moment matrix to Sato-Tate group pages

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -676,7 +676,7 @@ def render_by_label(label):
             info['simplex'] = t
     if data.get('character_matrix'):
         A = data['character_matrix']
-        info["character_matrix"] = r"\mathrm{E}\left[[\chi_i\chi_j]\right] = " + string_matrix(A) 
+        info["character_matrix"] = r"\mathrm{E}\left[\chi_i\chi_j\right] = " + string_matrix(A) 
         info["character_matrix"] += r",\qquad\mathrm{E}\left[\chi_i^2\right] = " + string_matrix([[A[i][i] for i in range(len(A))]])
     if data.get('counts'):
         c=data['counts']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -674,6 +674,8 @@ def render_by_label(label):
                 t += [s[m:m+n]]
                 m,n = m+n,n+1
             info['simplex'] = t
+    if data.get('character_matrix'):
+        info["character_matrix"] = string_matrix(data['character_matrix'])
     if data.get('counts'):
         c=data['counts']
         info['probabilities'] = [['\\mathrm{Pr}[%s=%d]=\\frac{%d}{%d}'%(c[i][0],c[i][1][j][0],c[i][1][j][1],data['components']) for j in range(len(c[i][1]))] for i in range(len(c))]

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -675,7 +675,9 @@ def render_by_label(label):
                 m,n = m+n,n+1
             info['simplex'] = t
     if data.get('character_matrix'):
-        info["character_matrix"] = string_matrix(data['character_matrix'])
+        A = data['character_matrix']
+        info["character_matrix"] = r"\mathrm{E}\left[[\chi_i\chi_j]_{ij}\right] = " + string_matrix(A) 
+        info["character_matrix"] += r",\qquad\mathrm{E}\left[\chi_i^2\right] = " + string_matrix([[A[i][i] for i in range(len(data))]])
     if data.get('counts'):
         c=data['counts']
         info['probabilities'] = [['\\mathrm{Pr}[%s=%d]=\\frac{%d}{%d}'%(c[i][0],c[i][1][j][0],c[i][1][j][1],data['components']) for j in range(len(c[i][1]))] for i in range(len(c))]

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -677,7 +677,7 @@ def render_by_label(label):
     if data.get('character_matrix'):
         A = data['character_matrix']
         info["character_matrix"] = r"\mathrm{E}\left[[\chi_i\chi_j]_{ij}\right] = " + string_matrix(A) 
-        info["character_matrix"] += r",\qquad\mathrm{E}\left[\chi_i^2\right] = " + string_matrix([[A[i][i] for i in range(len(data))]])
+        info["character_matrix"] += r",\qquad\mathrm{E}\left[\chi_i^2\right] = " + string_matrix([[A[i][i] for i in range(len(A))]])
     if data.get('counts'):
         c=data['counts']
         info['probabilities'] = [['\\mathrm{Pr}[%s=%d]=\\frac{%d}{%d}'%(c[i][0],c[i][1][j][0],c[i][1][j][1],data['components']) for j in range(len(c[i][1]))] for i in range(len(c))]

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -676,7 +676,7 @@ def render_by_label(label):
             info['simplex'] = t
     if data.get('character_matrix'):
         A = data['character_matrix']
-        info["character_matrix"] = r"\mathrm{E}\left[[\chi_i\chi_j]_{ij}\right] = " + string_matrix(A) 
+        info["character_matrix"] = r"\mathrm{E}\left[[\chi_i\chi_j]\right] = " + string_matrix(A) 
         info["character_matrix"] += r",\qquad\mathrm{E}\left[\chi_i^2\right] = " + string_matrix([[A[i][i] for i in range(len(A))]])
     if data.get('counts'):
         c=data['counts']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -666,7 +666,7 @@ def render_by_label(label):
         info['moments'] += data['moments']
     if data.get('simplex'):
         if data['degree'] == 4:
-            info['simplex_header'] = ["\\left(\\mathrm{E}[a_1^{e_1}a_2^{e_2}:\\sum ie_i=%d\\right)\\colon"%(2*d+2) for d in range(len(data['simplex']))]
+            info['simplex_header'] = [r"\left(\mathrm{E}\left[a_1^{e_1}a_2^{e_2}\right]:\\sum ie_i=%d\right)\colon"%(2*d+2) for d in range(len(data['simplex']))]
             s = data['simplex']
             t = [s[0:2]]
             m,n=2,3

--- a/lmfdb/sato_tate_groups/templates/st_display.html
+++ b/lmfdb/sato_tate_groups/templates/st_display.html
@@ -57,7 +57,7 @@
 {% endif %}
 
 {% if info['simplex'] %}
-<h2> {{ KNOWL('st_group.moment_simplex', title='Mixed moments') }} </h2>
+<h2> {{ KNOWL('st_group.moment_simplex', title='Moment simplex') }} </h2>
 <table border=1>
     {% for i in range(info['simplex']|length) %}
         <tr>
@@ -68,6 +68,11 @@
         </tr>
     {% endfor %}
 </table>
+{% endif %}
+
+{% if info['matrix'] %}
+<h2> {{ KNOWL('st_group.moment_matrix', title='Moment matrix') }} </h2>
+<p>${{info['character_matrix']}}$</p>
 {% endif %}
 
 {% if info['probabilities'] %}

--- a/lmfdb/sato_tate_groups/templates/st_display.html
+++ b/lmfdb/sato_tate_groups/templates/st_display.html
@@ -70,7 +70,7 @@
 </table>
 {% endif %}
 
-{% if info['matrix'] %}
+{% if info['character_matrix'] %}
 <h2> {{ KNOWL('st_group.moment_matrix', title='Moment matrix') }} </h2>
 <p>${{info['character_matrix']}}$</p>
 {% endif %}


### PR DESCRIPTION
This PR adds the matrix of moments of products of irreducible characters (orthogonality relations) to the Sato-Tate group pages.  Currently this data is only available for weight-1 degree-4 (ST groups of abelian surfaces), but will be added for additional groups later.

Tests pass on grace.