### PR TITLE
delete extraneous bracket

### DIFF
--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -38,7 +38,7 @@
 </div>
 {{ place_code('jacobi') }}
 {% set value_default = 2 %}
-<form style="margin-left:10px;"> \( \chi_{ {{modulus}} }({{number}},a) )\;\)  at \(\;a = \)
+<form style="margin-left:10px;"> \( \chi_{ {{modulus}} }({{number}},a) \;\)  at \(\;a = \)
     <input id="calc-value-input" size=10 placeholder={{gauss_default}}>
     <button id="calc-value-go"> Compute </button>
     <span class="formexample"> e.g. {{value_default}} </span>


### PR DESCRIPTION
tiny copy-paste error for values of dirichlet characters
see https://beta.lmfdb.org/Character/Dirichlet/14/d/3 under values we have `χ14​(3,a))  at a = ` with two right parens