### PR TITLE
Add missing suffixes to various statistics reload commands

### DIFF
--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -101,6 +101,12 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/?field=2.0.11.1&jinv=~-52893159101157376/11')
         assert '11.1-a1' not in L.get_data(as_text=True)
 
+    def test_browse(self):
+        r"""
+        Check that degree browse pages display correctly
+        """
+        for n, cnt in [(2, 77095), (3, 4416), (4, 4064), (5, 792), (6, 537)]:
+            self.check_args(f"/EllipticCurve/browse/{n}", str(cnt))
 
     def test_isodeg(self):
         r"""


### PR DESCRIPTION
Also adds a test for ecnf browse pages.  Here's what I did to test these changes:
```
sage: db.create_table_like("lf_test", "lf_fields", data=True)
sage: stat_cmds, split_cmds, nstat_cmds = db.lf_fields.stats._status() 
sage: for cols, ccols, cvals, threshold in stat_cmds:
....:     db.lf_test.stats.add_stats(cols, (ccols, cvals), threshold, suffix="")
2021-10-28 14:48:04,636 - Adding statistics to lf_test for e, n: n = ..15, p = 3
...
sage: db.lf_test.copy_to("lf_test.txt")
sage: db.lf_test.reload("lf_test.txt")
Reloading lf_test...
	Loaded data into lf_test in 4.177 secs from /Users/roed/Downloads/lf_test.txt
Built primary key on lf_test in 0.043 secs
2021-10-28 14:49:52,593 - Refreshing statistics on lf_test
2021-10-28 14:49:52,593 - Refreshing statistics on lf_test
INFO:lf_test@2021-10-28 14:49:52,593: Refreshing statistics on lf_test 
2021-10-28 14:49:52,711 - Adding statistics to lf_test for e, n: n = ..15, p = 3
...
Reloaded lf_test in 6.482 secs
sage: db.drop_table('lf_test')
```
I believe that the `reload` would currently fail to add statistics.

As a side note, perhaps there should be an argument to create_table_like that ports statistics as well....