### PR TITLE
Add search on Galois image and reorganize search layout for EC/Q

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -887,7 +887,7 @@ class ECSearchArray(SearchArray):
             knowl="ec.reduction",
             options=reduction_opts)
         galois_image = TextBox(
-            name="nonmaximal_image",
+            name="galois_image",
             label=r"Galois image",
             short_label=r"Galois image",
             example="13.91.3.2",

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -905,15 +905,15 @@ class ECSearchArray(SearchArray):
             short_label=r"Galois image",
             example="13.91.3.2",
             knowl="ec.galois_rep_elladic_image")
-        nonmax_quant = SubsetBox(
-            name="nonmax_quantifier")
-        nonmax_primes = TextBoxWithSelect(
-            name="nonmax_primes",
+        nonmaximal_quant = SubsetBox(
+            name="nonmaximal_quantifier")
+        nonmaximal_primes = TextBoxWithSelect(
+            name="nonmaximal_primes",
             label=r"Nonmaximal $\ell$",
             short_label=r"Nonmax $\ell$",
             knowl="ec.maximal_elladic_galois_rep",
             example="2,3",
-            select_box=nonmax_quant)
+            select_box=nonmaximal_quant)
         cm_opts = ([('', ''), ('noCM', 'no potential CM'), ('CM', 'potential CM')] +
                    [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(7))')] +
                    [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]])

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -407,7 +407,7 @@ def elliptic_curve_search(info, query):
         elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
             query['modell_images'] = { '$contains': labels }
         else:
-            raise ValueError("oops")
+            raise SearchParsingError("oops")
             raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:
             query['cm'] = 0

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -16,7 +16,7 @@ from lmfdb.utils import (
     web_latex, to_dict, comma, flash_error, display_knowl, raw_typeset,
     parse_rational_to_list, parse_ints, parse_floats, parse_bracketed_posints, parse_primes,
     SearchArray, TextBox, SelectBox, SubsetBox, TextBoxWithSelect, CountBox,
-    StatsDisplay, parse_element_of, parse_bool, parse_signed_ints, search_wrap, redirect_no_cache)
+    StatsDisplay, parse_element_of, parse_signed_ints, search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.isog_class import ECisog_class
@@ -933,7 +933,7 @@ class ECSearchArray(SearchArray):
             [torsion, cm],
             [rank, sha],
             [regulator, sha_primes],
-            [galois_image, nonmax_primes],
+            [galois_image, nonmaximal_primes],
             [class_size, class_deg],
             [num_int_pts, isodeg],
             [optimal, reduction],
@@ -943,6 +943,6 @@ class ECSearchArray(SearchArray):
         self.refine_array = [
             [cond, jinv, rank, torsion, cm],
             [bad_primes, disc, regulator, sha, galois_image],
-            [class_size, class_deg, isodeg, sha_primes, nonmax_primes],
+            [class_size, class_deg, isodeg, sha_primes, nonmaximal_primes],
             [optimal, reduction, num_int_pts, faltings_height]
             ]

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -450,7 +450,7 @@ def elliptic_curve_search(info, query):
                     info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
-                    info['galois__image'] = ','.join(modell_labels + elladic_labels)
+                    info['galois_image'] = ','.join(modell_labels + elladic_labels)
                 query['modell_images'] = { '$contains': modell_labels }
 
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -369,7 +369,6 @@ def elliptic_curve_search(info, query):
             else:
                 query['conductor'] = {'$in': ZZ(query['conductor']).divisors()}
     parse_signed_ints(info, query, 'discriminant', qfield=('signD', 'absD'))
-    parse_ints(info,query,'torsion','torsion order')
     parse_ints(info,query,'rank')
     parse_ints(info,query,'sha','analytic order of &#1064;')
     parse_ints(info,query,'num_int_pts','num_int_pts')
@@ -383,8 +382,12 @@ def elliptic_curve_search(info, query):
     parse_floats(info,query,'regulator','regulator')
     parse_floats(info, query, 'faltings_height', 'faltings_height')
     parse_bool(info,query,'semistable','semistable')
+    if info.get('torsion'):
+        if info['torsion'][0] == '[':
+            parse_bracketed_posints(info,query,'torsion',qfield='torsion_structure',maxlength=2,check_divisibility='increasing')
+        else:
+            parse_ints(info,query,'torsion')
     parse_bool(info,query,'potential_good_reduction','potential_good_reduction')
-    parse_bracketed_posints(info,query,'torsion_structure',maxlength=2,check_divisibility='increasing')
     # speed up slow torsion_structure searches by also setting torsion
     #if 'torsion_structure' in query and not 'torsion' in query:
     #    query['torsion'] = reduce(mul,[int(n) for n in query['torsion_structure']],1)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -904,7 +904,7 @@ class ECSearchArray(SearchArray):
             name="galois_image",
             label=r"Galois image",
             short_label=r"Galois image",
-            example="13.91.3.2",
+            example="13S4 or 13.91.3.2",
             knowl="ec.galois_rep_elladic_image")
         nonmax_quant = SubsetBox(
             name="nonmax_quantifier")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -436,7 +436,7 @@ def elliptic_curve_search(info, query):
         else:
             # try to help the user out if they specify a maximal group
             print(modell_labels)
-            if any([a.endswith("G") and modell_image_label_regex.match(a)[0] > 3 for a in modell_labels]):
+            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -427,17 +427,27 @@ def elliptic_curve_search(info, query):
         if not 'cm' in query:
             query['cm'] = 0
             info['cm'] = "noCM"
-        # try to help the user out if they specify a maximal group
         if query['cm']:
+            # try to help the user out if they specify the normalizer of a Cartan in the CM case (these are either maximal or impossible
             if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)
         else:
-            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]):
-                err = "To search for maximal images, exclude non-maximal primes"
-                flash_error(err)
-                raise ValueError(err)
+            # if the user specifies full mod-ell image with ell > 3, automatically exclude nonmax primes (if possible)
+            max_labels = [a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]
+            if max_labels:
+                if query['nonmax_primes'] then:
+                    err = "To search for maximal images, exclude non-maximal primes"
+                    flash_error(err)
+                    raise ValueError(err)
+                else:
+                    modell_labels = [a for a in modell_labels if not a in max_labels]
+                    info['nonmax_primes'] = max_labels.join(",")
+                    info['nanmax_quantifier'] = 'exclude'
+                    parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
+                                 qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
+                query['modell_images'] = { '$contains': modell_labels }
 
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -363,7 +363,8 @@ def elliptic_curve_search(info, query):
             query['semistable'] = True
         elif info['conductor_type'] == 'divides':
             if not isinstance(query.get('conductor'), int):
-                raise ValueError("You must specify a single level")
+                flash_error("You must specify a single conductor")
+                raise ValueError("You must specify a single conductor")
             else:
                 query['conductor'] = {'$in': ZZ(query['conductor']).divisors()}
     parse_signed_ints(info, query, 'discriminant', qfield=('signD', 'absD'))
@@ -374,7 +375,9 @@ def elliptic_curve_search(info, query):
     parse_ints(info,query,'class_size','class_size')
     if info.get('class_deg'):
         if not isinstance(query.get('class_deg'), int):
-            raise ValueError("You must specify a single degree")
+            err = "You must specify a single isogeny class degree"
+            flash_error(err)
+            raise ValueError(err)
         parse_ints(info,query,'class_deg','class_deg')
     parse_floats(info,query,'regulator','regulator')
     parse_floats(info, query, 'faltings_height', 'faltings_height')

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -444,7 +444,7 @@ def elliptic_curve_search(info, query):
                 else:
                     modell_labels = [a for a in modell_labels if not a in max_labels]
                     max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
-                    if info['nonmax_primes']:
+                    if info.get('nonmax_primes'):
                         max_primes += [l.strip() for l in info['nonmax_primes'].split(',') if not l.strip() in max_primes]
                     info['nonmax_primes'] = ','.join(max_primes)
                     info['nonmax_quantifier'] = 'exclude'

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -412,7 +412,7 @@ def elliptic_curve_search(info, query):
                  qfield='bad_primes',mode=info.get('bad_quantifier'))
     parse_primes(info, query, 'sha_primes', name='sha primes',
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
-    if info.get("galois_image"):
+    if info.get('galois_image'):
         labels = [a.strip() for a in info['galois_image'].split(',')]
         elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a) and is_prime_power(elladic_image_label_regex.match(a)[1])]
         modell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a) and is_prime(modell_image_label_regex.match(a)[1])]
@@ -450,6 +450,7 @@ def elliptic_curve_search(info, query):
                     info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
+                    info['galois__image'] = ','.join(modell_labels + elladic_labels)
                 query['modell_images'] = { '$contains': modell_labels }
 
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -6,7 +6,7 @@ from io import BytesIO
 import time
 
 from flask import render_template, url_for, request, redirect, make_response, send_file, abort
-from sage.all import ZZ, QQ, Qp, RealField, EllipticCurve, cputime
+from sage.all import ZZ, QQ, Qp, RealField, EllipticCurve, cputime, is_prime
 from sage.databases.cremona import parse_cremona_label, class_to_int
 
 from lmfdb import db

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -426,7 +426,7 @@ def elliptic_curve_search(info, query):
             query['modell_images'] = { '$contains': modell_labels }
         if not 'cm' in query:
             query['cm'] = 0
-            info['cm'] = 0
+            info['cm'] = "0"
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -428,15 +428,13 @@ def elliptic_curve_search(info, query):
             query['cm'] = 0
             info['cm'] = "noCM"
             # try to help the user out if they specify a maximal group
-            print(modell_labels)
-            if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
+            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)
         else:
             # try to help the user out if they specify a maximal group
-            print(modell_labels)
-            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
+            if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -443,7 +443,8 @@ def elliptic_curve_search(info, query):
                     raise ValueError(err)
                 else:
                     modell_labels = [a for a in modell_labels if not a in max_labels]
-                    info['nonmax_primes'] = ','.join(max_labels)
+                    max_primes = [int(modell_image_label_regex.match(a)[1]) for a in max_labels]
+                    info['nonmax_primes'] = ','.join(max_primes)
                     info['nanmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -445,7 +445,7 @@ def elliptic_curve_search(info, query):
                     modell_labels = [a for a in modell_labels if not a in max_labels]
                     max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
                     info['nonmax_primes'] = ','.join(max_primes)
-                    info['nanmax_quantifier'] = 'exclude'
+                    info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
                 query['modell_images'] = { '$contains': modell_labels }

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -6,7 +6,7 @@ from io import BytesIO
 import time
 
 from flask import render_template, url_for, request, redirect, make_response, send_file, abort
-from sage.all import ZZ, QQ, Qp, RealField, EllipticCurve, cputime, is_prime
+from sage.all import ZZ, QQ, Qp, RealField, EllipticCurve, cputime, is_prime, is_prime_power
 from sage.databases.cremona import parse_cremona_label, class_to_int
 
 from lmfdb import db
@@ -409,7 +409,7 @@ def elliptic_curve_search(info, query):
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
         labels = [a.strip() for a in info['galois_image'].split(',')]
-        elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a) and is_prime(elladic_image_label_regex.match(a)[1])]
+        elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a) and is_prime_power(elladic_image_label_regex.match(a)[1])]
         modell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a) and is_prime(modell_image_label_regex.match(a)[1])]
         if len(elladic_labels)+len(modell_labels) != len(labels):
             err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -426,7 +426,7 @@ def elliptic_curve_search(info, query):
             query['modell_images'] = { '$contains': modell_labels }
         if not 'cm' in query:
             query['cm'] = 0
-            info[['cm'] = 0
+            info['cm'] = 0
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -401,7 +401,6 @@ def elliptic_curve_search(info, query):
     parse_primes(info, query, 'sha_primes', name='sha primes',
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
-        print(info["galois_image"])
         try:
             parse_regex_restricted (info, query, field='galois_image', qfield='elladic_images', regex=elladic_image_label_regex)
         except SearchParsingError:
@@ -411,8 +410,6 @@ def elliptic_curve_search(info, query):
                 raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:
             query['cm'] = 0
-        print(query["elladic_images"])
-        print(query["modell_images"])
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -435,7 +435,7 @@ def elliptic_curve_search(info, query):
                 raise ValueError(err)
         else:
             # if the user specifies full mod-ell image with ell > 3, automatically exclude nonmax primes (if possible)
-            max_labels = [a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]
+            max_labels = [a for a in modell_labels if a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3]
             if max_labels:
                 if query.get('nonmax_primes'):
                     err = "To search for maximal images, exclude non-maximal primes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -427,15 +427,14 @@ def elliptic_curve_search(info, query):
         if not 'cm' in query:
             query['cm'] = 0
             info['cm'] = "noCM"
-            # try to help the user out if they specify a maximal group
+        # try to help the user out if they specify a maximal group
         if query['cm']:
-            # try to help the user out if they specify a maximal group
             if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)
         else:
-            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
+            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -428,13 +428,14 @@ def elliptic_curve_search(info, query):
             query['cm'] = 0
             info['cm'] = "noCM"
             # try to help the user out if they specify a maximal group
-            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
+        if query['cm']:
+            # try to help the user out if they specify a maximal group
+            if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)
         else:
-            # try to help the user out if they specify a maximal group
-            if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
+            if any([a.endswith("G") and int(modell_image_label_regex.match(a)[0]) > 3 for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -406,8 +406,8 @@ def elliptic_curve_search(info, query):
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
         labels = [a.strip() for a in info['galois_image'].split(',')]
-        elladic_labels = [a for a in label if elladic_image_label_regex.fullmatch(a)]
-        moddell_labels = [a for a in label if modell_image_label_regex.fullmatch(a)]
+        elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a)]
+        moddell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a)]
         if len(elladic_labels)+len(modell_labels) != len(labels):
             err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"
             flash_error(err, "13.91.3.1", "13S4")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -437,7 +437,7 @@ def elliptic_curve_search(info, query):
             # if the user specifies full mod-ell image with ell > 3, automatically exclude nonmax primes (if possible)
             max_labels = [a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]
             if max_labels:
-                if query['nonmax_primes'] then:
+                if query['nonmax_primes']:
                     err = "To search for maximal images, exclude non-maximal primes"
                     flash_error(err)
                     raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -363,8 +363,9 @@ def elliptic_curve_search(info, query):
             query['semistable'] = True
         elif info['conductor_type'] == 'divides':
             if not isinstance(query.get('conductor'), int):
-                flash_error("You must specify a single conductor")
-                raise ValueError("You must specify a single conductor")
+                err = "You must specify a single conductor"
+                flash_error(err)
+                raise ValueError(err)
             else:
                 query['conductor'] = {'$in': ZZ(query['conductor']).divisors()}
     parse_signed_ints(info, query, 'discriminant', qfield=('signD', 'absD'))
@@ -374,11 +375,11 @@ def elliptic_curve_search(info, query):
     parse_ints(info,query,'num_int_pts','num_int_pts')
     parse_ints(info,query,'class_size','class_size')
     if info.get('class_deg'):
+        parse_ints(info,query,'class_deg','class_deg')
         if not isinstance(query.get('class_deg'), int):
             err = "You must specify a single isogeny class degree"
             flash_error(err)
             raise ValueError(err)
-        parse_ints(info,query,'class_deg','class_deg')
     parse_floats(info,query,'regulator','regulator')
     parse_floats(info, query, 'faltings_height', 'faltings_height')
     parse_bool(info,query,'semistable','semistable')
@@ -410,8 +411,9 @@ def elliptic_curve_search(info, query):
         elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
             query['modell_images'] = { '$contains': labels }
         else:
-            raise SearchParsingError("oops")
-            raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
+            err = "Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}"
+            flash_error(err)
+            raise ValueError(err)
         if not 'cm' in query:
             query['cm'] = 0
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -401,6 +401,7 @@ def elliptic_curve_search(info, query):
     parse_primes(info, query, 'sha_primes', name='sha primes',
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
+        print(info["galois_image"])
         try:
             parse_regex_restricted (info, query, "elladic_images", elladic_image_label_regex)
         except SearchParsingError:
@@ -410,6 +411,8 @@ def elliptic_curve_search(info, query):
                 raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:
             query['cm'] = 0
+        print(query["elladic_images"])
+        print(query["modell_images"])
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -407,7 +407,7 @@ def elliptic_curve_search(info, query):
     if info.get("galois_image"):
         labels = [a.strip() for a in info['galois_image'].split(',')]
         elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a)]
-        moddell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a)]
+        modell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a)]
         if len(elladic_labels)+len(modell_labels) != len(labels):
             err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"
             flash_error(err, "13.91.3.1", "13S4")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -446,7 +446,7 @@ def elliptic_curve_search(info, query):
                     max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
                     if info.get('nonmax_primes'):
                         max_primes += [l.strip() for l in info['nonmax_primes'].split(',') if not l.strip() in max_primes]
-                    max_primes.sort(key=lambda x: int(x))
+                    max_primes.sort(key=int)
                     info['nonmax_primes'] = ','.join(max_primes)
                     info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -427,6 +427,18 @@ def elliptic_curve_search(info, query):
         if not 'cm' in query:
             query['cm'] = 0
             info['cm'] = "noCM"
+            # try to help the user out if they specify a maximal group
+            if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
+                err = "To search for maximal images, exclude non-maximal primes"
+                flash_error(err)
+                raise ValueError(err)
+        else:
+            # try to help the user out if they specify a maximal group
+            if any([a.endswith("G") and modell_image_label_regex.match(a)[0] > 3 for a in modell_labels]):
+                err = "To search for maximal images, exclude non-maximal primes"
+                flash_error(err)
+                raise ValueError(err)
+
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list
@@ -905,7 +917,7 @@ class ECSearchArray(SearchArray):
             label=r"Galois image",
             short_label=r"Galois image",
             example="13S4 or 13.91.3.2",
-            knowl="ec.galois_rep_elladic_image")
+            knowl="ec.galois_image_search")
         nonmax_quant = SubsetBox(
             name="nonmax_quantifier")
         nonmax_primes = TextBoxWithSelect(

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -406,14 +406,16 @@ def elliptic_curve_search(info, query):
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
         labels = [a.strip() for a in info['galois_image'].split(',')]
-        if all([elladic_image_label_regex.fullmatch(a) for a in labels]):
-            query['elladic_images'] = { '$contains': labels }
-        elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
-            query['modell_images'] = { '$contains': labels }
-        else:
-            err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s."
+        elladic_labels = [a for a in label if elladic_image_label_regex.fullmatch(a)]
+        moddell_labels = [a for a in label if modell_image_label_regex.fullmatch(a)]
+        if len(elladic_labels)+len(modell_labels) ne len(labels):
+            err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"
             flash_error(err, "13.91.3.1", "13S4")
             raise ValueError(err)
+        if elladic_labels:
+            query['elladic_images'] = { '$contains': elladic_labels }
+        if modell_labels:
+            query['modell_images'] = { '$contains': modell_labels }
         if not 'cm' in query:
             query['cm'] = 0
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -411,8 +411,8 @@ def elliptic_curve_search(info, query):
         elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
             query['modell_images'] = { '$contains': labels }
         else:
-            err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as 13.91.3.1, the label of a subgroup of GL(2,F_ell), such as 13S4."
-            flash_error(err)
+            err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s."
+            flash_error(err, "13.91.3.1", "13S4")
             raise ValueError(err)
         if not 'cm' in query:
             query['cm'] = 0

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -13,9 +13,9 @@ from lmfdb import db
 from lmfdb.app import app
 from lmfdb.backend.encoding import Json
 from lmfdb.utils import (
-    web_latex, to_dict, comma, flash_error, display_knowl, raw_typeset, parse_regex_restricted,
+    web_latex, to_dict, comma, flash_error, display_knowl, raw_typeset,
     parse_rational_to_list, parse_ints, parse_floats, parse_bracketed_posints, parse_primes,
-    SearchArray, TextBox, SelectBox, SubsetBox, TextBoxWithSelect, CountBox, SearchParsingError,
+    SearchArray, TextBox, SelectBox, SubsetBox, TextBoxWithSelect, CountBox,
     StatsDisplay, parse_element_of, parse_bool, parse_signed_ints, search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.elliptic_curves import ec_page, ec_logger

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -381,13 +381,20 @@ def elliptic_curve_search(info, query):
             raise ValueError(err)
     parse_floats(info,query,'regulator','regulator')
     parse_floats(info, query, 'faltings_height', 'faltings_height')
-    parse_bool(info,query,'semistable','semistable')
+    if info.get('reduction'):
+        if info['reduction'] == 'semistable':
+            query['semistable'] = True
+        ellif info['reduction'] == 'not semistable':
+            query['semistable'] = False
+        elif info['reduction'] == 'potentially good':
+            query['potential_good_reduction'] = True
+        elif info['reduction'] == 'not potentially good':
+            query['potential_good_reduction'] = False
     if info.get('torsion'):
         if info['torsion'][0] == '[':
             parse_bracketed_posints(info,query,'torsion',qfield='torsion_structure',maxlength=2,check_divisibility='increasing')
         else:
             parse_ints(info,query,'torsion')
-    parse_bool(info,query,'potential_good_reduction','potential_good_reduction')
     # speed up slow torsion_structure searches by also setting torsion
     #if 'torsion_structure' in query and not 'torsion' in query:
     #    query['torsion'] = reduce(mul,[int(n) for n in query['torsion_structure']],1)
@@ -399,8 +406,6 @@ def elliptic_curve_search(info, query):
         else:
             parse_ints(info,query,field='cm',qfield='cm')
     parse_element_of(info,query,'isogeny_degrees',split_interval=1000,contained_in=get_stats().isogeny_degrees)
-    parse_primes(info, query, 'maximal_primes', name='maximal primes',
-                 qfield='nonmaximal_primes', mode='exclude')
     parse_primes(info, query, 'nonmaximal_primes', name='non-maximal primes',
                  qfield='nonmaximal_primes',mode=info.get('max_quantifier'), radical='nonmax_rad')
     parse_primes(info, query, 'bad_primes', name='bad primes',
@@ -910,8 +915,8 @@ class ECSearchArray(SearchArray):
             example="2,3",
             select_box=nonmax_quant)
         cm_opts = ([('', ''), ('noCM', 'no potential CM'), ('CM', 'potential CM')] +
-                   [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]] +
-                   [('-3,-12,-27', 'potential CM by Q(zeta_3)'), ('-4,-16', 'potential CM by Q(i)'), ('-7,-28', 'potential CM by Q(sqrt(7))')])
+                   [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(7))')] +
+                   [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]])
         cm = SelectBox(
             name="cm",
             label="Complex multiplication",

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -408,7 +408,7 @@ def elliptic_curve_search(info, query):
         labels = [a.strip() for a in info['galois_image'].split(',')]
         elladic_labels = [a for a in label if elladic_image_label_regex.fullmatch(a)]
         moddell_labels = [a for a in label if modell_image_label_regex.fullmatch(a)]
-        if len(elladic_labels)+len(modell_labels) ne len(labels):
+        if len(elladic_labels)+len(modell_labels) != len(labels):
             err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"
             flash_error(err, "13.91.3.1", "13S4")
             raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -411,7 +411,7 @@ def elliptic_curve_search(info, query):
         elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
             query['modell_images'] = { '$contains': labels }
         else:
-            err = "Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}"
+            err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as 13.91.3.1, the label of a subgroup of GL(2,F_ell), such as 13S4."
             flash_error(err)
             raise ValueError(err)
         if not 'cm' in query:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -451,7 +451,6 @@ def elliptic_curve_search(info, query):
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
                     info['galois_image'] = ','.join(modell_labels + elladic_labels)
-                    print(info['galois_image'])
                 query['modell_images'] = { '$contains': modell_labels }
 
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -403,10 +403,10 @@ def elliptic_curve_search(info, query):
     if info.get("galois_image"):
         print(info["galois_image"])
         try:
-            parse_regex_restricted (info, query, "elladic_images", elladic_image_label_regex)
+            parse_regex_restricted (info, query, field='galois_image', qfield='elladic_images', regex=elladic_image_label_regex)
         except SearchParsingError:
             try:
-                parse_regex_restricted (info, query, "modell_images", elladic_image_label_regex)
+                parse_regex_restricted (info, query, field='galois_image', qfield='modell_images', regex=elladic_image_label_regex)
             except SearchParsingError:
                 raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -384,7 +384,7 @@ def elliptic_curve_search(info, query):
     if info.get('reduction'):
         if info['reduction'] == 'semistable':
             query['semistable'] = True
-        ellif info['reduction'] == 'not semistable':
+        elif info['reduction'] == 'not semistable':
             query['semistable'] = False
         elif info['reduction'] == 'potentially good':
             query['potential_good_reduction'] = True

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -407,6 +407,7 @@ def elliptic_curve_search(info, query):
         elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
             query['modell_images'] = { '$contains': labels }
         else:
+            raise ValueError("oops")
             raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:
             query['cm'] = 0

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -409,8 +409,8 @@ def elliptic_curve_search(info, query):
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
         labels = [a.strip() for a in info['galois_image'].split(',')]
-        elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a)]
-        modell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a)]
+        elladic_labels = [a for a in labels if elladic_image_label_regex.fullmatch(a) and is_prime(elladic_image_label_regex.match(a)[1])]
+        modell_labels = [a for a in labels if modell_image_label_regex.fullmatch(a) and is_prime(modell_image_label_regex.match(a)[1])]
         if len(elladic_labels)+len(modell_labels) != len(labels):
             err = "Unrecognized Galois image label, it should be the label of a subgroup of GL(2,Z_ell), such as %s, or the label of a subgroup of GL(2,F_ell), such as %s, or a list of such labels"
             flash_error(err, "13.91.3.1", "13S4")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -437,7 +437,7 @@ def elliptic_curve_search(info, query):
             # if the user specifies full mod-ell image with ell > 3, automatically exclude nonmax primes (if possible)
             max_labels = [a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3 for a in modell_labels]
             if max_labels:
-                if query['nonmax_primes']:
+                if query.get('nonmax_primes'):
                     err = "To search for maximal images, exclude non-maximal primes"
                     flash_error(err)
                     raise ValueError(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -426,7 +426,7 @@ def elliptic_curve_search(info, query):
             query['modell_images'] = { '$contains': modell_labels }
         if not 'cm' in query:
             query['cm'] = 0
-            info['cm'] = "0"
+            info['cm'] = "noCM"
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -426,6 +426,7 @@ def elliptic_curve_search(info, query):
             query['modell_images'] = { '$contains': modell_labels }
         if not 'cm' in query:
             query['cm'] = 0
+            info[['cm'] = 0
     # The button which used to be labelled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -446,6 +446,7 @@ def elliptic_curve_search(info, query):
                     max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
                     if info.get('nonmax_primes'):
                         max_primes += [l.strip() for l in info['nonmax_primes'].split(',') if not l.strip() in max_primes]
+                    max_primes.sort(key=lambda x: int(x))
                     info['nonmax_primes'] = ','.join(max_primes)
                     info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -401,13 +401,13 @@ def elliptic_curve_search(info, query):
     parse_primes(info, query, 'sha_primes', name='sha primes',
                  qfield='sha_primes',mode=info.get('sha_quantifier'))
     if info.get("galois_image"):
-        try:
-            parse_regex_restricted (info, query, field='galois_image', qfield='elladic_images', regex=elladic_image_label_regex)
-        except SearchParsingError:
-            try:
-                parse_regex_restricted (info, query, field='galois_image', qfield='modell_images', regex=elladic_image_label_regex)
-            except SearchParsingError:
-                raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
+        labels = [a.strip() for a in info['galois_image'].split(',')]
+        if all([elladic_image_label_regex.fullmatch(a) for a in labels]):
+            query['elladic_images'] = { '$contains': labels }
+        elif all([modell_image_label_regex.fullmatch(a) for a in labels]):
+            query['modell_images'] = { '$contains': labels }
+        else:
+            raise ValueError("Unrecognized Galois image label, it should be the label of a {{KNOWL('ec.galois_rep_modell_image','subgroup of GL(2,F_ell)')}} or a {{KNOWL('ec.galois_rep_elladic_image','subgroup of GL(2,Z_ell)')}}")
         if not 'cm' in query:
             query['cm'] = 0
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -428,12 +428,14 @@ def elliptic_curve_search(info, query):
             query['cm'] = 0
             info['cm'] = "noCM"
             # try to help the user out if they specify a maximal group
+            print(modell_labels)
             if any([a.endswith("Nn") for a in modell_labels]) or any([a.endswith("Ns") for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)
                 raise ValueError(err)
         else:
             # try to help the user out if they specify a maximal group
+            print(modell_labels)
             if any([a.endswith("G") and modell_image_label_regex.match(a)[0] > 3 for a in modell_labels]):
                 err = "To search for maximal images, exclude non-maximal primes"
                 flash_error(err)

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -443,7 +443,7 @@ def elliptic_curve_search(info, query):
                     raise ValueError(err)
                 else:
                     modell_labels = [a for a in modell_labels if not a in max_labels]
-                    info['nonmax_primes'] = max_labels.join(",")
+                    info['nonmax_primes'] = ','.join(max_labels)
                     info['nanmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -451,6 +451,7 @@ def elliptic_curve_search(info, query):
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
                                  qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
                     info['galois_image'] = ','.join(modell_labels + elladic_labels)
+                    print(info['galois_image'])
                 query['modell_images'] = { '$contains': modell_labels }
 
     # The button which used to be labelled Optimal only no/yes"

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -406,8 +406,8 @@ def elliptic_curve_search(info, query):
         else:
             parse_ints(info,query,field='cm',qfield='cm')
     parse_element_of(info,query,'isogeny_degrees',split_interval=1000,contained_in=get_stats().isogeny_degrees)
-    parse_primes(info, query, 'nonmaximal_primes', name='non-maximal primes',
-                 qfield='nonmaximal_primes',mode=info.get('max_quantifier'), radical='nonmax_rad')
+    parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',
+                 qfield='nonmax_primes', mode=info.get('nonmax_quantifier'), radical='nonmax_rad')
     parse_primes(info, query, 'bad_primes', name='bad primes',
                  qfield='bad_primes',mode=info.get('bad_quantifier'))
     parse_primes(info, query, 'sha_primes', name='sha primes',
@@ -905,15 +905,15 @@ class ECSearchArray(SearchArray):
             short_label=r"Galois image",
             example="13.91.3.2",
             knowl="ec.galois_rep_elladic_image")
-        nonmaximal_quant = SubsetBox(
-            name="nonmaximal_quantifier")
-        nonmaximal_primes = TextBoxWithSelect(
-            name="nonmaximal_primes",
+        nonmax_quant = SubsetBox(
+            name="nonmax_quantifier")
+        nonmax_primes = TextBoxWithSelect(
+            name="nonmax_primes",
             label=r"Nonmaximal $\ell$",
             short_label=r"Nonmax $\ell$",
             knowl="ec.maximal_elladic_galois_rep",
             example="2,3",
-            select_box=nonmaximal_quant)
+            select_box=nonmax_quant)
         cm_opts = ([('', ''), ('noCM', 'no potential CM'), ('CM', 'potential CM')] +
                    [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(7))')] +
                    [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]])
@@ -933,7 +933,7 @@ class ECSearchArray(SearchArray):
             [torsion, cm],
             [rank, sha],
             [regulator, sha_primes],
-            [galois_image, nonmaximal_primes],
+            [galois_image, nonmax_primes],
             [class_size, class_deg],
             [num_int_pts, isodeg],
             [optimal, reduction],
@@ -943,6 +943,6 @@ class ECSearchArray(SearchArray):
         self.refine_array = [
             [cond, jinv, rank, torsion, cm],
             [bad_primes, disc, regulator, sha, galois_image],
-            [class_size, class_deg, isodeg, sha_primes, nonmaximal_primes],
+            [class_size, class_deg, isodeg, sha_primes, nonmax_primes],
             [optimal, reduction, num_int_pts, faltings_height]
             ]

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -913,7 +913,7 @@ class ECSearchArray(SearchArray):
                    [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]] +
                    [('-3,-12,-27', 'potential CM by Q(zeta_3)'), ('-4,-16', 'potential CM by Q(i)'), ('-7,-28', 'potential CM by Q(sqrt(7))')])
         cm = SelectBox(
-            name="cm_disc",
+            name="cm",
             label="Complex multiplication",
             example="potential CM by Q(i)",
             knowl="ec.complex_multiplication",

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -437,13 +437,15 @@ def elliptic_curve_search(info, query):
             # if the user specifies full mod-ell image with ell > 3, automatically exclude nonmax primes (if possible)
             max_labels = [a for a in modell_labels if a.endswith("G") and int(modell_image_label_regex.match(a)[1]) > 3]
             if max_labels:
-                if query.get('nonmax_primes'):
+                if info.get('nonmax_primes') and info['nonmax_quantifier'] != 'exclude':
                     err = "To search for maximal images, exclude non-maximal primes"
                     flash_error(err)
                     raise ValueError(err)
                 else:
                     modell_labels = [a for a in modell_labels if not a in max_labels]
                     max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
+                    if info['nonmax_primes']:
+                        max_primes += [l.strip() for l in info['nonmax_primes'].split(',') if not l.strip() in max_primes]
                     info['nonmax_primes'] = ','.join(max_primes)
                     info['nonmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -443,7 +443,7 @@ def elliptic_curve_search(info, query):
                     raise ValueError(err)
                 else:
                     modell_labels = [a for a in modell_labels if not a in max_labels]
-                    max_primes = [int(modell_image_label_regex.match(a)[1]) for a in max_labels]
+                    max_primes = [modell_image_label_regex.match(a)[1] for a in max_labels]
                     info['nonmax_primes'] = ','.join(max_primes)
                     info['nanmax_quantifier'] = 'exclude'
                     parse_primes(info, query, 'nonmax_primes', name='non-maximal primes',

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -85,7 +85,7 @@ table td.params {
 <td class="center">{%if curve.nonmax_primes %}${{curve.nonmax_primes|join(",")}}${%endif %}</td>
 {% endif %}
 {% if info.galois_image %}
-<td class="center">{{curve.elladic_images}}</td>
+<td class="center">{{curve.elladic_images|join(",")}}</td>
 {% endif %}
 {% if info.num_int_pts %}
 <td class="center">{{curve.num_int_pts}}</td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -82,7 +82,7 @@ table td.params {
 <td class="center">{{curve.cm}}</td>
 {% endif %}
 {% if info.nonmax_primes %}
-<td class="center">{%if curve.nonmax_primes %}${{curve.nonmax_primes}}${%endif %}</td>
+<td class="center">{%if curve.nonmax_primes %}${{curve.nonmax_primes|join(",")}}${%endif %}</td>
 {% endif %}
 {% if info.galois_image %}
 <td class="center">{{curve.elladic_images}}</td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -37,13 +37,13 @@ table td.params {
 {% endif %}
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.torsion_subgroup', title='Torsion') }}</th>
-{% if info.cm %}
-  <th class="center">{{KNOWL('ec.complex_multiplication', title='CM discriminant')}}</th>
+{% if info.cm == "CM" or "," in info.cm %}
+  <th class="center">{{KNOWL('ec.complex_multiplication', title='CM disc')}}</th>
 {% endif %}
 {% if info.nonmax_primes %}
-  <th class="center">{{KNOWL('ec.maximal_elladic_galois_rep', title='Non-maximal primes')}}</th>
+  <th class="center">{{KNOWL('ec.maximal_elladic_galois_rep', title='Nonmax primes')}}</th>
 {% endif %}
-{% if info.nonmax_primes %}
+{% if info.galois_image %}
   <th class="center">{{KNOWL('ec.galois_rep_elladic_image', title='Galois images')}}</th>
 {% endif %}
 {% if info.num_int_pts %}

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -84,7 +84,7 @@ table td.params {
 {% if info.nonmax_primes %}
 <td class="center">{%if curve.nonmax_primes %}${{curve.nonmax_primes}}${%endif %}</td>
 {% endif %}
-{% if info.galois_images %}
+{% if info.galois_image %}
 <td class="center">{{curve.elladic_images}}</td>
 {% endif %}
 {% if info.num_int_pts %}

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -37,14 +37,17 @@ table td.params {
 {% endif %}
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
   <th class="center">{{ KNOWL('ec.torsion_subgroup', title='Torsion') }}</th>
-{% if info.nonmax_primes %}
-  <th class="center">{{KNOWL('ec.maximal_elladic_galois_rep', title='Non-maximal primes')}}</th>
-{% endif %}
 {% if info.cm %}
   <th class="center">{{KNOWL('ec.complex_multiplication', title='CM discriminant')}}</th>
 {% endif %}
+{% if info.nonmax_primes %}
+  <th class="center">{{KNOWL('ec.maximal_elladic_galois_rep', title='Non-maximal primes')}}</th>
+{% endif %}
+{% if info.nonmax_primes %}
+  <th class="center">{{KNOWL('ec.galois_rep_elladic_image', title='Galois images')}}</th>
+{% endif %}
 {% if info.num_int_pts %}
-  <th class="center">{{KNOWL('ec.q.integral_points', title='integral points')}}</th>
+  <th class="center">{{KNOWL('ec.q.integral_points', title='Integral points')}}</th>
 {% endif %}
 </tr>
 </thead>
@@ -76,10 +79,13 @@ table td.params {
 <td class="center">${{curve.rank}}$</td>
 <td class="center">{% if (curve.torsion_structure|length) == 0 %}trivial{% else %}${{curve.torsion_structure}}${% endif %}</td>
 {% if info.cm %}
-<td class="center">{{curve.cm_disc}}</td>
+<td class="center">{{curve.cm}}</td>
 {% endif %}
 {% if info.nonmax_primes %}
 <td class="center">{{curve.nonmax_primes}}</td>
+{% endif %}
+{% if info.galois_images %}
+<td class="center">{{curve.elladic_images}}</td>
 {% endif %}
 {% if info.num_int_pts %}
 <td class="center">{{curve.num_int_pts}}</td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -78,11 +78,11 @@ table td.params {
 {% endif %}
 <td class="center">${{curve.rank}}$</td>
 <td class="center">{% if (curve.torsion_structure|length) == 0 %}trivial{% else %}${{curve.torsion_structure}}${% endif %}</td>
-{% if info.cm %}
+{% if info.cm == "CM" or "," in info.cm %}
 <td class="center">{{curve.cm}}</td>
 {% endif %}
 {% if info.nonmax_primes %}
-<td class="center">{{curve.nonmax_primes}}</td>
+<td class="center">{%if (curve.nonmax_primes|length) == 0 %}none{% else %}${{curve.nonmax_primes[1:-1]}}${%endif %}</td>
 {% endif %}
 {% if info.galois_images %}
 <td class="center">{{curve.elladic_images}}</td>

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -36,12 +36,15 @@ table td.params {
   <th class="center">{{ KNOWL('ec.q.faltings_height',  title='Faltings height') }}</th>
 {% endif %}
   <th class="center">{{ KNOWL('ec.rank', title='Rank') }}</th>
-  <th class="center">{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</th>
-{% if info.surj_primes or info.nonsurj_primes  %}
+  <th class="center">{{ KNOWL('ec.torsion_subgroup', title='Torsion') }}</th>
+{% if info.nonmax_primes %}
   <th class="center">{{KNOWL('ec.maximal_elladic_galois_rep', title='Non-maximal primes')}}</th>
 {% endif %}
+{% if info.cm %}
+  <th class="center">{{KNOWL('ec.complex_multiplication', title='CM discriminant')}}</th>
+{% endif %}
 {% if info.num_int_pts %}
-  <th class="center">Number of {{KNOWL('ec.q.integral_points', title='integral points')}}</th>
+  <th class="center">{{KNOWL('ec.q.integral_points', title='integral points')}}</th>
 {% endif %}
 </tr>
 </thead>
@@ -72,7 +75,10 @@ table td.params {
 {% endif %}
 <td class="center">${{curve.rank}}$</td>
 <td class="center">{% if (curve.torsion_structure|length) == 0 %}trivial{% else %}${{curve.torsion_structure}}${% endif %}</td>
-{% if info.surj_primes or info.nonsurj_primes %}
+{% if info.cm %}
+<td class="center">{{curve.cm_disc}}</td>
+{% endif %}
+{% if info.nonmax_primes %}
 <td class="center">{{curve.nonmax_primes}}</td>
 {% endif %}
 {% if info.num_int_pts %}

--- a/lmfdb/elliptic_curves/templates/ec-search-results.html
+++ b/lmfdb/elliptic_curves/templates/ec-search-results.html
@@ -82,7 +82,7 @@ table td.params {
 <td class="center">{{curve.cm}}</td>
 {% endif %}
 {% if info.nonmax_primes %}
-<td class="center">{%if (curve.nonmax_primes|length) == 0 %}none{% else %}${{curve.nonmax_primes[1:-1]}}${%endif %}</td>
+<td class="center">{%if curve.nonmax_primes %}${{curve.nonmax_primes}}${%endif %}</td>
 {% endif %}
 {% if info.galois_images %}
 <td class="center">{{curve.elladic_images}}</td>

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -76,11 +76,11 @@ class HomePageTest(LmfdbTest):
                         '169136.i3')
         self.check_args("/EllipticCurve/Q/?torsion_structure=%5B2%2C4%5D&sha=&count=100",
                         '[0, 1, 0, -1664, -9804]')
-        self.check_args_with_timeout("/EllipticCurve/Q/?&surj_primes=&surj_quantifier=include&nonsurj_primes=2%2C3&count=100",
+        self.check_args_with_timeout("/EllipticCurve/Q/?nonmax_quantifier=include&nonmax_primes=2,3&count=100",
                         '[1, -1, 1, -24575, 1488935]')
-        self.check_args_with_timeout("/EllipticCurve/Q/?&surj_primes=&surj_quantifier=exactly&nonsurj_primes=5&optimal=on&count=100",
+        self.check_args_with_timeout("/EllipticCurve/Q/?nonmax_quantifier=exactly&nonmax_primes=5&optimal=on&count=100",
                         '[0, 0, 1, -75, 256]')
-        self.check_args("EllipticCurve/Q/?conductor=990&surj_quantifier=include&optimal=on",
+        self.check_args("EllipticCurve/Q/?conductor=990&optimal=on",
                         '990h1')
         L = self.tc.get("EllipticCurve/Q/?isogeny_degrees=13&search_type=List")
         assert '[0, 0, 1, -849658625, 9532675710156]' in L.get_data(as_text=True)

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -74,7 +74,7 @@ class HomePageTest(LmfdbTest):
                         '[0, -1, 0, -10560, -414180]')
         self.check_args("/EllipticCurve/Q/?conductor=&jinv=-4096%2F11&count=100",
                         '169136.i3')
-        self.check_args("/EllipticCurve/Q/?torsion_structure=%5B2%2C4%5D&sha=&count=100",
+        self.check_args("/EllipticCurve/Q/?torsion=%5B2%2C4%5D&sha=&count=100",
                         '[0, 1, 0, -1664, -9804]')
         self.check_args_with_timeout("/EllipticCurve/Q/?nonmax_quantifier=include&nonmax_primes=2,3&count=100",
                         '[1, -1, 1, -24575, 1488935]')

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -78,7 +78,7 @@ class EllCurveTest(LmfdbTest):
         assert 'rational number' in L.get_data(as_text=True)
 
     def test_tors_search(self):
-        L = self.tc.get('/EllipticCurve/Q/?start=0&torsion_structure=[7]&count=100')
+        L = self.tc.get('/EllipticCurve/Q/?start=0&torsion=[7]&count=100')
         assert '858.k1' in L.get_data(as_text=True)
         assert '[1, -1, 1, 9588, 2333199]' in L.get_data(as_text=True)
 
@@ -109,8 +109,8 @@ class EllCurveTest(LmfdbTest):
         assert not('11.a1' in L.get_data(as_text=True))
 
     def test_cm_disc_search(self):
-        self.check_args('EllipticCurve/Q/?cm_disc=-4', '32.a3')
-        self.not_check_args('EllipticCurve/Q/?cm_disc=-4', '11.a1')
+        self.check_args('EllipticCurve/Q/?cm=-4', '32.a3')
+        self.not_check_args('EllipticCurve/Q/?cm=-4', '11.a1')
 
     def test_one_per_search(self):
         # Test that we correctly fixed issue 4678
@@ -129,7 +129,7 @@ class EllCurveTest(LmfdbTest):
         assert '[1, -1, 1, -3, 3]' in L.get_data(as_text=True)
 
     def test_sha(self):
-        L = self.tc.get('EllipticCurve/Q/?start=0&&sha=2-&count=100')
+        L = self.tc.get('EllipticCurve/Q/?start=0&sha=2-&count=100')
         assert '[0, 1, 0, -73824640, -244170894880]' in L.get_data(as_text=True)
         assert '226920.h1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/Q/?start=0&sha=81&count=100')

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -49,7 +49,7 @@ class EllCurveTest(LmfdbTest):
         assert '11.1' in L.get_data(as_text=True) and 'not a valid label for an isogeny class' in L.get_data(as_text=True)
 
     def test_Cond_search(self):
-        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=1200&count=100')
         assert '[0, 1, 0, -2133408, 1198675188]' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/210/')
         assert '[1, 0, 0, 729, -176985]' in L.get_data(as_text=True)
@@ -63,7 +63,7 @@ class EllCurveTest(LmfdbTest):
         assert '/EllipticCurve/Q/%5B1%2C2%2C3%2C4%2C5%5D/' in L.get_data(as_text=True)
 
     def test_j_search(self):
-        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2000&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2000&count=100')
         assert '41616.bi2' in L.get_data(as_text=True)
         L = self.tc.get('/EllipticCurve/Q/?jinv=0,1728')
         t = L.get_data(as_text=True)
@@ -73,20 +73,21 @@ class EllCurveTest(LmfdbTest):
         assert '27.a3' not in t and '32.a3' not in t and '11.a3' in t
 
     def test_jbad_search(self):
-        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2.3&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=2.3&count=100')
         assert 'Error' in L.get_data(as_text=True)
         assert 'rational number' in L.get_data(as_text=True)
 
     def test_tors_search(self):
-        L = self.tc.get('/EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=[7]&sha=&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('/EllipticCurve/Q/?start=0&torsion_structure=[7]&count=100')
         assert '858.k1' in L.get_data(as_text=True)
         assert '[1, -1, 1, 9588, 2333199]' in L.get_data(as_text=True)
 
     def test_SurjPrimes_search(self):
-        self.check_args_with_timeout('/EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=2&surj_quantifier=include&nonsurj_primes=&count=100', '[0, 0, 1, -270, -1708]')
+        self.check_args_with_timeout('/EllipticCurve/Q/?start=0&nonmax_quantifier=exclude&nonmax_primes=2&count=100', '[0, 0, 1, -270, -1708]')
 
-    def test_NonSurjPrimes_search(self):
-        self.check_args_with_timeout('/EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=&optimal=&surj_primes=&surj_quantifier=exactly&nonsurj_primes=37&count=100', '[0, 0, 0, -36705844875, 2706767485056250]')
+    def test_NonMaxPrimes_search(self):
+        self.check_args_with_timeout('/EllipticCurve/Q/?start=0&nonmax_quantifier=exactly&nonmax_primes=37&count=100', '[0, 0, 0, -36705844875, 2706767485056250]')
+        self.check_args_with_timeout('/EllipticCurve/Q/?start=0&galois_image=13.91.3.2&count=100', '[0, -1, 1, -3098, 67979]')
 
     def test_BadPrimes_search(self):
         L = self.tc.get('/EllipticCurve/Q/?bad_quantifier=include&bad_primes=3%2C5')
@@ -128,12 +129,12 @@ class EllCurveTest(LmfdbTest):
         assert '[1, -1, 1, -3, 3]' in L.get_data(as_text=True)
 
     def test_sha(self):
-        L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=2&torsion=&torsion_structure=&sha=2-&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('EllipticCurve/Q/?start=0&&sha=2-&count=100')
         assert '[0, 1, 0, -73824640, -244170894880]' in L.get_data(as_text=True)
         assert '226920.h1' in L.get_data(as_text=True)
-        L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=81&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('EllipticCurve/Q/?start=0&sha=81&count=100')
         assert '101592.p1' in L.get_data(as_text=True)
-        L = self.tc.get('EllipticCurve/Q/?start=0&conductor=&jinv=&rank=&torsion=&torsion_structure=&sha=8.999&optimal=&surj_primes=&surj_quantifier=include&nonsurj_primes=&count=100')
+        L = self.tc.get('EllipticCurve/Q/?start=0&sha=8.999&count=100')
         assert 'Error' in L.get_data(as_text=True)
 
     def test_disc_factor(self):

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -129,7 +129,7 @@ class EllCurveTest(LmfdbTest):
         assert '[1, -1, 1, -3, 3]' in L.get_data(as_text=True)
 
     def test_sha(self):
-        L = self.tc.get('EllipticCurve/Q/?start=0&sha=2-&count=100')
+        L = self.tc.get('EllipticCurve/Q/?start=0&rank=2&sha=2-&count=100')
         assert '[0, 1, 0, -73824640, -244170894880]' in L.get_data(as_text=True)
         assert '226920.h1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/Q/?start=0&sha=81&count=100')

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -83,7 +83,7 @@ from .search_parsing import (
     parse_ints_to_list_flash, integer_options, nf_string_to_label,
     parse_subfield,
     clean_input, prep_ranges, input_string_to_poly)
-from .backend.utils import SearchParsingError
+from lmfdb.backend.utils import SearchParsingError
 
 from .search_wrapper import search_wrap, count_wrap
 from .search_boxes import (

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -83,7 +83,6 @@ from .search_parsing import (
     parse_ints_to_list_flash, integer_options, nf_string_to_label,
     parse_subfield,
     clean_input, prep_ranges, input_string_to_poly)
-from lmfdb.backend.utils import SearchParsingError
 
 from .search_wrapper import search_wrap, count_wrap
 from .search_boxes import (


### PR DESCRIPTION
This PR adds the ability to search on Galois images and combines/reorganizes some of the search options (e.g. there is now a single drop-down for torsion that lets you search both on order and by group, a single drop down for CM, etc...).
