### PR TITLE
fix typo in allowed_annotation_id

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -45,7 +45,7 @@ def allowed_id(ID):
         main_knowl = ".".join(ID.split(".")[:-2])
         return knowldb.knowl_exists(main_knowl)
     if ID.endswith('top') or ID.endswith('bottom'):
-        if not allow_annotation_id.match(ID):
+        if not allowed_annotation_id.match(ID):
             label = '.'.join(ID.split(".")[1:-1])
             flash_error("Label '%s' contains characters not allowed by knowl database; updated allowed_id function or change label scheme" % label)
             return False


### PR DESCRIPTION
Hotfix to a bug caused by a typo in lmfdb/knowledge/main.py.

@edgarcosta @alexjbest according to the details on PR #4557, all 20 checks passed.  But pyflakes gives an error on this typo that was apparently not part of any of the checks.   Do we need to add pyflakes to the list of tests we run via GitHub actions?