### PR TITLE
Add cyclic groups for unramified extensions

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -469,11 +469,15 @@ def render_field_webpage(args):
                         primefirstline=False
                     else:
                         loc_alg += '<tr>'
-                    if len(mm)==4:
-                        if mm[1]*mm[2]==1:
+                    if len(mm)==4:         # not in database
+                        if mm[1]*mm[2]==1: # Q_p
                             loc_alg += '<td>$\\Q_{%d}$</td><td>$x$</td><td>$1$</td><td>$1$</td><td>$0$</td><td>%s</td><td>$%s$</td>'%(p,group_display_knowl(1,1), show_slope_content([],1,1))
-                        elif mm[1]*mm[2]==2:
+                        elif mm[1]*mm[2]==2: # quadratic
                             loc_alg += '<td></td><td>Deg $2$</td><td>${}$</td><td>${}$</td><td>${}$</td><td>{}</td><td>${}$</td>'.format(mm[1],mm[2],mm[3],group_display_knowl(2,1), show_slope_content([],mm[1],mm[2]))
+                        elif mm[1]==1: # unramified
+                            # nT1 is cyclic except for n = 32
+                            cyc = 33 if mm[2] == 32 else 1
+                            loc_alg += '<td></td><td>Deg ${}$</td><td>${}$</td><td>${}$</td><td>${}$</td><td>{}</td><td>${}$</td>'.format(mm[1]*mm[2],mm[1],mm[2],mm[3],group_display_knowl(mm[2],cyc), show_slope_content([],mm[1],mm[2]))
                         else:
                             loc_alg += '<td></td><td>Deg ${}$</td><td>${}$</td><td>${}$</td><td>${}$</td><td></td><td></td>'.format(
                                 mm[1]*mm[2], mm[1], mm[2], mm[3])


### PR DESCRIPTION
This follows the suggestion in #4663 to show the Galois group and tame/unramified information for unramified entries of the local algebras as can be seen on

  http://127.0.0.1:37777/NumberField/42.0.148800059914663860358058572923291111558062081238577126241568395062423.1

