### PR TITLE
ECQ: handle curves with no modular degree

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -206,10 +206,10 @@ class WebEC(object):
 
         # modular degree:
         
-        if self.degree is None:
+        try:
+            data['degree'] = ZZ(self.degree) # convert None to 0
+        except AttributeError: # if not computed, db has Null and the attribute is missing
             data['degree'] = 0 # invalid, but will be displayed nicely
-        else:
-            data['degree'] = self.degree
 
         # coefficients of modular form / L-series:
 


### PR DESCRIPTION
Simple code change so that elliptic curves with no modular degree (null in the 'degree' column of ec_curvedata) do not crash.

I wrongly thought that self.degree would be None, but it does not exist at all.