### PR TITLE
Add inertia and wild group search

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -52,7 +52,7 @@ def smallgroup_cache(gap_labels, cache=None, reverse=None):
 def small_group_display_knowl(n, k, name=None, cache=None):
     label = '%s.%s' % (n, k)
     if not name:
-        myname = '$[%d, %d]$'%(n,k)
+        myname = 'GAP id $[%d, %d]$'%(n,k)
     else:
         myname = name
     if cache:

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -644,6 +644,11 @@ def group_alias_table():
     ans += r'</tbody></table>'
     return ans
 
+def nt2gap(n, t):
+    res = db.gps_transitive.lookup('{}T{}'.format(n,t))
+    if res and 'gapid' in res:
+        return [res['order'], res['gapid']]
+    raise NameError('GAP id not found')
 
 def complete_group_code(code):
     # Order direct products

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -10,7 +10,7 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.utils import (
     web_latex, coeff_to_poly, pol_to_html, display_multiset, display_knowl,
-    parse_bracketed_posints,
+    parse_bracketed_posints, parse_inertia,
     parse_galgrp, parse_ints, clean_input, parse_rats, flash_error,
     SearchArray, TextBox, TextBoxNoEg, CountBox, to_dict, comma,
     search_wrap, Downloader, StatsDisplay, totaler, proportioners, 
@@ -202,8 +202,8 @@ def local_field_search(info,query):
     parse_ints(info,query,'c',name='Discriminant exponent c')
     parse_ints(info,query,'e',name='Ramification index e')
     parse_rats(info,query,'topslope',qfield='top_slope',name='Top slope', process=ratproc)
-    parse_bracketed_posints(info,query,'inertia_gap',exactlength=2, allow0=True)
-    parse_bracketed_posints(info,query,'wild_gap',exactlength=2, allow0=True)
+    parse_inertia(info,query,qfield=('inertia_gap','inertia'))
+    parse_inertia(info,query,qfield=('wild_gap','wild_gap'), field='wild_gap')
     info['group_display'] = group_pretty_and_nTj
     info['display_poly'] = format_coeffs
     info['slopedisp'] = show_slope_content

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -10,7 +10,7 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.utils import (
     web_latex, coeff_to_poly, pol_to_html, display_multiset, display_knowl,
-    parse_bracketed_posints, parse_inertia,
+    parse_inertia,
     parse_galgrp, parse_ints, clean_input, parse_rats, flash_error,
     SearchArray, TextBox, TextBoxNoEg, CountBox, to_dict, comma,
     search_wrap, Downloader, StatsDisplay, totaler, proportioners, 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -472,6 +472,12 @@ class LFSearchArray(SearchArray):
             knowl='lf.ramification_index',
             example='3',
             example_span='3, or a range like 2..6')
+        f = TextBox(
+            name='f',
+            label='Residue field degree',
+            knowl='lf.residue_field_degree',
+            example='3',
+            example_span='3, or a range like 2..6')
         topslope = TextBox(
             name='topslope',
             label='Top slope',
@@ -505,22 +511,30 @@ class LFSearchArray(SearchArray):
         inertia = TextBox(
             name='inertia_gap',
             label='Inertia subgroup',
-            knowl='lf.inertia_group',
+            knowl='lf.inertia_group_search',
             example='[3,1]',
-            example_span=display_knowl('group.small_group_label', "GAP id") + ' of a group like [3,1]'
+            example_span='a %s, e.g. [8,3] or [16,7], a group name from the %s, e.g. C5 or S12, or a %s, e.g., 7T2 or 11T5' % (
+                display_knowl('group.small_group_label', "GAP id"),
+                display_knowl('nf.galois_group.name', 'list of group labels'),
+                display_knowl('gg.label', 'transitive group label'))
             )
         wild = TextBox(
             name='wild_gap',
             label='Wild inertia subgroup',
-            knowl='lf.wild_inertia_group',
+            knowl='lf.wild_inertia_group_search',
             example='[4,1]',
-            example_span=display_knowl('group.small_group_label', "GAP id") + ' of a group like [3,1]'
+            example_span='a %s, e.g. [8,3] or [16,7], a group name from the %s, e.g. C5 or S12, or a %s, e.g., 7T2 or 11T5' % (
+                display_knowl('group.small_group_label', "GAP id"),
+                display_knowl('nf.galois_group.name', 'list of group labels'),
+                display_knowl('gg.label', 'transitive group label'))
             )
         results = CountBox()
 
-        self.browse_array = [[degree], [qp], [c], [e], [topslope], [u], [t], [gal], [results], [inertia],
-            [wild]]
-        self.refine_array = [[degree, c, gal, inertia, u], [qp, e, topslope, wild, t]]
+        self.browse_array = [[degree], [qp], [c], [e], [f], [topslope], [u], 
+            [t], [gal], [inertia], [wild], [results]]
+        self.refine_array = [[degree, qp, gal, u], 
+            [e, c, inertia, t], 
+            [f, topslope, wild]]
 
 def ramdisp(p):
     return {'cols': ['n', 'e'],

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -57,6 +57,7 @@
     <table>
       <tr><td>{{ KNOWL('nf.galois_group', title='Galois group')}}:</td><td>{{info.gal|safe}}</td></tr>
       <tr><td>{{ KNOWL('lf.inertia_group', title='Inertia group')}}:</td><td>{{info.inertia|safe}}</td></tr>
+      <tr><td>{{ KNOWL('lf.wild_inertia_group', title='Wild inertia group')}}:</td><td>{{info.wild_inertia|safe}}</td></tr>
       <tr><td>{{ KNOWL('lf.unramified_degree', title='Unramified degree')}}:</td><td>${{info.u}}$</td></tr>
       <tr><td>{{ KNOWL('lf.tame_degree', title='Tame degree')}}:</td><td>${{info.t}}$</td></tr>
       <tr><td>{{ KNOWL('lf.wild_slopes', title='Wild slopes')}}:</td><td>{{info.slopes}}</td></tr>

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -20,7 +20,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'debug', 'flash_error', 'flash_warning', 'flash_info',
            'ajax_url',
            'image_callback', 'encode_plot',
-           'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1', 'parse_rational', 'parse_rational_to_list',
+           'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1', 'parse_rational', 
+           'parse_rational_to_list', 'parse_inertia',
            'parse_rats', 'parse_bracketed_posints', 'parse_bracketed_rats', 'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of', 'parse_not_element_of',
            'parse_subset', 'parse_submultiset', 'parse_list',
@@ -68,7 +69,8 @@ from .utilities import (
     datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)
 
 from .search_parsing import (
-    parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, parse_rational_to_list, parse_rats,
+    parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, parse_rational_to_list, 
+    parse_rats, parse_inertia,
     parse_bracketed_posints, parse_bracketed_rats, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_not_element_of, parse_subset, parse_submultiset, parse_list,
     parse_list_start, parse_string_start, parse_restricted, parse_noop,


### PR DESCRIPTION
Addresses the rest of issue #4509 by allowing one to search by gap id for the inertia and wild inertia subgroups.

There are two new columns in the database for these two search options.  Currently there are no indexes for them, but it already works and they can be added.

We were not displaying the wild inertia group up to isomorphism before, so this is added to the field's home pages.

Some items to be improved upon later:

- there are currently two inertia subgroups with orders which are not indexed by magma, 1536 and 2430, so you cannot search for those groups
- there is one wild ramification group of order 512.  If someone wants to compute its gap id, we can add that information.  It is the Sylow 2-subgroup of 12T222 (a.k.a. (D_4)^3).  There are roughly 3 million groups to check with the same rank and p-class (gap id numbers 7532393 to 10481221).
- you can only search by gap id.  An improvement would be to allow searching by nickname, and by T-notation.  The latter opens questions though -- if someone asks for inertia subgroup in T-notation, do we include places where the group is right as an abstract group, but maybe naturally sits only as an intransitive subgroup for the given polynomial?

To test, just search on the local fields page.  An example where data is not computed for the wild ramification group is

  http://127.0.0.1:37777/padicField/2.12.29.1

In almost every other case, it is computed.

