### PR TITLE
Lmfdb#4587 squarefree av search

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -375,11 +375,11 @@ class AbvarSearchArray(SearchArray):
             knowl="av.geometrically_simple",
             short_label="Geom. simple",
         )
-        geom_decomp = SelectBox(
-            name="geom_decomp",
+        geom_squarefree = SelectBox(
+            name="geom_squarefree",
             knowl="av.geometrically_squarefree",
-            label="(Geometric) Decomposition",
-            short_label="(Geom.) Decomp.",
+            label="(Geometrically) Squarefree",
+            short_label="(Geom.) Sq.free",
             options=[('', ''),
             ('Yes', 'yes'),
             ('YesAndGeom', 'yes; and geom.'),
@@ -505,7 +505,7 @@ class AbvarSearchArray(SearchArray):
             [simple, geom_simple, primitive, polarizable, jacobian],
             [newton_polygon, abvar_point_count, curve_point_count, simple_factors],
             [angle_rank, jac_cnt, hyp_cnt, twist_count, max_twist_degree],
-            [geom_deg, p_rank_deficit, geom_decomp],
+            [geom_deg, p_rank_deficit, geom_squarefree],
             use_geom_refine,
             [dim1, dim2, dim3, dim4, dim5],
             [dim1d, dim2d, dim3d, number_field, galois_group],
@@ -516,7 +516,7 @@ class AbvarSearchArray(SearchArray):
             [g, geom_simple],
             [initial_coefficients, polarizable],
             [p_rank, jacobian],
-            [p_rank_deficit, geom_decomp],
+            [p_rank_deficit, geom_squarefree],
             [jac_cnt, hyp_cnt],
             [geom_deg, angle_rank],
             [twist_count, max_twist_degree],
@@ -582,22 +582,22 @@ def common_parse(info, query):
     parse_nf_string(info, query, "number_field", qfield=nf_qfield)
     parse_galgrp(info, query, "galois_group", qfield=gal_qfield)
 
-    if 'geom_decomp' in info:
-        if info['geom_decomp'] == 'Yes':
+    if 'geom_squarefree' in info:
+        if info['geom_squarefree'] == 'Yes':
             query['is_squarefree'] = True
 
-        elif info['geom_decomp'] == 'YesAndGeom':
+        elif info['geom_squarefree'] == 'YesAndGeom':
             query['is_squarefree'] = True
             query['is_geometrically_squarefree'] = True
 
-        elif info['geom_decomp'] == 'YesNotGeom':
+        elif info['geom_squarefree'] == 'YesNotGeom':
             query['is_squarefree'] = True
             query['is_geometrically_squarefree'] = False
 
-        elif info['geom_decomp'] == 'No':
+        elif info['geom_squarefree'] == 'No':
             query['is_squarefree'] = False
 
-        elif info['geom_decomp'] == 'NotGeom':
+        elif info['geom_squarefree'] == 'NotGeom':
             query['is_geometrically_squarefree'] = False
 
 def jump(info):

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -204,7 +204,7 @@ class AbvarSearchArray(SearchArray):
     jump_knowl = "av.fq.search_input"
     jump_prompt = "Label or polynomial"
     def __init__(self):
-        qshort = display_knowl("ag.base_field", "base field")
+        qshort = display_knowl("ag.base_field", "Base field")
         q = TextBox(
             "q",
             label="Cardinality of the %s" % (qshort),
@@ -238,7 +238,6 @@ class AbvarSearchArray(SearchArray):
             label="$p$-rank deficit",
             knowl="av.fq.p_rank",
             example="2",
-            advanced=True,
         )
         angle_rank = TextBox(
             "angle_rank",
@@ -246,7 +245,6 @@ class AbvarSearchArray(SearchArray):
             knowl="av.fq.angle_rank",
             example="3",
             example_col=False,
-            advanced=True,
         )
         newton_polygon = TextBox(
             "newton_polygon",
@@ -375,6 +373,18 @@ class AbvarSearchArray(SearchArray):
             knowl="av.geometrically_simple",
             short_label="Geom. simple",
         )
+        squarefree = YesNoBox(
+            "squarefree",
+            label="Squarefree",
+            knowl="av.squarefree",
+            short_label="Squarefree",
+        )
+        geom_squarefree = YesNoBox(
+            "geom_squarefree",
+            label="Geometrically squarefree",
+            knowl="av.geometrically_squarefree",
+            short_label="Geom. squarefree",
+        )
         primitive = YesNoBox(
             "primitive",
             label="Primitive",
@@ -384,7 +394,7 @@ class AbvarSearchArray(SearchArray):
             "polarizable",
             label="Principally polarizable",
             knowl="av.princ_polarizable",
-            short_label="Princ polarizable",
+            short_label="Princ. polarizable",
         )
         jacobian = YesNoMaybeBox(
             "jacobian",
@@ -488,12 +498,13 @@ class AbvarSearchArray(SearchArray):
         count = CountBox()
 
         self.refine_array = [
-            [q, p, g, p_rank, initial_coefficients],
+            [q, p, g, p_rank, p_rank_deficit, initial_coefficients, angle_rank],
+            [simple, geom_simple, primitive, polarizable, jacobian, squarefree, geom_squarefree],
             [newton_polygon, abvar_point_count, curve_point_count, simple_factors],
-            [angle_rank, jac_cnt, hyp_cnt, twist_count, max_twist_degree],
-            [geom_deg, p_rank_deficit],
+            [geom_deg, jac_cnt, hyp_cnt, twist_count, max_twist_degree],
             #[size],
-            [simple, geom_simple, primitive, polarizable, jacobian],
+            # [simple, geom_simple, primitive, polarizable, jacobian, squarefree, geom_squarefree],
+            # [squarefree, geom_squarefree],
             use_geom_refine,
             [dim1, dim2, dim3, dim4, dim5],
             [dim1d, dim2d, dim3d, number_field, galois_group],
@@ -503,10 +514,11 @@ class AbvarSearchArray(SearchArray):
             [p, simple],
             [g, geom_simple],
             [initial_coefficients, polarizable],
-            [p_rank, jacobian],
-            [p_rank_deficit],
+            [angle_rank, jacobian],
+            [p_rank, squarefree],
+            [p_rank_deficit, geom_squarefree],
             [jac_cnt, hyp_cnt],
-            [geom_deg, angle_rank],
+            [geom_deg],
             [twist_count, max_twist_degree],
             [newton_polygon],
             [abvar_point_count],
@@ -536,6 +548,8 @@ def common_parse(info, query):
     parse_ints(info, query, "geom_deg", qfield="geometric_extension_degree")
     parse_bool(info, query, "simple", qfield="is_simple")
     parse_bool(info, query, "geom_simple", qfield="is_geometrically_simple")
+    parse_bool(info, query, "squarefree", qfield="is_squarefree")
+    parse_bool(info, query, "geom_squarefree", qfield="is_geometrically_squarefree")
     parse_bool(info, query, "primitive", qfield="is_primitive")
     parse_bool_unknown(info, query, "jacobian", qfield="has_jacobian")
     parse_bool_unknown(info, query, "polarizable", qfield="has_principal_polarization")

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -110,7 +110,6 @@ class AVHomeTest(LmfdbTest):
 
         # search for squarefree but not geometrically squarefree
         self.check_args("/Variety/Abelian/Fq/?geom_squarefree=YesNotGeom", "2.2.ad_f")
-        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=YesNotGeom", "1.2.ac")
 
         # search for non squarefree
         self.check_args("/Variety/Abelian/Fq/?geom_squarefree=No", "2.2.ae_i")
@@ -118,7 +117,6 @@ class AVHomeTest(LmfdbTest):
 
         # search for not geometrically squarefree
         self.check_args("/Variety/Abelian/Fq/?geom_squarefree=NotGeom", "2.2.ae_i")
-        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=NotGeom", "1.4.ac")
 
     def test_primitive_search(self):
         r"""

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -113,7 +113,7 @@ class AVHomeTest(LmfdbTest):
 
         # search for non squarefree
         self.check_args("/Variety/Abelian/Fq/?geom_squarefree=No", "2.2.ae_i")
-        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=No", "1.3.ab")
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=No&g=1", "No matches")
 
         # search for not geometrically squarefree
         self.check_args("/Variety/Abelian/Fq/?geom_squarefree=NotGeom", "2.2.ae_i")

--- a/lmfdb/abvar/fq/test_browse_page.py
+++ b/lmfdb/abvar/fq/test_browse_page.py
@@ -91,13 +91,34 @@ class AVHomeTest(LmfdbTest):
         # search for simple
         self.check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=yes", "2.2.ad_f")
         self.not_check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=yes", "2.2.ae_i")
-        self.check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=yes", "2.2.ad_f")
-        self.not_check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=yes", "2.2.ae_i")
         # search for not simple
         self.check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=no", "2.2.ae_i")
         self.not_check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=no", "2.2.ad_f")
-        self.check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=no", "2.2.ae_i")
-        self.not_check_args("/Variety/Abelian/Fq/?q=2&g=2&simple=no", "2.2.ad_f")
+
+    def test_geom_decomp_search(self):
+        r"""
+        Check that we can restrict to (geometrically) (non) squarefree
+        abelian varieties only.
+        """
+        # search for squarefree
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=Yes", "1.3.ab")
+        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=Yes", "2.2.ae_i")
+
+        # search for squarefree and geometrically squarefree
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=YesAndGeom", "1.2.ac")
+        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=YesAndGeom", "2.2.ad_f")
+
+        # search for squarefree but not geometrically squarefree
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=YesNotGeom", "2.2.ad_f")
+        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=YesNotGeom", "1.2.ac")
+
+        # search for non squarefree
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=No", "2.2.ae_i")
+        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=No", "1.3.ab")
+
+        # search for not geometrically squarefree
+        self.check_args("/Variety/Abelian/Fq/?geom_squarefree=NotGeom", "2.2.ae_i")
+        self.not_check_args("/Variety/Abelian/Fq/?geom_squarefree=NotGeom", "1.4.ac")
 
     def test_primitive_search(self):
         r"""
@@ -114,7 +135,6 @@ class AVHomeTest(LmfdbTest):
         """
         self.check_args("/Variety/Abelian/Fq/?q=9&g=2&p_rank=2", "2.9.ah_ba")
         self.check_args("/Variety/Abelian/Fq/?q=9&g=2&p_rank=2", "2.9.af_o")
-        self.not_check_args("/Variety/Abelian/Fq/?q=9&g=2&p_rank=2", "2.9.b_ad")
         self.not_check_args("/Variety/Abelian/Fq/?q=9&g=2&p_rank=2", "2.9.b_ad")
 
     def test_search_newton(self):

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -24,7 +24,7 @@ from lmfdb.genus2_curves import g2c_page
 from lmfdb.genus2_curves.web_g2c import WebG2C, min_eqn_pretty, st0_group_name
 
 ###############################################################################
-# List and dictionaries needed routing and searching
+# List and dictionaries needed for routing and searching
 ###############################################################################
 
 # lists determine display order in drop down lists, dictionary key is the
@@ -383,7 +383,7 @@ def genus2_curve_search(info, query):
     parse_bool(info,query,'is_simple_geom','is geometrically simple')
     parse_ints(info,query,'cond','conductor')
     if info.get('analytic_sha') == "None":
-        query['analytic_sha'] = None;
+        query['analytic_sha'] = None
     else:
         parse_ints(info,query,'analytic_sha','analytic order of sha')
     parse_ints(info,query,'num_rat_pts','rational points')


### PR DESCRIPTION
This PR addresses #4587 and adds an advanced search option for whether or not an abelian variety isogeny class over a finite field is (geometrically) squarefree. The functionality can be seen on [pink](https://pink.lmfdb.xyz).

Tests have been added for this. It was also observed that some other test methods had duplicate tests -- these have been removed.