### PR TITLE
Remove unused tables from test_api

### DIFF
--- a/lmfdb/api/test_api.py
+++ b/lmfdb/api/test_api.py
@@ -13,8 +13,7 @@ class ApiTest(LmfdbTest):
         r"""
         Check that one collection from each database works
         """
-        dbs = ['mwfp_forms', 'lat_lattices', 'lfunc_lfunctions',
-               'mwf_coeffs', 'sl2z_subgroups', 'av_fqisog',
+        dbs = ['lat_lattices', 'lfunc_lfunctions', 'av_fqisog',
                'artin_reps', 'bmf_forms', 'hgcwa_passports',
                'ec_curvedata', 'g2c_curves', 'halfmf_forms',
                'hgm_motives', 'hmf_forms', 'lf_fields',


### PR DESCRIPTION
The tables mwf_coeffs and mwfp_forms have been superseded by maass_newforms and are no longer referenced anywhere other than in the test_api function.  Similarly, sl2z_subgroups is not referenced anywhere (it was part of the old modular form implementation).  We can keep an archive copy of these tables for posterity if we want to, but there is no reason to keep them on the production database or to document/maintain their schemas (I'm trying to wrap up issue #4661).