### PR TITLE
EC/Q: update completeness info to include primes<10^6

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -159,9 +159,11 @@ class ECstats(StatsDisplay):
         self.nclasses = db.ec_classdata.count()
         self.nclasses_c = comma(self.nclasses)
         self.max_N_Cremona = 500000
-        self.max_N_Cremona_c = comma(500000)
+        self.max_N_Cremona_c = comma(self.max_N_Cremona)
         self.max_N = db.ec_curvedata.max('conductor')
         self.max_N_c = comma(self.max_N)
+        self.max_N_prime = 1000000
+        self.max_N_prime_c = comma(self.max_N_prime)
         self.max_rank = db.ec_curvedata.max('rank')
         self.max_rank_c = comma(self.max_rank)
         self.cond_knowl = display_knowl('ec.q.conductor', title = "conductor")
@@ -181,8 +183,9 @@ class ECstats(StatsDisplay):
             'The database currently includes {} {} in {} {}, with {} at most {},'.format(self.ncurves_c, self.ec_knowl, self.nclasses_c, self.cl_knowl, self.cond_knowl, self.max_N_c),
             'consisting of',
             '<ul>',
-            '<li>all curves of conductor less than {};</li>'.format(self.max_N_Cremona),
-            '<li> all curves with $7$-smooth conductor.</li>',
+            '<li>all curves of conductor less than {};</li>'.format(self.max_N_Cremona_c),
+            '<li>all curves with $7$-smooth conductor.</li>',
+            '<li>all curves of prime conductor less than {};</li>'.format(self.max_N_prime_c),
             '</ul>',
             '</p>',
         ])


### PR DESCRIPTION
This is in 3 parts, after uploading all elliptic curves with prime conductor between 500000 and 10^6:

- the source and reliability knowls have been updated, and will need reviewing
- the completeness knowl's content is set in the code and this PR updates that
- the 6 tables db.ec_curvedata, db.ec_localdata, db.ec_mwbsd,  db.ec_classdata, db.ec_2adic, db.ec_galrep need to be copied to prod

To see the 3775 new curves on beta, put in conductor>500000 and exclude 2,3,5,7 from the bad primes:  https://beta.lmfdb.org/EllipticCurve/Q/?hst=List&conductor=500000-&bad_quantifier=exclude&bad_primes=2%2C3%2C5%2C7&search_type=List