### PR TITLE
Improvements to storing table descriptions in meta_tables

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -343,11 +343,14 @@ def api_query(table, id = None):
         description = coll.description()
         if description:
             title += " (%s)" % description
-        schema = [(col, coll.col_type[col], coll.column_description(col)) for col in
-                  sorted(coll.search_cols) + sorted(coll.extra_cols)]
+        search_schema = [(col, coll.col_type[col], coll.column_description(col))
+                         for col in sorted(coll.search_cols)]
+        extra_schema = [(col, coll.col_type[col], coll.column_description(col))
+                        for col in sorted(coll.extra_cols)]
         return render_template("collection.html",
                                title=title,
-                               schema=schema,
+                               search_schema=search_schema,
+                               extra_schema=extra_schema,
                                single_object=single_object,
                                query_unquote = query_unquote,
                                url_args = url_args,

--- a/lmfdb/api/templates/collection.html
+++ b/lmfdb/api/templates/collection.html
@@ -4,13 +4,13 @@
 
 <script type="text/javascript">
   function show_schema() {
-    $("#schema-table").show();
+    $("div.schema-holder").show();
     $("#schema-hider").show();
     $("#schema-shower").hide();
     return false;
   }
   function hide_schema() {
-    $("#schema-table").hide();
+    $("div.schema-holder").hide();
     $("#schema-hider").hide();
     $("#schema-shower").show();
     return false;
@@ -18,7 +18,15 @@
 </script>
 
 <style>
-.api-entries > li { margin-bottom: 14px; }
+  .api-entries > li { margin-bottom: 14px; }
+  #schema-table {
+    width: 95%;
+  }
+  div.schema-holder {
+    height: 300px;
+    width: 97%;
+    overflow-y: scroll;
+  }
 </style>
 
 <div>
@@ -37,20 +45,31 @@ Query: <code><a href="{{ query }}">{{ query_unquote }}</a></code>
 <div>
   <a id="schema-shower" onclick="return show_schema();" href="#">Show schema</a>
   <a id="schema-hider" onclick="return hide_schema();" href="#" style="display: none;">Hide schema</a>
-  <table id="schema-table" class="ntdata" style="display: none;">
-    <tr>
-      <th>Column</th>
-      <th>Type</th>
-      <th>Description</th>
-    </tr>
-    {% for col, typ, desc in schema %}
+  <div class="schema-holder" style="display: none;">
+    <table id="schema-table" class="ntdata">
       <tr>
-        <td>{{col}}</td>
-        <td>{{typ}}</td>
-        <td>{{desc}}</td>
+        <th>Column</th>
+        <th>Type</th>
+        <th>Description</th>
       </tr>
-    {% endfor %}
-  </table>
+      {% for col, typ, desc in search_schema %}
+        <tr>
+          <td>{{col}}</td>
+          <td>{{typ}}</td>
+          <td style="white-space: normal; max-width: 600px;">{{desc}}</td>
+        </tr>
+      {% endfor %}
+      {% if extra_schema %}
+        {% for col, typ, desc in extra_schema %}
+          <tr{% if loop.index == 1 %} class="toplined"{% endif %}>
+            <td>{{col}}</td>
+            <td>{{typ}}</td>
+            <td style="white-space: normal; max-width: 600px;">{{desc}}</td>
+          </tr>
+        {% endfor %}
+      {% endif %}
+    </table>
+  </div>
 </div>
 
 {% if single_object %}

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 import traceback
+import itertools
 from collections import defaultdict, Counter
 from glob import glob
 
@@ -696,7 +697,14 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
             processed_extra_columns = process_columns(extra_columns, extra_order)
         else:
             processed_extra_columns = []
-        description_columns = [col for col in processed_search_columns + processed_extra_columns if col != 'id']
+        description_columns = []
+        for col in itertools.chain(search_columns.values(), [] if extra_columns is None else extra_columns.values()):
+            if col == 'id':
+                continue
+            if isinstance(col, str):
+                description_columns.append(col)
+            else:
+                description_columns.extend(col)
         if force_description:
             if table_description is None or col_description is None:
                 raise ValueError("You must provide table and column descriptions")

--- a/lmfdb/backend/database.py
+++ b/lmfdb/backend/database.py
@@ -205,8 +205,7 @@ class PostgresDatabase(PostgresBase):
 
         cur = self._execute(SQL(
             "SELECT name, label_col, sort, count_cutoff, id_ordered, out_of_order, "
-            "has_extras, stats_valid, total, include_nones, "
-            "table_description, col_description FROM meta_tables"
+            "has_extras, stats_valid, total, include_nones FROM meta_tables"
         ))
         self.tablenames = []
         for tabledata in cur:
@@ -529,8 +528,8 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
         else:
             extra_order = table.extra_cols
         label_col = table._label_col
-        table_description = table.table_description
-        col_description = table.col_description
+        table_description = table.description()
+        col_description = table.column_description()
         sort = table._sort_orig
         id_ordered = table._id_ordered
         search_order = table.search_cols
@@ -768,8 +767,6 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
             id_ordered=id_ordered,
             out_of_order=(not id_ordered),
             has_extras=(extra_columns is not None),
-            table_description=table_description,
-            col_description=col_description,
             total=0,
         )
         self.tablenames.append(name)
@@ -931,8 +928,7 @@ SELECT table_name, row_estimate, total_bytes, index_bytes, toast_bytes,
             tabledata = self._execute(
                 SQL(
                     "SELECT name, label_col, sort, count_cutoff, id_ordered, "
-                    "out_of_order, has_extras, stats_valid, total, include_nones, "
-                    "table_description, col_description "
+                    "out_of_order, has_extras, stats_valid, total, include_nones "
                     "FROM meta_tables WHERE name = %s"
                 ),
                 [new_name],

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -401,7 +401,7 @@ class LMFDBDatabase(PostgresDatabase):
             raise ValueError("Table name '%s' must contain an underscore; first part gives the LMFDB section" % name,)
         if "force_description" not in kwargs:
             kwargs["force_description"] = True
-        return PostgresDatabase.create_table(name, *args, **kwargs)
+        return PostgresDatabase.create_table(self, name, *args, **kwargs)
 
 
 db = LMFDBDatabase()

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -733,6 +733,9 @@ table.ntdata > thead {
 table.ntdata > thead > tr.bottomlined {
   border-bottom: 2px solid {{ color.table_ntdata_border }};
 }
+table.ntdata tr.toplined {
+  border-top: 2px solid {{ color.table_ntdata_border }};
+}
 
 table.ntdata th {
   text-align: left;


### PR DESCRIPTION
I fixed bugs in create_table_like and create_table, updated how descriptions are stored, and improved some front-end presentation of schemas in the API.

I've tested that `create_table_like` works.  For the front-end changes, check out the schema table in http://localhost:37777/api/ec_curves/ vs https://beta.lmfdb.org/api/ec_curves/


