### PR TITLE
enabling resort

### DIFF
--- a/lmfdb/backend/base.py
+++ b/lmfdb/backend/base.py
@@ -460,7 +460,7 @@ class PostgresBase(object):
         return [
             (locktype, pid)
             for (name, locktype, pid, t) in self._get_locks()
-            if name == tablename and (types == "all" or locktype in types)
+            if name == tablename and (types == "all" or locktype in types) and pid != self.conn.info.backend_pid
         ]
 
     def _index_exists(self, indexname, tablename=None):
@@ -1156,9 +1156,9 @@ class PostgresBase(object):
             for line in lines:
                 if line[table_name_idx] != search_table:
                     raise RuntimeError(
-                        "in %s column %d (= %s) in the file "
-                        "doesn't match the search table name %s"
-                        % (filename, table_name_idx, line[table_name_idx], search_table)
+                        f"column {table_name_idx} (= {line[table_name_idx]}) "
+                        f"in the file {filename} doesn't match "
+                        f"the search table name {search_table}"
                     )
 
         with DelayCommit(self, silence=True):

--- a/lmfdb/backend/searchtable.py
+++ b/lmfdb/backend/searchtable.py
@@ -412,8 +412,11 @@ class PostgresSearchTable(PostgresTable):
                     has_sort = False
                     raw = []
             elif self._primary_sort in query or self._out_of_order:
-                # We use the actual sort because the postgres query planner doesn't know that
+                # The first precedence is a hack to prevent sequential scans
+                # Thus, we use the actual sort because the postgres query planner doesn't know that
                 # the primary key is connected to the id.
+                #
+                # Also, if id_ordered = False, then out_of_order = False
                 sort = self._sort
                 raw = self._sort_orig
             else:


### PR DESCRIPTION
This enables resort, a function that has been disabled since the beginning.
This should help us to keep the tables sorted, and thus speed up most queries.

```
sage: db.test_xyz.set_sort(['bar']) # triggers resort
Dropped primary key on test_xyz in 0.029 secs
Built primary key on test_xyz in 0.222 secs
Resorted test_xyz in 1.792 secs

sage: list(db.test_xyz.search({}, sort=['id'], limit=10))
[{'col1': 'abc_98293', 'col2': 'abc_98293', 'foo': 4898, 'bar': 2},
 {'col1': 'abc_20930', 'col2': 'abc_20930', 'foo': 3266, 'bar': 3},
 {'col1': 'abc_74189', 'col2': 'abc_74189', 'foo': 1455, 'bar': 17},
 {'col1': 'abc_46639', 'col2': 'abc_46639', 'foo': 5488, 'bar': 36},
 {'col1': 'abc_82210', 'col2': 'abc_82210', 'foo': 1507, 'bar': 56},
 {'col1': 'abc_66230', 'col2': 'abc_66230', 'foo': 9372, 'bar': 57},
 {'col1': 'abc_42557', 'col2': 'abc_42557', 'foo': 1326, 'bar': 66},
 {'col1': 'abc_11724', 'col2': 'abc_11724', 'foo': 1635, 'bar': 83},
 {'col1': 'abc_98421', 'col2': 'abc_98421', 'foo': 8462, 'bar': 88},
 {'col1': 'abc_14786', 'col2': 'abc_14786', 'foo': 9264, 'bar': 99}]

sage: db.test_xyz.set_sort(['foo', 'bar']) # triggers resort
Index test_xyz_foo_bar created in 0.125 secs
Dropped primary key on test_xyz in 0.028 secs
Built primary key on test_xyz in 0.194 secs
Resorted test_xyz in 1.614 secs

sage: list(db.test_xyz.search({}, sort=['id'], limit=10))
[{'col1': 'abc_49128', 'col2': 'abc_49128', 'foo': 0, 'bar': 358313},
 {'col1': 'abc_82752', 'col2': 'abc_82752', 'foo': 0, 'bar': 614057},
 {'col1': 'abc_54330', 'col2': 'abc_54330', 'foo': 0, 'bar': 659923},
 {'col1': 'abc_27591', 'col2': 'abc_27591', 'foo': 1, 'bar': 163633},
 {'col1': 'abc_6849', 'col2': 'abc_6849', 'foo': 1, 'bar': 306840},
 {'col1': 'abc_23506', 'col2': 'abc_23506', 'foo': 1, 'bar': 356465},
 {'col1': 'abc_59972', 'col2': 'abc_59972', 'foo': 1, 'bar': 372017},
 {'col1': 'abc_91483', 'col2': 'abc_91483', 'foo': 1, 'bar': 423075},
 {'col1': 'abc_1662', 'col2': 'abc_1662', 'foo': 1, 'bar': 453063},
 {'col1': 'abc_68451', 'col2': 'abc_68451', 'foo': 1, 'bar': 470606}]
 ```
