### PR TITLE
Minor tweaks to Dirichlet character orbit pages

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -505,6 +505,7 @@ def _dir_knowl_data(label, orbit=False):
         inf += '<div align="right">\n'
         inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
         inf += '</div>\n'
+    print(inf)
     return inf
 
 def dirichlet_character_data(label):

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -392,7 +392,7 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
                 info = WebSmallDirichletGroup(**args).to_dict()
 
             info['title'] = 'Group of Dirichlet characters of modulus ' + str(modulus)
-            info['bread'] = bread([('%d'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus))])
+            info['bread'] = bread([('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus))])
             info['learnmore'] = learn()
             info['credit'] = credit()
             info['code'] = dict([(k[4:],info[k]) for k in info if k[0:4] == "code"])
@@ -406,7 +406,7 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
                     info = WebDBDirichletOrbit(**args).to_dict()
                 except ValueError:
                     flash_error(
-                    "No Galois orbit of Dirichlet characters with label %d.%s was found in the database.", modulus, orbit_label
+                    "No Galois orbit of Dirichlet characters with label %s.%s was found in the database.", modulus, orbit_label
                         )
                     return redirect(url_for(".render_DirichletNavigation"))
 
@@ -495,9 +495,9 @@ def _dir_knowl_data(label, orbit=False):
         webchar = make_webchar(args)
 
         if orbit and modulus <= 10000:
-            inf = "Dirichlet character orbit %d.%s\n" % (modulus, webchar.orbit_label)
+            inf = "Dirichlet character orbit %s.%s\n" % (modulus, webchar.orbit_label)
         else:
-            inf = r"Dirichlet character \(\chi_{%d}(%d, \cdot)\)" % (modulus, number) + "\n"
+            inf = r"Dirichlet character \(\chi_{%s}(%s, \cdot)\)" % (modulus, number) + "\n"
         inf += "<div><table class='chardata'>\n"
         def row_wrap(header, val):
             return "<tr><td>%s: </td><td>%s</td></tr>\n" % (header, val)
@@ -510,7 +510,7 @@ def _dir_knowl_data(label, orbit=False):
             inf += row_wrap('Characters', ",&nbsp;".join(numbers))
         if modulus <= 10000:
             if not orbit:
-                inf += row_wrap('Orbit label', '%d.%s' % (modulus, webchar.orbit_label))
+                inf += row_wrap('Orbit label', '%s.%s' % (modulus, webchar.orbit_label))
             inf += row_wrap('Orbit Index', webchar.orbit_index)
         inf += '</table></div>\n'
         if orbit:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -524,9 +524,11 @@ def _dir_knowl_data(label, orbit=False):
     return inf
 
 def dirichlet_character_data(label):
+    print("in dirichlet_character_data")
     return _dir_knowl_data(label, orbit=False)
 
 def dirichlet_orbit_data(label):
+    print("in dirichlet_orbit_data")
     return _dir_knowl_data(label, orbit=True)
 
 @app.context_processor

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -522,7 +522,6 @@ def _dir_knowl_data(label, orbit=False):
             inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
             inf += '</div>\n'
     except Exception as err: # yes we really want to catch everything here
-        print("Exception in _dir_knowl_data: %s", err)
         return "Unable to construct knowl for Dirichlet character label %s, please report this as a bug (include the URL of this page)." % label
     return inf
 

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -325,16 +325,16 @@ def extent_page():
 
 def make_webchar(args, get_bread=False):
     modulus = int(args['modulus'])
+    number = int(args['number']) if 'number' in args else None
+    orbit_label = args.get('orbit_label',None)
     bread_crumbs = []
     if modulus <= 10000:
-        if args.get('number') is None:
+        if number is None:
             if get_bread:
-                orbit_label = args['orbit_label']
                 bread_crumbs = bread(
                         [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
                         ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label))])
             return WebDBDirichletOrbit(**args), bread_crumbs
-        number = int(args['number'])
         if args.get('orbit_label') is None:
             orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
             orbit_label = cremona_letter_code(int(orbit_label.partition('.')[-1]) - 1)
@@ -345,7 +345,6 @@ def make_webchar(args, get_bread=False):
                     ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label, number=number))])
         return WebDBDirichletCharacter(**args), bread_crumbs
     else:
-        number = int(args['number'])
         if get_bread:
             bread_crumbs = bread(
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -31,8 +31,8 @@ def ctx_characters():
     return chardata
 
 def bread(tail=[]):
-    base = [('Characters',url_for(".render_characterNavigation")),
-            ('Dirichlet', url_for(".render_DirichletNavigation"))]
+    base = [('Characters',url_for("characters.render_characterNavigation")),
+            ('Dirichlet', url_for("characters.render_DirichletNavigation"))]
     if not isinstance(tail, list):
         tail = [(tail, " ")]
     return base + tail

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -329,23 +329,23 @@ def make_webchar(args):
         if args.get('number') is None:
             orbit_label = args['orbit_label']
             bread_crumbs = bread(
-                    [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
-                    ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label))])
+                    [('%s'%modulus, url_for("characters.render_Dirichletwebpage", modulus=modulus)),
+                    ('%s'%orbit_label, url_for("characters.render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label))])
             return bread_crumbs, WebDBDirichletOrbit(**args)
         number = int(args['number'])
         if args.get('orbit_label') is None:
             orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
             orbit_label = cremona_letter_code(int(orbit_label.partition('.')[-1]) - 1)
         bread_crumbs = bread(
-                [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
-                ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label)),
-                ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label, number=number))])
+                [('%s'%modulus, url_for("characters.render_Dirichletwebpage", modulus=modulus)),
+                ('%s'%orbit_label, url_for("characters.render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label)),
+                ('%s'%number, url_for("characters.render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label, number=number))])
         return bread_crumbs, WebDBDirichletCharacter(**args)
     else:
         number = int(args['number'])
         bread_crumbs = bread(
-                [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
-                ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, number=number))])
+                [('%s'%modulus, url_for("characters.render_Dirichletwebpage", modulus=modulus)),
+                ('%s'%number, url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number))])
         return bread_crumbs, WebSmallDirichletCharacter(**args)
 
 

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -463,6 +463,7 @@ def render_Dirichletwebpage(modulus=None, gal_orb_label=None, number=None):
     return render_template('Character.html', **info)
 
 def _dir_knowl_data(label, orbit=False):
+    printf("in _dir_knowl_data")
     modulus, number = label.split('.')
     modulus = int(modulus)
     try:
@@ -481,7 +482,9 @@ def _dir_knowl_data(label, orbit=False):
         number = numbers
         numbers = None
     args={'type': 'Dirichlet', 'modulus': modulus, 'number': number}
+    print("creating web character")
     _, webchar = make_webchar(args)
+    print("got it")
     if orbit and modulus <= 10000:
         inf = "Dirichlet character orbit %d.%s\n" % (modulus, webchar.orbit_label)
     else:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -433,15 +433,9 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
         return redirect(url_for(".render_DirichletNavigation"))
 
     if modulus <= 10000:
-        orbit_label = db.char_dir_values.lookup(
-                "{}.{}".format(modulus, number),
-                projection='orbit_label'
-            )
-        orbit_index = int(orbit_label.partition('.')[-1])
-        # The -1 in the line below is because labels index at 1, while
-        # the Cremona letter code indexes at 0
-        real_orbit_label = cremona_letter_code(orbit_index - 1)
-
+        db_orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
+        # The -1 in the line below is because labels index at 1, not 0
+        real_orbit_label = cremona_letter_code(int(db_orbit_label.partition('.')[-1]) - 1)
         if orbit_label is not None:
             if orbit_label != real_orbit_label:
                 flash_warning(

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -345,6 +345,7 @@ def make_webchar(args, get_bread=False):
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
                     ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label)),
                     ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label, number=number))])
+        print(args)
         return WebDBDirichletCharacter(**args), bread_crumbs
     else:
         if get_bread:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -513,7 +513,11 @@ def _dir_knowl_data(label, orbit=False):
                 inf += row_wrap('Orbit label', '%d.%s' % (modulus, webchar.orbit_label))
             inf += row_wrap('Orbit Index', webchar.orbit_index)
         inf += '</table></div>\n'
-        if numbers is None:
+        if orbit:
+            inf += '<div align="right">\n'
+            inf += '<a href="%s">%s.%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, orbit_label=webchar.orbit_label)), modulus, webchar.orbit_label)
+            inf += '</div>\n'
+        elif numbers is None:
             inf += '<div align="right">\n'
             inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
             inf += '</div>\n'

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -478,20 +478,20 @@ def _dir_knowl_data(label, orbit=False):
         numbers = label_to_number(modulus, number, all=True)
     except ValueError:
         return "Invalid label for Dirichlet character: %s" % label
-    if isinstance(numbers, list):
-        number = numbers[0]
-        def conrey_link(i):
-            return "<a href='%s'> %s.%s</a>" % (url_for("characters.render_Dirichletwebpage", modulus=modulus, number=i), modulus, i)
-        if len(numbers) <= 2:
-            numbers = [conrey_link(k) for k in numbers]
-        else:
-            numbers = [conrey_link(numbers[0]), '&#8230;', conrey_link(numbers[-1])]
-    else:
-        number = numbers
-        numbers = None
-    args={'type': 'Dirichlet', 'modulus': modulus, 'number': number}
-    print("creating web character")
     try:
+        if isinstance(numbers, list):
+            number = numbers[0]
+            def conrey_link(i):
+                return "<a href='%s'> %s.%s</a>" % (url_for("characters.render_Dirichletwebpage", modulus=modulus, number=i), modulus, i)
+            if len(numbers) <= 2:
+                numbers = [conrey_link(k) for k in numbers]
+            else:
+                numbers = [conrey_link(numbers[0]), '&#8230;', conrey_link(numbers[-1])]
+        else:
+            number = numbers
+            numbers = None
+
+        args = {'type': 'Dirichlet', 'modulus': modulus, 'number': number}
         webchar = make_webchar(args)
 
         if orbit and modulus <= 10000:
@@ -521,10 +521,9 @@ def _dir_knowl_data(label, orbit=False):
             inf += '<div align="right">\n'
             inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
             inf += '</div>\n'
-    except Exception as err:
-        print("exception in _dir_knowl_data!")
-        print(err)
-        raise BaseException
+    except Exception as err: # yes we really want to catch everything here
+        print("Exception in _dir_knowl_data: %s", err)
+        return "Unable to construct knowl for Dirichlet character label %s, please report this as a bug (include the URL of this page)." % label
     return inf
 
 def dirichlet_character_data(label):

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -463,7 +463,7 @@ def render_Dirichletwebpage(modulus=None, gal_orb_label=None, number=None):
     return render_template('Character.html', **info)
 
 def _dir_knowl_data(label, orbit=False):
-    printf("in _dir_knowl_data")
+    print("in _dir_knowl_data")
     modulus, number = label.split('.')
     modulus = int(modulus)
     try:

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -324,18 +324,17 @@ def extent_page():
                            **info)
 
 def make_webchar(args, get_bread=False):
-    print("webchar args = %s" % args)
     modulus = int(args['modulus'])
     number = int(args['number']) if 'number' in args else None
     orbit_label = args.get('orbit_label',None)
-    bread_crumbs = []
     if modulus <= 10000:
         if number is None:
             if get_bread:
                 bread_crumbs = bread(
                         [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
                         ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label))])
-            return WebDBDirichletOrbit(**args), bread_crumbs
+                return WebDBDirichletOrbit(**args), bread_crumbs
+            return WebDBDirichletOrbit(**args)
         if args.get('orbit_label') is None:
             db_orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
             orbit_label = cremona_letter_code(int(db_orbit_label.partition('.')[-1]) - 1)
@@ -345,14 +344,15 @@ def make_webchar(args, get_bread=False):
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
                     ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label)),
                     ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label, number=number))])
-        print(args)
-        return WebDBDirichletCharacter(**args), bread_crumbs
+            return WebDBDirichletCharacter(**args), bread_crumbs
+        return WebDBDirichletCharacter(**args)
     else:
         if get_bread:
             bread_crumbs = bread(
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),
                     ('%s'%number, url_for(".render_Dirichletwebpage", modulus=modulus, number=number))])
-        return WebSmallDirichletCharacter(**args), bread_crumbs
+            return WebSmallDirichletCharacter(**args), bread_crumbs
+        return WebSmallDirichletCharacter(**args)
 
 
 @characters_page.route("/Dirichlet/<modulus>")

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -493,42 +493,40 @@ def _dir_knowl_data(label, orbit=False):
     print("creating web character")
     try:
         webchar = make_webchar(args)
+
+        if orbit and modulus <= 10000:
+            inf = "Dirichlet character orbit %d.%s\n" % (modulus, webchar.orbit_label)
+        else:
+            inf = r"Dirichlet character \(\chi_{%d}(%d, \cdot)\)" % (modulus, number) + "\n"
+        inf += "<div><table class='chardata'>\n"
+        def row_wrap(header, val):
+            return "<tr><td>%s: </td><td>%s</td></tr>\n" % (header, val)
+        inf += row_wrap('Conductor', webchar.conductor)
+        inf += row_wrap('Order', webchar.order)
+        inf += row_wrap('Degree', euler_phi(webchar.order))
+        inf += row_wrap('Minimal', webchar.isminimal)
+        inf += row_wrap('Parity', webchar.parity)
+        if numbers:
+            inf += row_wrap('Characters', ",&nbsp;".join(numbers))
+        if modulus <= 10000:
+            if not orbit:
+                inf += row_wrap('Orbit label', '%d.%s' % (modulus, webchar.orbit_label))
+            inf += row_wrap('Orbit Index', webchar.orbit_index)
+        inf += '</table></div>\n'
+        if numbers is None:
+            inf += '<div align="right">\n'
+            inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
+            inf += '</div>\n'
     except Exception as err:
-        print("exception in make_webchar!")
+        print("exception in _dir_knowl_data!")
         print(err)
         raise BaseException
-
-    if orbit and modulus <= 10000:
-        inf = "Dirichlet character orbit %d.%s\n" % (modulus, webchar.orbit_label)
-    else:
-        inf = r"Dirichlet character \(\chi_{%d}(%d, \cdot)\)" % (modulus, number) + "\n"
-    inf += "<div><table class='chardata'>\n"
-    def row_wrap(header, val):
-        return "<tr><td>%s: </td><td>%s</td></tr>\n" % (header, val)
-    inf += row_wrap('Conductor', webchar.conductor)
-    inf += row_wrap('Order', webchar.order)
-    inf += row_wrap('Degree', euler_phi(webchar.order))
-    inf += row_wrap('Minimal', webchar.isminimal)
-    inf += row_wrap('Parity', webchar.parity)
-    if numbers:
-        inf += row_wrap('Characters', ",&nbsp;".join(numbers))
-    if modulus <= 10000:
-        if not orbit:
-            inf += row_wrap('Orbit label', '%d.%s' % (modulus, webchar.orbit_label))
-        inf += row_wrap('Orbit Index', webchar.orbit_index)
-    inf += '</table></div>\n'
-    if numbers is None:
-        inf += '<div align="right">\n'
-        inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
-        inf += '</div>\n'
     return inf
 
 def dirichlet_character_data(label):
-    print("in dirichlet_character_data")
     return _dir_knowl_data(label, orbit=False)
 
 def dirichlet_orbit_data(label):
-    print("in dirichlet_orbit_data")
     return _dir_knowl_data(label, orbit=True)
 
 @app.context_processor

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -337,8 +337,9 @@ def make_webchar(args, get_bread=False):
                         ('%s'%orbit_label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label))])
             return WebDBDirichletOrbit(**args), bread_crumbs
         if args.get('orbit_label') is None:
-            orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
-            orbit_label = cremona_letter_code(int(orbit_label.partition('.')[-1]) - 1)
+            db_orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
+            orbit_label = cremona_letter_code(int(db_orbit_label.partition('.')[-1]) - 1)
+            print("orbit_label: %s" % orbit_label)
         if get_bread:
             bread_crumbs = bread(
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -483,7 +483,13 @@ def _dir_knowl_data(label, orbit=False):
         numbers = None
     args={'type': 'Dirichlet', 'modulus': modulus, 'number': number}
     print("creating web character")
-    _, webchar = make_webchar(args)
+    try:
+        _, webchar = make_webchar(args)
+    except Exception as err:
+        print("exception in make_webchar!")
+        print(err)
+        raise BaseException
+
     print("got it")
     if orbit and modulus <= 10000:
         inf = "Dirichlet character orbit %d.%s\n" % (modulus, webchar.orbit_label)

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -324,6 +324,7 @@ def extent_page():
                            **info)
 
 def make_webchar(args, get_bread=False):
+    print("webchar args = %s" % args)
     modulus = int(args['modulus'])
     number = int(args['number']) if 'number' in args else None
     orbit_label = args.get('orbit_label',None)

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -445,8 +445,8 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
         if orbit_label is not None:
             if orbit_label != real_orbit_label:
                 flash_warning(
-            "The supplied character orbit label %d.%s was wrong. "
-            "The correct orbit label is %d.%s. The URL has been duly corrected.",
+            "The supplied character orbit label %s.%s was wrong. "
+            "The correct orbit label is %s.%s. The URL has been duly corrected.",
             modulus, orbit_label, modulus, real_orbit_label)
                 return redirect(url_for("characters.render_Dirichletwebpage",
                         modulus=modulus,
@@ -456,7 +456,7 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
     else:
         if orbit_label is not None:
             flash_warning(
-            "You entered the character orbit label %d.%s. However, such labels "
+            "You entered the character orbit label %s.%s. However, such labels "
             "have not been computed for this modulus. The supplied orbit "
             "label has therefore been ignored and expunged from the URL.",
             modulus, orbit_label)

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -521,7 +521,7 @@ def _dir_knowl_data(label, orbit=False):
             inf += '<div align="right">\n'
             inf += '<a href="%s">%s home page</a>\n' % (str(url_for("characters.render_Dirichletwebpage", modulus=modulus, number=number)), label)
             inf += '</div>\n'
-    except Exception as err: # yes we really want to catch everything here
+    except Exception: # yes we really want to catch everything here
         return "Unable to construct knowl for Dirichlet character label %s, please report this as a bug (include the URL of this page)." % label
     return inf
 

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -339,7 +339,7 @@ def make_webchar(args, get_bread=False):
         if args.get('orbit_label') is None:
             db_orbit_label = db.char_dir_values.lookup("{}.{}".format(modulus, number), projection='orbit_label')
             orbit_label = cremona_letter_code(int(db_orbit_label.partition('.')[-1]) - 1)
-            print("orbit_label: %s" % orbit_label)
+            args['orbit_label'] = orbit_label
         if get_bread:
             bread_crumbs = bread(
                     [('%s'%modulus, url_for(".render_Dirichletwebpage", modulus=modulus)),

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -48,7 +48,7 @@ def learn(current = None):
     if current != 'labels':
         r.append( ('Dirichlet character labels', url_for(".labels_page")) )
     if current != 'orbit_labels':
-        r.append( ('Dirichlet orbit labels', url_for(".orbit_labels_page")) )
+        r.append( ('Dirichlet character orbit labels', url_for(".orbit_labels_page")) )
     return r
 
 def credit():
@@ -286,7 +286,7 @@ def labels_page():
 @characters_page.route("/Dirichlet/OrbitLabels")
 def orbit_labels_page():
     info = {}
-    info['title'] = 'Dirichlet character Galois orbit labels'
+    info['title'] = 'Dirichlet character orbit labels'
     info['bread'] = bread('Orbit Labels')
     info['learnmore'] = learn('orbit_labels')
     info['credit'] = credit()
@@ -391,7 +391,7 @@ def render_Dirichletwebpage(modulus=None, gal_orb_label=None, number=None):
                     info = WebDBDirichletOrbit(**args).to_dict()
                 except ValueError:
                     flash_error(
-                    "The Galois orbit label %s is invalid.", gal_orb_label
+                    "The character orbit label %s is invalid.", gal_orb_label
                         )
                     return redirect(url_for(".render_DirichletNavigation"))
 
@@ -432,7 +432,7 @@ def render_Dirichletwebpage(modulus=None, gal_orb_label=None, number=None):
         if gal_orb_label is not None:
             if gal_orb_label != real_gal_orb_label:
                 flash_warning(
-            "The supplied Galois orbit label %s was wrong. "
+            "The supplied character orbit label %s was wrong. "
             "The correct one is %s. The URL has been duly corrected.",
             gal_orb_label, real_gal_orb_label)
                 return redirect(url_for("characters.render_Dirichletwebpage",
@@ -443,7 +443,7 @@ def render_Dirichletwebpage(modulus=None, gal_orb_label=None, number=None):
     else:
         if gal_orb_label is not None:
             flash_warning(
-            "You entered the Galois orbit label %s. However, such labels "
+            "You entered the character orbit label %s. However, such labels "
             "have not been computed for this modulus. The supplied orbit "
             "label has therefore been ignored and expunged from the URL.",
             gal_orb_label)

--- a/lmfdb/characters/templates/CharGroup.html
+++ b/lmfdb/characters/templates/CharGroup.html
@@ -71,7 +71,7 @@ and several values of the character.
       <td class="left">
         {% with mod,letter,orb_disp = orb %}
         <a class="center"
-          align="center" href="{{ url_character(type=type, number_field=nflabel, modulus=mod, gal_orb_label=letter) }}">
+          align="center" href="{{ url_character(type=type, number_field=nflabel, modulus=mod, orbit_label=letter) }}">
           {{ orb_disp }}
         </a>
         {% endwith %}

--- a/lmfdb/characters/templates/CharacterCommon.html
+++ b/lmfdb/characters/templates/CharacterCommon.html
@@ -30,7 +30,7 @@
   <tr> <td>{{KNOWL('character.dirichlet.conductor',title='Conductor')}}:</td> <td>\({{ conductor }}\)</td> <td>{{place_code('cond')}}</td> </tr>
   <tr> <td>{{KNOWL('character.dirichlet.order',title='Order')}}:</td> <td>\({{ order }}\)</td> <td>{{place_code('order')}}</td> </tr>
   <tr> <td>{{KNOWL('character.dirichlet.real',title='Real')}}:</td> <td> {{ isreal }} </td> </tr>
-  <tr> <td>{{KNOWL('character.dirichlet.primitive',title='Primitive')}}:</td> <td> {{ isprimitive }}{{(', induced from <a href="' + url_for('characters.render_Dirichletwebpage', modulus=conductor, gal_orb_label=ind_orbit_label, number=indlabel) + '">' + inducing + '</a>') | safe if isprimitive == "no"  }}</td> <td> {{ place_code('isprimitive') }}</td> </tr>
+  <tr> <td>{{KNOWL('character.dirichlet.primitive',title='Primitive')}}:</td> <td> {{ isprimitive }}{{(', induced from <a href="' + url_for('characters.render_Dirichletwebpage', modulus=conductor, orbit_label=ind_orbit_label, number=indlabel) + '">' + inducing + '</a>') | safe if isprimitive == "no"  }}</td> <td> {{ place_code('isprimitive') }}</td> </tr>
 {% if type == 'Dirichlet' %}
   {% if isminimal %}
   <tr> <td>{{KNOWL('character.dirichlet.minimal',title='Minimal')}}: </td> <td>{{ isminimal }}</td> </tr>
@@ -48,7 +48,7 @@
 {# Galois Orbits #}
 
 <h2>
-  {{ KNOWL('character.dirichlet.galois_orbit', title="Galois orbit") }} <a href="{{ url_character(type=type, number_field=nflabel, modulus=modulus, gal_orb_label=orbit_label)}}">  {{ modulus }}.{{ orbit_label }} </a>
+  {{ KNOWL('character.dirichlet.galois_orbit', title="Galois orbit") }} <a href="{{ url_character(type=type, number_field=nflabel, modulus=modulus, orbit_label=orbit_label)}}">  {{ modulus }}.{{ orbit_label }} </a>
 </h2>
 <p>
 {% for mod,num,label,prim in galoisorbit %}

--- a/lmfdb/characters/templates/CharacterCommon.html
+++ b/lmfdb/characters/templates/CharacterCommon.html
@@ -42,7 +42,8 @@
  </tbody>
 </table>
 
-{% if galoisorbit %}
+{% if not isorbit and galoisorbit %}
+{# Note that for Galois orbit home pages the characters in orbit are displayed in CharacterGaloisOrbit.html, not here. #}
 
 {# Galois Orbits #}
 

--- a/lmfdb/characters/templates/CharacterCommon.html
+++ b/lmfdb/characters/templates/CharacterCommon.html
@@ -76,7 +76,7 @@
 {% endif %}
 
 {# Fields #}
-<h2 style="margin-top:0px;">
+<h2>
   {{ KNOWL('character.dirichlet.related_fields', 'Related number fields') }}
 </h2>
 <table>

--- a/lmfdb/characters/templates/CharacterGaloisOrbit.html
+++ b/lmfdb/characters/templates/CharacterGaloisOrbit.html
@@ -18,7 +18,7 @@
       <td class="left">
         {% with mod,num,tex,prim = char %}
         <a class="{% if prim -%}primitive{%- else -%}imprimitive{%- endif %}"
-          align="center" href="{{ url_character(type=type, number_field=nflabel, modulus=mod, gal_orb_label=orbit_label, number=num) }}">
+          align="center" href="{{ url_character(type=type, number_field=nflabel, modulus=mod, orbit_label=orbit_label, number=num) }}">
           {{ tex }}
         </a>
         {% endwith %}

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -128,7 +128,7 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/5489/banana/100', follow_redirects=True)
         #import pdb; pdb.set_trace()
         assert bool_string(True) in W.get_data(as_text=True)
-        assert r"The supplied character orbit label <span style='color:red'>banana</span> was wrong. The correct one is <span style='color:red'>u</span>" in W.get_data(as_text=True)
+        assert r"The URL has been duly corrected." in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/254/banana', follow_redirects=True)
         assert 'Error: The character orbit label' in W.get_data(as_text=True)

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -128,13 +128,13 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/5489/banana/100', follow_redirects=True)
         #import pdb; pdb.set_trace()
         assert bool_string(True) in W.get_data(as_text=True)
-        assert r"The supplied Galois orbit label <span style='color:red'>banana</span> was wrong. The correct one is <span style='color:red'>u</span>" in W.get_data(as_text=True)
+        assert r"The supplied character orbit label <span style='color:red'>banana</span> was wrong. The correct one is <span style='color:red'>u</span>" in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/254/banana', follow_redirects=True)
         assert 'Error: The Galois orbit label' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/10001/banana/100', follow_redirects=True)
-        wrng_msg = (r'Warning: You entered the Galois orbit label '
+        wrng_msg = (r'Warning: You entered the character orbit label '
                     r"<span style='color:red'>banana</span>. However, such "
                     r'labels have not been computed for this modulus. '
                     r'The supplied orbit label has therefore been ignored '

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -134,12 +134,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'Error: No Galois orbit of Dirichlet characters with' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/10001/banana/100', follow_redirects=True)
-        wrng_msg = (r'Warning: You entered the character orbit label '
-                    r"<span style='color:red'>banana</span>. However, such "
-                    r'labels have not been computed for this modulus. '
-                    r'The supplied orbit label has therefore been ignored '
-                    r'and expunged from the URL.')
-        assert wrng_msg in W.get_data(as_text=True)
+        assert r'labels have not been computed for this modulus' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/9999999999/banana', follow_redirects=True)
         assert 'Error: Galois orbits have only been computed for modulus up to 10,000' in W.get_data(as_text=True)

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -131,7 +131,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert r"The supplied character orbit label <span style='color:red'>banana</span> was wrong. The correct one is <span style='color:red'>u</span>" in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/254/banana', follow_redirects=True)
-        assert 'Error: The Galois orbit label' in W.get_data(as_text=True)
+        assert 'Error: The character orbit label' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/10001/banana/100', follow_redirects=True)
         wrng_msg = (r'Warning: You entered the character orbit label '

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -131,7 +131,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert r"The URL has been duly corrected." in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/254/banana', follow_redirects=True)
-        assert 'Error: The character orbit label' in W.get_data(as_text=True)
+        assert 'Error: No Galois orbit of Dirichlet characters with' in W.get_data(as_text=True)
 
         W = self.tc.get('/Character/Dirichlet/10001/banana/100', follow_redirects=True)
         wrng_msg = (r'Warning: You entered the character orbit label '

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -1105,7 +1105,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
 
     @lazy_attribute
     def title(self):
-        return "Dirichlet character Galois orbit {}.{}".format(self.modulus, self.orbit_label)
+        return "Dirichlet character orbit {}.{}".format(self.modulus, self.orbit_label)
 
     def _set_galoisorbit(self, orbit_data):
         if self.modulus == 1:

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -945,7 +945,7 @@ class WebDBDirichletCharacter(WebChar, WebDBDirichlet):
         cglink = url_character(type=self.type, modulus=self.modulus)
         friendlist.append( ("Character group", cglink) )
         gal_orb_link = url_character(type=self.type, modulus=self.modulus, gal_orb_label = self.orbit_label)
-        friendlist.append( ("Character Galois orbit", gal_orb_link) )
+        friendlist.append( ("Character orbit", gal_orb_link) )
 
         if self.type == "Dirichlet" and self.isprimitive == bool_string(True):
             url = url_character(
@@ -1074,10 +1074,11 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
               'valuefield', 'vflabel', 'vfpol', 'kerfield', 'kflabel',
               'kfpol', 'contents', 'properties', 'friends', 'coltruncate',
               'charsums', 'codegauss', 'codejacobi', 'codekloosterman',
-              'orbit_label', 'orbit_index', 'isminimal']
+              'orbit_label', 'orbit_index', 'isminimal', 'isorbit']
 
     def __init__(self, **kwargs):
         self.type = "Dirichlet"
+        self.isorbit = True
         self.modulus = kwargs.get('modulus', None)
         if self.modulus:
             self.modulus = int(self.modulus)

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -944,7 +944,7 @@ class WebDBDirichletCharacter(WebChar, WebDBDirichlet):
         friendlist = []
         cglink = url_character(type=self.type, modulus=self.modulus)
         friendlist.append( ("Character group", cglink) )
-        gal_orb_link = url_character(type=self.type, modulus=self.modulus, gal_orb_label = self.orbit_label)
+        gal_orb_link = url_character(type=self.type, modulus=self.modulus, orbit_label = self.orbit_label)
         friendlist.append( ("Character orbit", gal_orb_link) )
 
         if self.type == "Dirichlet" and self.isprimitive == bool_string(True):
@@ -1093,7 +1093,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
             if self.number:
                 self.chi = ConreyCharacter(self.modulus, self.number)
         self.codelangs = ('pari', 'sage')
-        self.orbit_label = kwargs.get('gal_orb_label', None)  # this is what the user inserted, so might be banana
+        self.orbit_label = kwargs.get('orbit_label', None)  # this is what the user inserted, so might be banana
         self.label = "{}.{}".format(self.modulus, self.orbit_label)
         self.orbit_data = self.get_orbit_data(self.orbit_label)  # this is the meat
         self.maxrows = 30
@@ -1168,7 +1168,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
 
         if self.type == "Dirichlet" and self.isprimitive == bool_string(False):
             friendlist.append(('Primitive orbit '+self.inducing,
-                url_for('characters.render_Dirichletwebpage', modulus=self.conductor, gal_orb_label=self.ind_orbit_label)))
+                url_for('characters.render_Dirichletwebpage', modulus=self.conductor, orbit_label=self.ind_orbit_label)))
 
         return friendlist
 


### PR DESCRIPTION
This PR fixes a bug that is currentrlky preventing Dirichlet character knowls from appearing on any of the CMF pages, e.g. on https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/23/1/b/a/ neither the character orbit knowl for 23.b nor the character knowl for 23.22 are working right now (they will once this PR is merged and pushed to beta which I will do shortly).   In the process of fixing this bug I made some improvements to the character orbit knowl, including a link to the character orbit home pages that now exist.

This PR also prevents the list of characters in the Galois orbit from being displayed twice (once as a list and then again in a table) on Dirichlet character orbit home pages.

I also replaced "Galois orbit" with "character orbit" in a few places to be consistent with the usage on the CMF pages -- the phrase "banana orbit" is a more useful shortening of "Galois orbit of bananas" than "Galois orbit" is, since it lets us distinguish between "newform orbits" and "character orbits" (which are both "Galois orbits"), and to make the code a bit more consistent/readable, I replaced "gal_orb_label" with "orbit_label" throughout (in the code this always refers to the cremona_letter_code of the orbit, even the tables char_dir_orbits and char_dir_values have adb.e column "orbit_label" with a different meaning -- I plan to change the database column name, which has caused no end of confusion -- that is entirely my fault should have fixed this a long time ago, but I want to get all the new code working properly and in production first before I make a change that may break things.

