### PR TITLE
Annotation link

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -40,7 +40,7 @@ url_from_knowl = [
     (re.compile(r'hecke_algebra_l_adic\.(.*)'), 'ModularForm/GL2/Q/HeckeAlgebra/{0}/2', 'l-adic Hecke algebra {0}'),
     (re.compile(r'gal\.modl\.(.*)'), 'Representation/Galois/ModL/{0}', 'Mod-l Galois representation {0}'),
     (re.compile(r'modlmf\.(.*)'), 'ModularForm/GL2/ModL/{0}', 'Mod-l modular form {0}'),
-    (re.compile(f'group\.abstract\.(.*)'), 'Groups/Abstract/{0}', 'Abstract group {0}'),
+    (re.compile(r'group\.abstract\.(.*)'), 'Groups/Abstract/{0}', 'Abstract group {0}'),
 ]
 grep_extractor = re.compile(r'(.+?)([:|-])(\d+)([-|:])(.*)')
 # We need to convert knowl


### PR DESCRIPTION
Currently, when you create an annotation for an object that doesn't have one yet, it displays "None" in the title while being edited.  This PR fixes that, and adds a missing entry to support annotations for abstract groups.