### PR TITLE
EC/Q: fix display for incomplete MW/BSD data

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -65,7 +65,7 @@ white-space: pre in order to keep line breaks! #}
     <h2> {{ KNOWL('ec.mordell_weil_group', title='Mordell-Weil group') }} structure</h2>
     <p>
     {% if data.mwbsd.rank == '?' %}
-    Not known
+    Not computed
     {% if data.mwbsd.rank_bounds.0>0 %}
     (\( {{data.mwbsd.rank_bounds.0}} \le r \le {{data.mwbsd.rank_bounds.1}} \))
     {% else %}
@@ -102,7 +102,7 @@ white-space: pre in order to keep line breaks! #}
     {% endif %}
       {{ place_code('gens') }}
       {% if data.mwbsd.ngens==0 %}
-    No {% if data.mwbsd.rank==1 %} generator {% else %} generators  {% endif %} known
+    No {% if data.mwbsd.rank==1 %} generator {% else %} generators  {% endif %} computed
       {% else %}
       <div style='overflow:auto'><p>
       <table>
@@ -116,7 +116,7 @@ white-space: pre in order to keep line breaks! #}
       </p></div>
     </p>
       {% if data.mwbsd.ngens < data.mwbsd.rank %}
-	Only {{ data.mwbsd.ngens }} generators known
+	Only {{ data.mwbsd.ngens }} generators computed
       {% endif %}
 
     {%endif %}
@@ -142,7 +142,7 @@ white-space: pre in order to keep line breaks! #}
     {%endif %}
     {% if data.mwbsd.ngens < data.mwbsd.rank %}
      <p>
-     N.B. Integral points which are not combination of known generators (if any) are not shown.
+     N.B. Only integral points which are combinations of known generators are shown.
      </p>
     {%endif %}
 
@@ -234,7 +234,7 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.regulator', title='Regulator') }}:</td>
 	{% if data.mwbsd.reg == '?' %}
-	<td>Not known</td>
+	<td>Not computed</td>
 	{% else %}
         {% if data.rank==0 %}
         <td> \(1\)</td>
@@ -287,7 +287,7 @@ white-space: pre in order to keep line breaks! #}
         <td>{{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:</td>
 	<td>
 	  {% if data.mwbsd.sha == '?' %}
-	  Not known
+	  Not computed
 	  {% else %}
           \({{data.mwbsd.sha }}\)
 	  {% if data.mwbsd.sha > 1 %}
@@ -360,7 +360,7 @@ white-space: pre in order to keep line breaks! #}
         <tr>
         <td>{{ KNOWL('ec.q.optimal', title='\( \Gamma_0(N) \)-optimal') }}:</td>
         <td>
-	  {% if data.data.optimality_code==1 %}yes{% elif data.data.optimality_code==0 %}no{% else %}unknown<sup>*</sup> (one of {{ data.data.optimality_code }} curves in this isogeny class which might be optimal){% endif %}
+	  {% if data.data.optimality_code==1 %}yes{% elif data.data.optimality_code==0 %}no{% else %}not computed<sup>*</sup> (one of {{ data.data.optimality_code }} curves in this isogeny class which might be optimal){% endif %}
         </td>
         </tr>
         <tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -64,6 +64,14 @@ white-space: pre in order to keep line breaks! #}
 
     <h2> {{ KNOWL('ec.mordell_weil_group', title='Mordell-Weil group') }} structure</h2>
     <p>
+    {% if data.mwbsd.rank == '?' %}
+    Not known
+    {% if data.mwbsd.rank_bounds.0>0 %}
+    (\( {{data.mwbsd.rank_bounds.0}} \le r \le {{data.mwbsd.rank_bounds.1}} \))
+    {% else %}
+    (\(r \le {{data.mwbsd.rank_bounds.1}}\))
+    {%endif%}
+    {% else %}
     {% if data.mwbsd.rank == 0 %}
       {% if data.mwbsd.torsion == 1 %}
         trivial
@@ -83,6 +91,7 @@ white-space: pre in order to keep line breaks! #}
         \(\Z^{{data.mwbsd.rank}} \times {{data.mwbsd.tor_struct}}\)
       {% endif %}
     {%endif%}
+    {%endif%}
     </p>
 
     {% if data.mwbsd.rank!=0 %}
@@ -92,6 +101,9 @@ white-space: pre in order to keep line breaks! #}
     <p><h3> Infinite order Mordell-Weil generators and {{KNOWL('ec.q.canonical_height','heights')}}</h3>
     {% endif %}
       {{ place_code('gens') }}
+      {% if data.mwbsd.ngens==0 %}
+    No {% if data.mwbsd.rank==1 %} generator {% else %} generators  {% endif %} known
+      {% else %}
       <div style='overflow:auto'><p>
       <table>
         <tr><td>\(P\)</td><td>&nbsp;=&nbsp;</td>
@@ -103,7 +115,12 @@ white-space: pre in order to keep line breaks! #}
         </table>
       </p></div>
     </p>
+      {% if data.mwbsd.ngens < data.mwbsd.rank %}
+	Only {{ data.mwbsd.ngens }} generators known
+      {% endif %}
+
     {%endif %}
+    {%endif%}
 
     {% if data.mwbsd.torsion!=1 %}
     <h2> {{ KNOWL('ec.torsion_subgroup', title='Torsion generators') }}</h2>
@@ -122,6 +139,11 @@ white-space: pre in order to keep line breaks! #}
     </div>
     {%else %}
     <p> None </p>
+    {%endif %}
+    {% if data.mwbsd.ngens < data.mwbsd.rank %}
+     <p>
+     N.B. Integral points which are not combination of known generators (if any) are not shown.
+     </p>
     {%endif %}
 
     <h2> Invariants </h2>
@@ -211,10 +233,14 @@ white-space: pre in order to keep line breaks! #}
         </tr>
         <tr>
         <td>{{ KNOWL('ec.regulator', title='Regulator') }}:</td>
+	{% if data.mwbsd.reg == '?' %}
+	<td>Not known</td>
+	{% else %}
         {% if data.rank==0 %}
         <td> \(1\)</td>
         {% else %}
         <td> \({{ data.mwbsd.reg }}\)</td>
+        {% endif %}
         {% endif %}
         </tr>
 
@@ -259,7 +285,11 @@ white-space: pre in order to keep line breaks! #}
         </tr>
         <tr>
         <td>{{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:</td>
-        <td>\({{data.mwbsd.sha }}\)
+	<td>
+	  {% if data.mwbsd.sha == '?' %}
+	  Not known
+	  {% else %}
+          \({{data.mwbsd.sha }}\)
 	  {% if data.mwbsd.sha > 1 %}
 	  = {{data.mwbsd.sha2}}
           {% endif %}
@@ -268,8 +298,15 @@ white-space: pre in order to keep line breaks! #}
           {% else %}
           ({{ KNOWL('ec.q.analytic_sha_value',title="exact") }})
           {% endif %}
+          {% endif %}
         </td>
         </tr>
+	{% if data.mwbsd.sha == '?' %}
+        <tr>
+        <td>{{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }} \(\times\) {{ KNOWL('ec.regulator', title='Regulator') }}:</td>
+        <td> \({{ data.mwbsd.regsha }}\)</td>
+        </tr>
+        {% endif %}
 
         </table>
     </p>


### PR DESCRIPTION
Until today all elliptic curves over Q had complete data computed concerning their Mordell-Weil group, but  right now there is exaclt one curve where this is not (yet) true, namely label 289788419.a1 .  This will crash on beta but after this PR it is OK.

I cannot be sure that this PR will display well all possible combination of missing data, but this case is fairly simple: analytic rank 1 (hence algebraic rank 1 by a Theorem), but we have no generator.  Consequently: the integral points shown (in this case none) may not be complete (though in this case the chances of the huge generator being integral are zero);   we do not know the regulator or Analytic Sha; however we do know the product of the last two (by BSD, but the definition of Analytic Sha means that we do know this product! by definition it is (L'(E,1)*|torsion|^2)/(tamagawa product*period), and it is expected to be the height of the generator, tnough it might be n^2 times that height if |Sha|=n^2, so I thought it worth showing.

Please take a look at http://localhost:37777/EllipticCurve/Q/289788419/a/1 and tell me what you think.

No other curve displays should be affected by this, but looking at a few random ones would be a good idea, especially those of conductor >200000000 (that's 2*10^8) which were only uploaded today.