### PR TITLE
Address issue #4435 on Artin representation pages

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -354,7 +354,7 @@ def render_artin_representation_webpage(label):
                 friends.append(("Dirichlet character "+cc_name, url_for("characters.render_Dirichletwebpage", modulus=cc.modulus, number=cc.number)))
             else:
                 detrep = the_rep.central_character_as_artin_rep()
-                friends.append(("Determinant representation "+detrep.label(), detrep.url_for()))
+                friends.append(("Determinant "+detrep.label(), detrep.url_for()))
         add_lfunction_friends(friends,label)
 
         # once the L-functions are in the database, the link can always be shown

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -334,12 +334,14 @@ def render_artin_representation_webpage(label):
     wnf = None
     nf_url = the_nf.url_for()
     if nf_url:
-        friends.append(("Artin field", nf_url))
+        friends.append(("Field {}".format(the_nf.label()), nf_url))
         wnf = the_nf.wnf()
     proj_nf = WebNumberField.from_coeffs(the_rep._data['Proj_Polynomial'])
     if proj_nf._data:
-        friends.append(("Projective Artin field", 
-            str(url_for("number_fields.by_label", label=proj_nf.get_label()))))
+        proj_coefs = [int(z) for z in proj_nf.coeffs()]
+        if proj_coefs != the_nf.polynomial():
+            friends.append(("Field {}".format(proj_nf.get_label()), 
+                str(url_for("number_fields.by_label", label=proj_nf.get_label()))))
     if case == 'rep':
         cc = the_rep.central_character()
         if cc is not None:

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -332,16 +332,17 @@ def render_artin_representation_webpage(label):
 
     friends = []
     wnf = None
+    proj_wnf = None
     nf_url = the_nf.url_for()
     if nf_url:
         friends.append(("Field {}".format(the_nf.label()), nf_url))
         wnf = the_nf.wnf()
-    proj_nf = WebNumberField.from_coeffs(the_rep._data['Proj_Polynomial'])
-    if proj_nf._data:
-        proj_coefs = [int(z) for z in proj_nf.coeffs()]
+    proj_wnf = WebNumberField.from_coeffs(the_rep._data['Proj_Polynomial'])
+    if proj_wnf._data:
+        proj_coefs = [int(z) for z in proj_wnf.coeffs()]
         if proj_coefs != the_nf.polynomial():
-            friends.append(("Field {}".format(proj_nf.get_label()), 
-                str(url_for("number_fields.by_label", label=proj_nf.get_label()))))
+            friends.append(("Field {}".format(proj_wnf.get_label()), 
+                str(url_for("number_fields.by_label", label=proj_wnf.get_label()))))
     if case == 'rep':
         cc = the_rep.central_character()
         if cc is not None:
@@ -397,6 +398,7 @@ def render_artin_representation_webpage(label):
             object=the_rep,
             cycle_string=cycle_string,
             wnf=wnf,
+            proj_wnf=proj_wnf,
             properties=properties,
             info=info,
             learnmore=learnmore_list(),
@@ -414,6 +416,7 @@ def render_artin_representation_webpage(label):
         object=the_rep,
         cycle_string=cycle_string,
         wnf=wnf,
+        proj_wnf=proj_wnf,
         properties=properties,
         info=info,
         learnmore=learnmore_list(),

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -234,10 +234,7 @@ class ArtinRepresentation(object):
         if projfield == [0,1]:
             return formatfield(projfield)
         wnf = WebNumberField.from_coeffs(projfield)
-        ifgal = 'Galois closure of '
-        if wnf and wnf.is_galois():
-            ifgal = ''
-        return ifgal + formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
+        return formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
 
     def number_field_galois_group(self):
         try:

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -233,7 +233,11 @@ class ArtinRepresentation(object):
             return 'data not computed'
         if projfield == [0,1]:
             return formatfield(projfield)
-        return 'Galois closure of ' + formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
+        wnf = WebNumberField.from_coeffs(projfield)
+        ifgal = 'Galois closure of '
+        if wnf and wnf.is_galois():
+            ifgal = ''
+        return ifgal + formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
 
     def number_field_galois_group(self):
         try:

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -415,12 +415,8 @@ class ArtinRepresentation(object):
         #return "odd"
 
     def field_knowl(self):
-        from lmfdb.number_fields.web_number_field import nf_display_knowl
         nfgg = self.number_field_galois_group()
-        if nfgg.url_for():
-            return nf_display_knowl(nfgg.label(), nfgg.polredabshtml())
-        else:
-            return nfgg.polredabshtml()
+        return formatfield(nfgg.polynomial())
 
     def group(self):
         n,t = [int(z) for z in self._data['GaloisLabel'].split("T")]

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -233,7 +233,6 @@ class ArtinRepresentation(object):
             return 'data not computed'
         if projfield == [0,1]:
             return formatfield(projfield)
-        wnf = WebNumberField.from_coeffs(projfield)
         return formatfield(projfield, missing_text="Degree %s field"%(len(projfield)-1))
 
     def number_field_galois_group(self):

--- a/lmfdb/artin_representations/templates/artin-representation-search.html
+++ b/lmfdb/artin_representations/templates/artin-representation-search.html
@@ -16,7 +16,7 @@
 	<thead><tr><th>{{KNOWL('artin.label', 'Label')}}</th>
         <th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
 	<th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
-	<th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
+	<th>{{ KNOWL('artin.stem_field', title='Artin stem field') }} </th>
 	<th style="text-align: center"> {{ KNOWL('artin.gg_quotient', title='$G$') }}</th>
 {#	<th>{{ KNOWL('artin.root_number', title='Root number') }}</th> #}
 	<th>{{ KNOWL('artin.frobenius_schur_indicator', title='Ind') }}</th>

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -13,15 +13,15 @@
         {% if object.sign() %}
         <tr><td class="nowrap">{{ KNOWL('artin.root_number', title='Root number') }}: </td><td>${{ object.root_number()}}$</td></tr>
         {% endif %}
-        <tr><td class="nowrap"> {{ KNOWL('artin.number_field', title='Artin field') }}: </td><td>
-        {% if wnf %}
-          {% if wnf.is_galois() %}
-            {{wnf.knowl()|safe}}
-          {% else %}
-            Galois closure of {{wnf.knowl()|safe}}
-          {% endif %}
+        {% if wnf and not wnf.is_galois() %}
+          <tr><td class="nowrap"> {{ KNOWL('artin.stem_field', title='Artin stem field') }}: </td><td>
         {% else %}
-        Splitting field of defining polynomial $f(x)$ over $\Q$</td></tr>
+          <tr><td class="nowrap"> {{ KNOWL('artin.number_field', title='Artin field') }}: </td><td>
+        {% endif %}
+        {% if wnf %}
+          {{wnf.knowl()|safe}}
+        {% else %}
+          Splitting field of defining polynomial $f(x)$ over $\Q$</td></tr>
         {%endif%}
         <tr><td class="nowrap"> {{ KNOWL('artin.galois_orbit', title='Galois orbit size') }}: </td><td> ${{object.galois_conjugacy_size()}}$ </td></tr>
         <tr><td class="nowrap"> {{ KNOWL('artin.permutation_container', title='Smallest permutation container') }}: </td><td> {{object.smallest_gal_t_format()|safe}}</td></tr>

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -13,9 +13,13 @@
         {% if object.sign() %}
         <tr><td class="nowrap">{{ KNOWL('artin.root_number', title='Root number') }}: </td><td>${{ object.root_number()}}$</td></tr>
         {% endif %}
-        <tr><td class="nowrap"> {{ KNOWL('artin.number_field', title='Artin number field') }}: </td><td>
+        <tr><td class="nowrap"> {{ KNOWL('artin.number_field', title='Artin field') }}: </td><td>
         {% if wnf %}
-        Galois closure of {{wnf.knowl()|safe}}
+          {% if wnf.is_galois() %}
+            {{wnf.knowl()|safe}}
+          {% else %}
+            Galois closure of {{wnf.knowl()|safe}}
+          {% endif %}
         {% else %}
         Splitting field of defining polynomial $f(x)$ over $\Q$</td></tr>
         {%endif%}

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -36,7 +36,6 @@
             <tr><td> {{ KNOWL('artin.determinant', title='Determinant') }}: </td><td> {{ object.det_as_artin_display()|safe}} </td></tr>
         {% endif %}
             <tr><td class="nowrap"> {{ KNOWL('artin.projective_image', title='Projective image') }}: </td><td> {{ object.projective_group()|safe}} </td></tr>
-        {{proj_wnf.is_galois() }}
         {% if proj_wnf and not proj_wnf.is_galois() %}
             <tr><td class="nowrap"> {{ KNOWL('artin.projective_stem_field', title='Projective stem field') }}:
         {% else %}

--- a/lmfdb/artin_representations/templates/artin-representation-show.html
+++ b/lmfdb/artin_representations/templates/artin-representation-show.html
@@ -35,8 +35,14 @@
         {% else %}
             <tr><td> {{ KNOWL('artin.determinant', title='Determinant') }}: </td><td> {{ object.det_as_artin_display()|safe}} </td></tr>
         {% endif %}
-        <tr><td class="nowrap"> {{ KNOWL('artin.projective_image', title='Projective image') }}: </td><td> {{ object.projective_group()|safe}} </td></tr>
-        <tr><td class="nowrap"> {{ KNOWL('artin.projective_field', title='Projective field') }}: </td><td> {{ object.projective_field()|safe}} </td></tr>
+            <tr><td class="nowrap"> {{ KNOWL('artin.projective_image', title='Projective image') }}: </td><td> {{ object.projective_group()|safe}} </td></tr>
+        {{proj_wnf.is_galois() }}
+        {% if proj_wnf and not proj_wnf.is_galois() %}
+            <tr><td class="nowrap"> {{ KNOWL('artin.projective_stem_field', title='Projective stem field') }}:
+        {% else %}
+            <tr><td class="nowrap"> {{ KNOWL('artin.projective_field', title='Projective field') }}:
+        {% endif %}
+        </td><td> {{ object.projective_field()|safe}} </td></tr>
     </table>
      
     <h2>Defining polynomial</h2>

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -27,7 +27,7 @@ from lmfdb.galois_groups.transitive_group import (
 from lmfdb.number_fields import nf_page, nf_logger
 from lmfdb.number_fields.web_number_field import (
     field_pretty, WebNumberField, nf_knowl_guts, factor_base_factor,
-    factor_base_factorization_latex)
+    factor_base_factorization_latex, formatfield)
 
 assert nf_logger
 
@@ -623,7 +623,7 @@ def render_field_webpage(args):
         info["mydecomp"] = [dopow(x) for x in v]
     except AttributeError:
         pass
-    return render_template("nf-show-field.html", properties=properties, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=learnmore, info=info, KNOWL_ID="nf.%s"%label)
+    return render_template("nf-show-field.html", properties=properties, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=learnmore, info=info, formatfield=formatfield, KNOWL_ID="nf.%s"%label)
 
 
 def format_coeffs2(coeffs):

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -260,7 +260,7 @@ $\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) {{ info.cnf|safe }} {{ info.grh_labe
     <th>Label</th>
     <th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
     <th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
-    <th>Defining polynomial of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
+    <th>{{ KNOWL('nf.stem_field', title='Stem field')}} of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
     <th>{{ KNOWL('artin.gg_quotient', title='$G$') }}</th>
     {# <th>{{ KNOWL('artin.root_number', title='Root number') }}</th> #}
     <th>{{ KNOWL('artin.frobenius_schur_indicator', title='Ind') }}</th>
@@ -274,7 +274,7 @@ $\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) {{ info.cnf|safe }} {{ info.grh_labe
 {#    <td align="center">${{artin.conductor_equation()}}$</td> #}
       <td align="center">${{artin.factored_conductor_latex()}}$</td>
       {% if artin.number_field_galois_group().url_for() %}
-         <td align="center"><a href="{{artin.number_field_galois_group().url_for()}}">${{artin.number_field_galois_group().polredabslatex()}}$</a></td>
+         <td align="center">{{formatfield(artin.number_field_galois_group().polynomial(), show_poly=True) | safe}}
       {% else %}
           <td align="center">${{artin.number_field_galois_group().polredabslatex()}}$</td>
       {% endif %}

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -260,7 +260,7 @@ $\displaystyle\lim_{s\to 1} (s-1)\zeta_K(s) {{ info.cnf|safe }} {{ info.grh_labe
     <th>Label</th>
     <th>{{ KNOWL('artin.dimension', title='Dimension') }}</th>
     <th>{{ KNOWL('artin.conductor', title='Conductor') }}</th>
-    <th>{{ KNOWL('nf.stem_field', title='Stem field')}} of {{ KNOWL('artin.number_field', title='Artin field') }} </th>
+    <th>{{ KNOWL('artin.stem_field', title='Artin stem field') }} </th>
     <th>{{ KNOWL('artin.gg_quotient', title='$G$') }}</th>
     {# <th>{{ KNOWL('artin.root_number', title='Root number') }}</th> #}
     <th>{{ KNOWL('artin.frobenius_schur_indicator', title='Ind') }}</th>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -452,7 +452,7 @@ class WebNumberField:
         return self._data['gg']
 
     def is_galois(self):
-        return self.gg().order() == self.degree()
+        return self._data['is_galois']
 
     def is_abelian(self):
         return self.gg().is_abelian()


### PR DESCRIPTION
When giving the Artin field and Projective field of a representation, we now only say "Galois closure of" when the field is not already Galois closed (although this was not technically wrong before).  The related objects are just labeled "Field blah", which is in keeping of how things are labeled elsewhere as related objects, and avoids having to say something like "Stem field for the Artin field" in a small space.  If the Artin field is the same as the projective field, it is only listed once.

http://127.0.0.1:37777/ArtinRepresentation/2.39.4t3.a.a
http://127.0.0.1:37777/ArtinRepresentation/4.1609.5t5.a.a
http://127.0.0.1:37777/ArtinRepresentation/1.4.2t1.a.a

vs

http://beta.lmfdb.org/ArtinRepresentation/2.39.4t3.a.a
http://beta.lmfdb.org/ArtinRepresentation/4.1609.5t5.a.a
http://beta.lmfdb.org/ArtinRepresentation/1.4.2t1.a.a

In addition there is a change at the bottom of number field pages.  In the table of Artin representations, instead of giving polynomials, it gives labels (or "pretty names" for the field).  To test, click on the link to see the corresponding field for a representation above.  In particular, you get pretty names in the last case.
