### PR TITLE
Source and acknowledgments

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -39,12 +39,10 @@ def get_bread(*breads):
         bc.append(z)
     return bc
 
-abvarfq_credit = "Taylor Dupuy, Kiran Kedlaya, David Roe, Christelle Vincent"
-
 def learnmore_list():
     return [
+        ("Source and acknowledgments", url_for(".how_computed_page")),
         ("Completeness of the data", url_for(".completeness_page")),
-        ("Source of the data", url_for(".how_computed_page")),
         ("Reliability of the data", url_for(".reliability_page")),
         ("Labeling convention", url_for(".labels_page")),
     ]
@@ -113,7 +111,6 @@ def abelian_varieties_by_gqi(g, q, iso):
     return render_template(
         "show-abvarfq.html",
         properties=cl.properties(),
-        credit=abvarfq_credit,
         title='Abelian variety isogeny class %s over $%s$'%(label, cl.field()),
         bread=bread,
         cl=cl,
@@ -603,7 +600,6 @@ def jump(info):
     url_for_label=url_for_label,
     learnmore=learnmore_list,
     bread=lambda: get_bread(("Search results", " ")),
-    credit=lambda: abvarfq_credit,
 )
 def abelian_variety_search(info, query):
     common_parse(info, query)
@@ -616,7 +612,6 @@ def abelian_variety_search(info, query):
     err_title="Abelian variety search input error",
     overall=AbvarFqStats()._counts,
     bread=lambda: get_bread(("Count results", " ")),
-    credit=lambda: abvarfq_credit,
 )
 def abelian_variety_count(info, query):
     common_parse(info, query)
@@ -657,7 +652,6 @@ def abelian_variety_browse(info):
         "abvarfq-index.html",
         title="Isogeny classes of abelian varieties over finite fields",
         info=info,
-        credit=abvarfq_credit,
         bread=get_bread(),
         learnmore=learnmore_list(),
     )
@@ -682,7 +676,6 @@ def statistics():
     return render_template(
         "display_stats.html",
         info=AbvarFqStats(),
-        credit=abvarfq_credit,
         title=title,
         bread=get_bread(("Statistics", " ")),
         learnmore=learnmore_list(),
@@ -696,7 +689,6 @@ def dynamic_statistics():
     return render_template(
         "dynamic_stats.html",
         info=info,
-        credit=abvarfq_credit,
         title=title,
         bread=get_bread(("Dynamic Statistics", " ")),
         learnmore=learnmore_list(),
@@ -721,8 +713,20 @@ def interesting():
         url_for_label,
         title=r"Some interesting isogeny classes of abelian varieties over $\Fq$",
         bread=get_bread(("Interesting", " ")),
-        credit=abvarfq_credit,
         learnmore=learnmore_list()
+    )
+
+@abvarfq_page.route("/Source")
+def how_computed_page():
+    t = "Source and acknowledgments for Weil polynomial data"
+    bread = get_bread(("Source", " "))
+    return render_template(
+        "double.html",
+        kid="rcs.source.av.fq",
+        kid2="rcs.ack.av.fq",
+        title=t,
+        bread=bread,
+        learnmore=learnmore_list_remove("Source"),
     )
 
 @abvarfq_page.route("/Completeness")
@@ -732,7 +736,6 @@ def completeness_page():
     return render_template(
         "single.html",
         kid="rcs.cande.av.fq",
-        credit=abvarfq_credit,
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Completeness"),
@@ -745,23 +748,9 @@ def reliability_page():
     return render_template(
         "single.html",
         kid="rcs.rigor.av.fq",
-        credit=abvarfq_credit,
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Reliability"),
-    )
-
-@abvarfq_page.route("/Source")
-def how_computed_page():
-    t = "Source of Weil polynomial data"
-    bread = get_bread(("Source", " "))
-    return render_template(
-        "single.html",
-        kid="rcs.source.av.fq",
-        credit=abvarfq_credit,
-        title=t,
-        bread=bread,
-        learnmore=learnmore_list_remove("Source"),
     )
 
 @abvarfq_page.route("/Labels")
@@ -771,7 +760,6 @@ def labels_page():
     return render_template(
         "single.html",
         kid="av.fq.lmfdb_label",
-        credit=abvarfq_credit,
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Labels"),

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse, urlunparse
 from flask import (Flask, g, render_template, request, make_response,
                    redirect, url_for, current_app, abort)
 from sage.env import SAGE_VERSION
-# acknowledgement page, reads info from CONTRIBUTORS.yaml
+# acknowledgment page, reads info from CONTRIBUTORS.yaml
 
 from .logger import logger_file_handler, critical
 from .homepage import load_boxes, contribs

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -48,8 +48,8 @@ def get_bread(breads=[]):
     return bc
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".cande")),
-            ('Source and acknowledgments', url_for(".source")),
+    return [('Source and acknowledgments', url_for(".source")),
+            ('Completeness of the data', url_for(".cande")),
             ('Reliability of the data', url_for(".reliability")),
             ('Artin representations labels', url_for(".labels_page"))]
 

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -18,13 +18,10 @@ from lmfdb.nfutils.psort import ideal_from_label, primes_iter
 from lmfdb.bianchi_modular_forms import bmf_page
 from lmfdb.bianchi_modular_forms.web_BMF import WebBMF
 
-
-bianchi_credit = 'John Cremona, Aurel Page, Alexander Rahm, Haluk Sengun'
-
 field_label_regex = re.compile(r'2\.0\.(\d+)\.1')
 
 def learnmore_list():
-    return [('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
             ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Bianchi modular form labels', url_for(".labels_page"))]
@@ -69,11 +66,10 @@ def index():
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
 
-        credit = bianchi_credit
         t = 'Bianchi modular forms'
         bread = get_bread()
         info['learnmore'] = []
-        return render_template("bmf-browse.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+        return render_template("bmf-browse.html", info=info, title=t, bread=bread, learnmore=learnmore_list())
     else:
         return bianchi_modular_form_search(info)
 
@@ -92,7 +88,6 @@ def interesting():
         db.bmf_forms,
         url_for_label=url_for_label,
         title="Some interesting Bianchi modular forms",
-        credit=bianchi_credit,
         bread=get_bread("Interesting"),
         learnmore=learnmore_list()
     )
@@ -101,7 +96,7 @@ def interesting():
 def statistics():
     title = "Bianchi modular forms: statistics"
     bread = get_bread("Statistics")
-    return render_template("display_stats.html", info=BianchiStats(), credit=bianchi_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=BianchiStats(), title=title, bread=bread, learnmore=learnmore_list())
 
 def bianchi_modular_form_jump(info):
     label = info['jump'].strip()
@@ -281,7 +276,6 @@ def bmf_field_dim_table(**args):
 def render_bmf_space_webpage(field_label, level_label):
     info = {}
     t = "Bianchi modular forms of level %s over %s" % (level_label, field_label)
-    credit = bianchi_credit
     bread = get_bread([
         (field_pretty(field_label), url_for(".render_bmf_field_dim_table_gl2", field_label=field_label)),
         (level_label, '')])
@@ -343,7 +337,7 @@ def render_bmf_space_webpage(field_label, level_label):
                 properties = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
 
-    return render_template("bmf-space.html", info=info, credit=credit, title=t, bread=bread, properties=properties, friends=friends, learnmore=learnmore_list())
+    return render_template("bmf-space.html", info=info, title=t, bread=bread, properties=properties, friends=friends, learnmore=learnmore_list())
 
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/download/<download_type>')
@@ -551,7 +545,6 @@ def download_bmf_sage(**args):
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/')
 def render_bmf_webpage(field_label, level_label, label_suffix):
     label = "-".join([field_label, level_label, label_suffix])
-    credit = "John Cremona"
     info = {}
     title = "Bianchi cusp forms"
     data = None
@@ -586,7 +579,6 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
         "bmf-newform.html",
         downloads=info["downloads"],
         title=title,
-        credit=credit,
         bread=bread,
         data=data,
         properties=properties,
@@ -619,33 +611,29 @@ def bianchi_modular_form_by_label(lab):
 def how_computed_page():
     t = 'Source of Bianchi modular form data'
     bread = get_bread("Source")
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.mf.bianchi.source',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+    return render_template("double.html", kid='rcs.source.bianchi', kid2='rcs.ack.bianchi',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @bmf_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of Bianchi modular form data'
     bread = get_bread("Completeness")
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.mf.bianchi.extent',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+    return render_template("single.html", kid='rcs.cande.bianchi',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @bmf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of Bianchi modular form data'
     bread = get_bread("Reliability")
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.mf.bianchi.reliability',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+    return render_template("single.html", kid='rcs.rigor.bianchi',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @bmf_page.route("/Labels")
 def labels_page():
     t = 'Labels for Bianchi newforms'
     bread = get_bread("Labels")
-    credit = 'John Cremona'
     return render_template("single.html", kid='mf.bianchi.labels',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
 
 
 class BMFSearchArray(SearchArray):

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -611,21 +611,21 @@ def bianchi_modular_form_by_label(lab):
 def how_computed_page():
     t = 'Source of Bianchi modular form data'
     bread = get_bread("Source")
-    return render_template("double.html", kid='rcs.source.bianchi', kid2='rcs.ack.bianchi',
+    return render_template("double.html", kid='rcs.source.mf.bianchi', kid2='rcs.ack.mf.bianchi',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @bmf_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of Bianchi modular form data'
     bread = get_bread("Completeness")
-    return render_template("single.html", kid='rcs.cande.bianchi',
+    return render_template("single.html", kid='rcs.cande.mf.bianchi',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @bmf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of Bianchi modular form data'
     bread = get_bread("Reliability")
-    return render_template("single.html", kid='rcs.rigor.bianchi',
+    return render_template("single.html", kid='rcs.rigor.mf.bianchi',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @bmf_page.route("/Labels")

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -39,10 +39,10 @@ def bread(tail=[]):
 
 def learn(current = None):
     r = []
-    if current != 'extent':
-        r.append( ('Completeness of the data', url_for(".extent_page")) )
     if current != 'source':
         r.append( ('Source and acknowledgments', url_for(".how_computed_page")) )
+    if current != 'extent':
+        r.append( ('Completeness of the data', url_for(".extent_page")) )
     if current != 'reliability':
         r.append( ('Reliability of the data', url_for(".reliability")) )
     if current != 'labels':
@@ -292,7 +292,7 @@ def how_computed_page():
     info['title'] = 'Source and acknowledgments for Dirichlet character data'
     info['bread'] = bread('Source')
     info['learnmore'] = learn('source')
-    return render_template("double.html", kid='rcs.source.character.dirichlet',
+    return render_template("double.html", kid='rcs.source.character.dirichlet', kid2='rcs.ack.character.dirichlet',
                             **info)
 
 @characters_page.route("/Dirichlet/Reliability")
@@ -309,7 +309,7 @@ def extent_page():
     info['title'] = 'Completeness of Dirichlet character data'
     info['bread'] = bread('Extent')
     info['learnmore'] = learn('extent')
-    return render_template("single.html", kid='dq.character.dirichlet.extent',
+    return render_template("single.html", kid='rcs.cande.character.dirichlet',
                            **info)
 
 def make_webchar(args, get_bread=False):

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -46,8 +46,8 @@ def learnmore_list():
     """
     Return the learnmore list
     """
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Classical modular form labels', url_for(".labels_page"))]
 
@@ -57,15 +57,6 @@ def learnmore_list_remove(matchstring):
     Return the learnmore list with the matchstring entry removed
     """
     return [t for t in learnmore_list() if t[0].find(matchstring) < 0]
-
-
-@cached_function
-def credit():
-    """
-    Return the credit string
-    """
-    return "Alex Best, Jonathan Bober, Andrew Booker, Edgar Costa, John Cremona, David Roe, Andrew Sutherland, John Voight"
-
 
 @cached_function
 def Nk2_bound(nontriv=None):
@@ -213,7 +204,6 @@ def index():
     info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-2000', '2001-4000', '4001-6000', '6001-8000', '8001-%d' % level_bound() )
     return render_template("cmf_browse.html",
                            info=info,
-                           credit=credit(),
                            title="Classical modular forms",
                            learnmore=learnmore_list(),
                            bread=get_bread())
@@ -238,7 +228,6 @@ def interesting_newforms():
         url_for_label,
         regex=LABEL_RE,
         title="Some interesting newforms",
-        credit=credit(),
         bread=get_bread(other="Interesting newforms"),
         learnmore=learnmore_list()
     )
@@ -251,7 +240,6 @@ def interesting_spaces():
         url_for_label,
         regex=NEWSPACE_RE,
         title="Some interesting newspaces",
-        credit=credit(),
         bread=get_bread(other="Interesting newspaces"),
         learnmore=learnmore_list()
     )
@@ -400,7 +388,6 @@ def render_newform_webpage(label):
                            newform=newform,
                            properties=newform.properties,
                            downloads=newform.downloads,
-                           credit=credit(),
                            bread=newform.bread,
                            learnmore=learnmore_list(),
                            title=newform.title,
@@ -433,7 +420,6 @@ def render_embedded_newform_webpage(newform_label, embedding_label):
                            newform=newform,
                            properties=newform.properties,
                            downloads=newform.downloads,
-                           credit=credit(),
                            bread=newform.bread,
                            learnmore=learnmore_list(),
                            title=newform.embedded_title(m),
@@ -452,7 +438,6 @@ def render_space_webpage(label):
                            space=space,
                            properties=space.properties,
                            downloads=space.downloads,
-                           credit=credit(),
                            bread=space.bread,
                            learnmore=learnmore_list(),
                            title=space.title,
@@ -471,7 +456,6 @@ def render_full_gamma1_space_webpage(label):
                            space=space,
                            properties=space.properties,
                            downloads=space.downloads,
-                           credit=credit(),
                            bread=space.bread,
                            learnmore=learnmore_list(),
                            title=space.title,
@@ -804,8 +788,7 @@ def newspace_parse(info, query):
              projection=['label', 'level', 'weight', 'dim', 'analytic_conductor', 'trace_display', 'atkin_lehner_eigenvals', 'qexp_display', 'char_order', 'hecke_orbit_code', 'projective_image', 'field_poly', 'nf_label', 'is_cm', 'is_rm', 'cm_discs', 'rm_discs', 'field_poly_root_of_unity', 'field_poly_is_real_cyclotomic', 'field_disc', 'field_disc_factorization', 'fricke_eigenval', 'is_self_twist', 'self_twist_discs'],
              url_for_label=url_for_label,
              bread=get_search_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def newform_search(info, query):
     newform_parse(info, query)
     set_info_funcs(info)
@@ -875,8 +858,7 @@ def set_Trn(info, query, limit=1000):
              projection=['label', 'dim', 'hecke_orbit_code', 'weight'],
              postprocess=trace_postprocess,
              bread=get_search_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def trace_search(info, query):
     set_Trn(info, query)
     newform_parse(info, query)
@@ -892,8 +874,7 @@ def trace_search(info, query):
              projection=['label', 'dim', 'hecke_orbit_code', 'weight'],
              postprocess=space_trace_postprocess,
              bread=get_search_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def space_trace_search(info, query):
     set_Trn(info, query)
     newspace_parse(info, query)
@@ -1066,8 +1047,7 @@ def dimension_form_postprocess(res, info, query):
              projection=['level', 'weight', 'dim'],
              postprocess=dimension_form_postprocess,
              bread=get_dim_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def dimension_form_search(info, query):
     info.pop('count',None) # remove per_page so that we get all results
     if 'weight' not in info:
@@ -1086,8 +1066,7 @@ def dimension_form_search(info, query):
              projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_indexes', 'dim', 'hecke_orbit_dims', 'AL_dims', 'char_conductor','eis_dim','eis_new_dim','cusp_dim', 'mf_dim', 'mf_new_dim', 'plus_dim', 'num_forms'],
              postprocess=dimension_space_postprocess,
              bread=get_dim_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def dimension_space_search(info, query):
     info.pop('count',None) # remove per_page so that we get all results
     if 'weight' not in info:
@@ -1107,42 +1086,37 @@ def dimension_space_search(info, query):
              projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_indexes', 'dim', 'hecke_orbit_dims', 'AL_dims', 'char_order', 'char_orbit_label'],
              url_for_label=url_for_label,
              bread=get_search_bread,
-             learnmore=learnmore_list,
-             credit=credit)
+             learnmore=learnmore_list)
 def space_search(info, query):
     newspace_parse(info, query)
     set_info_funcs(info)
 
-@cmf.route("/Completeness")
-def completeness_page():
-    t = 'Completeness of classical modular form data'
-    return render_template("single.html", kid='rcs.cande.cmf',
-                           credit=credit(), title=t,
-                           bread=get_bread(other='Completeness'),
-                           learnmore=learnmore_list_remove('Completeness'))
-
-
 @cmf.route("/Source")
 def how_computed_page():
     t = 'Source of classical modular form data'
-    return render_template("single.html", kid='rcs.source.cmf',
-                           credit=credit(), title=t,
+    return render_template("double.html", kid='rcs.source.cmf',
+                           kid2='rcs.ack.cmf', title=t,
                            bread=get_bread(other='Source'),
                            learnmore=learnmore_list_remove('Source'))
+
+@cmf.route("/Completeness")
+def completeness_page():
+    t = 'Completeness of classical modular form data'
+    return render_template("single.html", kid='rcs.cande.cmf', title=t,
+                           bread=get_bread(other='Completeness'),
+                           learnmore=learnmore_list_remove('Completeness'))
 
 @cmf.route("/Labels")
 def labels_page():
     t = 'Labels for classical modular forms'
-    return render_template("single.html", kid='cmf.label',
-                           credit=credit(), title=t,
+    return render_template("single.html", kid='cmf.label', title=t,
                            bread=get_bread(other='Labels'),
                            learnmore=learnmore_list_remove('labels'))
 
 @cmf.route("/Reliability")
 def reliability_page():
     t = 'Reliability of classical modular form data'
-    return render_template("single.html", kid='rcs.rigor.cmf',
-                           credit=credit(), title=t,
+    return render_template("single.html", kid='rcs.rigor.cmf', title=t,
                            bread=get_bread(other='Reliability'),
                            learnmore=learnmore_list_remove('Reliability'))
 
@@ -1306,17 +1280,14 @@ class CMF_stats(StatsDisplay):
 @cmf.route("/stats")
 def statistics():
     title = 'Classical modular forms: Statistics'
-    return render_template("display_stats.html", info=CMF_stats(), credit=credit(), title=title, bread=get_bread(other='Statistics'), learnmore=learnmore_list())
+    return render_template("display_stats.html", info=CMF_stats(), title=title, bread=get_bread(other='Statistics'), learnmore=learnmore_list())
 
 @cmf.route("/dynamic_stats")
 def dynamic_statistics():
     info = to_dict(request.args, search_array=CMFSearchArray())
     CMF_stats().dynamic_setup(info)
     title = 'Classical modular forms: Dynamic statistics'
-    return render_template("dynamic_stats.html", info=info, credit=credit(), title=title, bread=get_bread(other='Dynamic Statistics'), learnmore=learnmore_list())
-
-
-
+    return render_template("dynamic_stats.html", info=info, title=title, bread=get_bread(other='Dynamic Statistics'), learnmore=learnmore_list())
 
 class CMFSearchArray(SearchArray):
     jump_example="3.6.a.a"

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -106,9 +106,6 @@ def get_nf_info(lab):
     return label, pretty
 
 
-ecnf_credit = "John Cremona, Alyson Deines, Steve Donelly, Paul Gunnells, Warren Moore, Haluk Sengun, Andrew Sutherland, John Voight, Dan Yasaki"
-
-
 def get_bread(*breads):
     bc = [("Elliptic curves", url_for(".index"))]
     for x in breads:
@@ -117,8 +114,8 @@ def get_bread(*breads):
 
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Elliptic curve labels', url_for(".labels_page"))]
 
@@ -132,9 +129,8 @@ def completeness_page():
     t = 'Completeness of elliptic curve data over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Completeness', '')]
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.ecnf.extent',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+    return render_template("single.html", kid='rcs.cande.ec',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 
 @ecnf_page.route("/Source")
@@ -142,27 +138,24 @@ def how_computed_page():
     t = 'Source of elliptic curve data over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Source', '')]
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.ecnf.source',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+    return render_template("double.html", kid='rcs.source.ec', kid2='rcs.ack.ec',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ecnf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of elliptic curve data over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Source', '')]
-    credit = 'John Cremona'
-    return render_template("single.html", kid='dq.ecnf.reliability',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+    return render_template("single.html", kid='rcs.rigor.ec',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @ecnf_page.route("/Labels")
 def labels_page():
     t = 'Labels for elliptic curves over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Labels', '')]
-    credit = 'John Cremona'
     return render_template("single.html", kid='ec.curve_label',
-                           credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
 
 
 @ecnf_page.route("/")
@@ -241,7 +234,6 @@ def interesting():
         url_for_label=url_for_label,
         regex=LABEL_RE, # include so that we don't catch elliptic curves over Q also
         title="Some interesting elliptic curves over number fields",
-        credit=ecnf_credit,
         bread=get_bread("Interesting"),
         learnmore=learnmore_list()
     )
@@ -250,7 +242,7 @@ def interesting():
 def statistics():
     title = "Elliptic curves: statistics"
     bread = get_bread("Statistics")
-    return render_template("display_stats.html", info=ECNF_stats(), credit=ecnf_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=ECNF_stats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @ecnf_page.route("/<nf>/")
 def show_ecnf1(nf):
@@ -332,7 +324,6 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
     return render_template("ecnf-isoclass.html",
-                           credit=ecnf_credit,
                            title=title,
                            bread=bread,
                            cl=cl,
@@ -371,7 +362,6 @@ def show_ecnf(nf, conductor_label, class_label, number):
     code['show'] = {'magma':'','pari':'','sage':''} # use default show names
     info = {}
     return render_template("ecnf-curve.html",
-                           credit=ecnf_credit,
                            title=title,
                            bread=bread,
                            ec=ec,
@@ -478,8 +468,7 @@ def url_for_label(label):
                        'field_knowl':lambda e: nf_display_knowl(e['field_label'], field_pretty(e['field_label']))},
              url_for_label=url_for_label,
              learnmore=learnmore_list,
-             bread=lambda:[('Elliptic curves', url_for(".index")), ('Search results', '.')],
-             credit=lambda:ecnf_credit)
+             bread=lambda:[('Elliptic curves', url_for(".index")), ('Search results', '.')])
 def elliptic_curve_search(info, query):
     parse_nf_string(info,query,'field',name="base number field",qfield='field_label')
     if query.get('field_label') == '1.1.1.1':
@@ -556,11 +545,10 @@ def browse():
     # We could use the dict directly but then could not control the order
     # of the keys (degrees), so we use a list
     info = [[d,['%s,%s'%sig for sig in data[d]]] for d in sorted(data.keys())]
-    credit = 'John Cremona'
     t = 'Elliptic curves over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Browse', ' ')]
-    return render_template("ecnf-stats.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+    return render_template("ecnf-stats.html", info=info, title=t, bread=bread, learnmore=learnmore_list())
 
 @ecnf_page.route("/browse/<int:d>/")
 def statistics_by_degree(d):
@@ -586,7 +574,6 @@ def statistics_by_degree(d):
 
     info['summary'] = ECNF_stats().degree_summary(d)
     info['sig_stats'] = [sig_counts(sig) for sig in sigs_by_deg[d]]
-    credit = 'John Cremona'
     if d==2:
         t = 'Elliptic curves over quadratic number fields'
     elif d==3:
@@ -602,7 +589,7 @@ def statistics_by_degree(d):
 
     bread = [('Elliptic curves', url_for("ecnf.index")),
               ('Degree %s' % d,' ')]
-    return render_template("ecnf-by-degree.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+    return render_template("ecnf-by-degree.html", info=info, title=t, bread=bread, learnmore=learnmore_list())
 
 @ecnf_page.route("/browse/<int:d>/<int:r>/")
 def statistics_by_signature(d,r):
@@ -631,7 +618,6 @@ def statistics_by_signature(d,r):
         return [f,counts_by_field[f]]
 
     info['sig_stats'] = [field_counts(f) for f in fields_by_sig[sig]]
-    credit = 'John Cremona'
     if info['sig'] == '2,0':
         t = 'Elliptic curves over real quadratic number fields'
     elif info['sig'] == '0,1':
@@ -651,7 +637,7 @@ def statistics_by_signature(d,r):
     bread = [('Elliptic curves', url_for("ecnf.index")),
               ('Degree %s' % d,url_for("ecnf.statistics_by_degree", d=d)),
               ('Signature (%s)' % info['sig'],' ')]
-    return render_template("ecnf-by-signature.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+    return render_template("ecnf-by-signature.html", info=info, title=t, bread=bread, learnmore=learnmore_list())
 
 @ecnf_page.route("/download_all/<nf>/<conductor_label>/<class_label>/<number>")
 def download_ECNF_all(nf,conductor_label,class_label,number):

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -25,12 +25,6 @@ from lmfdb.ecnf.ecnf_stats import latex_tor
 q = ZZ['x'].gen()
 the_ECstats = None
 
-#########################
-#   Data credit
-#########################
-
-def ec_credit():
-    return 'John Cremona, Enrique  Gonz&aacute;lez Jim&eacute;nez, Robert Pollack, Jeremy Rouse, Andrew Sutherland and others: see <a href={}>here</a> for details'.format(url_for(".how_computed_page"))
 
 #########################
 #   Utility functions
@@ -60,8 +54,8 @@ def get_stats():
 #########################
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Elliptic curve labels', url_for(".labels_page"))]
 
@@ -108,7 +102,6 @@ def rational_elliptic_curves(err_args=None):
         return redirect(url_for(".rational_elliptic_curves"))
     return render_template("ec-index.html",
                            info=info,
-                           credit=ec_credit(),
                            title=t,
                            bread=get_bread(),
                            learnmore=learnmore_list(),
@@ -124,7 +117,6 @@ def interesting():
         label_col="lmfdb_label",
         title=r"Some interesting elliptic curves over $\Q$",
         bread=get_bread("Interesting"),
-        credit=ec_credit(),
         learnmore=learnmore_list()
     )
 
@@ -178,7 +170,7 @@ class ECstats(StatsDisplay):
 
     @property
     def summary(self):
-        return r'Currently, the database includes {} {} in {} {}, with {} at most {}.'.format(self.ncurves_c, self.ec_knowl, self.nclasses_c, self.cl_knowl, self.cond_knowl, self.max_N_c)
+        return r'Currently, the database includes ${}$ {} over $\Q$ in ${}$ {}, with {} at most ${}$.'.format(self.ncurves_c, self.ec_knowl, self.nclasses_c, self.cl_knowl, self.cond_knowl, self.max_N_c)
     
     table = db.ec_curvedata
     baseurl_func = ".rational_elliptic_curves"
@@ -221,7 +213,7 @@ def ctx_elliptic_curve_summary():
 def statistics():
     title = r'Elliptic curves over $\Q$: Statistics'
     bread = get_bread("Statistics")
-    return render_template("display_stats.html", info=ECstats(), credit=ec_credit(), title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=ECstats(), title=title, bread=bread, learnmore=learnmore_list())
 
 
 @ec_page.route("/<int:conductor>/")
@@ -346,8 +338,7 @@ def url_for_label(label):
              learnmore=learnmore_list,
              shortcuts={'jump':elliptic_curve_jump,
                         'download':download_search},
-             bread=lambda:get_bread('Search results'),
-             credit=ec_credit)
+             bread=lambda:get_bread('Search results'))
 
 def elliptic_curve_search(info, query):
     parse_rational_to_list(info,query,'jinv','j-invariant')
@@ -487,7 +478,6 @@ def render_isogeny_class(iso_class):
                            info=class_data,
                            code=class_data.code,
                            bread=class_data.bread,
-                           credit=ec_credit(),
                            title=class_data.title,
                            friends=class_data.friends,
                            KNOWL_ID="ec.q.%s"%iso_class,
@@ -532,7 +522,6 @@ def render_curve_webpage_by_label(label):
     code['show'] = {'magma':'','pari':'','sage':''} # use default show names
     T =  render_template("ec-curve.html",
                          properties=data.properties,
-                         credit=ec_credit(),
                          data=data,
                          # set default show names but actually code snippets are filled in only when needed
                          code=code,
@@ -611,34 +600,33 @@ def download_EC_all(label):
     response.headers['Content-type'] = 'text/plain'
     return response
 
+@ec_page.route("/Source")
+def how_computed_page():
+    t = r'Source and acknowledgments for elliptic curve data over $\Q$'
+    bread = get_bread('Source')
+    return render_template("double.html", kid='rcs.source.ec.q', kid2='rcs.ack.ec.q',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ec_page.route("/Completeness")
 def completeness_page():
-    t = r'Completeness of Elliptic curve data over $\Q$'
+    t = r'Completeness of elliptic curve data over $\Q$'
     bread = get_bread('Completeness')
-    return render_template("single.html", kid='dq.ec.extent',
-                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
-
-@ec_page.route("/Source")
-def how_computed_page():
-    t = r'Source of Elliptic curve data over $\Q$'
-    bread = get_bread('Source')
-    return render_template("single.html", kid='dq.ec.source',
-                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+    return render_template("single.html", kid='rcs.cande.ec.q',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @ec_page.route("/Reliability")
 def reliability_page():
-    t = r'Reliability of Elliptic curve data over $\Q$'
+    t = r'Reliability of elliptic curve data over $\Q$'
     bread = get_bread('Reliability')
-    return render_template("single.html", kid='dq.ec.reliability',
-                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+    return render_template("single.html", kid='rcs.rigor.ec.q',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @ec_page.route("/Labels")
 def labels_page():
-    t = r'Labels for Elliptic curves over $\Q$'
+    t = r'Labels for elliptic curves over $\Q$'
     bread = get_bread('Labels')
     return render_template("single.html", kid='ec.q.lmfdb_label',
-                           credit=ec_credit(), title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
 
 @ec_page.route('/<conductor>/<iso>/<number>/download/<download_type>')
 def ec_code_download(**args):

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -131,7 +131,7 @@ class EllCurveTest(LmfdbTest):
         Test for factorization of large discriminants
         """
         L = self.tc.get('/EllipticCurve/Q/26569/a/1')
-        assert r'\(-1 \cdot 163^{9} \)' in L.get_data(as_text=True)
+        assert r'-1 \cdot 163^{9}' in L.get_data(as_text=True)
 
     def test_torsion_growth(self):
         """
@@ -150,16 +150,16 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/990/i/')
         row = '\n'.join([
             '<td class="center"><a href="/EllipticCurve/Q/990h3/">990h3</a></td>',
-            '<td class="center">\([1, -1, 1, -1568, -4669]\)</td>',
-            '<td class="center">\(15781142246787/8722841600\)</td>',
-            '<td class="center">\(235516723200\)</td>',
-            '<td align="center">\([6]\)</td>',
-            '<td align="center">',
-            '\(1728\)</td>',
-            '<td align="center">',
-            '\(0.87260\)',
-            '</td>',
-            '<td>',
+            r'<td class="center">\([1, -1, 1, -1568, -4669]\)</td>',
+            r'<td class="center">\(15781142246787/8722841600\)</td>',
+            r'<td class="center">\(235516723200\)</td>',
+            r'<td align="center">\([6]\)</td>',
+            r'<td align="center">',
+            r'\(1728\)</td>',
+            r'<td align="center">',
+            r'\(0.87260\)',
+            r'</td>',
+            r'<td>',
             r'  \(\Gamma_0(N)\)-optimal</td>'
         ])
         self.assertTrue(row in L.get_data(as_text=True),

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -37,8 +37,8 @@ def mult2mult(li):
 
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".cande")),
-            ('Source and acknowledgments', url_for(".source")),
+    return [('Source and acknowledgments', url_for(".source")),
+            ('Completeness of the data', url_for(".cande")),
             ('Reliability of the data', url_for(".reliability")),
             ('Galois group labels', url_for(".labels_page"))]
 

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -95,8 +95,8 @@ geom_aut_grp_dict_pretty = {
 ###############################################################################
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source and acknowledgments', url_for(".source_page")),
+    return [('Source and acknowledgments', url_for(".source_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Genus 2 curve labels', url_for(".labels_page"))]
 
@@ -498,6 +498,12 @@ def statistics():
     return render_template("display_stats.html", info=G2C_stats(), title=title, bread=bread, learnmore=learnmore_list())
 
 
+@g2c_page.route("/Q/Source")
+def source_page():
+    t = r'Source and acknowledgments for genus 2 curve data over $\Q$'
+    bread = get_bread("Source")
+    return render_template("double.html", kid='rcs.source.g2c', kid2='rcs.ack.g2c',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @g2c_page.route("/Q/Completeness")
 def completeness_page():
@@ -505,13 +511,6 @@ def completeness_page():
     bread = get_bread("Completeness")
     return render_template("single.html", kid='rcs.cande.g2c',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
-
-@g2c_page.route("/Q/Source")
-def source_page():
-    t = r'Source and acknowledgments for genus 2 curve data over $\Q$'
-    bread = get_bread("Source")
-    return render_template("double.html", kid='rcs.source.g2c',
-                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @g2c_page.route("/Q/Reliability")
 def reliability_page():

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -59,10 +59,6 @@ def split_passport_label(lab):
 def split_vector_label(lab):
     return vector_label_regex.match(lab).groups()
 
-
-credit = 'Jen Paulhus, using group and signature data originally computed by Thomas Breuer'
-
-
 def get_bread(tail=[]):
     base = [("Higher genus", url_for(".index")),
             ("C", url_for(".index")),
@@ -72,8 +68,8 @@ def get_bread(tail=[]):
     return base + tail
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Labeling convention', url_for(".labels_page"))]
 
@@ -182,7 +178,6 @@ def index():
     return render_template("hgcwa-index.html",
                            title="Families of higher genus curves with automorphisms",
                            bread=bread,
-                           credit=credit,
                            info=info,
                            learnmore=learnmore_list())
 
@@ -202,7 +197,6 @@ def interesting():
         label_col="label",
         title=r"Some interesting higher genus families",
         bread=get_bread("Interesting"),
-        credit=credit,
         learnmore=learnmore_list()
     )
 
@@ -210,7 +204,7 @@ def interesting():
 def statistics():
     title = 'Families of higher genus curves with automorphisms: Statistics'
     bread = get_bread('Statistics')
-    return render_template("hgcwa-stats.html", info=HGCWAstats(), credit=credit, title=title, learnmore=learnmore_list(), bread=bread)
+    return render_template("hgcwa-stats.html", info=HGCWAstats(), title=title, learnmore=learnmore_list(), bread=bread)
 
 
 @higher_genus_w_automorphisms_page.route("/stats/groups_per_genus/<int:genus>")
@@ -259,7 +253,6 @@ def groups_per_genus(genus):
 
     return render_template("hgcwa-stats-groups-per-genus.html",
                            info=info,
-                           credit=credit,
                            title=title,
                            learnmore=learnmore_list(),
                            bread=bread)
@@ -611,8 +604,7 @@ def parse_group_order(inp, query, qfield, parse_singleton=int):
             'download': hgcwa_code_download_search },
         cleaners={'signature': lambda field: ast.literal_eval(field['signature'])},
         bread=lambda: get_bread("Search results"),
-        learnmore=learnmore_list,
-        credit=lambda: credit)
+        learnmore=learnmore_list)
 def higher_genus_w_automorphisms_search(info, query):
     if info.get('signature'):
         # allow for ; in signature
@@ -778,7 +770,7 @@ def render_family(args):
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
                                KNOWL_ID="curve.highergenus.aut.%s" % label,
-                               learnmore=learnmore_list(), downloads=downloads, credit=credit)
+                               learnmore=learnmore_list(), downloads=downloads)
 
 
 def render_passport(args):
@@ -977,8 +969,7 @@ def render_passport(args):
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
                                learnmore=learnmore_list(), downloads=downloads,
-                               KNOWL_ID="curve.highergenus.aut.%s" % label,
-                               credit=credit)
+                               KNOWL_ID="curve.highergenus.aut.%s" % label)
 
 
 # Generate topological webpage
@@ -1050,11 +1041,11 @@ def topological_action(fam, cc):
 
     info = {'topological_class': sorted_braid, 'representative': representative, 'braid_num': len(Lbraid)}
 
-    return render_template("hgcwa-topological-action.html", info=info, credit=credit, title=title, bread=bread, downloads=downloads)
+    return render_template("hgcwa-topological-action.html", info=info, title=title, bread=bread, downloads=downloads)
 
 
 def search_input_error(info, bread):
-    return render_template("hgcwa-search.html", info=info, title='Family of higher genus curves with automorphisms search input error', learnmore=learnmore_list(),bread=bread, credit=credit)
+    return render_template("hgcwa-search.html", info=info, title='Family of higher genus curves with automorphisms search input error', learnmore=learnmore_list(),bread=bread)
 
 
 
@@ -1062,11 +1053,10 @@ def search_input_error(info, bread):
 def completeness_page():
     t = 'Completeness of higher genus curve with automorphisms data'
     bread = get_bread("Completeness")
-    return render_template("single.html", kid='dq.curve.highergenus.aut.extent',
+    return render_template("single.html", kid='rcs.cande.curve.highergenus.aut',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore_list_remove('Completeness'),
-                           credit=credit)
+                           learnmore=learnmore_list_remove('Completeness'))
 
 
 @higher_genus_w_automorphisms_page.route("/Labels")
@@ -1076,8 +1066,7 @@ def labels_page():
     return render_template("single.html", kid='dq.curve.highergenus.aut.label',
                            learnmore=learnmore_list_remove('Label'),
                            title=t,
-                           bread=bread,
-                           credit=credit)
+                           bread=bread)
 
 
 @higher_genus_w_automorphisms_page.route("/Reliability")
@@ -1085,23 +1074,22 @@ def reliability_page():
     t = 'Reliability of higher genus curve with automorphisms data'
     bread = get_bread("Reliability")
     return render_template("single.html",
-                           kid='dq.curve.highergenus.aut.reliability',
+                           kid='rcs.rigor.curve.highergenus.aut',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore_list_remove('Reliability'),
-                           credit=credit)
+                           learnmore=learnmore_list_remove('Reliability'))
 
 
 @higher_genus_w_automorphisms_page.route("/Source")
 def how_computed_page():
     t = 'Source of higher genus curve with automorphisms data'
     bread = get_bread("Source")
-    return render_template("single.html",
-                           kid='dq.curve.highergenus.aut.source',
+    return render_template("double.html",
+                           kid='rcs.source.curve.highergenus.aut',
+                           kid2='rcs.ack.curve.highergenus.aut',
                            title=t,
                            bread=bread,
-                           learnmore=learnmore_list_remove('Source'),
-                           credit=credit)
+                           learnmore=learnmore_list_remove('Source'))
 
 
 

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -517,7 +517,7 @@ def render_hmf_webpage(**args):
 def how_computed_page():
     t = 'Source and acknowledgments for Hilbert modular form data'
     bread = get_bread("Source")
-    return render_template("single.html", kid='rcs.source.hilbert', kid2='rcs.ack.hilbert',
+    return render_template("double.html", kid='rcs.source.hilbert', kid2='rcs.ack.hilbert',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @hmf_page.route("/Completeness")

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -517,20 +517,20 @@ def render_hmf_webpage(**args):
 def how_computed_page():
     t = 'Source and acknowledgments for Hilbert modular form data'
     bread = get_bread("Source")
-    return render_template("double.html", kid='rcs.source.hilbert', kid2='rcs.ack.hilbert',
+    return render_template("double.html", kid='rcs.source.mf.hilbert', kid2='rcs.ack.mf.hilbert',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @hmf_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of Hilbert modular form data'
     bread = get_bread("Completeness")
-    return render_template("single.html", kid='dq.mf.hilbert.extent',
+    return render_template("single.html", kid='rcs.cande.mf.hilbert',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 @hmf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of Hilbert modular form data'
     bread = get_bread("Reliability")
-    return render_template("single.html", kid='rcs.cande.hilbert',
+    return render_template("single.html", kid='rcs.rigor.mf.hilbert',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @hmf_page.route("/Labels")

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -49,8 +49,6 @@ def get_hmf_field(label):
     """
     return db.hmf_fields.lookup(label)
 
-hmf_credit =  'John Cremona, Lassina Dembele, Steve Donnelly, Aurel Page and <A HREF="http://www.math.dartmouth.edu/~jvoight/">John Voight</A>'
-
 @hmf_page.route("/random")
 @redirect_no_cache
 def random_hmf():    # Random Hilbert modular form
@@ -63,7 +61,6 @@ def interesting():
         db.hmf_forms,
         url_for_label,
         title="Some interesting Hilbert modular forms",
-        credit=hmf_credit,
         bread=get_bread("Interesting"),
         learnmore=learnmore_list()
     )
@@ -75,7 +72,7 @@ def hilbert_modular_form_render_webpage():
         t = 'Hilbert modular forms'
         info['stats'] = HMFstats()
         info['counts'] = HMFstats().counts()
-        return render_template("hilbert_modular_form_all.html", info=info, credit=hmf_credit, title=t, bread=get_bread(), learnmore=learnmore_list())
+        return render_template("hilbert_modular_form_all.html", info=info, title=t, bread=get_bread(), learnmore=learnmore_list())
     else:
         return hilbert_modular_form_search(info)
 
@@ -112,8 +109,8 @@ def hilbert_modular_form_by_label(lab):
 # Learn more box
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".completeness_page")),
-            ('Source of the data', url_for(".how_computed_page")),
+    return [('Source and acknowledgments', url_for(".how_computed_page")),
+            ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Hilbert modular form labels', url_for(".labels_page"))]
 
@@ -142,7 +139,6 @@ def hilbert_modular_form_jump(info):
              bread=lambda: get_bread("Search results"),
              learnmore=learnmore_list,
              url_for_label=url_for_label,
-             credit=lambda: hmf_credit,
              properties=lambda: [])
 def hilbert_modular_form_search(info, query):
     parse_nf_string(info,query,'field_label',name="Field")
@@ -509,7 +505,6 @@ def render_hmf_webpage(**args):
         downloads=info["downloads"],
         info=info,
         properties=properties,
-        credit=hmf_credit,
         title=t,
         bread=bread,
         friends=info['friends'],
@@ -518,46 +513,44 @@ def render_hmf_webpage(**args):
     )
 
 #data quality pages
+@hmf_page.route("/Source")
+def how_computed_page():
+    t = 'Source and acknowledgments for Hilbert modular form data'
+    bread = get_bread("Source")
+    return render_template("single.html", kid='rcs.source.hilbert', kid2='rcs.ack.hilbert',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
 @hmf_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of Hilbert modular form data'
     bread = get_bread("Completeness")
     return render_template("single.html", kid='dq.mf.hilbert.extent',
-                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
-
-@hmf_page.route("/Source")
-def how_computed_page():
-    t = 'Source of Hilbert modular form data'
-    bread = get_bread("Source")
-    return render_template("single.html", kid='dq.mf.hilbert.source',
-                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
-
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 @hmf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of Hilbert modular form data'
     bread = get_bread("Reliability")
-    return render_template("single.html", kid='dq.mf.hilbert.reliability',
-                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+    return render_template("single.html", kid='rcs.cande.hilbert',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 @hmf_page.route("/Labels")
 def labels_page():
     t = 'Labels for Hilbert Modular forms'
     bread = get_bread("Labels")
     return render_template("single.html", kid='mf.hilbert.label',
-                           credit=hmf_credit, title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
 
 @hmf_page.route("/browse/")
 def browse():
-    credit = 'John Voight'
     t = 'Hilbert modular forms'
     bread = get_bread("Browse")
-    return render_template("hmf_stats.html", info=HMFstats(), credit=credit, title=t, bread=bread, learnmore=learnmore_list())
+    return render_template("hmf_stats.html", info=HMFstats(), title=t, bread=bread, learnmore=learnmore_list())
 
 @hmf_page.route("/stats")
 def statistics():
     title = r'Hilbert modular forms: statistics'
     bread = get_bread("Statistics")
-    return render_template("display_stats.html", info=HMFstats(), credit=hmf_credit, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=HMFstats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @hmf_page.route("/browse/<int:d>/")
 def statistics_by_degree(d):
@@ -575,7 +568,6 @@ def statistics_by_degree(d):
         info['degree'] = d
         info['stats'] = HMFstats().statistics(d)
 
-    credit = 'John Cremona'
     if d==2:
         t = 'Hilbert modular forms over real quadratic number fields'
     elif d==3:
@@ -595,7 +587,7 @@ def statistics_by_degree(d):
         t = 'Hilbert modular forms'
         bread = bread[:-1]
 
-    return render_template("hmf_by_degree.html", info=info, credit=credit, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
+    return render_template("hmf_by_degree.html", info=info, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 
 class HMFSearchArray(SearchArray):

--- a/lmfdb/hilbert_modular_forms/templates/hmf_stats.html
+++ b/lmfdb/hilbert_modular_forms/templates/hmf_stats.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div>
-{{ KNOWL_INC('dq.mf.hilbert.extent') }}
+{{ KNOWL_INC('rcs.cande.mf.hilbert') }}
 </div>
 
 <h3>Browse by field degree:</h3>

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -32,8 +32,8 @@ def get_bread(breads=[]):
     return bc
 
 def learnmore_list():
-    return [('Completeness of the data', url_for(".cande")),
-            ('Source and acknowledgments', url_for(".source")),
+    return [('Source and acknowledgments', url_for(".source")),
+            ('Completeness of the data', url_for(".cande")),
             ('Reliability of the data', url_for(".reliability")),
             ('Local field labels', url_for(".labels_page"))]
 

--- a/lmfdb/maass_forms/main.py
+++ b/lmfdb/maass_forms/main.py
@@ -24,8 +24,8 @@ bread_prefix = lambda: [('Modular forms', url_for('modular_forms')),('Maass', ur
 ###############################################################################
 
 def learnmore_list():
-    return [('Completeness of the data', url_for('.completeness_page')),
-            ('Source of the data', url_for('.source_page')),
+    return [('Source and acknowledgments', url_for('.source_page')),
+            ('Completeness of the data', url_for('.completeness_page')),
             ('Reliability of the data', url_for('.reliability_page'))]
 
 def learnmore_list_remove(matchstring):

--- a/lmfdb/maass_forms/main.py
+++ b/lmfdb/maass_forms/main.py
@@ -35,8 +35,6 @@ def learnmore_list_remove(matchstring):
 # Pages
 ###############################################################################
 
-credit_string = "David Farmer, Stefan Lemurell, Fredrik Stromberg, and Holger Then"
-
 @maass_page.route('/')
 def index():
     info = to_dict(request.args, search_array=MaassSearchArray(), stats=MaassStats())
@@ -44,7 +42,7 @@ def index():
         return search(info)
     title = 'Maass forms'
     bread = bread_prefix()
-    return render_template('maass_browse.html', info=info, credit=credit_string, title=title, learnmore=learnmore_list(), bread=bread, dbcount=db.maass_newforms.count())
+    return render_template('maass_browse.html', info=info, title=title, learnmore=learnmore_list(), bread=bread, dbcount=db.maass_newforms.count())
 
 @maass_page.route('/random')
 @redirect_no_cache
@@ -60,7 +58,6 @@ def interesting():
         label_col="maass_id",
         url_for_label=lambda label: url_for(".by_label", label=label),
         title="Some interesting Maass forms",
-        credit=credit_string,
         bread=bread_prefix() + [("Interesting", " ")],
         learnmore=learnmore_list()
     )
@@ -69,7 +66,7 @@ def interesting():
 def statistics():
     title = "Maass forms: statistics"
     bread = bread_prefix() + [("Statistics", " ")]
-    return render_template("display_stats.html", info=MaassStats(), credit=credit_string, title=title, bread=bread, learnmore=learnmore_list())
+    return render_template("display_stats.html", info=MaassStats(), title=title, bread=bread, learnmore=learnmore_list())
 
 @maass_page.route('/<label>')
 def by_label(label):
@@ -123,26 +120,26 @@ def download(label):
 def download_coefficients(label):
     return MaassFormDownloader().download_coefficients(label)
 
+@maass_page.route('/Source')
+def source_page():
+    t = 'Source of Maass form data'
+    bread = bread_prefix() + [('Source','')]
+    return render_template('double.html', kid='rcs.source.maass',kid2='rcs.ack.maass',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
 @maass_page.route('/Completeness')
 def completeness_page():
     t = 'Completeness of Maass form data'
     bread = bread_prefix() + [('Completeness','')]
     return render_template('single.html', kid='rcs.cande.maass',
-                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
-
-@maass_page.route('/Source')
-def source_page():
-    t = 'Source of Maass form data'
-    bread = bread_prefix() + [('Source','')]
-    return render_template('single.html', kid='rcs.source.maass',
-                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
 
 @maass_page.route('/Reliability')
 def reliability_page():
     t = 'Reliability of Maass form data'
     bread = bread_prefix() + [('Reliability','')]
     return render_template('single.html', kid='rcs.rigor.maass',
-                           credit=credit_string, title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
 
 class MaassSearchArray(SearchArray):
     noun = "Maass form"
@@ -223,7 +220,6 @@ def parse_character(inp, query, qfield):
     },
     bread=lambda: bread_prefix() + [('Search results', '')],
     learnmore=learnmore_list,
-    credit=lambda: credit_string,
     url_for_label=lambda label: url_for(".by_label", label=label),
 )
 def search(info, query):
@@ -258,7 +254,6 @@ def search_by_label(label):
                            mf=mf,
                            properties=mf.properties,
                            downloads=mf.downloads,
-                           credit=credit_string,
                            bread=mf.bread,
                            learnmore=learnmore_list(),
                            title=mf.title,

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -107,8 +107,8 @@ def global_numberfield_summary():
 
 
 def learnmore_list():
-    return [(Completename, url_for(".render_discriminants_page")),
-            ('Source and acknowledgments', url_for(".source")),
+    return [('Source and acknowledgments', url_for(".source")),
+            (Completename, url_for(".render_discriminants_page")),
             ('Reliability of the data', url_for(".reliability")),
             ('Number field labels', url_for(".render_labels_page")),
             ('Galois group labels', url_for(".render_groups_page")),

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -323,8 +323,8 @@ def parse_component_group(inp, query, qfield):
 ###############################################################################
 
 def learnmore_list():
-    return [('Completeness of the data', url_for('.completeness_page')),
-            ('Source and acknowledgments', url_for('.source_page')),
+    return [('Source and acknowledgments', url_for('.source_page')),
+            ('Completeness of the data', url_for('.completeness_page')),
             ('Reliability of the data', url_for('.reliability_page')),
             ('Sato-Tate group labels', url_for('.labels_page'))]
 
@@ -903,19 +903,19 @@ def render_st_group(info, portrait=None):
                            title=title,
                            KNOWL_ID='st_group.%s'%(info['label']))
 
+@st_page.route('/Source')
+def source_page():
+    t = 'Source and acknowledgments for Sato-Tate group data'
+    bread = get_bread("Source")
+    return render_template('double.html', kid='rcs.source.st_group', kid2='rcs.ack.st_group',
+                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+
 @st_page.route('/Completeness')
 def completeness_page():
     t = 'Completeness of Sato-Tate group data'
     bread = get_bread("Completeness")
     return render_template('single.html', kid='rcs.cande.st_group',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
-
-@st_page.route('/Source')
-def source_page():
-    t = 'Source and acknowledgments for Sato-Tate group data'
-    bread = get_bread("Source")
-    return render_template('double.html', kid='rcs.source.st_group',
-                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @st_page.route('/Reliability')
 def reliability_page():

--- a/lmfdb/static/jquery.dataTables.js
+++ b/lmfdb/static/jquery.dataTables.js
@@ -7869,7 +7869,7 @@
 		 * table has already been initialised, this parameter will cause DataTables
 		 * to simply return the object that has already been set up - it will not take
 		 * account of any changes you might have made to the initialisation object
-		 * passed to DataTables (setting this parameter to true is an acknowledgement
+		 * passed to DataTables (setting this parameter to true is an acknowledgment
 		 * that you understand this). bDestroy can be used to reinitialise a table if
 		 * you need.
 		 *  @type boolean

--- a/lmfdb/symL/sympowlmfdb.py
+++ b/lmfdb/symL/sympowlmfdb.py
@@ -52,7 +52,7 @@ import os
 from sage.structure.sage_object import SageObject
 from sage.all import pager, Integer, PolynomialRing, RationalField
 # The next line triggers a Deprecation Warning but the import from sage.misc.verbose only works in Sage >=9.2
-from sage.misc.all import verbose
+from sage.misc.verbose import verbose
 
 class SympowLMFDB(SageObject):
     r"""

--- a/lmfdb/symL/sympowlmfdb.py
+++ b/lmfdb/symL/sympowlmfdb.py
@@ -52,7 +52,7 @@ import os
 from sage.structure.sage_object import SageObject
 from sage.all import pager, Integer, PolynomialRing, RationalField
 # The next line triggers a Deprecation Warning but the import from sage.misc.verbose only works in Sage >=9.2
-from sage.misc.verbose import verbose
+from sage.misc.all import verbose
 
 class SympowLMFDB(SageObject):
     r"""

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -203,6 +203,7 @@
         {%- endfor %}
       </div>
     {%- endwith %}
+    <div align="right" style="float: right; padding-left:5px;" id="rawtseticonspot"></div>
     {% if code %}
         <script>
         var cur_lang = null;
@@ -230,7 +231,6 @@
         </div>
     {% endif %}
 
-    <div align="right" style="float: right" id="rawtseticonspot"></div>
     {# Need to run after page has otherwise loaded #}
     <script>
     $().ready( function(){

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -293,8 +293,8 @@ The function which was called for this page is: {{calling_function}}
       {# <a href="{{ 'about' }}">About</a> #}
       &middot;
       {{ current_source|safe }}
-      &middot;
-      {{ latest_changeset|safe }}
+      {# &middot;
+      {{ latest_changeset|safe }} #}
       &middot;
       {{ sage_version|safe }}
       &middot;

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -230,8 +230,7 @@
         </div>
     {% endif %}
 
-    <div align="right" id="rawtseticonspot">
-    </div>
+    <div align="right" style="float: right" id="rawtseticonspot"></div>
     {# Need to run after page has otherwise loaded #}
     <script>
     $().ready( function(){

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -190,7 +190,7 @@
    {{ rightnavig("Origins of factors", factors_origins) }}
    {{ neighbors("Nearby objects", navi) }}
    {{ rightnavig("Downloads", downloads) }}
-   {{ rightnavig("Learn more about", learnmore) }}
+   {{ rightnavig("Learn more", learnmore) }}
     </div>
     {%- endif %}
 

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -272,7 +272,7 @@ The function which was called for this page is: {{calling_function}}
 </div>
 {% endif %}
 
-<div id="footer">
+<div id="footer" style="float: bottom";>
     {% if credit -%}
       Data computed by {{ credit|safe }}.<br />
     {%- endif %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -219,7 +219,7 @@
             }
         }
         </script>
-        <div align="right">
+        <div align="right" style="float: right">
             Show commands for:
             {% set slash = joiner("/ ") %}
             {% for lang in code['show'] %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -203,7 +203,7 @@
         {%- endfor %}
       </div>
     {%- endwith %}
-    <div align="right" style="float: right; padding-left:5px;" id="rawtseticonspot"></div>
+    <div align="right" style="float: right; padding-left:10px;" id="rawtseticonspot"></div>
     {% if code %}
         <script>
         var cur_lang = null;

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -272,7 +272,7 @@ The function which was called for this page is: {{calling_function}}
 </div>
 {% endif %}
 
-<div id="footer" style="float: bottom";>
+<div id="footer">
     {% if credit -%}
       Data computed by {{ credit|safe }}.<br />
     {%- endif %}

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -213,7 +213,7 @@ body.knowl #header {
     font-size: 180%;
     font-weight: bold;
     font-family: sans-serif;
-    padding-bottom: 3px;
+    padding-bottom: 2px;
     color: {{color.header_text_title}};
 }
 
@@ -419,7 +419,7 @@ body > .debug {
 }
 
 #content {
-  margin-top: 20px;
+  margin-top: 10px;
   font-size: 95%;
   line-height: 135%;
   padding-right: 10px;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -88,7 +88,7 @@ h2.link > a {
     clear: both;
     position: fixed;
     width: 100%;
-    margin-top: 40px;
+    bottom: 0;
     background-color: {{color.footer_background}};
     /* border-top: 2px solid {{ color.footer_border }}; */
     padding: 8px;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -307,7 +307,7 @@ body.knowl #header {
 
 body > .debug {
     margin: 10px 20px 20px 200px;
-    padding: 2px;
+    padding: 5px;
 }
 
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -86,9 +86,10 @@ h2.link > a {
 
 #footer {
     clear: both;
-    margin-top: 40px;
+    position: fixed;
+    width: 100%;
+    bottom: 0;
     background-color: {{color.footer_background}};
-    /* border-top: 2px solid {{ color.footer_border }}; */
     padding: 8px;
     text-align: center;
     font-size: 75%;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -393,7 +393,6 @@ body > .debug {
 .properties-header {
   border-top-left-radius: 10px;
   margin: 0;
-  margin-top: 5px;
   padding: 5px 9px;
   color: {{ color.properties_header_text }};
   background: {{ color.properties_header_background }};
@@ -401,8 +400,8 @@ body > .debug {
   cursor: pointer;
   padding-right: 30px;
 }
-.properties-header:first-child {
-  margin-top: 0;
+.properties-header ~ .properties-header {
+  margin-top: 5px;
 }
 #properties-collapser {
   cursor: pointer;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -413,7 +413,7 @@ body > .debug {
   width: 20px;
   height: 17px;
   position: absolute;
-  top:   12px;
+  top:   2px;
   right: 3px;
   {{ BORDER_RADIUS(20) }}
 }

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -39,6 +39,7 @@ h2.link > a {
 #content > h1:first-child,
 #content > h2:first-child {
     margin-top: 0px;
+    padding-top: 0px;
 }
 
 #content > h2

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -306,8 +306,8 @@ body.knowl #header {
 }
 
 body > .debug {
-    left: 184px;
     margin: 20px;
+    margin-left: 200px;
     padding: 2px;
 }
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -297,7 +297,7 @@ body.knowl #header {
 #main {
   margin:  0px 0px 0px 184px;
   padding: 0px 0px 0px 10px;
-  min-height: 700px;
+  min-height:600px;
 }
 
 .debug {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -26,7 +26,12 @@ h2.link > a {
 .katex {
     font-size: 1em !important;
 }
-/* TODO: where is content?*/
+
+#content
+{
+    padding-bottom: 40px;
+}
+
 #content > h1
 {
     font-size: 130%;
@@ -86,9 +91,10 @@ h2.link > a {
 
 #footer {
     clear: both;
-    position: fixed;
+    position: absolute;
     width: 100%;
     bottom: 0;
+    left: 0;
     background-color: {{color.footer_background}};
     padding: 8px;
     text-align: center;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -185,12 +185,10 @@ a:hover {
 
 #header {
   background: {{color.header_background}};
-/*  box-shadow: 0px 3px 3px {{color.header_shadow}}; */
 }
 
 body.knowl #header {
   background: {{ color.knowl_l }};
-  box-shadow: 0px 5px 5px {{color.knowl_shadow}};
 }
 
 #header #logo {
@@ -395,7 +393,6 @@ body > .debug {
 .properties-header {
   border-top-left-radius: 10px;
   margin: 0;
-  margin-top: 10px;
   padding: 5px 9px;
   color: {{ color.properties_header_text }};
   background: {{ color.properties_header_background }};

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -13,7 +13,6 @@ img { border: 0; }
 body {
     margin: 0px;
     padding: 0px;
-    padding-bottom: 40px;
     font-family: sans-serif;
     color: {{color.body_text}};
     background-color: {{color.body_background}};
@@ -27,7 +26,7 @@ h2.link > a {
 .katex {
     font-size: 1em !important;
 }
-
+/* TODO: where is content?*/
 #content > h1
 {
     font-size: 130%;
@@ -87,11 +86,11 @@ h2.link > a {
 
 #footer {
     clear: both;
-    position: absolute;
+    position: fixed;
     width: 100%;
-    bottom: 0;
-    left: 0;
+    margin-top: 40px;
     background-color: {{color.footer_background}};
+    /* border-top: 2px solid {{ color.footer_border }}; */
     padding: 8px;
     text-align: center;
     font-size: 75%;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -13,6 +13,7 @@ img { border: 0; }
 body {
     margin: 0px;
     padding: 0px;
+    padding-bottom: 40px;
     font-family: sans-serif;
     color: {{color.body_text}};
     background-color: {{color.body_background}};
@@ -25,11 +26,6 @@ h2.link > a {
 }
 .katex {
     font-size: 1em !important;
-}
-
-#content
-{
-    padding-bottom: 40px;
 }
 
 #content > h1

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -49,8 +49,8 @@ h2.link > a {
     text-align: left;
     font-weight: bold;
     color: {{color.a_text}};
-    padding: 5px 0 5px 0;
-    margin: 15px 0 10px 0;
+    padding: 5px 0;
+    margin: 10px 0;
 }
 #content > h3, td.table_h2 {
     font-family: sans-serif;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -185,7 +185,7 @@ a:hover {
 
 #header {
   background: {{color.header_background}};
-  box-shadow: 0px 3px 3px {{color.header_shadow}};
+/*  box-shadow: 0px 3px 3px {{color.header_shadow}}; */
 }
 
 body.knowl #header {
@@ -213,7 +213,7 @@ body.knowl #header {
     font-size: 180%;
     font-weight: bold;
     font-family: sans-serif;
-    padding-top: 5px;
+    padding-bottom: 3px;
     color: {{color.header_text_title}};
 }
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -86,7 +86,7 @@ h2.link > a {
 
 #footer {
     clear: both;
-    margin-top: 40px;
+    margin-top: 20px;
     background-color: {{color.footer_background}};
     padding: 8px;
     text-align: center;
@@ -433,12 +433,11 @@ body > .debug {
 #sidebar {
   float: left;
   width: 184px;
-  margin: 10px 0px 0px 0px;
+  margin: 10px 0px;
   font-family: sans-serif;
   font-size: 85%;
   color: {{color.sidebar_text}};
   background: {{color.sidebar_background}};
-  margin-bottom: 100px;
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
 }

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -88,7 +88,8 @@ h2.link > a {
     clear: both;
     margin-top: 20px;
     background-color: {{color.footer_background}};
-    padding: 8px;
+    padding-top: 6px;
+    padding-bottom: 10px;
     text-align: center;
     font-size: 75%;
     color: {{color.footer_text}};

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -393,12 +393,16 @@ body > .debug {
 .properties-header {
   border-top-left-radius: 10px;
   margin: 0;
+  margin-top: 5px;
   padding: 5px 9px;
   color: {{ color.properties_header_text }};
   background: {{ color.properties_header_background }};
   font-size: 14px;
   cursor: pointer;
   padding-right: 30px;
+}
+.properties-header:first-child {
+  margin-top: 0;
 }
 #properties-collapser {
   cursor: pointer;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -306,6 +306,7 @@ body.knowl #header {
 }
 
 body > .debug {
+    left: 184px;
     margin: 20px;
     padding: 2px;
 }
@@ -474,7 +475,8 @@ body > .debug {
   border-top-right-radius: 10px;
 }
 #sidebar ul:last-child li:last-child,
-#sidebar ul:last-child li:last-child a {
+#sidebar ul:last-child li:last-child a,
+#sidebar h2:last-child {
   border-bottom-right-radius: 10px;
 }
 #sidebar ul {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -413,7 +413,7 @@ body > .debug {
   width: 20px;
   height: 17px;
   position: absolute;
-  top:   2px;
+  top:   4px;
   right: 3px;
   {{ BORDER_RADIUS(20) }}
 }

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -306,8 +306,7 @@ body.knowl #header {
 }
 
 body > .debug {
-    margin: 20px;
-    margin-left: 200px;
+    margin: 10px 20px 20px 200px;
     padding: 2px;
 }
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -86,11 +86,8 @@ h2.link > a {
 
 #footer {
     clear: both;
-    position: fixed;
-    width: 100%;
-    bottom: 0;
+    margin-top: 40px;
     background-color: {{color.footer_background}};
-    /* border-top: 2px solid {{ color.footer_border }}; */
     padding: 8px;
     text-align: center;
     font-size: 75%;

--- a/lmfdb/tests/test_acknowlegments.py
+++ b/lmfdb/tests/test_acknowlegments.py
@@ -6,7 +6,7 @@ class HomePageTest(LmfdbTest):
     # All tests should pass
     #
     # The acknowledgments page
-    def test_acknowledgements(self):
+    def test_acknowledgments(self):
         homepage = self.tc.get("/acknowledgment").get_data(as_text=True)
         assert 'American Institute of Mathematics' in homepage
 

--- a/lmfdb/utils/color.py
+++ b/lmfdb/utils/color.py
@@ -229,7 +229,7 @@ class ColorScheme(object):
         'chi_table_background': 'col_main_ld', # This was specified twice in color.css; could also be col_main_ll
         'chi_table_border': 'col_main_dl',
 
-        # acknowledgements
+        # acknowledgments
         'text_affil': '#333',
         'text_notes': '#555',
         'text_trad_hyperlink': c.black,


### PR DESCRIPTION
This PR completes the source/acknowledgment knowl changes for all production sections of the LMFDB and renames all of the old dq.* knowls in production sections to the corresponding rcs.* knowl names where appropriate.  Credit strings have been copied into acknowledgments knowls for the moment, but these will require further editing (both expanding them to say more and removing information that is already contained in the source knowl).

There are also now generic and specific source and acknowledgment knowls for L-function data (specific knowls that depend on the origin are stored in the lfucn_rs_knowl table as before).

Credit strings no longer appear in the footer on any of the production pages (but they are still present for the beta sections Belyi/Siegel/HGM/Lattices -- these will need to be updated to use the new framework before we go into production).

There are also some minor page layout tweaks (footer is thinner and positioned more consistently, show commands and the  x -> x button now float right to avoid pushing the first header down the page, title bar now has a rounded lower right corner like it is supposed to, property box spacing has been lightly tweaked, header/footer box shadows have been removed, etc... -- most of these will not be noticeable unless you compare the pages side-by-side).

I am going to merge this as soon as Travis is happy. This PR touches almost every section of the LMFDB and I want to avoid potential merge conflicts.  I will then push to beta but then wait a few days before pushing to production to give people a change to catch anything I might have missed.