### PR TITLE
Initial conference page for LuCaNT

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -372,6 +372,11 @@ def workshops():
     bread = [("Acknowledgments" , url_for('.acknowledgment')) , ("Activities", '')]
     return render_template("workshops.html", title="LMFDB Activities", contribs=contribs, bread=bread)
 
+@app.route("/LuCaNT")
+def lucant():
+    bread = [("LuCaNT" , '')]
+    return render_template("lucant.html", title="LMFDB, Computation, and Number Theory (LuCaNT)", contribs=contribs, bread=bread)
+
 # google's CSE for www.lmfdb.org/* (and *only* those pages!)
 @app.route("/search")
 def search():
@@ -691,6 +696,7 @@ WhiteListedRoutes = [
     'L/tracehash',
     'L/download',
     'LocalNumberField',
+    'LuCaNT',
     'ModularForm/GL2/ImaginaryQuadratic',
     'ModularForm/GL2/Q/Maass',
     'ModularForm/GL2/Q/holomorphic',

--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -1,7 +1,7 @@
 ---
 title: A database
 image: families
-content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date&#58; <a href="/LuCaNT">LuCaNT 2023</a></p>
+content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p><b>Save the date</b>&#58; <a href="/LuCaNT">LuCaNT 2023</a></p>
 control: 1
 links:
   - [ 0,0 ]

--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -1,7 +1,7 @@
 ---
 title: A database
 image: families
-content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p>
+content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date: <a href="/LuCaNT">LuCaNT 2023</a></p>
 control: 1
 links:
   - [ 0,0 ]

--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -1,7 +1,7 @@
 ---
 title: A database
 image: families
-content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date: <a href="/LuCaNT">LuCaNT 2023</a></p>
+content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date for <a href="/LuCaNT">LuCaNT 2023</a></p>
 control: 1
 links:
   - [ 0,0 ]

--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -1,7 +1,7 @@
 ---
 title: A database
 image: families
-content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date for <a href="/LuCaNT">LuCaNT 2023</a></p>
+content: <p>The LMFDB is an extensive database of mathematical objects arising in Number Theory.</p><p>Sample lists&#58; <a href="/L/?degree=2">L-functions,</a> <a href="/EllipticCurve/Q/?conductor=1-99">Elliptic curves,</a> <a href="/zeros">Tables of zeros,</a>  <a href="/NumberField/?degree=2">Number fields</a></p><p>Save the date&#58; <a href="/LuCaNT">LuCaNT 2023</a></p>
 control: 1
 links:
   - [ 0,0 ]

--- a/lmfdb/templates/lucant.html
+++ b/lmfdb/templates/lucant.html
@@ -1,0 +1,6 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+{{KNOWL_INC('lucant.')}}
+
+{% endblock %}

--- a/lmfdb/templates/lucant.html
+++ b/lmfdb/templates/lucant.html
@@ -1,6 +1,6 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-{{KNOWL_INC('lucant.')}}
+{{KNOWL_INC('lucant')}}
 
 {% endblock %}


### PR DESCRIPTION
This PR adds a homepage for the LMFDB, Computation, and Number Theory (LuCaNT) conference being planned for 2023, along with a "save the date" link on the front page.  The content of the page is contained in the knowl  https://beta.lmfdb.org/knowledge/show/lucant.