### PR TITLE
Local algebra display tweaks

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -23,7 +23,7 @@ from lmfdb.utils import (
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.galois_groups.transitive_group import (
     cclasses_display_knowl,character_table_display_knowl,
-    group_phrase, galois_group_data,
+    group_phrase, galois_group_data, group_display_knowl,
     group_cclasses_knowl_guts, group_pretty_and_nTj,
     group_character_table_knowl_guts, group_alias_table)
 from lmfdb.number_fields import nf_page, nf_logger
@@ -470,8 +470,13 @@ def render_field_webpage(args):
                     else:
                         loc_alg += '<tr>'
                     if len(mm)==4:
-                        loc_alg += '<td></td><td>Deg {}</td><td>{}</td><td>{}</td><td>{}</td><td></td><td></td>'.format(
-                            mm[1]*mm[2], mm[1], mm[2], mm[3])
+                        if mm[1]*mm[2]==1:
+                            loc_alg += '<td>$\\Q_{%d}$</td><td>$x$</td><td>$1$</td><td>$1$</td><td>$0$</td><td>%s</td><td>$%s$</td>'%(p,group_display_knowl(1,1), show_slope_content([],1,1))
+                        elif mm[1]*mm[2]==2:
+                            loc_alg += '<td></td><td>Deg $2$</td><td>${}$</td><td>${}$</td><td>${}$</td><td>{}</td><td>${}$</td>'.format(mm[1],mm[2],mm[3],group_display_knowl(2,1), show_slope_content([],mm[1],mm[2]))
+                        else:
+                            loc_alg += '<td></td><td>Deg ${}$</td><td>${}$</td><td>${}$</td><td>${}$</td><td></td><td></td>'.format(
+                                mm[1]*mm[2], mm[1], mm[2], mm[3])
                     else:
                         lab = mm[0]
                         myurl = url_for('local_fields.by_label', label=lab)


### PR DESCRIPTION
Now that we show partial information about factors of local algebras on number field pages, there are places where we can easily display more information.  This adds that, and displays some numbers in that table in math mode for consistency (before, if we knew the local field, e, f, c were in math mode but not if we don't have the field).

http://127.0.0.1:37777/NumberField/6.2.873625.1
http://beta.lmfdb.org/NumberField/6.2.873625.1

shows a degree 1 factor, now labelled as Q_p, a ramified degree 2 factor with Galois group  and tame/unramified info, and a higher degree field with the current level of information

http://127.0.0.1:37777/NumberField/4.0.6025.1
http://beta.lmfdb.org/NumberField/4.0.6025.1

has two quadratic fields for a big prime, one ramified and one unramified to show that the tame/unramified info is displayed correctly.