### PR TITLE
Belyi download fix

### DIFF
--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -460,6 +460,8 @@ class Belyi_download(Downloader):
         s = ""
         #rec = db.belyi_galmaps.lookup(label)
         rec = db.belyi_galmaps_prim.lookup(label)
+        if rec is None:
+            return abort(404, "Label not found: %s" % label)
         s += "// Magma code for Belyi map with label %s\n\n" % label
         s += "\n// Group theoretic data\n\n"
         s += "d := %s;\n" % rec["deg"]
@@ -502,6 +504,8 @@ class Belyi_download(Downloader):
         s = ""
         #rec = db.belyi_galmaps.lookup(label)
         rec = db.belyi_galmaps_prim.lookup(label)
+        if rec is None:
+            return abort(404, "Label not found: %s" % label)
         s += "# Sage code for Belyi map with label %s\n\n" % label
         s += "\n# Group theoretic data\n\n"
         s += "d = %s\n" % rec["deg"]
@@ -550,9 +554,11 @@ class Belyi_download(Downloader):
     def download_galmap_text(self, label, lang="text"):
         #data = db.belyi_galmaps.lookup(label)
         data = db.belyi_galmaps_prim.lookup(label)
+        if rec is None:
+            return abort(404, "Label not found: %s" % label)
         return self._wrap(Json.dumps(data),
-        label,
-        title='Data for embedded Belyi map with label %s,'%label)
+                          label,
+                          title='Data for embedded Belyi map with label %s,'%label)
 
 
 @belyi_page.route("/download_galmap_to_magma/<label>")

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -554,7 +554,7 @@ class Belyi_download(Downloader):
     def download_galmap_text(self, label, lang="text"):
         #data = db.belyi_galmaps.lookup(label)
         data = db.belyi_galmaps_prim.lookup(label)
-        if rec is None:
+        if data is None:
             return abort(404, "Label not found: %s" % label)
         return self._wrap(Json.dumps(data),
                           label,


### PR DESCRIPTION
Fixes errors like this:
```
Exception on /Belyi/download_galmap_to_sage/7T3-7_3.3.1_3.3.1-a.sage [GET]
Traceback (most recent call last):
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.2/local/lib/python3.6/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/lmfdb/lmfdb-git-dev/lmfdb/belyi/main.py", line 564, in belyi_galmap_sage_download
    return Belyi_download().download_galmap_sage(label)
  File "/home/lmfdb/lmfdb-git-dev/lmfdb/belyi/main.py", line 507, in download_galmap_sage
    s += "d = %s\n" % rec["deg"]
TypeError: 'NoneType' object is not subscriptable
[2021-07-12 21:18:49 UTC] 500 error on URL https://beta.lmfdb.org/Belyi/download_galmap_to_sage/7T3-7_3.3.1_3.3.1-a.sage
```