### PR TITLE
Fix a bug in copy_from/copy_to

### DIFF
--- a/lmfdb/backend/base.py
+++ b/lmfdb/backend/base.py
@@ -17,7 +17,7 @@ from psycopg2.sql import SQL, Identifier, Placeholder, Literal, Composable
 from psycopg2.extras import execute_values
 
 from .encoding import Json
-from .utils import reraise, DelayCommit, QueryLogFilter
+from .utils import reraise, DelayCommit, QueryLogFilter, psycopg2_version
 
 
 # This list is used when creating new tables
@@ -869,11 +869,12 @@ class PostgresBase(object):
                 else:
                     addid = False
 
-                # We have to add quotes manually since copy_from doesn't accept
-                # psycopg2.sql.Identifiers
-                # None of our column names have double quotes in them. :-D
-                assert all('"' not in col for col in columns)
-                columns = ['"' + col + '"' for col in columns]
+                if psycopg2_version < (2, 9, 0):
+                    # We have to add quotes manually since copy_from doesn't accept
+                    # psycopg2.sql.Identifiers
+                    # None of our column names have double quotes in them. :-D
+                    assert all('"' not in col for col in columns)
+                    columns = ['"' + col + '"' for col in columns]
                 if addid:
                     # create sequence
                     cur_count = self.max_id(table)

--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -8,7 +8,7 @@ from psycopg2.sql import SQL, Identifier, Placeholder, Literal
 
 from .encoding import Json, copy_dumps
 from .base import PostgresBase, _meta_table_name
-from .utils import DelayCommit, EmptyContext, IdentifierWrapper, LockError
+from .utils import DelayCommit, EmptyContext, IdentifierWrapper, LockError, psycopg2_version
 from .base import (
     _meta_indexes_cols,
     _meta_constraints_cols,
@@ -2124,7 +2124,8 @@ class PostgresTable(PostgresBase):
                 now = time.time()
                 if addid:
                     cols = ["id"] + cols
-                cols_wquotes = ['"' + col + '"' for col in cols]
+                if psycopg2_version < (2, 9, 0):
+                    cols_wquotes = ['"' + col + '"' for col in cols]
                 cur = self._db.cursor()
                 with open(filename, "w") as F:
                     try:

--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -2126,6 +2126,8 @@ class PostgresTable(PostgresBase):
                     cols = ["id"] + cols
                 if psycopg2_version < (2, 9, 0):
                     cols_wquotes = ['"' + col + '"' for col in cols]
+                else:
+                    cols_wquotes = cols
                 cur = self._db.cursor()
                 with open(filename, "w") as F:
                     try:

--- a/lmfdb/backend/utils.py
+++ b/lmfdb/backend/utils.py
@@ -5,6 +5,13 @@ import re
 from collections import defaultdict
 
 from psycopg2.sql import SQL, Identifier, Placeholder
+from psycopg2 import __version__ as pg_ver_str
+
+psycopg2_version = pg_ver_str.split(" ")[0].split(".")[:3]
+if len(psycopg2_version) < 3:
+    psycopg2_version += ["0"] * (3 - len(psycopg2_version))
+psycopg2_version = tuple(int(c) for c in psycopg2_version)
+
 
 class SearchParsingError(ValueError):
     """
@@ -82,7 +89,6 @@ def filter_sql_injection(clause, col, col_type, op, table):
             else:
                 raise SearchParsingError("%s: invalid characters %s (only +*-/^() allowed)" % (clause, piece))
     return SQL("{0} %s {1}" % op).format(col, SQL("").join(processed)), values
-
 
 def IdentifierWrapper(name, convert=True):
     """


### PR DESCRIPTION
The error message complained about extra quotes, and appeared when we updated to a new version of psycopg2.