### PR TITLE
another tweak to parse_element_of

### DIFF
--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -765,7 +765,7 @@ def parse_element_of(
             query[qfield] = {"$overlaps": options}
         else:
             # element of the empty set should return no results (this can easily happen if contained_in is specified, or for empty intervals like [2,1])
-            query[qfield] = {"$contains": [parse_singleton("0")], "$notcontains": [parse_singleon("0")]}
+            query[qfield] = {"$contains": [parse_singleton("0")], "$notcontains": [parse_singleton("0")]}
     else:
         query[qfield] = {"$contains": [parse_singleton(inp)]}
 


### PR DESCRIPTION
One further change to handle empty intervals like [2,1] correctly (and speed up searches we know will yield no matches)