### PR TITLE
More acknowledgment changes

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -49,7 +49,7 @@ def get_bread(breads=[]):
 
 def learnmore_list():
     return [('Completeness of the data', url_for(".cande")),
-            ('Source of the data', url_for(".source")),
+            ('Source and acknowledgments', url_for(".source")),
             ('Reliability of the data', url_for(".reliability")),
             ('Artin representations labels', url_for(".labels_page"))]
 
@@ -450,7 +450,7 @@ def labels_page():
 
 @artin_representations_page.route("/Source")
 def source():
-    t = 'Source of Artin representation data'
+    t = 'Source and acknowledgments for Artin representation pages'
     bread = get_bread([("Source", '')])
     learnmore = learnmore_list_remove('Source')
     return render_template("double.html", kid='rcs.source.artin',

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -31,8 +31,6 @@ try:
 except:
     logger.fatal("It looks like the SPKGes gap_packages and database_gap are not installed on the server.  Please install them via 'sage -i ...' and try again.")
 
-GG_credit = 'GAP, Magma, J. Jones, and A. Bartel'
-
 # convert [0,5,21,0,1] to [[1,5],[2,21],[4,1]]
 def mult2mult(li):
     return [[j, li_j] for j, li_j in enumerate(li) if li_j > 0]
@@ -40,7 +38,7 @@ def mult2mult(li):
 
 def learnmore_list():
     return [('Completeness of the data', url_for(".cande")),
-            ('Source of the data', url_for(".source")),
+            ('Source and acknowledgments', url_for(".source")),
             ('Reliability of the data', url_for(".reliability")),
             ('Galois group labels', url_for(".labels_page"))]
 
@@ -89,7 +87,7 @@ def index():
     if request.args:
         return galois_group_search(info)
     info['degree_list'] = list(range(1, 48))
-    return render_template("gg-index.html", title="Galois groups", bread=bread, info=info, credit=GG_credit, learnmore=learnmore_list())
+    return render_template("gg-index.html", title="Galois groups", bread=bread, info=info, learnmore=learnmore_list())
 
 # For the search order-parsing
 def make_order_key(order):
@@ -102,8 +100,7 @@ def make_order_key(order):
              err_title='Galois group search input error',
              url_for_label=lambda label: url_for(".by_label", label=label),
              learnmore=learnmore_list,
-             bread=lambda: get_bread([("Search results", ' ')]),
-             credit=lambda: GG_credit)
+             bread=lambda: get_bread([("Search results", ' ')]))
 def galois_group_search(info, query):
     def includes_composite(s):
         s = s.replace(' ','').replace('..','-')
@@ -274,7 +271,7 @@ def render_group_webpage(args):
             data['nilpotency'] += ' (not nilpotent)'
 
         bread = get_bread([(label, ' ')])
-        return render_template("gg-show-group.html", credit=GG_credit, title=title, bread=bread, info=data, properties=prop2, friends=friends, KNOWL_ID="gg.%s"%label, learnmore=learnmore_list())
+        return render_template("gg-show-group.html", title=title, bread=bread, info=data, properties=prop2, friends=friends, KNOWL_ID="gg.%s"%label, learnmore=learnmore_list())
 
 
 def search_input_error(info, bread):
@@ -294,7 +291,6 @@ def interesting():
         url_for_label=lambda label: url_for(".by_label", label=label),
         title=r"Some interesting Galois groups",
         bread=get_bread([("Interesting", " ")]),
-        credit=GG_credit,
         learnmore=learnmore_list()
     )
 
@@ -302,7 +298,7 @@ def interesting():
 def statistics():
     title = "Galois groups: statistics"
     bread = get_bread([("Statistics", " ")])
-    return render_template("display_stats.html", info=GaloisStats(), credit=GG_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=GaloisStats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @galois_groups_page.route("/Completeness")
 def cande():
@@ -310,7 +306,7 @@ def cande():
     bread = get_bread([("Completeness", )])
     learnmore = learnmore_list_remove('Completeness')
     return render_template("single.html", kid='rcs.cande.gg',
-                           credit=GG_credit, title=t, bread=bread, 
+                           title=t, bread=bread, 
                            learnmore=learnmore)
 
 @galois_groups_page.route("/Labels")
@@ -319,14 +315,14 @@ def labels_page():
     bread = get_bread([("Labels", '')])
     return render_template("single.html", kid='gg.label',
            learnmore=learnmore_list_remove('label'), 
-           credit=GG_credit, title=t, bread=bread)
+           title=t, bread=bread)
 
 @galois_groups_page.route("/Source")
 def source():
-    t = 'Source of Galois group data'
+    t = 'Source and acknowledgments for Galois group pages'
     bread = get_bread([("Source", '')])
-    return render_template("single.html", kid='rcs.source.gg',
-                           credit=GG_credit, title=t, bread=bread, 
+    return render_template("double.html", kid='rcs.source.gg', kid2='rcs.ack.gg',
+                           title=t, bread=bread, 
                            learnmore=learnmore_list_remove('Source'))
 
 @galois_groups_page.route("/Reliability")
@@ -334,7 +330,7 @@ def reliability():
     t = 'Reliability of Galois group data'
     bread = get_bread([("Reliability", '')])
     return render_template("single.html", kid='rcs.rigor.gg',
-                           credit=GG_credit, title=t, bread=bread, 
+                           title=t, bread=bread, 
                            learnmore=learnmore_list_remove('Reliability'))
 
 class GalSearchArray(SearchArray):

--- a/lmfdb/local_fields/__init__.py
+++ b/lmfdb/local_fields/__init__.py
@@ -16,6 +16,7 @@ def body_class():
 from . import main
 assert main
 
+app.register_blueprint(local_fields_page, url_prefix="/padicField")
 app.register_blueprint(local_fields_page, url_prefix="/LocalNumberField")
 
 register_search_function(

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -33,7 +33,7 @@ def get_bread(breads=[]):
 
 def learnmore_list():
     return [('Completeness of the data', url_for(".cande")),
-            ('Source of the data', url_for(".source")),
+            ('Source and acknowledgments', url_for(".source")),
             ('Reliability of the data', url_for(".reliability")),
             ('Local field labels', url_for(".labels_page"))]
 
@@ -174,7 +174,7 @@ class LF_download(Downloader):
     title = '$p$-adic fields'
     columns = ['p', 'coeffs']
     data_format = ['p', '[coeffs]']
-    data_description = 'defining the local field over Qp by adjoining a root of f(x).'
+    data_description = 'defining the $p$-adic field over Qp by adjoining a root of f(x).'
     function_body = {'magma':['Prec := 100; // Default precision of 100',
                               'return [LocalField( pAdicField(r[1], Prec) , PolynomialRing(pAdicField(r[1], Prec))![c : c in r[2]] ) : r in data];'],
                      'sage':['Prec = 100 # Default precision of 100',
@@ -411,8 +411,8 @@ def labels_page():
 
 @local_fields_page.route("/Source")
 def source():
-    t = 'Source of $p$-adic field data'
-    ttag = 'Source of p-adic field data'
+    t = 'Source and acknowledgments for $p$-adic field pages'
+    ttag = 'Source and acknowledgments for p-adic field pages'
     bread = get_bread([("Source", '')])
     return render_template("double.html", kid='rcs.source.lf',
                            kid2='rcs.ack.lf', title=t,

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -108,7 +108,7 @@ def global_numberfield_summary():
 
 def learnmore_list():
     return [(Completename, url_for(".render_discriminants_page")),
-            ('Source of the data', url_for(".source")),
+            ('Source and acknowledgments', url_for(".source")),
             ('Reliability of the data', url_for(".reliability")),
             ('Number field labels', url_for(".render_labels_page")),
             ('Galois group labels', url_for(".render_groups_page")),
@@ -131,7 +131,7 @@ def poly_to_field_label(pol):
 @nf_page.route("/Source")
 def source():
     learnmore = learnmore_list_remove('Source')
-    t = 'Source of number field data'
+    t = 'Source and acknowledgments for number field pages'
     bread = bread_prefix() + [('Source', ' ')]
     return render_template("double.html", kid='rcs.source.nf', kid2='rcs.ack.nf',
         title=t, bread=bread, learnmore=learnmore)


### PR DESCRIPTION
For number fields, p-adic fields, and Artin representations, the learn more about link now says "Source and acknowledgments".

The titles for these pages is now also changed to say "Source and acknowledgments for X pages"

There are more changes of text on local field pages so that local field says $p$-adic field.

The new acknowledgments are put in for Galois groups.

If you are just exploring the site, the url prefix for $p$-adic fields is now padicField.  If you enter a url which uses LocalNumberField, it will still work.  It does not redirect -- that is something we could do in the future.  The current code change for this part is just one line whereas redirects will be more involved.
