### PR TITLE
Fix two typos in L-function template

### DIFF
--- a/lmfdb/lfunctions/templates/Lfunction.html
+++ b/lmfdb/lfunctions/templates/Lfunction.html
@@ -94,11 +94,11 @@
 
   {% if analytic_conductor %}
   <tr>
-    <td> {{ KNOWL('lfunction.analytic_conductor', title="Analtyic conductor") }}: </td>
+    <td> {{ KNOWL('lfunction.analytic_conductor', title="Analytic conductor") }}: </td>
     <td> \({{ analytic_conductor }}\) </td>
   </tr>
   <tr>
-    <td> {{ KNOWL('lfunction.root_analytic_conductor', title="Root analtyic conductor") }}: </td>
+    <td> {{ KNOWL('lfunction.root_analytic_conductor', title="Root analytic conductor") }}: </td>
     <td> \({{ root_analytic_conductor }}\) </td>
   </tr>
   {% endif %}


### PR DESCRIPTION
This fixes something reported in the feedback page.

On 

https://beta.lmfdb.org/L/2/131/131.130/c0/0/0
https://127.0.0.1:37777/L/2/131/131.130/c0/0/0

the word analytic is misspelled twice.