### PR TITLE
Show isogeny classes instead of curves in 'Jacobian is isogenous to...'

### DIFF
--- a/lmfdb/genus2_curves/templates/g2c_isogeny_class.html
+++ b/lmfdb/genus2_curves/templates/g2c_isogeny_class.html
@@ -77,6 +77,14 @@ text-align: center;
 {% endif %}
 </p>
 
+<h2 style="display: inline"> {{ KNOWL('g2c.decomposition', 'Decomposition of the Jacobian') }} </h2>
+
+<!-- Description of a splitting field of minimal degree: -->
+<p>{{data.split_field_statement|safe}}</p>
+
+<!-- Description of the splittings themselves. -->
+<p>{{data.split_statement|safe}}</p>
+
 <h2> {{ KNOWL('g2c.jac_endomorphisms', title='Endomorphisms of the Jacobian') }} </h2>
 
 <p>{{data.gl2_statement_base}}</p>

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -20,9 +20,9 @@ class Genus2Test(LmfdbTest):
         L = self.tc.get('/Genus2Curve/Q/169.a.169.1',follow_redirects=True)
         assert 'square of' in L.get_data(as_text=True) and 'E_6' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/1152.a.147456.1',follow_redirects=True)
-        assert 'non-isogenous elliptic curves' in L.get_data(as_text=True) and '24.a5' in L.get_data(as_text=True) and '48.a5' in L.get_data(as_text=True)
+        assert 'non-isogenous elliptic curve' in L.get_data(as_text=True) and '24.a' in L.get_data(as_text=True) and '48.a' in L.get_data(as_text=True)
         L = self.tc.get('/Genus2Curve/Q/15360.f.983040.2',follow_redirects=True)
-        assert r"N(\mathrm{U}(1)\times\mathrm{SU}(2))" in L.get_data(as_text=True) and '480.b3' in L.get_data(as_text=True) and '32.a3' in L.get_data(as_text=True)
+        assert r"N(\mathrm{U}(1)\times\mathrm{SU}(2))" in L.get_data(as_text=True) and '480.b' in L.get_data(as_text=True) and '32.a' in L.get_data(as_text=True)
 
     def test_isogeny_class_label(self):
         L = self.tc.get('/Genus2Curve/Q/1369/a/')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -462,14 +462,14 @@ def split_field_statement(is_simple_geom, field_label, poly):
 
 def split_statement(coeffs, labels, condnorms):
     if len(coeffs) == 1:
-        statement = "Decomposes up to isogeny as the square of the elliptic curve:"
+        statement = "Decomposes up to isogeny as the square of the elliptic curve isogeny class:"
     else:
-        statement = "Decomposes up to isogeny as the product of the non-isogenous elliptic curves:"
+        statement = "Decomposes up to isogeny as the product of the non-isogenous elliptic curve isogeny classes:"
     for n in range(len(coeffs)):
         # Use labels when possible:
         label = labels[n] if labels else ''
         if label:
-            statement += "<br>&nbsp;&nbsp;Elliptic curve <a href=%s>%s</a>" % (url_for_ec(label), label)
+            statement += "<br>&nbsp;&nbsp;Elliptic curve isogeny class <a href=%s>%s</a>" % (url_for_ec_class(label), ec_label_class(label))
         # Otherwise give defining equation:
         else:
             statement += r"<br>&nbsp;&nbsp;\(y^2 = x^3 - g_4 / 48 x - g_6 / 864\) with"


### PR DESCRIPTION
This should resolve issue #4478. You can see the changes for example on:
http://localhost:37777/Genus2Curve/Q/196/a/21952/1 and http://localhost:37777/Genus2Curve/Q/196/a/