### PR TITLE
Enforce that positive integers must be positive

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -617,7 +617,7 @@ def higher_genus_w_automorphisms_search(info, query):
     if info.get('signature'):
         # allow for ; in signature
         info['signature'] = info['signature'].replace(';',',')
-        parse_bracketed_posints(info,query,'signature',split=False,name='Signature',keepbrackets=True)
+        parse_bracketed_posints(info,query,'signature',split=False,name='Signature',keepbrackets=True, allow0=True)
         if query.get('signature'):
             query['signature'] = info['signature'] = str(sort_sign(ast.literal_eval(query['signature']))).replace(' ','')
     parse_gap_id(info,query,'group',qfield='group')

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -778,7 +778,7 @@ def number_field_jump(info):
 def number_field_search(info, query):
     parse_ints(info,query,'degree')
     parse_galgrp(info,query, qfield=('galois_label', 'degree'))
-    parse_bracketed_posints(info,query,'signature',qfield=('degree','r2'),exactlength=2,extractor=lambda L: (L[0]+2*L[1],L[1]))
+    parse_bracketed_posints(info,query,'signature',qfield=('degree','r2'),exactlength=2, allow0=True, extractor=lambda L: (L[0]+2*L[1],L[1]))
     parse_signed_ints(info,query,'discriminant',qfield=('disc_sign','disc_abs'))
     parse_floats(info, query, 'rd')
     parse_floats(info, query, 'regulator')

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -22,7 +22,7 @@ SPACES_RE = re.compile(r'\d\s+\d')
 LIST_RE = re.compile(r'^(\d+|(\d*-(\d+)?))(,(\d+|(\d*-(\d+)?)))*$')
 FLOAT_STR = r'(-?(((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?)|(-?\d+/\d+))'
 LIST_FLOAT_RE = re.compile(r'^({0}|{0}-|{0}-{0})(,({0}|{0}-|{0}-{0}))*$'.format(FLOAT_STR))
-BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
+BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[[1-9]\d*(,[1-9]\d*)*\]$')
 BRACKETED_RAT_RE = re.compile(r'^\[\]|\[-?(\d+|\d+/\d+)(,-?(\d+|\d+/\d+))*\]$')
 QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
 # Single non-negative rational, allowing decimals, used in parse_range2rat
@@ -716,19 +716,19 @@ def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None
         (exactlength is not None and inp.count(',') != exactlength - 1) or
         (exactlength is not None and inp == '[]' and exactlength > 0)):
         if exactlength == 2:
-            lstr = "pair of integers"
+            lstr = "pair of positive integers"
             example = "[6,2] or [32,32]"
         elif exactlength == 1:
-            lstr = "list of 1 integer"
+            lstr = "list of 1 positive integer"
             example = "[2]"
         elif exactlength is not None:
-            lstr = "list of %s integers" % exactlength
+            lstr = "list of %s positive integers" % exactlength
             example = str(list(range(2,exactlength+2))).replace(" ","") + " or " + str([3]*exactlength).replace(" ","")
         elif maxlength is not None:
-            lstr = "list of at most %s integers" % maxlength
+            lstr = "list of at most %s positive integers" % maxlength
             example = str(list(range(2,maxlength+2))).replace(" ","") + " or " + str([2]*max(1, maxlength-2)).replace(" ","")
         else:
-            lstr = "list of integers"
+            lstr = "list of positive integers"
             example = "[1,2,3] or [5,6]"
         raise SearchParsingError("It needs to be a %s in square brackets, such as %s." % (lstr, example))
     else:

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -23,6 +23,7 @@ LIST_RE = re.compile(r'^(\d+|(\d*-(\d+)?))(,(\d+|(\d*-(\d+)?)))*$')
 FLOAT_STR = r'(-?(((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?)|(-?\d+/\d+))'
 LIST_FLOAT_RE = re.compile(r'^({0}|{0}-|{0}-{0})(,({0}|{0}-|{0}-{0}))*$'.format(FLOAT_STR))
 BRACKETED_POSINT_RE = re.compile(r'^\[\]|\[[1-9]\d*(,[1-9]\d*)*\]$')
+BRACKETED_NN_RE = re.compile(r'^\[\]|\[\d+(,\d+)*\]$')
 BRACKETED_RAT_RE = re.compile(r'^\[\]|\[-?(\d+|\d+/\d+)(,-?(\d+|\d+/\d+))*\]$')
 QQ_RE = re.compile(r'^-?\d+(/\d+)?$')
 # Single non-negative rational, allowing decimals, used in parse_range2rat
@@ -710,8 +711,9 @@ def parse_primes(inp, query, qfield, mode=None, radical=None):
     _parse_subset(primes, query, qfield, mode, radical, prod)
 
 @search_parser(clean_info=True) # see SearchParser.__call__ for actual arguments when calling
-def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, listprocess=None, check_divisibility=None, keepbrackets=False, extractor=None):
-    if (not BRACKETED_POSINT_RE.match(inp) or
+def parse_bracketed_posints(inp, query, qfield, maxlength=None, exactlength=None, split=True, process=None, listprocess=None, check_divisibility=None, keepbrackets=False, extractor=None, allow0=False):
+    myregex = BRACKETED_NN_RE if allow0 else BRACKETED_POSINT_RE
+    if (not myregex.match(inp) or
         (maxlength is not None and inp.count(',') > maxlength - 1) or
         (exactlength is not None and inp.count(',') != exactlength - 1) or
         (exactlength is not None and inp == '[]' and exactlength > 0)):


### PR DESCRIPTION
Addresses issue #4436 by enforcing that the invariant factors of the class group need to be non-zero.

https://beta.lmfdb.org/NumberField/?hst=List&galois_group=D10&class_number=5&class_group=%5B0%2C1%2C5%5D&search_type=List
http://127.0.0.1:37777/NumberField/?hst=List&galois_group=D10&class_number=5&class_group=%5B0%2C1%2C5%5D&search_type=List