### PR TITLE
ECNF code (magma, sage etc) refactoring

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-import os
-import yaml
 from flask import url_for
 from six.moves.urllib_parse import quote
 from six import PY3
@@ -673,7 +671,7 @@ class ECNF(object):
         self._code = None # will be set if needed by get_code()
 
         self.downloads = [('All stored data to text', url_for(".download_ECNF_all", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number))]
-        for lang in [["Magma","magma"], ["SageMath","sage"], ["GP", "gp"]]:
+        for lang in [["Magma","magma"], ["GP", "gp"], ["SageMath","sage"]]:
             self.downloads.append(('Code to {}'.format(lang[0]),
                                    url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
                                            class_label=self.iso_label, number=self.number, download_type=lang[1])))
@@ -697,25 +695,84 @@ class ECNF(object):
 
     def code(self):
         if self._code is None:
-            self.make_code_snippets()
+            self._code =  make_code(self.label)
         return self._code
 
-    def make_code_snippets(self):
-        # read in code.yaml from current directory:
+sorted_code_names = ['field', 'curve', 'is_min', 'cond', 'cond_norm',
+                     'disc', 'disc_norm', 'jinv', 'cm', 'rank',
+                     'gens', 'heights', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
 
-        _curdir = os.path.dirname(os.path.abspath(__file__))
-        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
+code_names = {'field': 'Define the base number field',
+              'curve': 'Define the curve',
+              'is_min': 'Test whether it is a global minimal model',
+              'cond': 'Compute the conductor',
+              'cond_norm': 'Compute the norm of the conductor',
+              'disc': 'Compute the discriminant',
+              'disc_norm': 'Compute the norm of the discriminant',
+              'jinv': 'Compute the j-invariant',
+              'cm': 'Test for Complex Multiplication',
+              'rank': 'Compute the Mordell-Weil rank',
+              'ntors': 'Compute the order of the torsion subgroup',
+              'gens': 'Compute the generators (of infinite order)',
+              'heights': 'Compute the heights of the generators (of infinite order)',
+              'reg': 'Compute the regulator',
+              'tors': 'Compute the torsion subgroup',
+              'torgens': 'Compute the generators of the torsion subgroup',
+              'localdata': 'Compute the local reduction data at primes of bad reduction'
+}
 
-        # Fill in placeholders for this specific curve:
+Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP', 'pari': 'Pari/GP'}
+Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\'}
 
-        gen = self.field.generator_name().replace("\\","") # phi not \phi
-        for lang in ['sage', 'magma', 'pari']:
-            pol = str(self.field.poly())
-            if lang=='pari':
-                pol = pol.replace('x',gen)
-            elif lang=='magma':
-                pol = str(self.field.poly().list())
-            self._code['field'][lang] = (self._code['field'][lang] % pol).replace("<a>", "<%s>" % gen)
+def make_code(label, lang=None):
+    """Return a dict of code snippets for one curve in either one
+    language (if lang is 'pari' or 'gp', 'sage', or 'magma') or all
+    three (if lang is None).
+    """
+    if lang=='gp':
+        lang = 'pari'
+    all_langs = ['magma', 'pari', 'sage']
 
-        for lang in ['sage', 'magma', 'pari']:
-            self._code['curve'][lang] = self._code['curve'][lang] % self.ainvs
+    # Get the base field label and a-invariants:
+    
+    E = db.ec_nfcurves.lookup(label, projection = ['field_label', 'ainvs'])
+   
+    # Look up the defining polynomial of the base field:
+    
+    from lmfdb.utils import coeff_to_poly
+    poly = coeff_to_poly(db.nf_fields.lookup(E['field_label'], projection = 'coeffs'))
+
+    # read in code.yaml from current directory:
+
+    import os
+    import yaml
+    _curdir = os.path.dirname(os.path.abspath(__file__))
+    Ecode =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
+
+    # Fill in placeholders for this specific curve and language:
+    if lang:
+        for k in sorted_code_names:
+            Ecode[k] = Ecode[k][lang] if lang in Ecode[k] else None
+
+    # Fill in field polynomial coefficients:
+    if lang:
+        Ecode['field'] = Ecode['field'] % str(poly.list())
+    else:
+        for l in all_langs:
+            Ecode['field'][l] = Ecode['field'][l] % str(poly.list())
+
+    # Fill in curve coefficients:
+    ainvs = ["".join(["[",ai,"]"]) for ai in E['ainvs'].split(";")]
+    ainvs_string = {
+        'magma': "[" + ",".join(["K!{}".format(ai) for ai in ainvs]) + "]",
+        'sage':  "[" + ",".join(["K({})".format(ai) for ai in ainvs]) + "]",
+        'pari':  "[" + ",".join(["Pol(Vecrev({}))".format(ai) for ai in ainvs]) + "], K",
+        }
+    if lang:
+        Ecode['curve'] = Ecode['curve'] % ainvs_string[lang]
+    else:
+        for l in all_langs:
+            Ecode['curve'][l] = Ecode['curve'][l] % ainvs_string[l]
+
+    return Ecode
+

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -105,8 +105,10 @@ def ideal_from_string(K,s, IQF_format=False):
         return "wrong" ## caller must check
 
 def pretty_ideal(I):
-    easy = True#I.number_field().degree()==2 or I.norm()==1
+    easy = I.number_field().degree()<5 or I.norm()==1
     gens = I.gens_reduced() if easy else I.gens()
+    if len(gens)==2 and gens[0]==gens[1]: # yes this can happen!
+        gens = gens[:1]
     return r"\((" + ",".join([latex(g) for g in gens]) + r")\)"
 
 # HNF of an ideal I in a quadratic field

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -17,24 +17,26 @@ not-implemented:
     // (not yet implemented)
 
 field:
-  sage:  x = polygen(QQ);  K.<a> = NumberField(%s)
-  pari:  K = nfinit(%s);
+  sage:  R.<x> = PolynomialRing(QQ);  K.<a> = NumberField(R(%s))
+  pari:  K = nfinit(Pol(Vecrev(%s)));
   magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(R!%s);
 
 curve:
-  sage:  E = EllipticCurve(K, %s)
-  pari:  E = ellinit(%s,K)
-  magma: E := ChangeRing(EllipticCurve(%s),K);
+  sage:  E = EllipticCurve(%s)
+  pari:  E = ellinit(%s);
+  magma: E := EllipticCurve(%s);
 
 is_min:
   sage:  E.is_global_minimal_model()
 
 cond:
   sage:  E.conductor()
+  pari:  ellglobalred(E)[1]
   magma: Conductor(E);
 
 cond_norm:
   sage:  E.conductor().norm()
+  pari:  idealnorm(ellglobalred(E)[1])
   magma: Norm(Conductor(E));
 
 disc:
@@ -88,7 +90,7 @@ torgens:
 
 ntors:
   sage:  T.order()
-  pari:  T[3]
+  pari:  T[1]
   magma: Order(T);
 
 localdata:


### PR DESCRIPTION
This should fix the issue at #4323.   I refactored the code which prepares the sage/gp/magma code both for the code snippets on a curve's home page, and for the download all code links.  In particular if you go straight to a URL like 
http://localhost:37777/EllipticCurve/4.4.13448.1/40.2/j/2/download/gp
you should notice that it is faster than on beta, and simiarly with 
http://localhost:37777/EllipticCurve/6.6.371293.1/233.4/b/4/download/gp
which can timeout on beta.

This does not address the issue that the ECNF() constructor which is called when an indivudual curve page is created takes too long, which will be addressed separately, except that I have avoided the call to gens_reduced() on an ideal when the base field has degree > 4.

Note that when I did a full test locally there was a failure with a call to magma_free in test_cmf which has nothing to do with this.