### PR TITLE
Fix bug in deleting all data from a table

### DIFF
--- a/lmfdb/backend/statstable.py
+++ b/lmfdb/backend/statstable.py
@@ -330,6 +330,7 @@ class PostgresStatsTable(PostgresBase):
         else:
             if count == 0:
                 updater = SQL("DELETE FROM {0} WHERE cols = %s AND values = %s AND split = %s")
+                data = [cols, vals, split_list]
             else:
                 updater = SQL("UPDATE {0} SET count = %s WHERE cols = %s AND values = %s AND split = %s")
         try:


### PR DESCRIPTION
This fixes a bug in deleting all data from a table.  I just checked that after making this change, `db.gps_char.delete({})` succeeds.