### PR TITLE
BMF fix display of non-principal primes and update browse pages for bmf and ecnf

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -57,10 +57,10 @@ def index():
     """
     info = to_dict(request.args, search_array=BMFSearchArray(), stats=BianchiStats())
     if not request.args:
-        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11,19,43,67,163]]
+        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11,19,43,67,163, 23,31]]
         sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [20]]
-        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11,19,43,67,163]]
-        sl2_names = gl2_names + [r"\(\Q(\sqrt{-%s})\)" % d for d in [5]]
+        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11,19,43,67,163, 23,31]]
+        sl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [4,8,3,7,11,19,43,67,163,5]]
         info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]

--- a/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
@@ -54,7 +54,7 @@
 {% for entry in data.AL_table: %}
 <tr>
 <td>{{entry[0]}}</td>
-<td>{{entry[1]}} = ({{entry[2]}})</td>
+<td>{{entry[1]}} = {{entry[2]}}</td>
 <td align=right>{{entry[3]}}</td>
 </tr>
 {% endfor %}
@@ -95,7 +95,7 @@ We only show the eigenvalues $a_{\mathfrak{p}}$ for primes $\mathfrak{p}$ which 
 {% for entry in data.hecke_table: %}
 <tr>
 <td>{{entry[0]}}</td>
-<td>{{entry[1]}} = ({{entry[2]}})</td>
+<td>{{entry[1]}} = {{entry[2]}}</td>
 <td align=right>{{entry[3]}}</td>
 </tr>
 {% endfor %}

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -160,13 +160,13 @@ class WebBMF(object):
         self.neigs = self.nap0 + len(badp)
         self.hecke_table = [[web_latex(p.norm()),
                              ideal_label(p),
-                             web_latex(p.gens_reduced()[0]),
+                             web_latex(p.gens_reduced()),
                              web_latex(ap)] for p,ap in zip(primes_iter(K), self.hecke_eigs[:self.neigs]) if p not in badp]
         self.have_AL = self.AL_eigs[0]!='?'
         if self.have_AL:
             self.AL_table = [[web_latex(p.norm()),
                              ideal_label(p),
-                              web_latex(p.gens_reduced()[0]),
+                              web_latex(p.gens_reduced()),
                               web_latex(ap)] for p,ap in zip(badp, self.AL_eigs)]
             # The following helps to create Sage download data
             self.AL_table_data = [[p.gens_reduced(),ap] for p,ap in zip(badp, self.AL_eigs)]

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -186,7 +186,7 @@ def index():
                             for nf in rqfs)])
 
     # Imaginary quadratics (sample)
-    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11, 19, 43, 67, 163]]
+    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11, 19, 43, 67, 163, 23, 31]]
     info['fields'].append(['By <a href="{}">imaginary quadratic field</a>'.format(url_for('.statistics_by_signature', d=2, r=0)),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in iqfs)])


### PR DESCRIPTION
I have uploaded BMF and ECNF data for the imaginary quadratic fields of discriminants -23 and -31, the first two fields of class number 3.  This includes dimension data and rational newforms for all levels of norm up to 1000 in each case, and elliptic curves attached to each newform, with complete data for these and isogenous curves.

These are the first Bianchi newforms over fields of class number >1 in the database.  Minor tweaks are needed for the display of prime ideals in tables of Atkin-Lehner and Hecke eigenvalues, since the existing code assumed these were principal (so without these changes only the first generator is shown, see the AL table at https://beta.lmfdb.org/ModularForm/GL2/ImaginaryQuadratic/2.0.31.1/20.3/a/ for an example).

I also updated the browse pages for BMF and ECNF to include these two extra fields, and I updated the relevant rcs knowls, including a citation to Lingham's 2005 thesis (he first worked out how to handle these fields, using methods which apply in principal to all IQFs of odd class number).

Behind this is a major extension of my bianchi-progs C++ code to handle arbitrary class number, after some precomputation for each field (which the code only partially automates at present).  I may now do these precomputations for the 5 remaining fields of odd class number and discriminant > -100 (-59 and -83 have h=3, -47 and -79 have h=5, and -71 has h=7), and I may also extend the code to handle even class numbers, starting with -5 (h=2) as in Bygott's thesis, for which most of the extra coding has already been done.

As well as merging these code updates, please could someone copy bmf_forms, bmf_dims and ec_nfcurves to prod, and also review the 4 knowls I just updated?  Thanks.