### PR TITLE
avoid output classname

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
@@ -118,8 +118,8 @@ function show_qexp(qstyle) {
   <form>
     <table class="qexp-table">
       <tr>
-        <td class="output smalloutput">{{ space.trace_expansion(prec_max=10) | safe }}</td>
-        <td class="output mediumoutput nodisplay">{{ space.trace_expansion(prec_max=100) | safe }}</td>
+        <td class="qexp-output smalloutput">{{ space.trace_expansion(prec_max=10) | safe }}</td>
+        <td class="qexp-output mediumoutput nodisplay">{{ space.trace_expansion(prec_max=100) | safe }}</td>
       </tr>
     </table>
     <p>

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -201,15 +201,15 @@ function show_qexp(qstyle) {
       <tr>
         <td class="fdef">\(f(q)\)</td>
         <td class="op">\(=\)</td>
-        <td class="output smalloutput">{{ newform.q_expansion(prec_max=10) | safe }}</td>
-        <td class="output mediumoutput nodisplay">{{ newform.q_expansion(prec_max=100) | safe }}</td>
+        <td class="qexp-output smalloutput">{{ newform.q_expansion(prec_max=10) | safe }}</td>
+        <td class="qexp-output mediumoutput nodisplay">{{ newform.q_expansion(prec_max=100) | safe }}</td>
       </tr>
       {% if newform.dim > 1 %}
       <tr>
         <td class="topspace fdef">\(\operatorname{Tr}(f)(q)\)</td>
         <td class="op topspace">\(=\)</td>
-        <td class="output topspace smalloutput">{{ newform.trace_expansion(prec_max=10) | safe }}</td>
-        <td class="output topspace mediumoutput nodisplay">{{ newform.trace_expansion(prec_max=100) | safe }}</td>
+        <td class="qexp-output topspace smalloutput">{{ newform.trace_expansion(prec_max=10) | safe }}</td>
+        <td class="qexp-output topspace mediumoutput nodisplay">{{ newform.trace_expansion(prec_max=100) | safe }}</td>
       </tr>
       {% endif %}
     </table>

--- a/lmfdb/classical_modular_forms/templates/cmf_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_space.html
@@ -157,8 +157,8 @@ function show_qexp(qstyle) {
   <form>
     <table class="qexp-table">
       <tr>
-        <td class="output smalloutput">{{ space.trace_expansion(prec_max=10) | safe }}</td>
-        <td class="output mediumoutput nodisplay">{{ space.trace_expansion(prec_max=100) | safe }}</td>
+        <td class="qexp-output smalloutput">{{ space.trace_expansion(prec_max=10) | safe }}</td>
+        <td class="qexp-output mediumoutput nodisplay">{{ space.trace_expansion(prec_max=100) | safe }}</td>
       </tr>
     </table>
     <p>

--- a/lmfdb/lattice/templates/lattice-single.html
+++ b/lmfdb/lattice/templates/lattice-single.html
@@ -47,7 +47,7 @@
 <h2> {{ KNOWL('lattice.theta', title='Theta Series') }} </h2>
 
 <p><form>
-<div class="output"><span id="theta_output">{{info.theta_series}}</span></div>
+<div class="lattice-output"><span id="theta_output">{{info.theta_series}}</span></div>
 <div class="emptyspace"><br></div>
 <button id="morebutton">More coefficients</button>
 </form></p>

--- a/lmfdb/modlmf/templates/modlmf-single.html
+++ b/lmfdb/modlmf/templates/modlmf-single.html
@@ -6,7 +6,7 @@
 <h2> {{ KNOWL('modlmf.q_expansion', title='<i>q</i>-expansion') }} </h2>
 
 <p><form>
-<div class="output"><span id="q_exp_output">{{info.q_exp}}</span></div>
+<div class="modlmf-output"><span id="q_exp_output">{{info.q_exp}}</span></div>
 <div class="emptyspace"><br></div>
 <button id="morebutton">More coefficients</button>
 </form>
@@ -117,7 +117,7 @@ $\F_{ {{info.characteristic}} }$
 
 <p><form>
 See the <i>q</i>-expansion as an old form at $p$ for $p=$ <input type='text' name='old_level' value="{{info.old_level}}" size=5> or at weight $k=$<input type='text' name='old_weight' value="{{info.old_weight}}" size=5>
-<div class="output"><span id="q_exp_output">{{info.q_exp}}</span></div>
+<div class="modlmf-output"><span id="q_exp_output">{{info.q_exp}}</span></div>
 <div class="emptyspace"><br></div>
 <button id="morebutton">More coefficients</button>
 </form>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2353,7 +2353,7 @@ table.qexp-table td.op {
 td.topspace {
     padding-top: 15px;
 }
-table.qexp-table td.output {
+table.qexp-table td.qexp-output {
     margin-left: 0;
     padding-left: 0;
     vertical-align: top;


### PR DESCRIPTION
To prevent another #4723, we should the output class name, as it is used in several pages, but not styled in the css, so one person tweaking their page will unwillingly affect the others