### PR TITLE
Search number fields by p-adic completions

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -36,7 +36,7 @@ def learnmore_list():
     return [('Source and acknowledgments', url_for(".source")),
             ('Completeness of the data', url_for(".cande")),
             ('Reliability of the data', url_for(".reliability")),
-            ('Local field labels', url_for(".labels_page"))]
+            ('$p$-adic field labels', url_for(".labels_page"))]
 
 # Return the learnmore list with the matchstring entry removed
 def learnmore_list_remove(matchstring):
@@ -321,6 +321,9 @@ def render_field_webpage(args):
             friends.append(('Unramified subfield', unramfriend))
         if rffriend != '':
             friends.append(('Discriminant root field', rffriend))
+        if db.nf_fields.exists({'local_algs': {'$contains': label}}):
+            friends.append(('Number fields with this completion', 
+                url_for('number_fields.number_field_render_webpage')+"?completions={}".format(label) ))
 
         bread = get_bread([(label, ' ')])
         return render_template(

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1081,6 +1081,12 @@ class NFSearchArray(SearchArray):
             example_span="2.2.5.1 or x^2-5 or a "+
                 display_knowl("nf.nickname", "field nickname"),
             example="x^2-5")
+        completion = TextBox(
+            name="completion",
+            label="$p$-adic completion",
+            knowl="nf.padic_completion",
+            example_span="2.4.10.7",
+            example="2.4.10.7")
         count = CountBox()
 
         self.browse_array = [
@@ -1091,9 +1097,9 @@ class NFSearchArray(SearchArray):
             [num_ram, cm_field],
             [ram_primes, ur_primes],
             [regulator, subfield],
-            [count]]
+            [count, completion]]
 
         self.refine_array = [
             [degree, signature, class_number, class_group, cm_field],
             [num_ram, ram_primes, ur_primes, gal, is_galois],
-            [discriminant, rd, regulator, subfield]]
+            [discriminant, rd, regulator, subfield, completion]]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1085,8 +1085,8 @@ class NFSearchArray(SearchArray):
         completion = TextBox(
             name="completions",
             label="$p$-adic completions",
-            knowl="nf.padic_completion",
-            example_span="2.4.10.7",
+            knowl="nf.padic_completion.search",
+            example_span="2.4.10.7 or 2.4.10.7,3.2.1.2",
             example="2.4.10.7")
         count = CountBox()
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -18,8 +18,8 @@ from lmfdb.utils import (
     SearchArray, TextBox, YesNoBox, SubsetNoExcludeBox, TextBoxWithSelect,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
-    parse_floats, parse_subfield, search_wrap, bigint_knowl, raw_typeset,
-    flash_info, input_string_to_poly)
+    parse_floats, parse_subfield, search_wrap, parse_padicfields, bigint_knowl, 
+    raw_typeset, flash_info, input_string_to_poly)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.galois_groups.transitive_group import (
     cclasses_display_knowl,character_table_display_knowl,
@@ -806,6 +806,7 @@ def number_field_search(info, query):
     parse_primes(info,query,'ram_primes',name='Ramified primes',
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad')
     parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
+    parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions')
     info['wnf'] = WebNumberField.from_data
     info['gg_display'] = group_pretty_and_nTj
 
@@ -1082,8 +1083,8 @@ class NFSearchArray(SearchArray):
                 display_knowl("nf.nickname", "field nickname"),
             example="x^2-5")
         completion = TextBox(
-            name="completion",
-            label="$p$-adic completion",
+            name="completions",
+            label="$p$-adic completions",
             knowl="nf.padic_completion",
             example_span="2.4.10.7",
             example="2.4.10.7")

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -20,7 +20,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'debug', 'flash_error', 'flash_warning', 'flash_info',
            'ajax_url',
            'image_callback', 'encode_plot',
-           'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1', 'parse_rational', 
+           'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1', 
+           'parse_rational', 'parse_padicfields',
            'parse_rational_to_list', 'parse_inertia',
            'parse_rats', 'parse_bracketed_posints', 'parse_bracketed_rats', 'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of', 'parse_not_element_of',
@@ -69,8 +70,8 @@ from .utilities import (
     datetime_to_timestamp_in_ms, timestamp_in_ms_to_datetime)
 
 from .search_parsing import (
-    parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, parse_rational_to_list, 
-    parse_rats, parse_inertia,
+    parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational, 
+    parse_rational_to_list, parse_padicfields, parse_rats, parse_inertia,
     parse_bracketed_posints, parse_bracketed_rats, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_not_element_of, parse_subset, parse_submultiset, parse_list,
     parse_list_start, parse_string_start, parse_restricted, parse_noop,

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -38,6 +38,7 @@ SIGNED_LIST_RE = re.compile(r'^(-?\d+|(-?\d+--?\d+))(,(-?\d+|(-?\d+--?\d+)))*$')
 FLOAT_RE = re.compile('^' + FLOAT_STR + '$')
 BRACKETING_RE = re.compile(r'(\[[^\]]*\])') # won't work for iterated brackets [[a,b],[c,d]]
 PREC_RE = re.compile(r'^-?((?:\d+(?:[.]\d*)?)|(?:[.]\d+))(?:e([-+]?\d+))?$')
+LF_LABEL_RE = re.compile(r'^\d+\.\d+\.\d+\.\d+$')
 
 import ast
 class PowMulNodeVisitor(ast.NodeTransformer):
@@ -925,6 +926,14 @@ def parse_inertia(inp, query, qfield, err_msg=None):
             raise SearchParsingError(err_msg)
         else:
             raise SearchParsingError("It needs to be a GAP id, such as [4,1] or [12,5], ia transitive group in nTj notation, such as 5T1, or a <a title = 'Group label' knowl='nf.galois_group.name'>group label</a>")
+
+@search_parser(clean_info=True, error_is_safe=True) # see SearchParser.__call__ for actual arguments when calling
+def parse_padicfields(inp, query, qfield):
+    labellist = inp.split(',')
+    for label in labellist:
+        if not LF_LABEL_RE.match(label):
+            raise SearchParsingError('It needs to be a <a title = "$p$-adic field label" knowl="lf.field.label">$p$-adic field label</a> or a list of local field labels')
+    query[qfield] = {'$contains': labellist}
 
 def input_string_to_poly(FF):
     # Change unicode dash with minus sign


### PR DESCRIPTION
This allows users to search for number fields based on p-adic completions (see main number field search page for testing) resolving issue #4537 .  As the knowl there explains, one can enter a single label of a p-adic field, or a list.  In the latter case, the fields in the search results will match all of p-adic fields listed (they can be for different p or some with the same p).

On the page for a p-adic field, if there are any number fields which have it as a completion, there is a friends link to search for them.  Any low degree p-adic field will have some.  An example where there is **no** friends link is

http://127.0.0.1:37777/padicField/19.15.14.2

The search parsing checks that the labels match the right general format, but does not check to see if they are labels of local fields in the database (if it is not in the database, the search results will be empty).

For the knowl for the number field search page, it currently uses

https://beta.lmfdb.org/knowledge/show/nf.place

but before noticing this, I wrote the more detailed

https://beta.lmfdb.org/knowledge/show/nf.padic_completion

We can switch it (which only involves editing a knowl), or delete the new knowl.