### PR TITLE
Support knowls for column descriptions

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -339,9 +339,9 @@ def api_query(table, id = None):
         description = coll.description()
         if description:
             title += " (%s)" % description
-        search_schema = [(col, coll.col_type[col], coll.column_description(col))
+        search_schema = [(col, coll.col_type[col])
                          for col in sorted(coll.search_cols)]
-        extra_schema = [(col, coll.col_type[col], coll.column_description(col))
+        extra_schema = [(col, coll.col_type[col])
                         for col in sorted(coll.extra_cols)]
         return render_template("collection.html",
                                title=title,

--- a/lmfdb/api/templates/collection.html
+++ b/lmfdb/api/templates/collection.html
@@ -50,21 +50,18 @@ Query: <code><a href="{{ query }}">{{ query_unquote }}</a></code>
       <tr>
         <th>Column</th>
         <th>Type</th>
-        <th>Description</th>
       </tr>
-      {% for col, typ, desc in search_schema %}
+      {% for col, typ in search_schema %}
         <tr>
-          <td>{{col}}</td>
+          <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
           <td>{{typ}}</td>
-          <td style="white-space: normal; max-width: 600px;">{{desc}}</td>
         </tr>
       {% endfor %}
       {% if extra_schema %}
-        {% for col, typ, desc in extra_schema %}
+        {% for col, typ in extra_schema %}
           <tr{% if loop.index == 1 %} class="toplined"{% endif %}>
-            <td>{{col}}</td>
+            <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
             <td>{{typ}}</td>
-            <td style="white-space: normal; max-width: 600px;">{{desc}}</td>
           </tr>
         {% endfor %}
       {% endif %}

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -22,6 +22,7 @@ import re
 text_keywords = re.compile(r"\b[a-zA-Z0-9-]{3,}\b")
 top_knowl_re = re.compile(r"(.*)\.top$")
 comment_knowl_re = re.compile(r"(.*)\.(\d+)\.comment$")
+coldesc_knowl_re = re.compile(r"columns.([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)")
 bottom_knowl_re = re.compile(r"(.*)\.bottom$")
 url_from_knowl = [
     (re.compile(r'g2c\.(\d+\.[a-z]+\.\d+\.\d+)'), 'Genus2Curve/Q/{0}', 'Genus 2 curve {0}'),
@@ -82,6 +83,9 @@ def extract_typ(kid):
         typ = -2
         source = m.group(1)
         return typ, source, None
+    m = coldesc_knowl_re.match(kid)
+    if m:
+        return 2, m.group(1), m.group(2)
     m = top_knowl_re.match(kid)
     if m:
         prelabel = m.group(1)
@@ -104,7 +108,7 @@ def extract_typ(kid):
     return typ, url, name
 
 def extract_links(content):
-    return sorted(set(x[2] for x in link_finder_re.findall(content)))
+    return sorted(set(x[2] for x in link_finder_re.findall(content) if x[2]))
 
 def normalize_define(term):
     m = define_fixer.search(term)
@@ -175,7 +179,7 @@ class KnowlBackend(PostgresBase):
         if cur.rowcount > 0:
             return {k:v for k,v in zip(fields, cur.fetchone())}
 
-    def get_all_knowls(self, fields=None, types=[1,0,-1,-2]):
+    def get_all_knowls(self, fields=None, types=[2, 1,0,-1,-2]):
         if fields is None:
             fields = ['id'] + self._default_fields
         selecter = SQL("SELECT DISTINCT ON (id) {0} FROM kwl_knowls WHERE status >= %s AND type = ANY(%s) ORDER BY id, timestamp DESC").format(SQL(", ").join(map(Identifier, fields)))
@@ -280,7 +284,10 @@ class KnowlBackend(PostgresBase):
         else:
             typ, source, name = extract_typ(knowl.id)
         links = extract_links(knowl.content)
-        defines = extract_defines(knowl.content)
+        if typ == 2: # column description
+            defines = [knowl.id.split(".")[-1]]
+        else:
+            defines = extract_defines(knowl.content)
         # id, authors, cat, content, last_author, timestamp, title, status, type, links, defines, source, source_name
         values = (knowl.id, authors, cat, knowl.content, who, knowl.timestamp, knowl.title, knowl.status, typ, links, defines, source, name, search_keywords)
         with DelayCommit(self):
@@ -317,6 +324,32 @@ class KnowlBackend(PostgresBase):
         selecter = SQL("SELECT id, last_author, timestamp FROM (SELECT DISTINCT ON (id) id, last_author, timestamp FROM kwl_knowls WHERE type = %s AND source = %s AND status >= 0 ORDER BY id, timestamp) knowls ORDER BY timestamp DESC")
         cur = self._execute(selecter, [-2, ID])
         return list(cur)
+
+    def get_column_descriptions(self, table):
+        fields = ['id'] + self._default_fields
+        selecter = SQL("SELECT {0} FROM (SELECT DISTINCT ON (id) {0} FROM kwl_knowls WHERE id LIKE %s AND type = %s AND status >= %s ORDER BY id, timestamp) knowls ORDER BY id").format(SQL(", ").join(map(Identifier, fields)))
+        cur = self._execute(selecter, [f"columns.{table}.%", 2, 0])
+        return {rec[0].split(".")[-1]: Knowl(rec[0], data={k:v for k,v in zip(fields, rec)}) for rec in cur}
+
+    def set_column_description(self, table, col, description):
+        from lmfdb import db
+        uid = db.login()
+        kid = f"columns.{table}.{col}"
+        data = {
+            'title': f"Column {col} of table {table}",
+            'content': description,
+            'defines': col,
+        }
+        kwl = Knowl(kid, data=data)
+        old = self.get_knowl(kid, beta=True)
+        if old is None:
+            old = {'authors': []}
+        self.save(kwl, uid, most_recent=old)
+
+    def drop_column(self, table, col):
+        kid = f"columns.{table}.{col}"
+        kwl = Knowl(kid)
+        self.delete(kwl)
 
     def delete(self, knowl):
         """deletes this knowl from the db. This is effected by setting the status to -2 on all copies of the knowl"""
@@ -356,8 +389,8 @@ class KnowlBackend(PostgresBase):
         tdelta = timedelta(days=days)
         time = now - tdelta
         fields = ['id'] + self._default_fields
-        selecter = SQL("SELECT {0} FROM (SELECT DISTINCT ON (id) {0} FROM kwl_knowls WHERE timestamp >= %s AND status >= %s AND type != %s ORDER BY id, timestamp DESC) knowls WHERE status = 0 ORDER BY timestamp DESC").format(SQL(", ").join(map(Identifier, fields)))
-        cur = self._execute(selecter, [time, 0, -2])
+        selecter = SQL("SELECT {0} FROM (SELECT DISTINCT ON (id) {0} FROM kwl_knowls WHERE timestamp >= %s AND status >= %s AND (type == 1 OR type == -1) ORDER BY id, timestamp DESC) knowls WHERE status = 0 ORDER BY timestamp DESC").format(SQL(", ").join(map(Identifier, fields)))
+        cur = self._execute(selecter, [time, 0])
         knowls = [Knowl(rec[0], data={k:v for k,v in zip(fields, rec)}) for rec in cur]
 
         kids = [k.id for k in knowls]
@@ -730,7 +763,7 @@ def knowl_url_prefix():
 # allowed qualities for knowls
 knowl_status_code = {'reviewed':1, 'beta':0, 'in progress': -1, 'deleted': -2}
 reverse_status_code = {v:k for k,v in knowl_status_code.items()}
-knowl_type_code = {'normal': 0, 'top': 1, 'bottom': -1}
+knowl_type_code = {'normal': 0, 'top': 1, 'bottom': -1, 'coldesc': 2}
 
 class Knowl(object):
     """
@@ -788,6 +821,8 @@ class Knowl(object):
                 self.type = 1
             elif bottom_knowl_re.match(ID):
                 self.type = -1
+            elif coldesc_knowl_re.match(ID):
+                self.type = 2
             else:
                 self.type = 0
         #self.reviewer = data.get('reviewer') # Not returned by get_knowl by default


### PR DESCRIPTION
To test, go to localhost:37777/api, click on any table, then click "Show schema."  The column headers are now knowls which can be edited as usual.

When you add a column, you need to provide a column description, which creates a knowl.