### PR TITLE
Alert user if they use the jump box for NF and we change the polynomial

### DIFF
--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -17,7 +17,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'polyquo_knowl', 'web_latex_poly', 'list_to_latex_matrix',
            'code_snippet_knowl',
            'Pagination',
-           'debug', 'flash_error', 'flash_warning',
+           'debug', 'flash_error', 'flash_warning', 'flash_info',
            'ajax_url',
            'image_callback', 'encode_plot',
            'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1', 'parse_rational', 'parse_rational_to_list',
@@ -62,7 +62,7 @@ from .utilities import (
     bigpoly_knowl, factor_base_factor, factor_base_factorization_latex,
     polyquo_knowl, web_latex_poly, list_to_latex_matrix, code_snippet_knowl,
     Pagination,
-    debug, flash_error, flash_warning,
+    debug, flash_error, flash_warning, flash_info,
     ajax_url,  # try to eliminate?
     image_callback, encode_plot, raw_typeset, letters2num, num2letters,
     datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -1111,6 +1111,9 @@ def flash_warning(errmsg, *args):
     """ flash warning in grey with args in red; warning may contain markup, including latex math mode"""
     flash(Markup("Warning: " + (errmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args))), "warning")
 
+def flash_info(errmsg, *args):
+    """ flash information in grey with args in black; warning may contain markup, including latex math mode"""
+    flash(Markup("Note: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args))), "info")
 
 ################################################################################
 #  Ajax utilities


### PR DESCRIPTION
Go to the number field index page and type a polynomial in the jump box.  If it is one of our defining polynomials, nothing different happens (even if it is rearranged like -1+x^3+3*x or -1+x^3+3x or even -1+x+x^3+x+x).  But if it is a different polynomial which changes under polredabs (e.g., x^3+3x+11), then there is a message added at the top of the page.