### PR TITLE
Search completions (part 2)

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -460,21 +460,25 @@ def render_field_webpage(args):
                 loc_alg += '<tr><td>%s<td colspan="7">Data not computed'%str(ram_primes[j]).rstrip('L')
             else:
                 from lmfdb.local_fields.main import show_slope_content
+                primefirstline=True
                 mydat = ramified_algebras_data[j]
                 p = ram_primes[j]
                 loc_alg += '<tr><td rowspan="%d">$%s$</td>'%(len(mydat),str(p))
-                mm = mydat[0]
-                myurl = url_for('local_fields.by_label', label=mm[0])
-                lab = mm[0]
-                if mm[3]*mm[2] == 1:
-                    lab = r'$\Q_{%s}$'%str(p)
-                loc_alg += '<td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
-                for mm in mydat[1:]:
-                    lab = mm[0]
-                    myurl = url_for('local_fields.by_label', label=lab)
-                    if mm[3]*mm[2] == 1:
-                        lab = r'$\Q_{%s}$'%str(p)
-                    loc_alg += '<tr><td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                print("**************")
+                print(mydat)
+                for mm in mydat:
+                    if not primefirstline:
+                        loc_alg += '<tr>'
+                        primefirstline=False
+                    if len(mm)==4:
+                        loc_alg += '<td><td>Deg {}<td>{}<td>{}<td>{}<td><td>'.format(
+                            mm[1]*mm[2], mm[1], mm[2], mm[3])
+                    else:
+                        lab = mm[0]
+                        myurl = url_for('local_fields.by_label', label=lab)
+                        if mm[3]*mm[2] == 1:
+                            lab = r'$\Q_{%s}$'%str(p)
+                        loc_alg += '<td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
         loc_alg += '</tbody></table>'
 
     ram_primes = str(ram_primes)[1:-1]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -457,7 +457,7 @@ def render_field_webpage(args):
         loc_alg = ''
         for j in range(npr):
             if ramified_algebras_data[j] is None:
-                loc_alg += '<tr><td>%s<td colspan="7">Data not computed'%str(ram_primes[j]).rstrip('L')
+                loc_alg += '<tr><td>$%s$<td colspan="7">Data not computed'%str(ram_primes[j]).rstrip('L')
             else:
                 from lmfdb.local_fields.main import show_slope_content
                 primefirstline=True
@@ -465,18 +465,20 @@ def render_field_webpage(args):
                 p = ram_primes[j]
                 loc_alg += '<tr><td rowspan="%d">$%s$</td>'%(len(mydat),str(p))
                 for mm in mydat:
-                    if not primefirstline:
-                        loc_alg += '<tr>'
+                    if primefirstline:
                         primefirstline=False
+                    else:
+                        loc_alg += '<tr>'
                     if len(mm)==4:
-                        loc_alg += '<td><td>Deg {}<td>{}<td>{}<td>{}<td><td>'.format(
+                        loc_alg += '<td></td><td>Deg {}</td><td>{}</td><td>{}</td><td>{}</td><td></td><td></td>'.format(
                             mm[1]*mm[2], mm[1], mm[2], mm[3])
                     else:
                         lab = mm[0]
                         myurl = url_for('local_fields.by_label', label=lab)
                         if mm[3]*mm[2] == 1:
                             lab = r'$\Q_{%s}$'%str(p)
-                        loc_alg += '<td><a href="%s">%s</a><td>$%s$<td>$%d$<td>$%d$<td>$%d$<td>%s<td>$%s$'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                        loc_alg += '<td><a href="%s">%s</a></td><td>$%s$</td><td>$%d$</td><td>$%d$</td><td>$%d$</td><td>%s</td><td>$%s$</td>'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+            loc_alg += '</tr>'
         loc_alg += '</tbody></table>'
 
     ram_primes = str(ram_primes)[1:-1]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -464,8 +464,6 @@ def render_field_webpage(args):
                 mydat = ramified_algebras_data[j]
                 p = ram_primes[j]
                 loc_alg += '<tr><td rowspan="%d">$%s$</td>'%(len(mydat),str(p))
-                print("**************")
-                print(mydat)
                 for mm in mydat:
                     if not primefirstline:
                         loc_alg += '<tr>'

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -457,7 +457,7 @@ def render_field_webpage(args):
         loc_alg = ''
         for j in range(npr):
             if ramified_algebras_data[j] is None:
-                loc_alg += '<tr><td>$%s$<td colspan="7">Data not computed'%str(ram_primes[j]).rstrip('L')
+                loc_alg += '<tr><td>$%s$</td><td colspan="7">Data not computed</td></tr>'%str(ram_primes[j]).rstrip('L')
             else:
                 from lmfdb.local_fields.main import show_slope_content
                 primefirstline=True
@@ -478,8 +478,8 @@ def render_field_webpage(args):
                         if mm[3]*mm[2] == 1:
                             lab = r'$\Q_{%s}$'%str(p)
                         loc_alg += '<td><a href="%s">%s</a></td><td>$%s$</td><td>$%d$</td><td>$%d$</td><td>$%d$</td><td>%s</td><td>$%s$</td>'%(myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
-            loc_alg += '</tr>'
-        loc_alg += '</tbody></table>'
+            loc_alg += '</tr>\n'
+        loc_alg += '</tbody></table>\n'
 
     ram_primes = str(ram_primes)[1:-1]
     # Get rid of python L for big numbers

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -879,8 +879,8 @@ class WebNumberField:
         for lab in local_algs:
             if lab[0] == 'm': # signals data about field not in lf db
                 lab1 = lab[1:] # deletes marker m
-                p, deg, c, e = [int(z) for z in lab1.split('.')]
-                f = deg/e
+                p, e, f, c = [int(z) for z in lab1.split('.')]
+                deg = e*f
                 if str(p) not in local_algebra_dict:
                     local_algebra_dict[str(p)] = [[deg,c,e,f]]
                 else:

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -882,9 +882,9 @@ class WebNumberField:
                 p, e, f, c = [int(z) for z in lab1.split('.')]
                 deg = e*f
                 if str(p) not in local_algebra_dict:
-                    local_algebra_dict[str(p)] = [[deg,c,e,f]]
+                    local_algebra_dict[str(p)] = [[deg,e,f,c]]
                 else:
-                    local_algebra_dict[str(p)].append([deg,c,e,f])
+                    local_algebra_dict[str(p)].append([deg,e,f,c])
             else:
                 LF = db.lf_fields.lookup(lab)
                 f = latex(R(LF['coeffs']))
@@ -897,34 +897,6 @@ class WebNumberField:
                 else:
                     local_algebra_dict[str(p)].append(thisdat)
         return local_algebra_dict
-
-        local_algebra_dict = self._data.get('loc_algebras', None)
-        if local_algebra_dict is None:
-            return None
-        if str(p) in local_algebra_dict:
-            R = PolynomialRing(QQ, 'x')
-            palg = local_algebra_dict[str(p)]
-            palgs = [R(str(s)) for s in palg.split(',')]
-            try:
-                palgstr = [
-                    list2string([int(c) for c in pol.coefficients(sparse=False)])
-                    for pol in palgs]
-                palgrec = [db.lf_fields.lucky({'p': p, 'coeffs': [int(cf) for cf in c.split(',')]}) for c in palgstr]
-                return [
-                    [
-                        LF['label'],
-                        latex(f),
-                        int(LF['e']),
-                        int(LF['f']),
-                        int(LF['c']),
-                        group_display_knowl(LF['n'], int(LF['galois_label'].split('T')[1])),
-                        LF['t'],
-                        LF['u'],
-                        LF['slopes']
-                    ]
-                    for LF, f in zip(palgrec, palgs) ]
-            except: # we were unable to find the local fields in the database
-                return None
 
     def ramified_algebras_data(self):
         if 'local_algs' not in self._data:


### PR DESCRIPTION
I decided on a format for the partial information for a completion.  There are only a couple of number fields where this data has been uploaded so most pages will look the same, but

  http://127.0.0.1:37777/NumberField/2.2.1641.1

shows an example of the partial data at a large prime (this page currently throws an error on beta).  The difference is for the local algebra of the large prime.

Fields which don't have the new data (almost every other one of the 21 million number field pages) will display the same.