### PR TITLE
avoid DeprecationWarning in Sage 9.3

### DIFF
--- a/lmfdb/logger/start.py
+++ b/lmfdb/logger/start.py
@@ -17,7 +17,7 @@ def logger_file_handler():
     # set by start_logging
     return file_handler
 
-LMFDB_SAGE_VERSION = '7.1'
+LMFDB_SAGE_VERSION = '9.2'
 def check_sage_version():
     if [int(c) for c in sage_version.split(".")[:2]] < [int(c) for c in LMFDB_SAGE_VERSION.split(".")[:2]]:
         warning("*** WARNING: SAGE VERSION %s IS OLDER THAN %s ***"%(sage_version,LMFDB_SAGE_VERSION))

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -129,7 +129,7 @@ def make_keys(K,p):
                 key_dict[P] = (P.norm(),e,i)
 
         # Lastly we add a field j to each key (n,e,i) -> (n,j,e,i)
-        # which is its index in the sublist with same n-value.  This
+        # which is its index in the sublist with the same n-value.  This
         # will not affect sorting but is used in the label n.j.
 
         vals = list(key_dict.values())
@@ -208,7 +208,13 @@ def primes_iter(K, condition=None, sort_key=prime_label, maxnorm=Infinity):
     # The set of possible degrees f of primes is the set of cycle
     # lengths in the Galois group acting as permutations on the roots
     # of the defining polynomial:
-    dlist = Set(sum([list(g.cycle_type()) for g in K.galois_group('gap').group()],[]))
+
+    from sage.version import version as sage_version
+    if [int(c) for c in sage_version.split(".")[:2]] < [9, 3]:
+        Kgal = K.galois_group('gap').group()
+    else:
+        Kgal = K.galois_group()
+    dlist = Set(sum([list(g.cycle_type()) for g in Kgal],[]))
 
     # Create an array of iterators, one for each residue degree
     PPs = [primes_of_degree_iter(K,d, condition, sort_key, maxnorm=maxnorm)  for d in dlist]

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -209,12 +209,7 @@ def primes_iter(K, condition=None, sort_key=prime_label, maxnorm=Infinity):
     # lengths in the Galois group acting as permutations on the roots
     # of the defining polynomial:
 
-    from sage.version import version as sage_version
-    if [int(c) for c in sage_version.split(".")[:2]] < [9, 3]:
-        Kgal = K.galois_group('gap').group()
-    else:
-        Kgal = K.galois_group()
-    dlist = Set(sum([list(g.cycle_type()) for g in Kgal],[]))
+    dlist = Set([1, 2]) if K.degree() == 2 else Set(sum([list(g.cycle_type()) for g in K.galois_group()],[]))
 
     # Create an array of iterators, one for each residue degree
     PPs = [primes_of_degree_iter(K,d, condition, sort_key, maxnorm=maxnorm)  for d in dlist]


### PR DESCRIPTION
I made a minor change in nfutils/psort so that the code works both with Sage versions <=9.2 and with 9.3: small change in interface to the galois_group mehotd for number fields.  See #4571.  

I also changed one line in logger/start which gives a warning if users start the website with a version of Sage which is "too old" -- that used to be 7.2 and is now 9.2.  This is probably redundant now that (almost?) no development happens outside legendre, but is surely harmless.