### PR TITLE
Artin and p-adic field acknowledgments

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This Blueprint is about Artin representations
-# Author: Paul-Olivier Dehaye, John Jones
+# Authors: Paul-Olivier Dehaye, John Jones
 
 import re
 import random
@@ -264,10 +264,6 @@ def by_partial_data(dim, conductor):
     return artin_representation_search({'dimension': dim, 'conductor': conductor, 'search_array': ArtinSearchArray()})
 
 
-# credit information should be moved to the databases themselves, not at the display level. that's too late.
-tim_credit = "Tim Dokchitser, John Jones, and David Roberts"
-support_credit = "Support by Paul-Olivier Dehaye."
-
 @artin_representations_page.route("/<label>/")
 @artin_representations_page.route("/<label>")
 def render_artin_representation_webpage(label):
@@ -390,8 +386,6 @@ def render_artin_representation_webpage(label):
     if case == 'rep':
         return render_template(
             "artin-representation-show.html",
-            credit=tim_credit,
-            support=support_credit,
             title=title,
             bread=bread,
             friends=friends,
@@ -407,8 +401,6 @@ def render_artin_representation_webpage(label):
     # else we have an orbit
     return render_template(
         "artin-representation-galois-orbit.html",
-        credit=tim_credit,
-        support=support_credit,
         title=title,
         bread=bread,
         allchars=allchars,
@@ -440,7 +432,6 @@ def interesting():
         label_col="Baselabel",
         title=r"Some interesting Artin representations",
         bread=get_bread([("Interesting", " ")]),
-        credit=tim_credit,
         learnmore=learnmore_list(),
     )
 
@@ -448,22 +439,23 @@ def interesting():
 def statistics():
     title = "Artin representations: statistics"
     bread = get_bread([("Statistics", " ")])
-    return render_template("display_stats.html", info=ArtinStats(), credit=tim_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=ArtinStats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @artin_representations_page.route("/Labels")
 def labels_page():
     t = 'Labels for Artin representations'
     bread = get_bread([("Labels", '')])
     learnmore = learnmore_list_remove('labels')
-    return render_template("single.html", kid='artin.label',learnmore=learnmore, credit=tim_credit, title=t, bread=bread)
+    return render_template("single.html", kid='artin.label',learnmore=learnmore, title=t, bread=bread)
 
 @artin_representations_page.route("/Source")
 def source():
     t = 'Source of Artin representation data'
     bread = get_bread([("Source", '')])
     learnmore = learnmore_list_remove('Source')
-    return render_template("single.html", kid='rcs.source.artin',
-                           credit=tim_credit, title=t, bread=bread, 
+    return render_template("double.html", kid='rcs.source.artin',
+                           kid2='rcs.ack.artin',
+                           title=t, bread=bread, 
                            learnmore=learnmore)
 
 @artin_representations_page.route("/Reliability")
@@ -472,7 +464,7 @@ def reliability():
     bread = get_bread([("Reliability", '')])
     learnmore = learnmore_list_remove('Reliability')
     return render_template("single.html", kid='rcs.rigor.artin',
-                           credit=tim_credit, title=t, bread=bread, 
+                           title=t, bread=bread, 
                            learnmore=learnmore)
 
 @artin_representations_page.route("/Completeness")
@@ -481,7 +473,7 @@ def cande():
     bread = get_bread([("Completeness", '')])
     learnmore = learnmore_list_remove('Completeness')
     return render_template("single.html", kid='rcs.cande.artin',
-                           credit=tim_credit, title=t, bread=bread, 
+                           title=t, bread=bread, 
                            learnmore=learnmore)
 
 class ArtinSearchArray(SearchArray):

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -25,8 +25,6 @@ from lmfdb.number_fields.web_number_field import (
 
 import re
 
-LF_credit = 'J. Jones and D. Roberts'
-
 def get_bread(breads=[]):
     bc = [("$p$-adic fields", url_for(".index"))]
     for b in breads:
@@ -153,7 +151,7 @@ def index():
     info = to_dict(request.args, search_array=LFSearchArray(), stats=LFStats())
     if len(request.args) != 0:
         return local_field_search(info)
-    return render_template("lf-index.html", title="$p$-adic fields", titletag="p-adic fields", bread=bread, credit=LF_credit, info=info, learnmore=learnmore_list())
+    return render_template("lf-index.html", title="$p$-adic fields", titletag="p-adic fields", bread=bread, info=info, learnmore=learnmore_list())
 
 
 @local_fields_page.route("/<label>")
@@ -193,8 +191,7 @@ class LF_download(Downloader):
              shortcuts={'jump': local_field_jump, 'download': LF_download()},
              bread=lambda:get_bread([("Search results", ' ')]),
              learnmore=learnmore_list,
-             url_for_label=url_for_label,
-             credit=lambda:LF_credit)
+             url_for_label=url_for_label)
 def local_field_search(info,query):
     parse_ints(info,query,'p',name='Prime p')
     parse_ints(info,query,'n',name='Degree')
@@ -317,7 +314,6 @@ def render_field_webpage(args):
         bread = get_bread([(label, ' ')])
         return render_template(
             "lf-show-field.html",
-            credit=LF_credit,
             title=title,
             titletag=titletag,
             bread=bread,
@@ -386,7 +382,6 @@ def interesting():
         url_for_label,
         title=r"Some interesting $p$-adic fields",
         bread=get_bread([("Interesting", " ")]),
-        credit=LF_credit,
         learnmore=learnmore_list()
     )
 
@@ -394,7 +389,7 @@ def interesting():
 def statistics():
     title = "Local fields: statistics"
     bread = get_bread([("Statistics", " ")])
-    return render_template("display_stats.html", info=LFStats(), credit=LF_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=LFStats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @local_fields_page.route("/Completeness")
 def cande():
@@ -402,7 +397,7 @@ def cande():
     tt = 'Completeness of p-adic field data'
     bread = get_bread([("Completeness", )])
     return render_template("single.html", kid='rcs.cande.lf',
-                           credit=LF_credit, title=t, titletag=tt, bread=bread,
+                           title=t, titletag=tt, bread=bread,
                            learnmore=learnmore_list_remove('Completeness'))
 
 @local_fields_page.route("/Labels")
@@ -412,15 +407,16 @@ def labels_page():
     bread = get_bread([("Labels", '')])
     return render_template("single.html", kid='lf.field.label',
                   learnmore=learnmore_list_remove('label'),
-                  credit=LF_credit, title=t, titletag=tt, bread=bread)
+                  title=t, titletag=tt, bread=bread)
 
 @local_fields_page.route("/Source")
 def source():
     t = 'Source of $p$-adic field data'
     ttag = 'Source of p-adic field data'
     bread = get_bread([("Source", '')])
-    return render_template("single.html", kid='rcs.source.lf',
-                           credit=LF_credit, title=t, titletag=ttag, bread=bread,
+    return render_template("double.html", kid='rcs.source.lf',
+                           kid2='rcs.ack.lf', title=t,
+                           titletag=ttag, bread=bread,
                            learnmore=learnmore_list_remove('Source'))
 
 @local_fields_page.route("/Reliability")
@@ -429,7 +425,7 @@ def reliability():
     ttag = 'Reliability of p-adic field data'
     bread = get_bread([("Reliability", '')])
     return render_template("single.html", kid='rcs.source.lf',
-                           credit=LF_credit, title=t, titletag=ttag, bread=bread,
+                           title=t, titletag=ttag, bread=bread,
                            learnmore=learnmore_list_remove('Reliability'))
 
 class LFSearchArray(SearchArray):

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -34,7 +34,6 @@ assert nf_logger
 
 bread_prefix = lambda: [('Number fields', url_for(".number_field_render_webpage"))]
 
-NF_credit = 'the PARI group, J. Voight, J. Jones, D. Roberts, J. Kl&uuml;ners, G. Malle'
 Completename = 'Completeness of the data'
 dnc = 'data not computed'
 
@@ -135,7 +134,7 @@ def source():
     t = 'Source of number field data'
     bread = bread_prefix() + [('Source', ' ')]
     return render_template("double.html", kid='rcs.source.nf', kid2='rcs.ack.nf',
-        credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
+        title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/Reliability")
@@ -144,7 +143,7 @@ def reliability():
     t = 'Reliability of number field data'
     bread = bread_prefix() + [('Reliability', ' ')]
     return render_template("single.html", kid='rcs.rigor.nf',
-        credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
+        title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/GaloisGroups")
@@ -153,7 +152,7 @@ def render_groups_page():
     learnmore = learnmore_list_remove('Galois group')
     t = 'Galois group labels'
     bread = bread_prefix() + [('Galois group labels', ' ')]
-    return render_template("galois_groups.html", al=group_alias_table(), info=info, credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
+    return render_template("galois_groups.html", al=group_alias_table(), info=info, title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/FieldLabels")
@@ -162,7 +161,7 @@ def render_labels_page():
     learnmore = learnmore_list_remove('number field labels')
     t = 'Labels for number fields'
     bread = bread_prefix() + [('Labels', '')]
-    return render_template("single.html", info=info, credit=NF_credit, kid='nf.label', title=t, bread=bread, learnmore=learnmore)
+    return render_template("single.html", info=info, kid='nf.label', title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/Completeness")
@@ -171,7 +170,7 @@ def render_discriminants_page():
     t = 'Completeness of number field data'
     bread = [('Number fields', url_for(".number_field_render_webpage")), ('Completeness', ' ')]
     return render_template("single.html", kid='rcs.cande.nf',
-        credit=NF_credit, title=t, bread=bread, learnmore=learnmore)
+        title=t, bread=bread, learnmore=learnmore)
 
 
 @nf_page.route("/QuadraticImaginaryClassGroups")
@@ -212,12 +211,12 @@ def render_class_group_data():
             info['message'] = 'Invalid congruence requested'
             return class_group_request_error(info, bread)
 
-    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread, learnmore=learnmore)
+    return render_template("class_group_data.html", info=info, title=t, bread=bread, learnmore=learnmore)
 
 
 def class_group_request_error(info, bread):
     t = 'Class groups of quadratic imaginary fields'
-    return render_template("class_group_data.html", info=info, credit="A. Mosunov and M. J. Jacobson, Jr.", title=t, bread=bread)
+    return render_template("class_group_data.html", info=info, title=t, bread=bread)
 
 
 # Helper for stats page
@@ -334,7 +333,6 @@ def statistics():
             'maxdeg': max_deg}
     return render_template("nf-statistics.html",
                            info=info,
-                           credit=NF_credit,
                            title=title,
                            bread=bread)
 
@@ -359,7 +357,7 @@ def number_field_render_webpage():
         info['discriminant_list'] = discriminant_list
         t = 'Number fields'
         bread = bread_prefix()
-        return render_template("nf-index.html", info=info, credit=NF_credit, title=t, bread=bread, learnmore=learnmore_list())
+        return render_template("nf-index.html", info=info, title=t, bread=bread, learnmore=learnmore_list())
     else:
         return number_field_search(info)
 
@@ -636,7 +634,7 @@ def render_field_webpage(args):
         info["mydecomp"] = [dopow(x) for x in v]
     except AttributeError:
         pass
-    return render_template("nf-show-field.html", properties=properties, credit=NF_credit, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=learnmore, info=info, formatfield=formatfield, KNOWL_ID="nf.%s"%label)
+    return render_template("nf-show-field.html", properties=properties, title=title, bread=bread, code=nf.code, friends=info.pop('friends'), downloads=downloads, learnmore=learnmore, info=info, formatfield=formatfield, KNOWL_ID="nf.%s"%label)
 
 
 def format_coeffs2(coeffs):
@@ -682,7 +680,6 @@ def interesting():
         url_for_label,
         title=r"Some interesting number fields",
         bread=bread_prefix() + [("Interesting", " ")],
-        credit=NF_credit,
         learnmore=learnmore_list(),
     )
 

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -58,7 +58,7 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/GaloisGroups', 'abstract group may have')
 
     def test_imaginary_quadratic_page(self):
-        self.check_args('/NumberField/QuadraticImaginaryClassGroups', 'Mosunov')
+        self.check_args('/NumberField/QuadraticImaginaryClassGroups', 'extensive computations')
 
     def test_discriminants_page(self):
         self.check_args('/NumberField/Source', 'Jones-David Roberts')


### PR DESCRIPTION
This adds the new style acknowledgements to Artin representations and p-adic field pages.

On these two sections and number fields, it removes the old credit footers.  Also, the knowls for number fields were adjusted to account for the quadratic imaginary field data.

Here are random pages from each area, and then one can click on the link for the source of the data.

http://127.0.0.1:37777/NumberField/8.6.198299379991.1
http://127.0.0.1:37777/LocalNumberField/23.23.29.9
http://127.0.0.1:37777/ArtinRepresentation/5.145800000.6t14.b.a
