### PR TITLE
ECNF: fix display of special value

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -635,7 +635,7 @@ class ECNF(object):
         try:
             r = int(self.analytic_rank)
             # lhs = "L(E,1) = " if r==0 else "L'(E,1) = " if r==1 else "L^{{({})}}(E,1)/{}! = ".format(r,r)
-            self.Lvalue = "\\(" + str(self.Lvalue) + r"\\)"
+            self.Lvalue = web_latex(self.Lvalue)
         except (TypeError, AttributeError):
             self.Lvalue = "not available"
             

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -303,7 +303,13 @@ cellpadding="5";
 
         <tr>
         <td align='left'>{{ KNOWL('lfunction.leading_coeff', title='Leading coefficient') }}:</td>
-        <td> {{ ec.Lvalue }}</td>
+        <td>
+	  {% if ec.Lvalue=='not available' %}
+	  not available
+	  {% else %}
+	  {{ ec.Lvalue }}
+	  {% endif %}
+	</td>
         </tr>
 
         <tr>


### PR DESCRIPTION
Small fix after #4329.  Pick a random ecnf curve and look at the display of the special value on beta. It is only a typo but I now use the same as for the regulator, which correctly handles the value "not available" (look at any curve over a degree 6 field to check this).

It's very minor so I'll merge when I see that tests pass, unless someone else does.

I noticed this when checking the results of the data update fixing #4332, but it has nothing to do with that.