### PR TITLE
Fix bug that makes it impossible to drop a column interactively

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -348,7 +348,7 @@ class KnowlBackend(PostgresBase):
 
     def drop_column(self, table, col):
         kid = f"columns.{table}.{col}"
-        kwl = Knowl(kid)
+        kwl = Knowl(kid, data=self.get_knowl(kid, beta=True))
         self.delete(kwl)
 
     def delete(self, knowl):


### PR DESCRIPTION
To test, create a column in a test table then drop it.  Before the change, this will give a `RuntimeError: Working outside of application context`.