### PR TITLE
Add local field friends to Galois group pages

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -251,6 +251,8 @@ def render_group_webpage(args):
         friends = []
         if db.nf_fields.exists({'degree': n, 'galt': t}):
             friends.append(('Number fields with this Galois group', url_for('number_fields.number_field_render_webpage')+"?galois_group=%dT%d" % (n, t) ))
+        if db.lf_fields.exists({'n': n, 'galT': t}):
+            friends.append(('$p$-adic fields with this Galois group', url_for('local_fields.index')+"?gal=%dT%d" % (n, t) ))
         prop2 = [('Label', label),
             ('Degree', prop_int_pretty(data['n'])),
             ('Order', prop_int_pretty(order)),


### PR DESCRIPTION
Fixes issue #4536 by adding a friend link to Galois group pages where there are local fields in the database with that Galois group.  The first group has matches, and the second does not:

http://127.0.0.1:37777/GaloisGroup/8T5
http://127.0.0.1:37777/GaloisGroup/5T5

same on beta:

http://beta.lmfdb.org/GaloisGroup/8T5
http://beta.lmfdb.org/GaloisGroup/5T5