### PR TITLE
Fix artin footer

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -280,10 +280,8 @@ The function which was called for this page is: {{calling_function}}
 
     {% if support -%}
       {{ support|safe }}<br/>
-    {%- else -%}
-        <h4>{{shortthanks|safe}}</h4>
-<br />
     {%- endif %}
+    <h4>{{shortthanks|safe}}</h4>
     <div>
       <a href="{{ url_for('contact') }}">Contact</a>
       &middot;


### PR DESCRIPTION
This restores the grant support line on the bottom of Artin representation pages and shrinks the space between the grant line and the next by a little bit.

https://beta.lmfdb.org/ArtinRepresentation/2.140.6t5.b.a
http://127.0.0.1:37777//ArtinRepresentation/2.140.6t5.b.a