### PR TITLE
omit unknown base-change labels for ecnf

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -651,6 +651,7 @@ class ECNF(object):
             ('CM', self.cm_bool)]
 
         if self.base_change:
+            self.base_change = [lab for lab in self.base_change if '?' not in lab]
             self.properties += [('Base change', 'yes: %s' % ','.join([str(lab) for lab in self.base_change]))]
         else:
             self.base_change = []  # in case it was False instead of []

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -504,7 +504,7 @@ Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>   con
 <div>
 <p>
 This curve {% if ec.base_change %} is the
-{{KNOWL('ec.base_change','base change')}} of elliptic curves
+{{KNOWL('ec.base_change','base change')}} of
 {% for E0 in ec.base_change%}
 <a href={{url_for("ec.by_ec_label",label=E0)}}>{{E0}}</a>,
 {% endfor %}


### PR DESCRIPTION
Some of the curves just uploaded over 2.0.163.1 are base-change of a pair of curves over Q which are -163-twists of each other, where one of the pair has conductor too large to be in the EC/Q database, so does not have a complete label and cannot be linked to.  In the ec_nfcurves table these are stored with dummy labels of the form N.?.? where N is the large conductor.

This small change stops these non-labels being shown (with links which obviously do not work).  For example http://localhost:37777/EllipticCurve/2.0.163.1/576.1/a/5