### PR TITLE
Hotfix for Sato-Tate groups

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -37,7 +37,12 @@ INFINITY = -1
 credit_string = 'Andrew Sutherland'
 
 # use a list and a dictionary (for pretty printing) so that we can control the display order (switch to ordered dictionary once everyone is on python 3.1)
-st0_list = ( 'U(1)', 'SU(2)', 'U(1)_2', 'SU(2)_2','U(1)xU(1)', 'U(1)xSU(2)','SU(2)xSU(2)','USp(4)' )
+st0_list = (
+    'U(1)', 'SU(2)',
+    'U(1)_2', 'SU(2)_2', 'U(1)xU(1)', 'U(1)xSU(2)', 'SU(2)xSU(2)', 'USp(4)',
+    'U(1)_3', 'SU(2)_3', 'U(1)xU(1)_2', 'SU(2)xU(1)_2', 'U(1)xSU(2)_2', 'SU(2)xSU(2)_2', 'U(1)^3',
+    'U(1)^2xSU(2)', 'U(1)xSU(2)^2', 'SU(2)^3', 'U(1)xUSp(4)', 'SU(2)xUSp(4)', 'U(3)', 'USp(6)'
+)
 st0_dict = {
     'U(1)':'\\mathrm{U}(1)',
     'SU(2)':'\\mathrm{SU}(2)',
@@ -47,6 +52,20 @@ st0_dict = {
     'U(1)xSU(2)':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)',
     'SU(2)xSU(2)':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)',
     'USp(4)':'\\mathrm{USp}(4)'
+    'U(1)_3':'\\mathrm{U}(1)_3',
+    'SU(2)_3':'\\mathrm{SU}(2)_3',
+    'U(1)xU(1)_2':'\\mathrm{U}(1)\\times\\mathrm{U}(1)_2',
+    'SU(2)xU(1)_2':'\\mathrm{SU}(2)\\times\\mathrm{U}(1)_2',
+    'U(1)xSU(2)_2':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)_2',
+    'SU(2)xSU(2)':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)_2',
+    'U(1)^3':'\\mathrm{U}(1)^3',
+    'U(1)^2xSU(2)':'\\mathrm{U}(1)^2\\times\\mathrm{SU}(2)',
+    'U(1)xSU(2)^2':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)^2',
+    'SU(2)^3':'\\mathrm{SU}(2)^3',
+    'U(3)':'\\mathrm{U}(3)',
+    'U(1)xUSp(4)':'\\mathrm{U}(1)\\times\\mathrm{USp}(4)'
+    'SU(2)xUSp(4)':'\\mathrm{SU}(2)\\times\\mathrm{USp}(4)'
+    'USp(6)':'\\mathrm{USp}(6)'
 }
 
 ###############################################################################

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -38,12 +38,19 @@ credit_string = 'Andrew Sutherland'
 
 # use a list and a dictionary (for pretty printing) so that we can control the display order (switch to ordered dictionary once everyone is on python 3.1)
 st0_list = (
+    'SO(1)', 'SO(2)', 'SO(3)', 'SO(4)', 'SO(5)', 'SO(6)',
     'U(1)', 'SU(2)',
     'U(1)_2', 'SU(2)_2', 'U(1)xU(1)', 'U(1)xSU(2)', 'SU(2)xSU(2)', 'USp(4)',
     'U(1)_3', 'SU(2)_3', 'U(1)xU(1)_2', 'SU(2)xU(1)_2', 'U(1)xSU(2)_2', 'SU(2)xSU(2)_2', 'U(1)^3',
     'U(1)^2xSU(2)', 'U(1)xSU(2)^2', 'SU(2)^3', 'U(1)xUSp(4)', 'SU(2)xUSp(4)', 'U(3)', 'USp(6)'
 )
 st0_dict = {
+    'SO(1)':'\\mathrm{SO}(1)',
+    'SO(2)':'\\mathrm{SO}(2)',
+    'SO(3)':'\\mathrm{SO}(3)',
+    'SO(4)':'\\mathrm{SO}(4)',
+    'SO(5)':'\\mathrm{SO}(5)',
+    'SO(6)':'\\mathrm{SO}(6)',
     'U(1)':'\\mathrm{U}(1)',
     'SU(2)':'\\mathrm{SU}(2)',
     'U(1)_2':'\\mathrm{U}(1)_2',

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -51,20 +51,20 @@ st0_dict = {
     'U(1)xU(1)':'\\mathrm{U}(1)\\times\\mathrm{U}(1)',
     'U(1)xSU(2)':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)',
     'SU(2)xSU(2)':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)',
-    'USp(4)':'\\mathrm{USp}(4)'
+    'USp(4)':'\\mathrm{USp}(4)',
     'U(1)_3':'\\mathrm{U}(1)_3',
     'SU(2)_3':'\\mathrm{SU}(2)_3',
     'U(1)xU(1)_2':'\\mathrm{U}(1)\\times\\mathrm{U}(1)_2',
     'SU(2)xU(1)_2':'\\mathrm{SU}(2)\\times\\mathrm{U}(1)_2',
     'U(1)xSU(2)_2':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)_2',
-    'SU(2)xSU(2)':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)_2',
+    'SU(2)xSU(2)_2':'\\mathrm{SU}(2)\\times\\mathrm{SU}(2)_2',
     'U(1)^3':'\\mathrm{U}(1)^3',
     'U(1)^2xSU(2)':'\\mathrm{U}(1)^2\\times\\mathrm{SU}(2)',
     'U(1)xSU(2)^2':'\\mathrm{U}(1)\\times\\mathrm{SU}(2)^2',
     'SU(2)^3':'\\mathrm{SU}(2)^3',
     'U(3)':'\\mathrm{U}(3)',
-    'U(1)xUSp(4)':'\\mathrm{U}(1)\\times\\mathrm{USp}(4)'
-    'SU(2)xUSp(4)':'\\mathrm{SU}(2)\\times\\mathrm{USp}(4)'
+    'U(1)xUSp(4)':'\\mathrm{U}(1)\\times\\mathrm{USp}(4)',
+    'SU(2)xUSp(4)':'\\mathrm{SU}(2)\\times\\mathrm{USp}(4)',
     'USp(6)':'\\mathrm{USp}(6)'
 }
 

--- a/lmfdb/sato_tate_groups/templates/st_browse.html
+++ b/lmfdb/sato_tate_groups/templates/st_browse.html
@@ -15,9 +15,6 @@
     <td>By {{ KNOWL('st_group.degree', title='degree') }}:</td>
     <td>{% for r in info.degree_list %} <a href="?degree={{r}}">{{r}}</a>&nbsp; {% endfor %}</td>
   </tr><tr>
-    <td>By {{ KNOWL('st_group.identity_component', title='identity component') }}:</td>
-    <td>{% for r in info.st0_list %} <a href="?identity_component={{r}}">${{info.st0_dict[r]}}$</a>&nbsp;&nbsp; {% endfor %}</td>
-  </tr><tr>
     <td colspan="2">Some <a href="{{url_for('.interesting')}}">interesting Sato-Tate groups</a> or a <a href="{{url_for('.random')}}">random Sato-Tate group</a></td>
   </tr>
 </table>


### PR DESCRIPTION
Fixes identity component selector so it recognizes subgroups of USp(6).  Tests pass on grace.