### PR TITLE
Adding number field acknowledgments

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -134,7 +134,7 @@ def source():
     learnmore = learnmore_list_remove('Source')
     t = 'Source of number field data'
     bread = bread_prefix() + [('Source', ' ')]
-    return render_template("single.html", kid='rcs.source.nf',
+    return render_template("double.html", kid='rcs.source.nf', kid2='rcs.ack.nf',
         credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
 
 

--- a/lmfdb/templates/double.html
+++ b/lmfdb/templates/double.html
@@ -1,0 +1,11 @@
+{% extends "homepage.html" %}
+{% block content %}
+
+{{ KNOWL_INC(kid) }}
+
+{% if kid2 is defined %}
+  {{ KNOWL_INC(kid2) }}
+{% endif %}
+
+{% endblock %}
+


### PR DESCRIPTION
This is a prototype for adding additional acknowledgements.  The only page changed is

  http://127.0.0.1:37777/NumberField/Source

The plan is to have source knowls also give credit to people who were directly involved in the LMFDB side of a section of the web site, but to store this information in a new knowl.

There are several choices made here where we might want to do differently:

1. I added the template double.html for displaying 2 knowls on a page.  But, the second knowl is optional, so we could just replace single.html with this which would cause no harm and make the transition slightly easier.  The downside of just using single.html is the aesthetic factor that a file called "single.html" would be able to display two things.
2. I named the new knowl rcs.ack.nf.  We could use a different prefix, or we could spell out the whole word acknowledgment.
3. In rcs.ack.nf, I used a "h2" to separate its content from the source information.  I thought it would be a little awkward to have it flow continuously from one to the other.

So, this is open for discussion.