### PR TITLE
Addresses part of #2625 for ECQ

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -760,7 +760,7 @@ class ECSearchArray(SearchArray):
                      ('divides','divides'),
                      ],
             min_width=110)
-        cond = TextBox(
+        cond = TextBoxWithSelect(
             name="conductor",
             label="Conductor",
             knowl="ec.q.conductor",

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -349,6 +349,7 @@ def url_for_label(label):
 
 def elliptic_curve_search(info, query):
     parse_rational_to_list(info,query,'jinv','j-invariant')
+    parse_ints(info,query,'conductor')
     if info.get('conductor_type'):
         if info['conductor_type'] == 'prime':
             query['num_bad_primes'] = 1
@@ -362,7 +363,6 @@ def elliptic_curve_search(info, query):
                 raise ValueError("You must specify a single level")
             else:
                 query['conductor'] = {'$in': ZZ(query['conductor']).divisors()}
-    parse_ints(info,query,'conductor')
     parse_signed_ints(info, query, 'discriminant', qfield=('signD', 'absD'))
     parse_ints(info,query,'torsion','torsion order')
     parse_ints(info,query,'rank')

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -349,6 +349,19 @@ def url_for_label(label):
 
 def elliptic_curve_search(info, query):
     parse_rational_to_list(info,query,'jinv','j-invariant')
+    if info.get('conductor_type'):
+        if info['conductor_type'] == 'prime':
+            query['num_bad_primes'] = 1
+            query['semistable'] = True
+        elif info['conductor_type'] == 'prime_power':
+            query['num_bad_primes'] = 1
+        elif info['conductor_type'] == 'squarefree':
+            query['semistable'] = True
+        elif info['conductor_type'] == 'divides':
+            if not isinstance(query.get('conductor'), int):
+                raise ValueError("You must specify a single level")
+            else:
+                query['conductor'] = {'$in': ZZ(query['conductor']).divisors()}
     parse_ints(info,query,'conductor')
     parse_signed_ints(info, query, 'discriminant', qfield=('signD', 'absD'))
     parse_ints(info,query,'torsion','torsion order')
@@ -738,12 +751,22 @@ class ECSearchArray(SearchArray):
     jump_prompt = "Label or coefficients"
     jump_knowl = "ec.q.search_input"
     def __init__(self):
+        cond_quantifier = SelectBox(
+            name='conductor_type',
+            options=[('', ''),
+                     ('prime', 'prime'),
+                     ('prime_power', 'prime power'),
+                     ('squarefree', 'squarefree'),
+                     ('divides','divides'),
+                     ],
+            min_width=110)
         cond = TextBox(
             name="conductor",
             label="Conductor",
             knowl="ec.q.conductor",
             example="389",
-            example_span="389 or 100-200")
+            example_span="389 or 100-200",
+            select_box=cond_quantifier)
         disc = TextBox(
             name="discriminant",
             label="Discriminant",


### PR DESCRIPTION
This implements searches by prime/prime-power/squarefree/divides for ECQ.  It does not allow searching on square conductors or any of these options for discriminants -- these all seem less important and would probably require adding some new columns, I just implemented what was easy to do with the existing schema and what people have mostly been asking for (prime/prime-power conductor).
