### PR TITLE
ell-adic galois images for CM elliptic curves E/Q

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -768,7 +768,7 @@ class ECSearchArray(SearchArray):
         surj_primes = TextBox(
             name="surj_primes",
             label="Maximal primes",
-            knowl="ec.maximal_galois_rep",
+            knowl="ec.maximal_ladic_galois_rep",
             example="2,3")
         isodeg = TextBox(
             name="isogeny_degrees",
@@ -823,7 +823,7 @@ class ECSearchArray(SearchArray):
         nonsurj_primes = TextBoxWithSelect(
             name="nonsurj_primes",
             label="Nonmax $p$",
-            knowl="ec.maximal_galois_rep",
+            knowl="ec.maximal_ladic_galois_rep",
             example="2,3",
             select_box=surj_quant)
         bad_quant = SubsetBox(

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -439,7 +439,7 @@ text-align: center;
   The {{KNOWL('ec.galois_rep', title='mod-$\ell$  Galois representation')}}
   has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
   {% if data.data.galois_data %} {# any non-maximal primes? #}
-    for all primes $\ell < 1000$ except those listed in the table below.
+    for all primes $\ell$ except those listed in the table below.
     </p>
     <table class="ntdata"><thead>
     <tr>
@@ -479,7 +479,7 @@ text-align: center;
 
   <p>
     The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}}
-    has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}} $\GL(2,\Z_\ell)$
+    has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
   {% if data.data.galois_data %} {# any non-maximal primes? #}
     for all primes $\ell$ except those listed in the table below.
     </p>
@@ -499,7 +499,8 @@ text-align: center;
     {% endfor %}
     </tbody>
     </table>
-  {% else %} {# non non-maximal primes (that we know of) #}
+    Each $\ell$-adic image label listed in the table above denotes a subgroup $\overline H$ of $\GL_2(\Z/\ell^e\Z)$ where $e$ is $4,3,1,1,\ldots$ for $\ell=2,3,5,7,\ldots$.  The $\ell$-adic image $H=\rho_{E,\ell}(G_\Q)$ is the full inverse image of $\overline H$ under the composition of the maps $\Aut_{\mathcal O}(E[\ell^\infty])\hookrightarrow\Aut(E[\ell^infty])\simeq \GL_2(\Z_\ell)\twoheadrightarrow \GL_2(\Z/\ell^e\Z)$, where $\O$ is the geometric endomorphism ring of $E$.
+  {% else %} {# no non-maximal primes #}
     for all primes $\ell$.
     </p>
   {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -460,8 +460,6 @@ text-align: center;
     {% endfor %}
     </tbody>
     </table>
-    Each $\ell$-adic image label listed in the table above denotes a subgroup of $\GL_2(\Z/\ell^e\Z)$ where $e$ is $4,3,1,1,\ldots$ for $\ell=2,3,5,7,\ldots$.<br>
-    The $\ell$-adic image $H=\rho_{E,\ell}(G_\Q)$ is the inverse image of this subgroup in $\Aut_{\mathcal O}(E[\ell^\infty])\hookrightarrow\Aut(E[\ell^\infty])\simeq \GL_2(\Z_\ell)\twoheadrightarrow \GL_2(\Z/\ell^e\Z)$, where $\mathcal O$ is the geometric endomorphism ring of $E$.
   {% else %} {# no non-maximal primes #}
     for all primes $\ell$.
     </p>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -460,7 +460,8 @@ text-align: center;
     {% endfor %}
     </tbody>
     </table>
-    Each $\ell$-adic image label listed in the table above denotes a subgroup $\overline H$ of $\GL_2(\Z/\ell^e\Z)$ where $e$ is $4,3,1,1,\ldots$ for $\ell=2,3,5,7,\ldots$.  The $\ell$-adic image $H=\rho_{E,\ell}(G_\Q)$ is the full inverse image of $\overline H$ under the composition of the maps $\Aut_{\mathcal O}(E[\ell^\infty])\hookrightarrow\Aut(E[\ell^infty])\simeq \GL_2(\Z_\ell)\twoheadrightarrow \GL_2(\Z/\ell^e\Z)$, where $\O$ is the geometric endomorphism ring of $E$.
+    Each $\ell$-adic image label listed in the table above denotes a subgroup of $\GL_2(\Z/\ell^e\Z)$ where $e$ is $4,3,1,1,\ldots$ for $\ell=2,3,5,7,\ldots$.<br>
+    The $\ell$-adic image $H=\rho_{E,\ell}(G_\Q)$ is the inverse image of this subgroup in $\Aut_{\mathcal O}(E[\ell^\infty])\hookrightarrow\Aut(E[\ell^\infty])\simeq \GL_2(\Z_\ell)\twoheadrightarrow \GL_2(\Z/\ell^e\Z)$, where $\mathcal O$ is the geometric endomorphism ring of $E$.
   {% else %} {# no non-maximal primes #}
     for all primes $\ell$.
     </p>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -435,7 +435,7 @@ text-align: center;
   {{ place_code('galrep') }}
 
 <p>
-The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
+The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {{KNOWL('ec.maximal_ladic_galois_rep', title='maximal image')}}
 {% if data.data.galois_data %}
   for all primes $\ell$ except those listed in the table below.
   </p>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -430,41 +430,35 @@ text-align: center;
 </tbody>
 </table>
 
-    <h2> {{KNOWL('ec.galois_rep', title='Galois representations')}} </h2>
+<h2> {{KNOWL('ec.galois_rep', title='Galois representations')}} </h2>
 
-    {{ place_code('galrep') }}
+  {{ place_code('galrep') }}
 
-{% if data.data.CMD %}
-  <p>
-  The {{KNOWL('ec.galois_rep', title='mod-$\ell$  Galois representation')}}
-  has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
-  <p>
-    The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}}
-    has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
-  {% if data.data.galois_data %} {# any non-maximal primes? #}
-    for all primes $\ell$ except those listed in the table below.
-    </p>
-    <table class="ntdata"><thead>
+<p>
+The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
+{% if data.data.galois_data %}
+  for all primes $\ell$ except those listed in the table below.
+  </p>
+  <table class="ntdata"><thead>
+  <tr>
+  <th>prime $\ell$</th>
+  <th>{{KNOWL('ec.q.galois_rep_image', title='mod-$\ell$ image')}}</th>
+  <th>{{KNOWL('ec.q.galois_rep_elladic_image', title='$\ell$-adic image')}}</th>
+  </tr>
+  </thead><tbody>
+  {% for pr in data.data.galois_data %}
     <tr>
-    <th>prime $\ell$</th>
-    <th>{{KNOWL('ec.q.galois_rep_image', title='mod-$\ell$ image')}}</th>
-    <th>{{KNOWL('ec.q.galois_rep_elladic_image', title='$\ell$-adic image')}}</th>
+    <td align=center>${{pr.prime}}$</td>
+    <td align=center>{{pr.modell_image}}</td>
+    <td align=center>{{data.display_elladic_image(pr.elladic_image) | safe}}</td>
     </tr>
-    </thead><tbody>
-    {% for pr in data.data.galois_data %}
-      <tr>
-      <td align=center>${{pr.prime}}$</td>
-      <td align=center>{{pr.modell_image}}</td>
-      <td align=center>{{data.display_elladic_image(pr.elladic_image) | safe}}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-    </table>
-  {% else %} {# no non-maximal primes #}
-    for all primes $\ell$.
-    </p>
-  {% endif %}
-{% endif %} {# end non-CM case #}
+  {% endfor %}
+  </tbody>
+  </table>
+{% else %} {# no non-maximal primes #}
+  for all primes $\ell$.
+  </p>
+{% endif %}
 
 <h2>$p$-adic regulators</h2>
 

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -438,45 +438,6 @@ text-align: center;
   <p>
   The {{KNOWL('ec.galois_rep', title='mod-$\ell$  Galois representation')}}
   has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}
-  {% if data.data.galois_data %} {# any non-maximal primes? #}
-    for all primes $\ell$ except those listed in the table below.
-    </p>
-    <table class="ntdata"><thead>
-    <tr>
-    <th>prime $\ell$</th>
-    <th>{{KNOWL('ec.q.galois_rep_image', title='mod-$\ell$ image')}}</th>
-    </tr>
-    </thead><tbody>
-    {% for pr in data.data.galois_data %}
-      <tr>
-      <td align=center>${{pr.prime}}$</td>
-      <td align=center>{{pr.modell_image}}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-    </table>
-    <p>
-    For all other primes $\ell$ the image is
-    {% if data.data.cm_nramp!=0 %}
-      a {{KNOWL('gl2.borel', title='Borel subgroup')}}
-      {% if data.data.cm_nramp==1 %}
-        if $\ell={{data.data.cm_ramp}}$, 
-      {% else %}
-        if $\ell\in \{ {{ data.data.cm_ramp }}\}$,
-      {% endif %}
-    {% endif %}
-    the {{KNOWL('gl2.normalizer_split_cartan', title='normalizer of a split Cartan subgroup')}}
-    if $\left(\frac{ {{data.data.cm_sqf}} }{\ell}\right)=+1$ or
-    the {{KNOWL('gl2.normalizer_nonsplit_cartan', title='normalizer of a nonsplit Cartan subgroup')}}
-    if $\left(\frac{ {{data.data.cm_sqf}} }{\ell}\right)=-1$.
-    </p>
-  {% else %} {# non non-maximal primes (that we know of) #}
-    for all primes $\ell < 1000$.
-    </p>
-  {% endif %}
-
-{% else %}  {# end CM case, begin non-CM case #}
-
   <p>
     The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}}
     has {{KNOWL('ec.maximal_galois_rep', title='maximal image')}}

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -38,7 +38,7 @@ table td.params {
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</th>
 {% if info.surj_primes or info.nonsurj_primes  %}
-  <th class="center">{{KNOWL('ec.maximal_galois_rep', title='Non-maximal primes')}}</th>
+  <th class="center">{{KNOWL('ec.maximal_ladic_galois_rep', title='Non-maximal primes')}}</th>
 {% endif %}
 {% if info.num_int_pts %}
   <th class="center">Number of {{KNOWL('ec.q.integral_points', title='integral points')}}</th>


### PR DESCRIPTION
The data for ell-adic Galois images of CM elliptic curves over Q has now been added (and copied to the production database).  This PR makes it visible.  Previously the pages for CM curves only showed mod-ell images while pages for non-CM curves showed ell-adic images and mod-ell images), and removes the special code path for distinguishing the two cases.

The lists of non-maximal primes have been updated to include all primes where the ell-adic image is not maximal, even when the mod-ell image is (this can happen at the primes 2 and 3) and the knowls have been updated accordingly.

There is still some more work to do on the knowls (including updating the rcs knowls), but that shouldn't hold up this PR (it will be easier to work on the knowls when everyone can see them in context).