### PR TITLE
EC/Q fix code use of labels

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -17,15 +17,9 @@ not-implemented:
     // (not yet implemented)
 
 curve:
-  sage: |
-    E = EllipticCurve(%s)    # or
-    E = EllipticCurve("%s")
-  pari: |
-    E = ellinit(%s)       \\ or
-    E = ellinit("%s")
-  magma: |
-    E := EllipticCurve(%s); // or
-    E := EllipticCurve("%s");
+  sage:  E = EllipticCurve(%s)
+  pari:  E = ellinit(%s)
+  magma: E := EllipticCurve(%s);
 
 gens:
   sage:  E.gens()
@@ -121,5 +115,5 @@ galrep:
 
 padicreg:
   sage: |
-    [E.padic_regulator(p) for p in primes(3,20) if E.conductor().valuation(p)<2]
+    [E.padic_regulator(p) for p in primes(5,20) if E.conductor().valuation(p)<2]
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -583,7 +583,11 @@ class WebEC(object):
         # Fill in placeholders for this specific curve:
 
         for lang in ['sage', 'pari', 'magma']:
-            self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.lmfdb_label)
+            if self.conductor < CREMONA_BOUND:
+                self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.Clabel)
+            else:
+                ecode = self._code['curve'][lang][:code.index(")")+1:]
+                self._code['curve'][lang] = ecode % (self.data['ainvs'])
         return
         for k in self._code:
             if k != 'prompt':

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -571,29 +571,13 @@ class WebEC(object):
 
     def code(self):
         if self._code is None:
-            self.make_code_snippets()
+
+            # read in code.yaml from current directory:
+            _curdir = os.path.dirname(os.path.abspath(__file__))
+            self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
+
+            # Fill in placeholders for this specific curve:
+            for lang in ['sage', 'pari', 'magma']:
+                self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'])
+
         return self._code
-
-    def make_code_snippets(self):
-        # read in code.yaml from current directory:
-
-        _curdir = os.path.dirname(os.path.abspath(__file__))
-        self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
-
-        # Fill in placeholders for this specific curve:
-
-        for lang in ['sage', 'pari', 'magma']:
-            if self.conductor < CREMONA_BOUND:
-                self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.Clabel)
-            else:
-                ecode = self._code['curve'][lang]
-                ecode = ecode[:ecode.index(")")+1:]
-                self._code['curve'][lang] = ecode % (self.data['ainvs'])
-        return
-        for k in self._code:
-            if k != 'prompt':
-                for lang in self._code[k]:
-                    self._code[k][lang] = self._code[k][lang].split("\n")
-                    # remove final empty line
-                    if len(self._code[k][lang][-1])==0:
-                        self._code[k][lang] = self._code[k][lang][:-1]

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -586,7 +586,8 @@ class WebEC(object):
             if self.conductor < CREMONA_BOUND:
                 self._code['curve'][lang] = self._code['curve'][lang] % (self.data['ainvs'],self.Clabel)
             else:
-                ecode = self._code['curve'][lang][:code.index(")")+1:]
+                ecode = self._code['curve'][lang]
+                ecode = ecode[:ecode.index(")")+1:]
                 self._code['curve'][lang] = ecode % (self.data['ainvs'])
         return
         for k in self._code:


### PR DESCRIPTION
This fixes #4371, correcting the Sage/Magma/GP code for constructing curves.  First, the second line showing how to construct a curve from a label, uses the Cremona label (which is the only labelling which any of the three recognise).  Second, this second line is omitted for conductors over 500000.  The change works both in the code snippets on a home page and on the compete file of code to download.

To test, take  random curves both with conductor <500000 and >500000 and look at the code snippets on the home page (all three languages) and the code download.
