### PR TITLE
Lmfdb#4326 Code download and compile helpers

### DIFF
--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -115,23 +115,15 @@ class BMFTest(LmfdbTest):
             # but the goal is to test that itself doesn't show in the friends list
             assert notitself not in L.get_data(as_text=True)
 
-    def check_compile_and_get_level(self, download_data):
-        """Simulates a user downloading the sage code, and then loading it into
-        a sage session. This requires the sage import at the top"""
-
-        sage_code = download_data.get_data(as_text=True)
-        exec(sage_code, globals())
-        global NN
-        return NN
-
     def test_download_sage(self):
+
         # A dimension 1 example
-        L1 = self.tc.get('/ModularForm/GL2/ImaginaryQuadratic/2.0.3.1/18333.3/a/download/sage')
-        L1_level = self.check_compile_and_get_level(L1)
+        L1_sage_code = self.tc.get('/ModularForm/GL2/ImaginaryQuadratic/2.0.3.1/18333.3/a/download/sage').get_data(as_text=True)
+        L1_level = self.check_sage_compiles_and_extract_var(L1_sage_code, 'NN')
         assert L1_level.norm() == Integer(18333)
-        assert 'NN = ZF.ideal((6111, 3*a + 5052))' in L1.get_data(as_text=True)
-        assert '(27*a-22,),(-29*a+15,),(-29*a+14,),(29*a-11,),(-29*a+18,),(-29*a+9,)' in L1.get_data(as_text=True)
-        assert 'hecke_eigenvalues_array = [0, -1, 2, -1, 1, -3, 4, 0, -2, -8, 7, -9, -8, -4, -9, 8, 10, -11,' in L1.get_data(as_text=True)
+        assert 'NN = ZF.ideal((6111, 3*a + 5052))' in L1_sage_code
+        assert '(27*a-22,),(-29*a+15,),(-29*a+14,),(29*a-11,),(-29*a+18,),(-29*a+9,)' in L1_sage_code
+        assert 'hecke_eigenvalues_array = [0, -1, 2, -1, 1, -3, 4, 0, -2, -8, 7, -9, -8, -4, -9, 8, 10, -11,' in L1_sage_code
         """
         Observe that example 1 above checks equality of the level norm between
         the loaded sage code and what appears on the homepage, but then checks
@@ -143,8 +135,8 @@ class BMFTest(LmfdbTest):
         """
 
         # A dimension 2 example
-        L2 = self.tc.get('/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/377.1/a2/download/sage')
-        L2_level = self.check_compile_and_get_level(L2)
+        L2_sage_code = self.tc.get('/ModularForm/GL2/ImaginaryQuadratic/2.0.4.1/377.1/a2/download/sage').get_data(as_text=True)
+        L2_level = self.check_sage_compiles_and_extract_var(L2_sage_code, 'NN')
 
         P = PolynomialRing(QQ,'x')
         g = P([1, 0, 1])
@@ -155,8 +147,8 @@ class BMFTest(LmfdbTest):
         L2_level_actual = ZF.ideal((16*i - 11))  # the level displayed on BMF homepage
         assert L2_level == L2_level_actual
         assert L2_level.norm() == 377
-        assert '(2*i+3,),(i+4,),(i-4,),(-2*i+5,),(2*i+5,),(i+6,)' in L2.get_data(as_text=True)
-        assert 'hecke_eigenvalues_array = [-z, 2*z, -1, 2*z+2, "not known", 2*z-1, 4, 2*z+3, "not known", 2*z+1, -2*z-5, -4*z+5, -4*z+5, 2*z+1, 2*z]' in L2.get_data(as_text=True)
+        assert '(2*i+3,),(i+4,),(i-4,),(-2*i+5,),(2*i+5,),(i+6,)' in L2_sage_code
+        assert 'hecke_eigenvalues_array = [-z, 2*z, -1, 2*z+2, "not known", 2*z-1, 4, 2*z+3, "not known", 2*z+1, -2*z-5, -4*z+5, -4*z+5, 2*z+1, 2*z]' in L2_sage_code
 
     def test_download_magma(self):
         # A dimension 1 example

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -573,8 +573,7 @@ class CmfTest(LmfdbTest):
             assert "make_data" in sage_code
             assert "aps_data" in sage_code
             sage_code += "\n\nout = str(make_data().list()[2:5])\n"
-            exec(sage_code, globals())
-            global out
+            out = self.check_sage_compiles_and_extract_var(sage_code, 'out')
             assert str(out) == exp
         for label in ['212.2.k.a', '887.2.a.b']:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_qexp/{}'.format(label), follow_redirects=True)
@@ -587,12 +586,16 @@ class CmfTest(LmfdbTest):
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/23.10', follow_redirects=True)
         assert '[0, 187, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, -11, 969023, -478731' in page.get_data(as_text=True)
+
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/1161.1.i', follow_redirects=True)
         assert '[0, 14, 0, 0, -2, 0, 0, 0, 0, 0, -2, 0, 0, 1, 0, 0, -10, 0, 0, 1, 0, 0' in page.get_data(as_text=True)
+
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/1161.1.i.maria.josefina', follow_redirects=True)
         assert 'Invalid label' in page.get_data(as_text=True)
+
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/4021.2.mz', follow_redirects=True)
         assert 'Label not found:'
+
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_traces/4021.2.c', follow_redirects=True)
         assert 'We have not computed traces for' in page.get_data(as_text=True)
 

--- a/lmfdb/tests/__init__.py
+++ b/lmfdb/tests/__init__.py
@@ -7,7 +7,16 @@ from six.moves.urllib.error import URLError
 import ssl
 import errno
 from lmfdb.app import app
+
+# The following sage imports are used to check that various sage code
+# download pages actually compile in sage. Future tests requiring additional
+# imports should be declared here. The assertions following the imports
+# keep pyflakes happy.
+
 from sage.all import PolynomialRing, QQ, NumberField
+assert PolynomialRing
+assert QQ
+assert NumberField
 
 
 class LmfdbTest(unittest2.TestCase):
@@ -84,7 +93,7 @@ class LmfdbTest(unittest2.TestCase):
     def check_sage_compiles_and_extract_var(self, sage_code, my_name):
         """
         Simulates a user downloading the sage code, and then loading it
-        into a sage session. This requires the sage import at the top of
+        into a sage session. This requires the sage imports at the top of
         the file. It returns a desired variable for further checks.
 
         sage_code [Type: str] : the sage code to execute

--- a/lmfdb/tests/__init__.py
+++ b/lmfdb/tests/__init__.py
@@ -7,7 +7,7 @@ from six.moves.urllib.error import URLError
 import ssl
 import errno
 from lmfdb.app import app
-from sage.all import Integer, PolynomialRing, QQ, NumberField
+from sage.all import PolynomialRing, QQ, NumberField
 
 
 class LmfdbTest(unittest2.TestCase):

--- a/lmfdb/tests/__init__.py
+++ b/lmfdb/tests/__init__.py
@@ -7,6 +7,7 @@ from six.moves.urllib.error import URLError
 import ssl
 import errno
 from lmfdb.app import app
+from sage.all import Integer, PolynomialRing, QQ, NumberField
 
 
 class LmfdbTest(unittest2.TestCase):
@@ -79,3 +80,18 @@ class LmfdbTest(unittest2.TestCase):
                 pass
             else:
                 raise
+
+    def check_sage_compiles_and_extract_var(self, sage_code, my_name):
+        """
+        Simulates a user downloading the sage code, and then loading it
+        into a sage session. This requires the sage import at the top of
+        the file. It returns a desired variable for further checks.
+
+        sage_code [Type: str] : the sage code to execute
+        my_name [Type: str] : name of the variable to extract from the
+                              sage code. This then allows the developer
+                              to implement subsequent checks.
+        """
+
+        exec(sage_code, globals())
+        return globals()[my_name]


### PR DESCRIPTION
This PR addresses Part 2 of #4326, to create helper functions when creating unit tests for downloading code, checking it compiles, and running assertion checks on some variables in that code.

The previous PR addressing Part 1 of this ticket effectively added a magma helper function which replaced all calls to magma in the rest of the testing code.

This PR has implemented a similar helper function for sage, replacing all calls to `exec(sage_code, globals())` in the testing code.

The individual tests affected by this refactor have been run locally on legendre, and they still pass.