### PR TITLE
added search fields for unramified degree and tame degree

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -481,22 +481,22 @@ class LFSearchArray(SearchArray):
                 display_knowl('gg.label', 'transitive group labels')))
         u = TextBox(
             name='u',
-            label='Unramified degree',
+            label='Galois unramified degree',
             knowl='lf.unramified_degree',
             example='3',
-            example_span='4, or a range like 1..4'
+            example_span='3, or a range like 1..4'
             )
         t = TextBox(
             name='t',
-            label='Tame degree',
+            label='Galois tame degree',
             knowl='lf.tame_degree',
-            example='3',
+            example='2',
             example_span='2, or a range like 2..3'
             )
         results = CountBox()
 
         self.browse_array = [[degree], [qp], [c], [e], [topslope], [u], [t], [gal], [results]]
-        self.refine_array = [[degree, c, gal], [qp, e, topslope], [u, t]]
+        self.refine_array = [[degree, c, gal, u], [qp, e, topslope, t]]
 
 def ramdisp(p):
     return {'cols': ['n', 'e'],

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -195,6 +195,8 @@ class LF_download(Downloader):
 def local_field_search(info,query):
     parse_ints(info,query,'p',name='Prime p')
     parse_ints(info,query,'n',name='Degree')
+    parse_ints(info,query,'u',name='Unramified degree')
+    parse_ints(info,query,'t',name='Tame degree')
     parse_galgrp(info,query,'gal',qfield=('galois_label','n'))
     parse_ints(info,query,'c',name='Discriminant exponent c')
     parse_ints(info,query,'e',name='Ramification index e')
@@ -477,10 +479,24 @@ class LFSearchArray(SearchArray):
                 display_knowl('group.small_group_label', "GAP id's"),
                 display_knowl('nf.galois_group.name', 'list of group labels'),
                 display_knowl('gg.label', 'transitive group labels')))
+        u = TextBox(
+            name='u',
+            label='Unramified degree',
+            knowl='lf.unramified_degree',
+            example='3',
+            example_span='e.g. 3, or a range like 2..6'
+            )
+        t = TextBox(
+            name='t',
+            label='Tame degree',
+            knowl='lf.tame_degree',
+            example='3',
+            example_span='e.g. 3, or a range like 2..6'
+            )
         results = CountBox()
 
-        self.browse_array = [[degree], [qp], [c], [e], [topslope], [gal], [results]]
-        self.refine_array = [[degree, c, gal], [qp, e, topslope]]
+        self.browse_array = [[degree], [qp], [c], [e], [topslope], [u], [t], [gal], [results]]
+        self.refine_array = [[degree, c, gal], [qp, e, topslope], [u, t]]
 
 def ramdisp(p):
     return {'cols': ['n', 'e'],

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -484,14 +484,14 @@ class LFSearchArray(SearchArray):
             label='Unramified degree',
             knowl='lf.unramified_degree',
             example='3',
-            example_span='e.g. 3, or a range like 2..6'
+            example_span='4, or a range like 1..4'
             )
         t = TextBox(
             name='t',
             label='Tame degree',
             knowl='lf.tame_degree',
             example='3',
-            example_span='e.g. 3, or a range like 2..6'
+            example_span='2, or a range like 2..3'
             )
         results = CountBox()
 


### PR DESCRIPTION
Addressing a part of issue #4509 that was asking for the possibility to search for p-adic fields by their unramified degree and tame degree. I added these two search boxes to the p-adic field start page and to the p-adic field search page. They work exactly like the other search boxes on these pages.  

Before: http://www.lmfdb.org/padicField/ and http://www.lmfdb.org/padicField/?search_type=List&all=1
After: http://localhost:37777/padicField/ and http://localhost:37777/padicField/?u=4&t=2&search_type=List