### PR TITLE
Galois orbit size = degree (not order)

### DIFF
--- a/lmfdb/characters/templates/CharacterGaloisOrbit.html
+++ b/lmfdb/characters/templates/CharacterGaloisOrbit.html
@@ -4,7 +4,7 @@
 
 {% if contents %}
 {# Characters #}
-<h2> {%if rowtruncate%}First {{contents|count}} of {{order}} {{KNOWL('character.dirichlet',title='characters')}}{% else %}{{KNOWL('character.dirichlet',title='Characters')}}{%endif%} in Galois orbit</h2>
+<h2> {%if rowtruncate%}First {{contents|count}} of {{degree}} {{KNOWL('character.dirichlet',title='characters')}}{% else %}{{KNOWL('character.dirichlet',title='Characters')}}{%endif%} in Galois orbit</h2>
 <table class="ntdata" id="chitable">
   <thead class="space">
     <tr>

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -1112,9 +1112,9 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
             self.galoisorbit = [self._char_desc(1, mod=1,prim=True)]
             return
 
-        upper_limit = min(self.maxrows + 1, self.order + 1)
+        upper_limit = min(self.maxrows + 1, self.degree + 1)
 
-        if self.maxrows < self.order + 1:
+        if self.maxrows < self.degree + 1:
             self.rowtruncate = True
         self.galorbnums = orbit_data['galois_orbit'][:upper_limit]
         self.galoisorbit = list(

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -1074,7 +1074,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
               'valuefield', 'vflabel', 'vfpol', 'kerfield', 'kflabel',
               'kfpol', 'contents', 'properties', 'friends', 'coltruncate',
               'charsums', 'codegauss', 'codejacobi', 'codekloosterman',
-              'orbit_label', 'orbit_index', 'isminimal', 'isorbit']
+              'orbit_label', 'orbit_index', 'isminimal', 'isorbit', 'degree']
 
     def __init__(self, **kwargs):
         self.type = "Dirichlet"
@@ -1134,6 +1134,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
 
         self.conductor = orbit_data['conductor']
         self.order = orbit_data['order']
+        self.degree = orbit_data['char_degree']
         self.isprimitive = bool_string(orbit_data['is_primitive'])
         self.isminimal = bool_string(orbit_data['is_minimal'])
         self.parity = parity_string(int(orbit_data['parity']))


### PR DESCRIPTION
This PR fixes a bug on the Dirichlet orbit pages -- the size of the Galois orbit of a Dirichlet character is its degree, not its order. (degree=euler_phi(order) is the degree of the value field).