### PR TITLE
Colum description knowl fixes

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -336,7 +336,6 @@ class KnowlBackend(PostgresBase):
         uid = db.login()
         kid = f"columns.{table}.{col}"
         data = {
-            'title': f"Column {col} of table {table}",
             'content': description,
             'defines': col,
         }
@@ -501,7 +500,7 @@ class KnowlBackend(PostgresBase):
         filename = None
         code = []
         for line in match.split('\n'):
-            if not line.strip():
+            if not line.strip() or line.startswith("Binary file "):
                 continue
             m = grep_extractor.match(line)
             if not m:
@@ -722,9 +721,8 @@ class KnowlBackend(PostgresBase):
         kt = self.knowl_title(kid)
         if kt is not None:
             return True
-        if allow_deleted:
-            return self.get_knowl(kid, ['id'], beta=True, allow_deleted=True) is not None
-        return False
+        k = self.get_knowl(kid, ['id'], beta=True, allow_deleted=allow_deleted)
+        return k is not None
 
     def get_categories(self):
         """
@@ -763,7 +761,7 @@ def knowl_url_prefix():
 # allowed qualities for knowls
 knowl_status_code = {'reviewed':1, 'beta':0, 'in progress': -1, 'deleted': -2}
 reverse_status_code = {v:k for k,v in knowl_status_code.items()}
-knowl_type_code = {'normal': 0, 'top': 1, 'bottom': -1, 'coldesc': 2}
+knowl_type_code = {'normal': 0, 'top': 1, 'bottom': -1, 'column': 2}
 
 class Knowl(object):
     """
@@ -825,6 +823,15 @@ class Knowl(object):
                 self.type = 2
             else:
                 self.type = 0
+        if self.type == 2:
+            pieces = ID.split(".")
+            # Ignore the title passed in
+            self.title = f"Column {pieces[2]} of table {pieces[1]}"
+            from lmfdb import db
+            if pieces[1] in db.tablenames:
+                self.coltype = db[pieces[1]].col_type.get(pieces[2], "DEFUNCT")
+            else:
+                self.coltype = "DEFUNCT"
         #self.reviewer = data.get('reviewer') # Not returned by get_knowl by default
         #self.review_timestamp = data.get('review_timestamp') # Not returned by get_knowl by default
 

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -585,11 +585,12 @@ def orphans():
 def columns():
     from lmfdb import db
     bad_cat = knowldb.search(category="columns", types=["normal", "top", "bottom"])
-    knowls = defaultdict(list)
-    for k in knowldb.search(types=["column"], projection=['id', 'cat']):
+    knowls = defaultdict(dict)
+    for k in knowldb.search(types=["column"], projection=['id', 'cat', 'content']):
         if k['cat'] == "columns" and k['id'].count('.') == 2:
             pieces = k['id'].split('.')
-            knowls[pieces[1]].append(pieces[2])
+            if k['content'].strip():
+                knowls[pieces[1]][pieces[2]] = k['content']
         else:
             bad_cat.append(k)
     missing_tables = {tbl: sorted(db[tbl].search_cols) + sorted(db[tbl].extra_cols) for tbl in db.tablenames if tbl not in knowls}
@@ -608,7 +609,8 @@ def columns():
                            missing_knowls=missing_knowls,
                            missing_tables=missing_tables,
                            bad_tables=bad_tables,
-                           bad_cat=bad_cat)
+                           bad_cat=bad_cat,
+                           knowls=knowls)
 
 @knowledge_page.route("/new_comment/<ID>")
 def new_comment(ID):

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -17,7 +17,7 @@ import re
 import json
 import time
 from xml.etree import ElementTree
-from collections import Counter
+from collections import Counter, defaultdict
 from lmfdb.app import app, is_beta
 from datetime import datetime
 from flask import abort, flash, jsonify, make_response,\
@@ -44,7 +44,7 @@ def allowed_id(ID):
     if ID.endswith('comment'):
         main_knowl = ".".join(ID.split(".")[:-2])
         return knowldb.knowl_exists(main_knowl)
-    if ID.endswith('top') or ID.endswith('bottom'):
+    if ID.endswith('top') or ID.endswith('bottom') or ID.startswith("columns."):
         if not allowed_annotation_id.match(ID):
             label = '.'.join(ID.split(".")[1:-1])
             flash_error("Label '%s' contains characters not allowed by knowl database; updated allowed_id function or change label scheme" % label)
@@ -351,6 +351,15 @@ def edit(ID):
         title = "Comment on '%s'" % knowl.source
     elif knowl.type == 0:
         title = "Edit Knowl '%s'" % ID
+    elif knowl.type == 2:
+        pieces = ID.split(".")
+        title = f"Edit column information for '{pieces[2]}' in '{pieces[1]}'"
+        knowl.title = f"Column {pieces[2]} of table {pieces[1]}"
+        from lmfdb import db
+        if pieces[1] in db.tablenames:
+            knowl.coltype = db[pieces[1]].col_type.get(pieces[2], "DEFUNCT")
+        else:
+            knowl.coltype = "DEFUNCT"
     else:
         ann_type = 'Top' if knowl.type == 1 else 'Bottom'
         title = 'Edit %s Knowl for <a href="/%s">%s</a>' % (ann_type, knowl.source, knowl.source_name)
@@ -392,7 +401,11 @@ def show(ID):
             can_delete = (current_user.is_admin() or current_user.get_id() == author)
             author_name = userdb.lookup(author)["full_name"]
             k.comments[i] = (cid, author_name, timestamp, can_delete)
-    b = get_bread([(k.category, url_for('.index', category=k.category)), ('%s' % title, url_for('.show', ID=ID))])
+    if k.type == 2:
+        caturl = url_for('.index', category=k.category, column="on")
+    else:
+        caturl = url_for('.index', category=k.category)
+    b = get_bread([(k.category, caturl), ('%s' % title, url_for('.show', ID=ID))])
 
     return render_template(u"knowl-show.html",
                            title=title,
@@ -567,6 +580,35 @@ def orphans():
                            title="Orphaned knowls",
                            orphans=orphans,
                            bread=b)
+
+@knowledge_page.route("/columns")
+def columns():
+    from lmfdb import db
+    bad_cat = knowldb.search(category="columns", types=["normal", "top", "bottom"])
+    knowls = defaultdict(list)
+    for k in knowldb.search(types=["column"], projection=['id', 'cat']):
+        if k['cat'] == "columns" and k['id'].count('.') == 2:
+            pieces = k['id'].split('.')
+            knowls[pieces[1]].append(pieces[2])
+        else:
+            bad_cat.append(k)
+    missing_tables = {tbl: sorted(db[tbl].search_cols) + sorted(db[tbl].extra_cols) for tbl in db.tablenames if tbl not in knowls}
+    bad_tables = {tbl: klist for (tbl, klist) in knowls.items() if tbl not in db.tablenames}
+    for tbl in bad_tables:
+        del knowls[tbl]
+    missing_knowls = defaultdict(list)
+    for tbl in knowls:
+        table = db[tbl]
+        for col in sorted(table.search_cols) + sorted(table.extra_cols):
+            if col not in knowls[tbl]:
+                missing_knowls[tbl].append(col)
+    b = get_bread([("Missing columns", " ")])
+    return render_template("knowl-columns.html",
+                           title="Missing columns",
+                           missing_knowls=missing_knowls,
+                           missing_tables=missing_tables,
+                           bad_tables=bad_tables,
+                           bad_cat=bad_cat)
 
 @knowledge_page.route("/new_comment/<ID>")
 def new_comment(ID):
@@ -836,9 +878,13 @@ def index():
         if len(t) == 0 or t[0] not in string.ascii_letters:
             return "?"
         return t[0].upper()
+    def get_table(k):
+        return k['id'].split(".")[1]
 
     def knowl_sort_key(knowl):
         '''sort knowls, special chars at the end'''
+        if cur_cat == "columns":
+            return knowl['id']
         title = knowl['title']
         if title and title[0] in string.ascii_letters:
             return (0, title.lower())
@@ -847,7 +893,10 @@ def index():
 
     knowls = sorted(knowls, key=knowl_sort_key)
     from itertools import groupby
-    knowls = groupby(knowls, first_char)
+    if cur_cat == "columns":
+        knowls = groupby(knowls, get_table)
+    else:
+        knowls = groupby(knowls, first_char)
     knowl_qualities = ["reviewed", "beta"]
     #if current_user.is_authenticated:
     #    knowl_qualities.append("in progress")

--- a/lmfdb/knowledge/templates/knowl-columns.html
+++ b/lmfdb/knowledge/templates/knowl-columns.html
@@ -46,5 +46,18 @@
   </ul>
 {% endfor %}
 {% endif %}
+<h2>Current content</h2>
+<p>Here are the existing column descriptions.</p>
+{% for tbl, coldict in knowls.items() %}
+  <h3>{{ tbl }}</h3>
+  <table>
+    {% for col, content in coldict.items() %}
+      <tr>
+        <td><a href="{{url_for('.edit', ID='columns.' + tbl + '.' + col)}}">{{ col }}</a></td>
+        <td>{{ content|safe }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endfor %}
 
 {% endblock %}

--- a/lmfdb/knowledge/templates/knowl-columns.html
+++ b/lmfdb/knowledge/templates/knowl-columns.html
@@ -1,0 +1,50 @@
+{% extends "homepage.html" %}
+
+{% block content %}
+{% if bad_cat %}
+<h2>Bad category</h2>
+<p>The following knowls are miscategorized, either with type set to column but without the right category, or with category columns but without the right type.  This likely results from a bug in the knowl editing code.</p>
+<ul>
+  {% for k in bad_cat %}
+    <li>{{ KNOWL(k.id, k.id) }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if bad_tables %}
+<h2>Defunct tables</h2>
+<p>The following knowls are associated to tables that no longer exist and should be either deleted or renamed using the db.tablename.port_column_knowls command line function.</p>
+{% for tbl, collist in bad_tables.items() %}
+  <h3>{{ tbl }}</h3>
+  <ul>
+    {% for col in collist %}
+      <li>{{ KNOWL('columns.' + tbl + '.' + col, col) }}</li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+{% endif %}
+{% if missing_knowls %}
+<h2>Missing columns</h2>
+<p>The following columns do not have knowls written.</p>
+{% for tbl, collist in missing_knowls.items() %}
+  <h3>{{ tbl }}</h3>
+  <ul>
+    {% for col in collist %}
+      <li>{{ KNOWL('columns.' + tbl + '.' + col, col) }}</li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+{% endif %}
+{% if missing_tables %}
+<h2>Missing tables</h2>
+<p>The following tables do not have any knowls written.</p>
+{% for tbl, collist in missing_tables.items() %}
+  <h3>{{ tbl }}</h3>
+  <ul>
+    {% for col in collist %}
+      <li>{{ KNOWL('columns.' + tbl + '.' + col, col) }}</li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+{% endif %}
+
+{% endblock %}

--- a/lmfdb/knowledge/templates/knowl-edit.html
+++ b/lmfdb/knowledge/templates/knowl-edit.html
@@ -82,8 +82,18 @@
         {% endif %} {# renamable #}
         <tr>
           <td>{{KNOWL("doc.knowl.description",title="Description")}}</td>
-          <td><input size="40" name="title" id="ktitle" value="{{ k.title }}" /></td>
+          {% if k.type == 2 %}
+            <td>{{ k.title }}<input name="title" id="ktitle" value="{{ k.title }}" type="hidden" /></td>
+          {% else %}
+            <td><input size="40" name="title" id="ktitle" value="{{ k.title }}" /></td>
+          {% endif %}
         </tr>
+        {% if k.type == 2 %}
+          <tr>
+            <td>Postgres column type</td>
+            <td>{{ k.coltype }}</td>
+          </tr>
+        {% endif %}
         <tr>
           <td>Quality</td>
           <td>

--- a/lmfdb/knowledge/templates/knowl-index.html
+++ b/lmfdb/knowledge/templates/knowl-index.html
@@ -93,7 +93,8 @@ $(function() {
         {%- if user_is_authenticated -%},
           <a href="{{ url_for('.comment_history') }}">Recent comments</a>,
           <a href="{{ url_for('.broken_links') }}">Broken links</a>,
-          <a href="{{ url_for('.orphans') }}">Orphaned knowls</a>
+          <a href="{{ url_for('.orphans') }}">Orphaned knowls</a>,
+          <a href="{{ url_for('.columns') }}">Column description status</a>
         {%- endif -%}
         {%- if user_can_review_knowls -%},
           <a href="{{ url_for('.review_recent', days=10) }}">Review recent knowls</a>,

--- a/lmfdb/knowledge/templates/knowl-show.html
+++ b/lmfdb/knowledge/templates/knowl-show.html
@@ -4,6 +4,11 @@
 {% from "knowl-defs.html" import knowlbar with context %}
 {{ knowlbar(show_kid=True) }}
 
+{% if k.type == 2 %}
+  <p>
+    Postgres column type: {{ k.coltype }}
+  </p>
+{% endif %}
 {{ render|safe }}
 
 {% if user_is_authenticated and type != -2 %}


### PR DESCRIPTION
Various fixes and improvements around column description knowls.

* http://localhost:37777/knowledge/broken_links should work now.
* There's a [new view](http://localhost:37777/knowledge/columns) that shows columns that don't have an annotation and an overview of all column descriptions (not rendered completely for speed)
* In the knowl index, there is now a checkbox for a "column" type in addition to normal, top and bottom.  When restricting to the "columns" category, knowls are displayed by their table.
* Column description knowls now display the postgres type of the column in show and edit mode.
* There is a new function for renaming column description knowls in case a table name is changed.