### PR TITLE
Hopefully final LocalNumberField -> padicField changes

### DIFF
--- a/lmfdb/local_fields/__init__.py
+++ b/lmfdb/local_fields/__init__.py
@@ -27,6 +27,7 @@ def redirect_local():
 
 
 app.register_blueprint(local_fields_page, url_prefix="/padicField")
+app.register_blueprint(local_fields_page, url_prefix="/LocalNumberField")
 
 register_search_function(
     "$p$-adic_fields",

--- a/lmfdb/local_fields/__init__.py
+++ b/lmfdb/local_fields/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from lmfdb.app import app
 from lmfdb.logger import make_logger
-from flask import Blueprint
+from flask import Blueprint, request, redirect
 from lmfdb.api2.searchers import register_search_function
 
 local_fields_page = Blueprint("local_fields", __name__, template_folder='templates', static_folder="static")
@@ -16,8 +16,17 @@ def body_class():
 from . import main
 assert main
 
+from six.moves.urllib.parse import urlparse, urlunparse
+@local_fields_page.before_request
+def redirect_local():
+        urlparts = urlparse(request.url)
+        if 'LocalNumberField' in urlparts.path:
+            urlparts = urlparts._replace(path=urlparts.path.replace('LocalNumberField', 'padicField'))
+            return redirect(urlunparse(urlparts), 301)
+        return
+
+
 app.register_blueprint(local_fields_page, url_prefix="/padicField")
-app.register_blueprint(local_fields_page, url_prefix="/LocalNumberField")
 
 register_search_function(
     "$p$-adic_fields",

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -69,7 +69,7 @@ def local_algebra_data(labels):
     fall = [db.lf_fields.lookup(label) for label in labs]
     for f in fall:
         l = str(f['label'])
-        ans += '<tr><td><a href="/LocalNumberField/%s">%s</a><td>'%(l,l)
+        ans += '<tr><td><a href="%s">%s</a><td>'%(url_for_label(l),l)
         ans += format_coeffs(f['coeffs'])
         ans += '<td>%d<td>%d<td>%d<td>'%(f['e'],f['f'],f['c'])
         galnt = [int(z) for z in f['galois_label'].split('T')]
@@ -246,7 +246,7 @@ def render_field_webpage(args):
             logger.fatal("Cannot find unramified field!")
             unramfriend = ''
         else:
-            unramfriend = "/LocalNumberField/%s" % unramlabel
+            unramfriend = url_for_label(unramlabel)
             unramdata = db.lf_fields.lookup(unramlabel)
 
         Px = PolynomialRing(QQ, 'x')
@@ -270,7 +270,7 @@ def render_field_webpage(args):
             logger.fatal("Cannot find discriminant root field!")
             rffriend = ''
         else:
-            rffriend = "/LocalNumberField/%s" % rflabel
+            rffriend = url_for_label(rflabel)
         gsm = data['gsm']
         if gsm == [0]:
             gsm = 'Not computed'

--- a/lmfdb/local_fields/templates/lf-search.html
+++ b/lmfdb/local_fields/templates/lf-search.html
@@ -23,7 +23,7 @@
 
 {% for field in info.results: %}
 <tr>
-<td><a href="/LocalNumberField/{{field.label}}"> {{field.label}} </a></td>
+<td><a href="{{url_for('local_fields.by_label', label=field.label)}}"> {{field.label}} </a></td>
 <td align='left'>{{info.display_poly(field.coeffs)|safe}}</td>
 <td>${{field.p}}$</td>
 <td>${{field.e}}$</td>

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -7,25 +7,25 @@ class LocalFieldTest(LmfdbTest):
     # All tests should pass
     #
     def test_search_ramif_cl_deg(self):
-        L = self.tc.get('/LocalNumberField/?n=8&c=24&gal=8T5&p=2&e=8&count=20')
+        L = self.tc.get('/padicField/?n=8&c=24&gal=8T5&p=2&e=8&count=20')
         assert '4 matches' in L.get_data(as_text=True)
 
     def test_search_top_slope(self):
-        L = self.tc.get('/LocalNumberField/?p=2&topslope=3.5')
+        L = self.tc.get('/padicField/?p=2&topslope=3.5')
         assert '81' in L.get_data(as_text=True) # number of matches
-        L = self.tc.get('/LocalNumberField/?p=2&topslope=3.4..3.55')
+        L = self.tc.get('/padicField/?p=2&topslope=3.4..3.55')
         assert '81' in L.get_data(as_text=True) # number of matches
-        L = self.tc.get('/LocalNumberField/?p=2&topslope=7/2')
+        L = self.tc.get('/padicField/?p=2&topslope=7/2')
         assert '81' in L.get_data(as_text=True) # number of matches
 
     def test_field_page(self):
-        L = self.tc.get('/LocalNumberField/11.6.4.2')
+        L = self.tc.get('/padicField/11.6.4.2')
         assert 'x^{2} - x + 7' in L.get_data(as_text=True) # bad (not robust) test, but it's the best i was able to find...
         assert 'x^{3} - 11 t' in L.get_data(as_text=True) # bad (not robust) test, but it's the best i was able to find...
 
     def test_global_splitting_models(self):
         # The first one will have to change if we compute a GSM for it
-        L = self.tc.get('/LocalNumberField/163.8.7.2')
+        L = self.tc.get('/padicField/163.8.7.2')
         assert 'Not computed' in L.get_data(as_text=True)
-        L = self.tc.get('/LocalNumberField/2.8.0.1')
+        L = self.tc.get('/padicField/2.8.0.1')
         assert 'Does not exist' in L.get_data(as_text=True)


### PR DESCRIPTION
Entering a url using LocalNumberField now redirects to padicField.

Also, links in the search table were still pointing to LocalNumberField, so that is now fixed.

A few other places were not using url_for (or some variation), and those are now fixed.  (There is no visible change to the user on those.)

Pages to check are anything in the padicField area, such as

http://127.0.0.1:37777/padicField/?p=3&n=6  (search results)
http://127.0.0.1:37777/LocalNumberField/3.6.6.4  (both that it redirects, and that the root field and unramified subfield friends still go to the correct places)
