### PR TITLE
Fix issue #4595 - bad latex toggle of a polynomial

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import
 from lmfdb.app import app
 import re
 from flask import render_template, url_for, request, redirect, abort
-from sage.all import gcd, euler_phi
+from sage.all import gcd, euler_phi, PolynomialRing, QQ
 from lmfdb.utils import (
     to_dict, flash_error, SearchArray, YesNoBox, display_knowl, ParityBox,
-    TextBox, CountBox, parse_bool, parse_ints, search_wrap,
+    TextBox, CountBox, parse_bool, parse_ints, search_wrap, raw_typeset,
     StatsDisplay, totaler, proportioners, comma, flash_warning)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.characters.utils import url_character
@@ -593,6 +593,9 @@ def dirichlet_group_table(**args):
     info['headers'] = h
     info['contents'] = c
     info['title'] = 'Group of Dirichlet characters'
+    if info['poly'] != '???':
+        info['poly'] = PolynomialRing(QQ, 'x')(info['poly'])
+        info['poly'] = raw_typeset(info['poly'])
     return render_template("CharacterGroupTable.html", **info)
 
 

--- a/lmfdb/characters/templates/CharacterGroupTable.html
+++ b/lmfdb/characters/templates/CharacterGroupTable.html
@@ -43,7 +43,7 @@
   Group table for the <a title="character group" knowl='character.dirichlet.group'>character group</a> for $\textrm{Gal}(K/\mathbb{Q})$
 </h2>
 <p>
-$K$ is the global number field defined by {{ poly }}
+$K$ is the global number field defined by {{ poly|safe }}
 
 <div>
 <table class="ntdata" id="chitable">

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -54,7 +54,7 @@ class DirichletSearchTest(LmfdbTest):
 class DirichletTableTest(LmfdbTest):
 
     def test_table(self):
-        get=r'modulus=35&poly=\%28+x^{6}+\%29+-+\%28+x^{5}+\%29+-+\%28+7+x^{4}+\%29+%2B+\%28+2+x^{3}+\%29+%2B+\%28+7+x^{2}+\%29+-+\%28+2+x+\%29+-+\%28+1+\%29&char_number_list=1%2C4%2C9%2C11%2C16%2C29'
+        get= r'modulus=35&poly=x%5E6+-+x%5E5+-+7%2Ax%5E4+%2B+2%2Ax%5E3+%2B+7%2Ax%5E2+-+2%2Ax+-+1&char_number_list=1%2C4%2C9%2C11%2C16%2C29'
         W = self.tc.get('/Character/Dirichlet/grouptable?%s'%get)
         assert '35 }(29' in W.get_data(as_text=True)
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -540,7 +540,7 @@ def render_field_webpage(args):
                                         modulus=int(conductor),
                                         char_number_list=','.join(
                                             str(a) for a in dirichlet_chars),
-                                        poly=info['polynomial'])))
+                                        poly=nf.poly())))
     resinfo = []
     galois_closure = nf.galois_closure()
     if galois_closure[0]>0:


### PR DESCRIPTION
We were getting raw html on a polynomial toggle on Dirichlet character group pages.  See

http://127.0.0.1:37777/Character/Dirichlet/grouptable?modulus=105&char_number_list=64%2C1%2C83%2C62&poly=x%5E4+-+x%5E3+%2B+26%2Ax%5E2+-+26%2Ax+%2B+151

http://beta.lmfdb.org/Character/Dirichlet/grouptable?modulus=105&char_number_list=64%2C1%2C83%2C62&poly=x%5E4+-+x%5E3+%2B+26%2Ax%5E2+-+26%2Ax+%2B+151