### PR TITLE
Fix broken link on EC isogeny class page

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -94,10 +94,9 @@ class ECisog_class(object):
             for c in self.curves:
                 c['optimal'] = None
                 c['optimality_known'] = False
-                
         for c in self.curves:
             c['ai'] = c['ainvs']
-            c['curve_url_lmfdb'] = url_for(".by_triple_label", conductor=self.conductor, iso_label=self.iso_label, number=c['lmfdb_number'])
+            c['curve_url_lmfdb'] = url_for(".by_ec_label", label=c['lmfdb_label'])
             c['curve_url_cremona'] = url_for(".by_ec_label", label=c['Clabel']) if self.conductor < CREMONA_BOUND else "N/A"
             if self.label_type == 'Cremona':
                 c['curve_label'] = c['Clabel']


### PR DESCRIPTION
Compare the links in the LMFDB label column between [beta](http://beta.lmfdb.org/EllipticCurve/Q/5445g/) and [localhost](http://localhost:37777/EllipticCurve/Q/5445g/).