### PR TITLE
Minor rearrangement of L-function search inputs

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -268,7 +268,10 @@ def makeLfromdata(L):
         from .main import url_for_lfunction
         dual_L_Lhash = data['conjugate']
         dual_L_data = get_lfunction_by_Lhash(dual_L_Lhash)
-        L.dual_link = url_for_lfunction(dual_L_data['label'])
+        if dual_L_data.get('label'):
+            L.dual_link = url_for_lfunction(dual_L_data['label'])
+        elif dual_L_data.get('origin'):
+            L.dual_link = '/L/' + dual_L_data['origin']
         L.dual_accuracy = dual_L_data.get('accuracy', None)
         L.negative_zeros_raw = [display_float(z, 12, 'round') if isinstance(z, float) else z for z in dual_L_data['positive_zeros']]
         if L.dual_accuracy is not None:

--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -65,10 +65,6 @@ class Lfunction(object):
     def rational(self):
         return None
 
-    @lazy_attribute
-    def label(self):
-        return None
-
 
     ############################################################################
     ### other useful methods not implemented universally yet

--- a/lmfdb/lfunctions/Lfunction_base.py
+++ b/lmfdb/lfunctions/Lfunction_base.py
@@ -65,6 +65,10 @@ class Lfunction(object):
     def rational(self):
         return None
 
+    @lazy_attribute
+    def label(self):
+        return None
+
 
     ############################################################################
     ### other useful methods not implemented universally yet

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -502,7 +502,7 @@ class LFunctionSearchArray(SearchArray):
             [spectral_label, primitive],
             [origin, origin_exclude],
         ]
-        if force_rational:
+        if not force_rational:
             self.browse_array += [[algebraic, self_dual]]
         self.browse_array += [[count]]
 
@@ -511,7 +511,7 @@ class LFunctionSearchArray(SearchArray):
             [degree, bad_primes, root_analytic_conductor, motivic_weight, root_angle],
             [spectral_label, primitive, origin, origin_exclude],
         ]
-        if force_rational:
+        if not force_rational:
             self.refine_array[2] += [algebraic, self_dual]
 
         if force_rational:

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1077,8 +1077,11 @@ def l_function_genus2_page(cond,x):
 @l_function_page.route("/Lhash/<lhash>")
 @l_function_page.route("/Lhash/<lhash>/")
 def l_function_by_hash_page(lhash):
-    args = {'Lhash': lhash}
-    return render_single_Lfunction(Lfunction_from_db, args, request)
+    label = db.lfunc_lfunctions.lucky({'Lhash': lhash, 'label': {'$exists': True}}, projection = "label")
+    if label is None:
+        errmsg = 'Did not find an L-function with Lhash = %s' % Lhash
+        return render_lfunction_exception(errmsg)
+    return redirect(url_for_lfunction(label), 301)
 
 #by trace_hash
 @l_function_page.route("/tracehash/<int:trace_hash>")
@@ -1088,11 +1091,11 @@ def l_function_by_trace_hash_page(trace_hash):
         errmsg = r'trace_hash = %s not in [0, 2^61]' % trace_hash
         return render_lfunction_exception(errmsg)
 
-    lhash = db.lfunc_lfunctions.lucky({'trace_hash': trace_hash}, projection = "Lhash")
-    if lhash is None:
+    label = db.lfunc_lfunctions.lucky({'trace_hash': trace_hash, 'label': {'$exists': True}}, projection = "label")
+    if label is None:
         errmsg = 'Did not find an L-function with trace_hash = %s' % trace_hash
         return render_lfunction_exception(errmsg)
-    return redirect(url_for('.l_function_by_hash_page', lhash = lhash), 301)
+    return redirect(url_for_lfunction(label), 301)
 
 
 ################################################################################

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -503,7 +503,7 @@ class LFunctionSearchArray(SearchArray):
             [origin, origin_exclude],
         ]
         if not force_rational:
-            self.browse_array += [[algebraic, self_dual]]
+            self.browse_array += [[self_dual, algebraic]]
         self.browse_array += [[count]]
 
         self.refine_array = [
@@ -512,7 +512,8 @@ class LFunctionSearchArray(SearchArray):
             [spectral_label, primitive, origin, origin_exclude],
         ]
         if not force_rational:
-            self.refine_array[2] += [algebraic, self_dual]
+            self.refine_array[2] += [self_dual]
+            self.refine_array += [[algebraic]]
 
         if force_rational:
             trace_coldisplay = TextBox(

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -508,8 +508,8 @@ class LFunctionSearchArray(SearchArray):
 
         self.refine_array = [
             [z1, conductor, analytic_conductor, central_character, analytic_rank],
-            [degree, bad_primes, root_analytic_conductor, motivic_weight, root_angle],
-            [spectral_label, primitive, origin, origin_exclude],
+            [degree, bad_primes, root_analytic_conductor, motivic_weight, spectral_label],
+            [root_angle, primitive, origin, origin_exclude],
         ]
         if not force_rational:
             self.refine_array[2] += [self_dual]

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -255,6 +255,14 @@ def common_parse(info, query):
     parse_ints(info,query,'degree')
     parse_ints(info,query,'conductor')
     parse_bool(info,query,'primitive')
+    if info.get("algebraic") == "rational":
+        query['rational'] = True
+    elif info.get("algebraic") == "irrational":
+        query['rational'] = False
+    elif info.get("algebraic") == "algebraic":
+        query['algebraic'] = True
+    elif info.get("algebraic") == "transcendental":
+        query['algebraic'] = False
     parse_bool(info,query,'algebraic')
     parse_bool(info,query,'self_dual')
     parse_bool(info,query,'rational')
@@ -407,11 +415,16 @@ class LFunctionSearchArray(SearchArray):
             knowl="lfunction.primitive",
             label="Primitive",
             example_col=True)
-        algebraic = YesNoBox(
+        algebraic = SelectBox(
             name="algebraic",
             knowl="lfunction.arithmetic",
             label="Arithmetic",
-            example_col=True)
+            example_col=True,
+            options=[('', ''),
+                     ('rational', 'rational'),
+                     ('irrational', 'irrational'),
+                     ('algebraic', 'algebraic'),
+                     ('transcendental', 'transcendental')])
         self_dual = YesNoBox(
             name="self_dual",
             knowl="lfunction.self-dual",
@@ -478,23 +491,29 @@ class LFunctionSearchArray(SearchArray):
             options=origins_list)
         count = CountBox()
 
+        self.force_rational = force_rational
+
         self.browse_array = [
             [z1, degree],
             [conductor, bad_primes],
             [analytic_conductor, root_analytic_conductor],
-            [central_character, root_angle],
-            [analytic_rank, motivic_weight],
-            [spectral_label],
-            [primitive, algebraic],
+            [central_character, motivic_weight],
+            [analytic_rank, root_angle],
+            [spectral_label, primitive],
+            [origin, origin_exclude],
         ]
+        if force_rational:
+            self.browse_array += [[algebraic, self_dual]]
+        self.browse_array += [[count]]
 
         self.refine_array = [
-            [degree, conductor, bad_primes, central_character, analytic_conductor, root_analytic_conductor],
-            [primitive, algebraic],
-            [root_angle, analytic_rank, motivic_weight, z1, spectral_label]
+            [z1, conductor, analytic_conductor, central_character, analytic_rank],
+            [degree, bad_primes, root_analytic_conductor, motivic_weight, root_angle],
+            [spectral_label, primitive, origin, origin_exclude],
         ]
+        if force_rational:
+            self.refine_array[2] += [algebraic, self_dual]
 
-        self.force_rational = force_rational
         if force_rational:
             trace_coldisplay = TextBox(
                 name='n',
@@ -546,19 +565,6 @@ class LFunctionSearchArray(SearchArray):
             self.euler_array = [
                 RowSpacer(22),
                 [euler_coldisplay, euler_constraints]]
-
-            self.browse_array += [[origin, origin_exclude], [count]]
-            self.refine_array[1] += [origin, origin_exclude]
-
-        else:
-            rational = YesNoBox(
-                name="rational",
-                knowl="lfunction.rational",
-                label="Rational",
-                example_col=True)
-
-            self.browse_array += [[self_dual, rational], [origin, origin_exclude], [count]]
-            self.refine_array[1] += [self_dual, rational, origin, origin_exclude]
 
     def search_types(self, info):
         if self.force_rational:

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -226,7 +226,7 @@ def parse_spectral(inp, query, qfield):
     reals, e, imags = M.groups()
     e = 1 if e is None else int(e)
     def extract(t, x):
-        return Counter(map(int, re.findall(t+r'([0-9.]+)', x)))
+        return Counter(list(map(int, re.findall(t+r'([0-9.]+)', x))))
     if imags == '0': # algebraic
         GRcount = extract('r', reals)
         # We store the real parts of nu doubled

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -263,7 +263,6 @@ def common_parse(info, query):
         query['algebraic'] = True
     elif info.get("algebraic") == "transcendental":
         query['algebraic'] = False
-    parse_bool(info,query,'algebraic')
     parse_bool(info,query,'self_dual')
     parse_bool(info,query,'rational')
     # If searching on the rational page, there will be root_number; if on the all L-function page, root_angle

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -503,19 +503,19 @@ class LfunctionTest(LmfdbTest):
         Checking L/lhash/ pages
         """
         # The hash for /L/EllipticCurve/Q/324016/h
-        L = self.tc.get('/L/lhash/1938322253992393114/')
+        L = self.tc.get('/L/lhash/1938322253992393114/', follow_redirects=True)
         assert '324016' in L.get_data(as_text=True), "Missing data in /L/lhash/1938322253992393114/"
         assert 'Dual L-function' not in L.get_data(as_text=True)
         assert '2-324016-1.1-c1-0-6' in L.get_data(as_text=True)
         assert 'Elliptic curve 324016.h' in L.get_data(as_text=True)
 
-        L = self.tc.get('/L/lhash/dirichlet_L_6253.458/')
+        L = self.tc.get('/L/lhash/dirichlet_L_6253.458/', follow_redirects=True)
         assert '1.0612' in L.get_data(as_text=True), "Missing data in /L/lhash/dirichlet_L_6253.458/"
         assert '1-6253-6253.458-r1-0-0' in L.get_data(as_text=True) 
         assert 'Dual L-function' in L.get_data(as_text=True)
         assert 'Character/Dirichlet/6253/458' in L.get_data(as_text=True)
 
-        L = self.tc.get('/L/Lhash/7200459463482029776252499748763/')
+        L = self.tc.get('/L/Lhash/7200459463482029776252499748763/', follow_redirects=True)
         assert 'Dual L-function' in L.get_data(as_text=True)
         assert 'Modular form 13.4.c.a.3.1' in L.get_data(as_text=True)
         assert 'ModularForm/GL2/Q/holomorphic/13/4/c/a/3/1' in L.get_data(as_text=True)

--- a/lmfdb/utils/names_and_urls.py
+++ b/lmfdb/utils/names_and_urls.py
@@ -143,7 +143,8 @@ def name_and_object_from_url(url, check_existence=False):
             obj_exists = True
     else:
         # FIXME
-        print("unknown url", url)
+        #print("unknown url", url)
+        pass
 
 
     return name, obj_exists


### PR DESCRIPTION
This PR makes some minor tweaks the layout of the browse and refine search options to (1) remove the arithmetic selector from the rational search page (where it makes no sense), (2) combine rational/arithmetic into a single selector with rationa/irrational/algebraic/transcendental options, (3) fill in an unnecessary gap, (4) keep the refine search array 5 boxes wide (as elsewhere in the LMFDB) to make it work better on narrower screens and avoid colliding with the learnmore box.

