### PR TITLE
BMFs and ECNFs: minor changes to show data for field 2.0.43.1

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -58,10 +58,10 @@ def index():
     """
     info = to_dict(request.args, search_array=BMFSearchArray(), stats=BianchiStats())
     if not request.args:
-        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11,19]]
-        sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [43,67,163,20]]
-        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11,19]]
-        sl2_names = gl2_names + [r"\(\Q(\sqrt{-%s})\)" % d for d in [43,67,163,5]]
+        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11,19,43]]
+        sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [67,163,20]]
+        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11,19,43]]
+        sl2_names = gl2_names + [r"\(\Q(\sqrt{-%s})\)" % d for d in [67,163,5]]
         info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -21,6 +21,11 @@ logger = make_logger("bmf")
 # Schembri.  At some point we will want to list these abelian surfaces
 # as friends when there is no curve.
 
+# TO (after adding 31 more for 2.0.43.1): make this list into a table,
+# OR add a column to the bmf_forms table to indicate whether or not a
+# curve exists (which could be because we have not foud one, but is
+# normally because there really is not curve).
+
 bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.4.1-34225.7-a',
                       '2.0.4.1-34225.3-b',
@@ -38,7 +43,38 @@ bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.3.1-123201.3-b',
                       '2.0.3.1-123201.3-c',
                       '2.0.19.1-1849.1-a',
-                      '2.0.19.1-1849.3-a']
+                      '2.0.19.1-1849.3-a',
+                      '2.0.43.1-121.1-a',
+                      '2.0.43.1-121.3-a',
+                      '2.0.43.1-256.1-c',
+                      '2.0.43.1-256.1-d',
+                      '2.0.43.1-256.1-e',
+                      '2.0.43.1-256.1-f',
+                      '2.0.43.1-529.1-a',
+                      '2.0.43.1-529.3-a',
+                      '2.0.43.1-961.1-a',
+                      '2.0.43.1-961.3-a',
+                      '2.0.43.1-1849.1-b',
+                      '2.0.43.1-1936.1-a',
+                      '2.0.43.1-1936.3-a',
+                      '2.0.43.1-2209.1-a',
+                      '2.0.43.1-2209.3-a',
+                      '2.0.43.1-3481.1-a',
+                      '2.0.43.1-3481.3-a',
+                      '2.0.43.1-4096.1-d',
+                      '2.0.43.1-4096.1-e',
+                      '2.0.43.1-4096.1-f',
+                      '2.0.43.1-4096.1-g',
+                      '2.0.43.1-4489.1-a',
+                      '2.0.43.1-4489.3-a',
+                      '2.0.43.1-6241.1-a',
+                      '2.0.43.1-6241.3-a',
+                      '2.0.43.1-6889.1-a',
+                      '2.0.43.1-6889.3-a',
+                      '2.0.43.1-8464.1-a',
+                      '2.0.43.1-8464.3-a',
+                      '2.0.43.1-9801.1-a',
+                      '2.0.43.1-9801.3-a']
 
 def cremona_label_to_lmfdb_label(lab):
     if "." in lab:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -185,7 +185,7 @@ def index():
                             for nf in rqfs)])
 
     # Imaginary quadratics (sample)
-    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11, 19]]
+    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11, 19, 43]]
     info['fields'].append(['By <a href="{}">imaginary quadratic field</a>'.format(url_for('.statistics_by_signature', d=2, r=0)),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in iqfs)])


### PR DESCRIPTION
See #4573.  This adds Q(sqrt(-43)) to the browse lists for BMF and ECNF now that the data for this field has been uploaded.  It also updates a hard-wired list of special BMFs to include 31 new exceptional ones.  (There is an interesting story behind these, which this PR is too narrow to include details of.)

Before this is pushed to production it would be better for the three tables bmf_forms, bmf_dims, ec_nfcurves to be copied over.  (Otherwise users may click on Q(sqrt(-43)) on a brows page and get no forms of curves -- nothing worse than that).

I will deal separately with the issue that, now that the list of BMFs with no curves is longer (49 so far after just adding 31 more), that information needs to be handled differently.  I will do that in due course.