### PR TITLE
Adding search option for bad primes 

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -8,8 +8,8 @@ from sage.all import latex, QQ, PolynomialRing
 from lmfdb import db
 from lmfdb.utils import (
     to_dict, web_latex_ideal_fact, flash_error, comma, display_knowl,
-    nf_string_to_label, parse_nf_string, parse_noop, parse_start, parse_count, parse_ints,
-    SearchArray, TextBox, SelectBox, ExcludeOnlyBox, CountBox,
+    nf_string_to_label, parse_nf_string, parse_noop, parse_start, parse_count, parse_ints, parse_primes,
+    SearchArray, TextBox, SelectBox, ExcludeOnlyBox, CountBox, SubsetBox, TextBoxWithSelect,
     teXify_pol, search_wrap)
 from lmfdb.utils.display_stats import StatsDisplay, totaler, proportioners
 from lmfdb.utils.interesting import interesting_knowls
@@ -152,6 +152,10 @@ def bianchi_modular_form_search(info, query):
     parse_noop(info, query, 'label')
     parse_ints(info, query, 'dimension')
     parse_ints(info, query, 'level_norm')
+    parse_primes(info, query, 'field_bad_primes', name='field bad primes',
+         qfield='field_bad_primes',mode=info.get('field_bad_quantifier'))
+    parse_primes(info, query, 'level_bad_primes', name='level bad primes',
+         qfield='level_bad_primes',mode=info.get('level_bad_quantifier'))
     if not 'sfe' in info:
         info['sfe'] = "any"
     elif info['sfe'] != "any":
@@ -693,17 +697,34 @@ class BMFSearchArray(SearchArray):
             label='CM',
             knowl='mf.bianchi.cm'
         )
+        field_bad_quant = SubsetBox(
+            name="field_bad_quantifier")
+        field_bad_primes = TextBoxWithSelect(
+            name="field_bad_primes",
+            label="Field bad primes",
+            knowl="nf.ramified_primes",
+            example="5,13",
+            select_box=field_bad_quant)
+        level_bad_quant = SubsetBox(
+            name="level_bad_quantifier")
+        level_bad_primes = TextBoxWithSelect(
+            name="level_bad_primes",
+            label="Level bad primes",
+            knowl="mf.bianchi.level",
+            example="5,13",
+            select_box=level_bad_quant)
         count = CountBox()
 
         self.browse_array = [
             [field],
             [level, sign],
             [dimension, base_change],
-            [count, CM]
+            [count, CM],
+            [field_bad_primes, level_bad_primes]
         ]
         self.refine_array = [
-            [field, level, dimension],
-            [sign, base_change, CM]
+            [field, level, dimension, field_bad_primes],
+            [sign, base_change, CM, level_bad_primes]
         ]
 
 label_finder = re.compile(r"label=([0-9.]+)")

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -16,8 +16,8 @@ from lmfdb.backend.encoding import Json
 from lmfdb.utils import (
     to_dict, flash_error,
     parse_ints, parse_noop, nf_string_to_label, parse_element_of,
-    parse_nf_string, parse_nf_elt, parse_bracketed_posints, parse_bool, parse_floats,
-    SearchArray, TextBox, ExcludeOnlyBox, SelectBox, CountBox, YesNoBox,
+    parse_nf_string, parse_nf_elt, parse_bracketed_posints, parse_bool, parse_floats, parse_primes,
+    SearchArray, TextBox, ExcludeOnlyBox, SelectBox, CountBox, YesNoBox, SubsetBox, TextBoxWithSelect,
     search_wrap, parse_rational,
     redirect_no_cache
     )
@@ -546,6 +546,8 @@ def elliptic_curve_search(info, query):
             query['cm'] = 0
 
     parse_ints(info,query,field='cm_disc',qfield='cm')
+    parse_primes(info, query, 'conductor_norm_factors', name='bad primes',
+             qfield='conductor_norm_factors',mode=info.get('bad_quantifier'))
     info['field_pretty'] = field_pretty
     info['web_ainvs'] = web_ainvs
     parse_ints(info,query,'bf_deg',name='Base field degree',qfield='degree')
@@ -800,6 +802,14 @@ class ECNFSearchArray(SearchArray):
             label="Regulator*",
             knowl="ec.regulator",
             example="8.4-9.1")
+        bad_quant = SubsetBox(
+            name="bad_quantifier")
+        bad_primes = TextBoxWithSelect(
+            name="conductor_norm_factors",
+            label="Primes dividing conductor",
+            knowl="ec.conductor",
+            example="5,13",
+            select_box=bad_quant)
         isodeg = TextBox(
             name="isodeg",
             label="Cyclic isogeny degree",
@@ -838,12 +848,12 @@ class ECNFSearchArray(SearchArray):
             [class_size, class_deg],
             [semistable, potential_good_reduction],
             [jinv],
-            [count]
+            [count, bad_primes]
             ]
 
         self.refine_array = [
             [field, conductor_norm, rank, torsion, cm_disc],
             [bf_deg, include_base_change, include_Q_curves, torsion_structure, include_cm],
             [sha, isodeg, class_size, semistable, jinv],
-            [regulator, one, class_deg, potential_good_reduction],
+            [regulator, one, class_deg, potential_good_reduction, bad_primes],
             ]

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -806,8 +806,8 @@ class ECNFSearchArray(SearchArray):
             name="bad_quantifier")
         bad_primes = TextBoxWithSelect(
             name="conductor_norm_factors",
-            label="Primes dividing conductor",
-            knowl="ec.conductor",
+            label="Bad primes",
+            knowl="ec.reduction_type",
             example="5,13",
             select_box=bad_quant)
         isodeg = TextBox(

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -5,9 +5,9 @@ from flask import render_template, url_for, request, redirect, make_response
 from lmfdb import db
 from lmfdb.utils import (
     flash_error, to_dict,
-    parse_nf_string, parse_ints, parse_hmf_weight,
+    parse_nf_string, parse_ints, parse_hmf_weight, parse_primes,
     teXify_pol, add_space_if_positive,
-    SearchArray, TextBox, ExcludeOnlyBox, CountBox,
+    SearchArray, TextBox, ExcludeOnlyBox, CountBox, SubsetBox, TextBoxWithSelect,
     search_wrap, redirect_no_cache)
 from lmfdb.ecnf.main import split_class_label
 from lmfdb.number_fields.number_field import field_pretty
@@ -151,6 +151,10 @@ def hilbert_modular_form_search(info, query):
     parse_ints(info,query,'dimension')
     parse_ints(info,query,'level_norm', name="Level norm")
     parse_hmf_weight(info,query,'weight',qfield=('parallel_weight','weight'))
+    parse_primes(info, query, 'field_bad_primes', name='field bad primes',
+         qfield='field_bad_primes',mode=info.get('field_bad_quantifier'))
+    parse_primes(info, query, 'level_bad_primes', name='level bad primes',
+         qfield='level_bad_primes',mode=info.get('level_bad_quantifier'))
     if 'cm' in info:
         if info['cm'] == 'exclude':
             query['is_CM'] = 'no'
@@ -660,6 +664,22 @@ class HMFSearchArray(SearchArray):
             label='CM',
             knowl='mf.cm',
         )
+        field_bad_quant = SubsetBox(
+            name="field_bad_quantifier")
+        field_bad_primes = TextBoxWithSelect(
+            name="field_bad_primes",
+            label="Field bad primes",
+            knowl="nf.ramified_primes",
+            example="5,13",
+            select_box=field_bad_quant)
+        level_bad_quant = SubsetBox(
+            name="level_bad_quantifier")
+        level_bad_primes = TextBoxWithSelect(
+            name="level_bad_primes",
+            label="Level bad primes",
+            knowl="mf.hilbert.level_norm",
+            example="5,13",
+            select_box=level_bad_quant)
         count = CountBox()
 
         self.browse_array = [
@@ -667,9 +687,10 @@ class HMFSearchArray(SearchArray):
             [degree, discriminant],
             [level, weight],
             [dimension, base_change],
-            [count, CM]
+            [count, CM],
+            [field_bad_primes, level_bad_primes]
         ]
         self.refine_array = [
-            [field, degree, discriminant, CM],
-            [weight, level, dimension, base_change],
+            [field, degree, discriminant, CM, field_bad_primes],
+            [weight, level, dimension, base_change, level_bad_primes],
         ]


### PR DESCRIPTION
Adding search option for bad primes  for elliptic curves over number fields, Bianchi modular forms, and Hilbert modular forms, as requested in issue #3771.