### PR TITLE
Resolves #4428

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1258,8 +1258,9 @@ class ArtinLfunction(Lfunction):
         self.algebraic = True
         self.motivic_weight = 0
         cc = self.artin.central_character()
-        if cc:
-            self.charactermodulus, self.characternumber = cc.modulus, cc.number
+        if not cc:
+            raise ValueError('Error constructing Artin representation %s, unable to compute central character.'%self.origin_label)
+        self.charactermodulus, self.characternumber = cc.modulus, cc.number
 
         # Compute Dirichlet coefficients and period ########################
         if self.degree == 1:

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1258,7 +1258,8 @@ class ArtinLfunction(Lfunction):
         self.algebraic = True
         self.motivic_weight = 0
         cc = self.artin.central_character()
-        self.charactermodulus, self.characternumber = cc.modulus, cc.number
+        if cc:
+            self.charactermodulus, self.characternumber = cc.modulus, cc.number
 
         # Compute Dirichlet coefficients and period ########################
         if self.degree == 1:

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1259,7 +1259,7 @@ class ArtinLfunction(Lfunction):
         self.motivic_weight = 0
         cc = self.artin.central_character()
         if not cc:
-            raise ValueError('Error constructing Artin representation %s, unable to compute central character.'%self.origin_label)
+            raise ValueError('Error constructing Artin representation %s, unable to compute central character, possibly because the modulus is too large.'%self.origin_label)
         self.charactermodulus, self.characternumber = cc.modulus, cc.number
 
         # Compute Dirichlet coefficients and period ########################


### PR DESCRIPTION
Raises a ValueError when attempting to construct an ArtinLFunction if the central character is unavailable (this will happen if the modulus is too large) -- this error will be caught and displays a reasonable message to the user telling them what happened rather than throwing a server error (which will keep the flasklog clean, which is the main point of this PR).