### PR TITLE
Newpolyfix

### DIFF
--- a/.environment.yml
+++ b/.environment.yml
@@ -10,8 +10,6 @@ channel_priority: strict
 safety_checks: disabled
 channels:
   - conda-forge
-channels:
-  - conda-forge
 dependencies:
   - python=3.9
   - sage=9.2

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 from lmfdb.tests import LmfdbTest
-import unittest2
 
 from . import cmf_logger
 cmf_logger.setLevel(100)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -19,7 +19,7 @@ from lmfdb.utils import (
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, bigint_knowl, raw_typeset,
-    flash_info)
+    flash_info, input_string_to_poly)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.galois_groups.transitive_group import (
     cclasses_display_knowl,character_table_display_knowl,
@@ -766,9 +766,10 @@ def number_field_jump(info):
     query = {'label_orig': info['jump']}
     try:
         parse_nf_string(info, query, 'jump',name="Label", qfield='label')
-        if 'x' in info['jump'].lower():
-            if is_new_poly(info['jump'].lower(), query['label']):
-                flash_info(r"The requested field $\Q[x]/\langle {}\rangle$ is isomorphic to the field below, but uses a different defining polynomial.".format(info['jump']))
+        # we end up parsing the string twice, but that is okay
+        F1, _, _ = input_string_to_poly(info['jump'])
+        if F1 and F1.list() != db.nf_fields.lookup(query['label'], 'coeffs'):
+            flash_info(r"The requested field $\Q[{}]/\langle {}\rangle$ is isomorphic to the field below, but uses a different defining polynomial.".format(str(F1.parent().gen()), latex(F1)))
         return redirect(url_for(".by_label", label=query['label']))
     except ValueError:
         return redirect(url_for(".number_field_render_webpage"))

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -753,15 +753,6 @@ def download_search(info):
                      as_attachment=True,
                      add_etags=False)
 
-# Test if a user input polynomial is exactly the same as the one
-# in the database
-def is_new_poly(userinp, label):
-    dbcoeffs = db.nf_fields.lookup(label)['coeffs']
-    userinp = re.sub(r'[<>]','', userinp)
-    R = PolynomialRing(ZZ, 'x')
-    userpol = [int(z) for z in R(userinp).coefficients(sparse=False)]
-    return userpol != dbcoeffs
-
 def number_field_jump(info):
     query = {'label_orig': info['jump']}
     try:

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -43,7 +43,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'datetime_to_timestamp_in_ms', 'timestamp_in_ms_to_datetime',
            'TraceHash', 'TraceHashClass',
            'redirect_no_cache', 'nums2letters', 'letters2num', 'num2letters',
-           'raw_typeset']
+           'raw_typeset', 'input_string_to_poly']
 
 from flask import (request, make_response, flash, url_for,
                    render_template, send_file)
@@ -65,7 +65,7 @@ from .utilities import (
     debug, flash_error, flash_warning, flash_info,
     ajax_url,  # try to eliminate?
     image_callback, encode_plot, raw_typeset, letters2num, num2letters,
-    datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)
+    datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime, input_string_to_poly)
 
 from .search_parsing import (
     parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, parse_rational_to_list, parse_rats,

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -65,7 +65,7 @@ from .utilities import (
     debug, flash_error, flash_warning, flash_info,
     ajax_url,  # try to eliminate?
     image_callback, encode_plot, raw_typeset, letters2num, num2letters,
-    datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime, input_string_to_poly)
+    datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)
 
 from .search_parsing import (
     parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, parse_rational_to_list, parse_rats,
@@ -76,7 +76,7 @@ from .search_parsing import (
     parse_nf_elt, parse_container, parse_hmf_weight, parse_count, parse_start,
     parse_ints_to_list_flash, integer_options, nf_string_to_label,
     parse_subfield,
-    clean_input, prep_ranges)
+    clean_input, prep_ranges, input_string_to_poly)
 
 from .search_wrapper import search_wrap, count_wrap
 from .search_boxes import (

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -884,7 +884,7 @@ def input_string_to_poly(FF):
     F = FF.lower() # keep original if needed
     # check if a polynomial was entered
     try:
-        return coeff_to_poly(F), F
+        return coeff_to_poly(F), F, FF
     except Exception:
         return None, F, FF
 


### PR DESCRIPTION
I did some refactoring so we can display the message:
```
Note: The requested field Q[x]/f(x) is isomorphic to the field below, but uses a different defining polynomial.
```
- with polynomial properly formatted in latex, e.g., https://beta.lmfdb.org/NumberField/?jump=x^10+%2B+2048 vs http://localhost:37777/NumberField/?jump=x^10+%2B+2048
<img width="815" alt="Screen Shot 2021-05-04 at 11 58 51" src="https://user-images.githubusercontent.com/322822/117033141-19be2980-acd0-11eb-8566-26453c5e2804.png">


- display info message even if one didn't use x as the defining variable, e.g., https://beta.lmfdb.org/NumberField/?jump=w^10+%2B+2048 vs http://localhost:37777/NumberField/?jump=w^10+%2B+2048
<img width="526" alt="Screen Shot 2021-05-04 at 11 59 07" src="https://user-images.githubusercontent.com/322822/117033194-23479180-acd0-11eb-9d28-7f3b6dee8705.png">