### PR TITLE
move create_table name check to lmfdb_database

### DIFF
--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -613,8 +613,6 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
         """
         if name in self.tablenames:
             raise ValueError("%s already exists" % name)
-        if "_" not in name:
-            raise ValueError("Table name must contain an underscore; first part gives LMFDB section")
         now = time.time()
         if id_ordered is None:
             id_ordered = sort is not None

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -393,7 +393,7 @@ class LMFDBDatabase(PostgresDatabase):
     def create_table(self, name, *args, **kwargs):
         if "_" not in name:
             raise ValueError("Table name '%s' must contain an underscore; first part gives the LMFDB section" % name,)
-        return PostgresDatabase.create_table(name=name, *args, **kwargs)
+        return PostgresDatabase.create_table(name, *args, **kwargs)
 
 
 db = LMFDBDatabase()

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -390,11 +390,10 @@ class LMFDBDatabase(PostgresDatabase):
                 disp().setup(delete=False)
 
     @overrides(PostgresDatabase)
-    def create_table(self, *args, **kwargs):
-        name = args[0]
+    def create_table(self, name, *args, **kwargs):
         if "_" not in name:
             raise ValueError("Table name '%s' must contain an underscore; first part gives the LMFDB section" % name,)
-        return PostgresDatabase.create_table(*args, **kwargs)
+        return PostgresDatabase.create_table(name=name, *args, **kwargs)
 
 
 db = LMFDBDatabase()


### PR DESCRIPTION
Moving the underscore check on the name of a new table to lmfdb_database.

This should allow us to keep the folder `lmfdb/backend`  matching the `psycodict` folder of https://github.com/roed314/psycodict/