### PR TITLE
Make counts show up on the empty query

### DIFF
--- a/lmfdb/backend/statstable.py
+++ b/lmfdb/backend/statstable.py
@@ -270,6 +270,8 @@ class PostgresStatsTable(PostgresBase):
 
         Either an integer giving the number of results, or None if not cached.
         """
+        if not query:
+            return self.total
         cols, vals = self._split_dict(query)
         selecter = SQL(
             "SELECT count FROM {0} WHERE cols = %s AND values = %s AND split = %s"
@@ -364,8 +366,6 @@ class PostgresStatsTable(PostgresBase):
             244006
         """
         if groupby is None:
-            if not query:
-                return self.total
             nres = self.quick_count(query)
             if nres is None:
                 nres = self._slow_count(query, record=record)


### PR DESCRIPTION
As noted in #4591, we don't currently show the count when doing an [empty search](https://beta.lmfdb.org/Genus2Curve/Q/?search_type=List&all=1).   I'm not sure how this regression happened, but this change should fix it.  See http://localhost:37777/Genus2Curve/Q/?search_type=List