### PR TITLE
Resolves #4456

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -101,8 +101,8 @@ def get_nf_info(lab):
     try:
         label = nf_string_to_label(lab)
         pretty = field_pretty (label)
-    except ValueError:
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid number field label. %s" % escape(lab)))
+    except ValueError as err:
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid number field label. %s" % (escape(lab),err)))
     return label, pretty
 
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -334,6 +334,7 @@ class WebNumberField:
         if data is None:
             self._data = self._get_dbdata()
             if self._data is None:
+              self._data = {}
               raise ValueError('Label not found')
         else:
             self._data = data

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -487,7 +487,7 @@ class WebNumberField:
         return coeff_to_poly(self._data['coeffs'])
 
     def haskey(self, key):
-        return self._data and self._data.get(key) is not None
+        return self._data.get(key) is not None
 
     # Warning, this produces our preferred integral basis
     # But, if you have the sage number field do computations,

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -487,7 +487,7 @@ class WebNumberField:
         return coeff_to_poly(self._data['coeffs'])
 
     def haskey(self, key):
-        return self._data.get(key) is not None
+        return self._data and self._data.get(key) is not None
 
     # Warning, this produces our preferred integral basis
     # But, if you have the sage number field do computations,

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -333,6 +333,8 @@ class WebNumberField:
         self.gen_name = gen_name
         if data is None:
             self._data = self._get_dbdata()
+            if self._data is None:
+              raise ValueError('Label not found')
         else:
             self._data = data
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -333,9 +333,6 @@ class WebNumberField:
         self.gen_name = gen_name
         if data is None:
             self._data = self._get_dbdata()
-            if self._data is None:
-              self._data = {}
-              raise ValueError('Label not found')
         else:
             self._data = data
 
@@ -487,7 +484,7 @@ class WebNumberField:
         return coeff_to_poly(self._data['coeffs'])
 
     def haskey(self, key):
-        return self._data.get(key) is not None
+        return self._data and self._data.get(key) is not None
 
     # Warning, this produces our preferred integral basis
     # But, if you have the sage number field do computations,


### PR DESCRIPTION
Minimalist fix to "haskey" method of WebNumberField return False rather than failing when _data is None (which happens whenever you try to create a WebNumberField object with a label that is not in the database and do not supply data).  I'm not sure it makes sense to create a WebNumberField object with _data set to None, but there are apparently several places in the code that rely on this behavior (16 tests fail if you raise an error when WebNumberField is called with a non-existent label and no data), so I left this behavior unchanged.
 
Tests pass on grace.