### PR TITLE
Show unfactored L-polynomial on abvar pages

### DIFF
--- a/lmfdb/abvar/fq/isog_class.py
+++ b/lmfdb/abvar/fq/isog_class.py
@@ -96,6 +96,10 @@ class AbvarFq_isoclass(object):
         self.decompositioninfo = decomposition_display(list(zip(self.simple_distinct, self.simple_multiplicities)))
         self.basechangeinfo = self.basechange_display()
         self.formatted_polynomial = list_to_factored_poly_otherorder(self.polynomial, galois=False, vari="x")
+        if self.is_simple and QQ['x'](self.polynomial).is_irreducible():
+            self.expanded_polynomial = ''
+        else:
+            self.expanded_polynomial = latex.latex(QQ[['x']](self.polynomial))
 
     @property
     def p(self):

--- a/lmfdb/abvar/fq/templates/show-abvarfq.html
+++ b/lmfdb/abvar/fq/templates/show-abvarfq.html
@@ -9,6 +9,9 @@
     <tr><td>{{ KNOWL('ag.base_field',title = "Base field") }}:</td><td>&nbsp;&nbsp;${{cl.field()}}$</td></tr>
     <tr><td>{{ KNOWL('ag.dimension',title = "Dimension") }}:</td><td>&nbsp;&nbsp;${{cl.g}}$</td></tr>
     <tr><td>{{ KNOWL('av.fq.l-polynomial',title='L-polynomial') }}:</td><td>&nbsp;&nbsp;${{cl.formatted_polynomial}}$</td></tr>
+    {% if cl.expanded_polynomial %}
+    <tr><td></td><td>&nbsp;&nbsp;${{cl.expanded_polynomial}}$</td></tr>
+    {% endif %}
     <tr><td>{{KNOWL('av.fq.frobenius_angles',title='Frobenius angles')}}:</td><td>&nbsp;&nbsp;{{cl.frob_angles()}}</td></tr>
     <tr><td>{{ KNOWL('av.fq.angle_rank',title="Angle rank") }}:</td><td>&nbsp;&nbsp;${{cl.angle_rank}}$ ({{KNOWL('av.fq.frobenius_angles_correctness',title='numerical')}})</td></tr>
     {% if cl.is_simple %}


### PR DESCRIPTION
This partially addresses #3632 by showing the L-polynomial in unfactored form on the isogeny class pages.

Here is an example of a page with a factored L-polynomial, which displays both the factored and unfactored form.
Before: https://beta.lmfdb.org/Variety/Abelian/Fq/5/3/f_p_bk_cs_es
After: http://127.0.0.1:37777/Variety/Abelian/Fq/5/3/f_p_bk_cs_es

Here is an example of a page with an irreducible L-polynomial, which is not changed:
Before: https://beta.lmfdb.org/Variety/Abelian/Fq/1/2/ac
After: http://127.0.0.1:37777/Variety/Abelian/Fq/1/2/ac