### PR TITLE
Lmfdb#4583 download abvar

### DIFF
--- a/lmfdb/abvar/fq/download.py
+++ b/lmfdb/abvar/fq/download.py
@@ -1,0 +1,16 @@
+from lmfdb import db
+from lmfdb.utils import Downloader
+from lmfdb.backend.encoding import Json
+
+class AbvarFq_download(Downloader):
+    table = db.av_fq_isog
+    title = 'Abelian variety isogeny classes'
+
+    def download_all(self, label, lang='text'):
+        data = db.av_fq_isog.lookup(label)
+        if data is None:
+            return abort(404, "Label not found: %s"%label)
+        return self._wrap(Json.dumps(data),
+                          label,
+                          lang=lang,
+                          title='Stored data for abelian variety isogeny class %s,'%(label))

--- a/lmfdb/abvar/fq/download.py
+++ b/lmfdb/abvar/fq/download.py
@@ -1,5 +1,6 @@
 from lmfdb import db
 from lmfdb.utils import Downloader
+from flask import abort
 from lmfdb.backend.encoding import Json
 
 class AbvarFq_download(Downloader):
@@ -14,3 +15,10 @@ class AbvarFq_download(Downloader):
                           label,
                           lang=lang,
                           title='Stored data for abelian variety isogeny class %s,'%(label))
+
+    def download_curves(self, label, lang='text'):
+        data = db.av_fq_isog.lookup(label)
+        return self._wrap('\n'.join(data['curves']),
+                          label + '.curves',
+                          lang=lang,
+                          title='Curves in abelian variety isogeny class %s,'%(label))

--- a/lmfdb/abvar/fq/download.py
+++ b/lmfdb/abvar/fq/download.py
@@ -18,6 +18,10 @@ class AbvarFq_download(Downloader):
 
     def download_curves(self, label, lang='text'):
         data = db.av_fq_isog.lookup(label)
+        if data is None:
+            return abort(404, "Label not found: %s"%label)
+        if not 'curves' in data or ('curves' in data and not data['curves']):
+            return abort(404, "No curves for abelian variety isogeny class %s"%label)
         return self._wrap('\n'.join(data['curves']),
                           label + '.curves',
                           lang=lang,

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -23,6 +23,7 @@ from .search_parsing import parse_newton_polygon, parse_nf_string, parse_galgrp
 from .isog_class import validate_label, AbvarFq_isoclass
 from .stats import AbvarFqStats
 from lmfdb.utils import redirect_no_cache
+from lmfdb.abvar.fq.download import AbvarFq_download
 
 logger = make_logger("abvarfq")
 
@@ -50,6 +51,16 @@ def learnmore_list():
 # Return the learnmore list with the matchstring entry removed
 def learnmore_list_remove(matchstring):
     return [t for t in learnmore_list() if t[0].find(matchstring) < 0]
+
+
+#########################
+#    Downloads
+#########################
+
+@abvarfq_page.route("/download_all/<label>")
+def download_all(label):
+    return AbvarFq_download().download_all(label)
+
 
 #########################
 #  Search/navigate
@@ -108,9 +119,14 @@ def abelian_varieties_by_gqi(g, q, iso):
         (iso, url_for(".abelian_varieties_by_gqi", g=g, q=q, iso=iso))
     )
 
+    downloads = [
+        ('All stored data to text', url_for('.download_all', label=label))
+    ]
+
     return render_template(
         "show-abvarfq.html",
         properties=cl.properties(),
+        downloads=downloads,
         title='Abelian variety isogeny class %s over $%s$'%(label, cl.field()),
         bread=bread,
         cl=cl,

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -61,6 +61,10 @@ def learnmore_list_remove(matchstring):
 def download_all(label):
     return AbvarFq_download().download_all(label)
 
+@abvarfq_page.route("/download_curves/<label>")
+def download_curves(label):
+    return AbvarFq_download().download_curves(label)
+
 
 #########################
 #  Search/navigate
@@ -122,6 +126,9 @@ def abelian_varieties_by_gqi(g, q, iso):
     downloads = [
         ('All stored data to text', url_for('.download_all', label=label))
     ]
+
+    if hasattr(cl, "curves") and cl.curves:
+        downloads.append(('Curves to text', url_for('.download_curves', label=label)))
 
     return render_template(
         "show-abvarfq.html",

--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -126,3 +126,14 @@ class AVTest(LmfdbTest):
         response = self.tc.get("Variety/Abelian/Fq/5/2/?Submit=magma&download=1&query=%7B%27q%27%3A+2%2C+%27g%27%3A+5%7D")
         self.assertTrue("Below is a list" in response.get_data(as_text=True))
         self.assertTrue("32*x^10" in response.get_data(as_text=True))
+
+    def test_download_all(self):
+        r"""
+        Test downloading all stored data to text
+        """
+
+        page = self.tc.get('Variety/Abelian/Fq/download_all/1.81.r', follow_redirects=True)
+        assert '"abvar_counts": [64, 6400, 529984, 43033600,' in page.get_data(as_text=True)
+
+        page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
+        assert '"curve_counts": [21, 283, 4719, 84395' in page.get_data(as_text=True)

--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -137,3 +137,20 @@ class AVTest(LmfdbTest):
 
         page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
         assert '"curve_counts": [21, 283, 4719, 84395' in page.get_data(as_text=True)
+
+    def test_download_curves(self):
+        r"""
+        Test downloading all stored data to text
+        """
+
+        page = self.tc.get('Variety/Abelian/Fq/2.19.ae_w', follow_redirects=True)
+        assert 'Curves to text' in page.get_data(as_text=True)
+
+        page = self.tc.get('Variety/Abelian/Fq/download_curves/2.19.ae_w', follow_redirects=True)
+        assert 'y^2=3*x^6+18*x^5+15*x^4+12*x^3+x^2+5*x+18' in page.get_data(as_text=True)
+
+        page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
+        assert not 'Curves to text' in page.get_data(as_text=True)
+
+        page = self.tc.get('Variety/Abelian/Fq/download_curves/3.17.d_b_act', follow_redirects=True)
+        assert 'No curves for abelian variety isogeny class 3.17.d_b_act' in page.get_data(as_text=True)

--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -133,7 +133,7 @@ class AVTest(LmfdbTest):
         """
 
         page = self.tc.get('Variety/Abelian/Fq/download_all/1.81.r', follow_redirects=True)
-        assert '"abvar_counts": [64, 6400, 529984, 43033600,' in page.get_data(as_text=True)
+        assert '"abvar_counts": [99, 6435, 532224, 43043715,' in page.get_data(as_text=True)
 
         page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
         assert '"curve_counts": [21, 283, 4719, 84395' in page.get_data(as_text=True)
@@ -149,7 +149,7 @@ class AVTest(LmfdbTest):
         page = self.tc.get('Variety/Abelian/Fq/download_curves/2.19.ae_w', follow_redirects=True)
         assert 'y^2=3*x^6+18*x^5+15*x^4+12*x^3+x^2+5*x+18' in page.get_data(as_text=True)
 
-        page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
+        page = self.tc.get('Variety/Abelian/Fq/3.17.d_b_act', follow_redirects=True)
         assert not 'Curves to text' in page.get_data(as_text=True)
 
         page = self.tc.get('Variety/Abelian/Fq/download_curves/3.17.d_b_act', follow_redirects=True)


### PR DESCRIPTION
This PR adds two download options to Abelian varieties over finite fields:

1. All stored data to text;
2. Curves to text (if curves exist)

This addresses #4583 ; functionality live on [pink](https://pink.lmfdb.xyz/Variety/Abelian/Fq/2/19/ae_w)

Opening as draft until tests pass.