### PR TITLE
fix typo in CM menu sqrt(-7)

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -943,7 +943,7 @@ class ECSearchArray(SearchArray):
             example="2,3",
             select_box=nonmax_quant)
         cm_opts = ([('', ''), ('noCM', 'no potential CM'), ('CM', 'potential CM')] +
-                   [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(-7))')] +
+                   [('-4,-16', 'CM field Q(sqrt(-1))'), ('-3,-12,-27', 'CM field Q(sqrt(-3))'), ('-7,-28', 'CM field Q(sqrt(-7))')] +
                    [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]])
         cm = SelectBox(
             name="cm",

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -943,7 +943,7 @@ class ECSearchArray(SearchArray):
             example="2,3",
             select_box=nonmax_quant)
         cm_opts = ([('', ''), ('noCM', 'no potential CM'), ('CM', 'potential CM')] +
-                   [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(7))')] +
+                   [('-3,-12,-27', 'CM field Q(zeta_3)'), ('-4,-16', 'CM field Q(i)'), ('-7,-28', 'CM field Q(sqrt(-7))')] +
                    [('-%d'%d, 'CM discriminant -%d'%d) for  d in [3,4,7,8,11,12,16,19,27,38,43,67,163]])
         cm = SelectBox(
             name="cm",


### PR DESCRIPTION
In the CM drop-down menu at http://www.lmfdb.org/EllipticCurve/Q/ one option for the CM field is "Q(sqrt(7))".  This PR just inserts the missing minus sign. (As reported by Enrique Gonzalez Jimenez.)

I think I would prefer the other two fields in the list to be shows as Q(sqrt(-1)) instead of Q(i) and Q(sqrt(-3)) instead of Q(zeta_3), for consistency.  (If you really wanted to stress the fact that one of those is a cyclotomic field then make the other one Q(zeta_4)!).  

It would also be nice to explain (perhaps in the knowl) why we list 3 fields and 13 discriminants (the reason of course is that only in these fields is there more than one order of class number 1).

If a reviewer agrees with my suggestion in the second parapraph, I'll update the PR beore it is merged.