### PR TITLE
Fix server error when typing a space into the url

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -206,6 +206,8 @@ def by_conductor(cond):
 @g2c_page.route("/Q/<label>")
 def by_label(label):
     # handles curve, isogeny class, and Lhash labels
+    if not label.strip(): # just spaces
+        return redirect(url_for(".index"))
     return genus2_curve_search({'jump':label})
 
 def render_curve_webpage(label):


### PR DESCRIPTION
This fixes a problem observed in the flasklog that occurs when a user enters the url `beta.lmfdb.org/Genus2Curve/Q/ ` (with a space).