### PR TITLE
Subgroup diagram improvements

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -709,12 +709,16 @@ def sub_diagram(label):
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
-    maxw = max(len(z) for z in gp.subgroup_profile.values())
     h = 160 * len(gp.subgroup_profile)
     h = min(h, 1000)
-    w = 200 * maxw
+    dojs, orders = diagram_js_string(gp)
+    rowcounts = {z:0 for z in orders}
+    for grp in gp.subgroups.values():
+        rowcounts[grp.subgroup_order] += 1
+    widest = max(rowcounts.values())
+    w = 100 * widest
     w = min(w, 1500)
-    info = {"dojs": diagram_js_string(gp), "w": w, "h": h,
+    info = {"dojs": dojs, "w": w, "h": h,
             "type": "conj"}
     return render_template(
         "diagram_page.html",
@@ -975,15 +979,15 @@ def diagram_js(gp, layers, aut=False):
     ]
     orders = sorted(set(sub.subgroup_order for sub in gp.subgroups.values()))
 
-    return [ll, layers[1], orders]
+    return [ll, layers[1], orders], orders
 
 def diagram_js_string(gp):
     glist = [[],[]]
     if gp.diagram_ok and not gp.outer_equivalence:
-        glist[0] = diagram_js(gp, gp.subgroup_lattice)
+        glist[0], orders = diagram_js(gp, gp.subgroup_lattice)
 
-    glist[1] = diagram_js(gp, gp.subgroup_lattice_aut,aut=True)
-    return f'var [sdiagram,glist] = make_sdiagram("subdiagram", "{gp.label}",{glist});'
+    glist[1], orders = diagram_js(gp, gp.subgroup_lattice_aut,aut=True)
+    return f'var [sdiagram,glist] = make_sdiagram("subdiagram", "{gp.label}",{glist});', orders
 
 # Writes individual pages
 def render_abstract_group(label):
@@ -1008,8 +1012,14 @@ def render_abstract_group(label):
         (z[0], display_profile_line(z[1], ambient=label, aut=True)) for z in autprof
     ]
 
-    info["dojs"] = diagram_js_string(gp)
-    info["wide"] = len(gp.subgroups) > 20 # boolean
+    info["dojs"], orders = diagram_js_string(gp)
+    # find the widest row of the diagram
+    rowcounts = {z:0 for z in orders}
+    for grp in gp.subgroups.values():
+        rowcounts[grp.subgroup_order] += 1
+    widest = max(rowcounts.values())
+
+    info["wide"] = widest > 8 # boolean
 
     info["max_sub_cnt"] = gp.max_sub_cnt
     info["max_quo_cnt"] = gp.max_quo_cnt

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -946,7 +946,7 @@ def diagram_js(gp, layers, aut=False):
             grp.count,
             grp.subgroup_order,
             gp.tex_images.get(grp.subgroup_tex, gp.tex_images["?"]),
-            grp.diagram_aut_x if aut else grp.diagram_aut_x,
+            grp.diagram_aut_x if aut else grp.diagram_x,
         ]
         for grp in layers[0]
     ]
@@ -954,15 +954,13 @@ def diagram_js(gp, layers, aut=False):
 
     return [ll, layers[1], orders]
 
-    return f'var [sautdiagram,gautlist] = make_sdiagram("autdiagram", "{gp.label}",[[{ll},{layers[1]},{orders}]]);'
-
 def diagram_js_string(gp):
     glist = [[],[]]
     if gp.diagram_ok and not gp.outer_equivalence:
         glist[0] = diagram_js(gp, gp.subgroup_lattice)
 
     glist[1] = diagram_js(gp, gp.subgroup_lattice_aut,aut=True)
-    return f'var [sdiagram,glist] = make_sdiagram("autdiagram", "{gp.label}",{glist});'
+    return f'var [sdiagram,glist] = make_sdiagram("subdiagram", "{gp.label}",{glist});'
 
 # Writes individual pages
 def render_abstract_group(label):

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -714,11 +714,34 @@ def sub_diagram(label):
     h = min(h, 1000)
     w = 200 * maxw
     w = min(w, 1500)
-    info = {"dojs": diagram_js(gp, gp.subgroup_lattice), "w": w, "h": h}
+    info = {"dojs": diagram_js_string(gp), "w": w, "h": h,
+            "type": "conj"}
     return render_template(
         "diagram_page.html",
         info=info,
-        title="Subgroup diagram for %s" % label,
+        title="Diagram of subgroups up to conjugation for group %s" % label,
+        bread=get_bread([("Subgroup diagram", " ")]),
+        learnmore=learnmore_list(),
+    )
+
+@abstract_page.route("/autdiagram/<label>")
+def aut_diagram(label):
+    label = clean_input(label)
+    gp = WebAbstractGroup(label)
+    if gp.is_null():
+        flash_error("No group with label %s was found in the database.", label)
+        return redirect(url_for(".index"))
+    maxw = max(len(z) for z in gp.subgroup_autprofile.values())
+    h = 160 * len(gp.subgroup_autprofile)
+    h = min(h, 1000)
+    w = 200 * maxw
+    w = min(w, 1500)
+    info = {"dojs": diagram_js_string(gp), "w": w, "h": h,
+            "type": "aut"}
+    return render_template(
+        "diagram_page.html",
+        info=info,
+        title="Diagram of subgroups up to automorphism for group %s" % label,
         bread=get_bread([("Subgroup diagram", " ")]),
         learnmore=learnmore_list(),
     )

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -11,6 +11,7 @@
     $(".subgp").on('touchstart', highlight_group);
   });
 </script>
+
 <script type="text/javascript" src="{{ url_for('static', filename='graphs/graph.js') }}"></script>
 
 <script>
@@ -29,11 +30,19 @@
   }
 
   function show_info(style) {
-    $('#subgroup_diagram').hide();
-    $('#subgroup_profile').hide();
-    $('#subgroup_autdiagram').hide();
-    $('#subgroup_autprofile').hide();
-    $('#subgroup_'+style).show();
+    $('.subgroup_diagram').hide();
+    $('.subgroup_profile').hide();
+    $('.subgroup_autdiagram').hide();
+    $('.subgroup_autprofile').hide();
+    if(style=="diagram") {
+      sdiagram.newgraph(glist[0]);
+      $('.subgroup_diagram').show();
+    } else if(style=="autdiagram") {
+      sdiagram.newgraph(glist[1]);
+      $('.subgroup_autdiagram').show();
+    } else {
+      $('.subgroup_'+style).show();
+    }
     $('button.diagram').show();
     $('button.profile').show();
     $('button.autdiagram').show();
@@ -286,56 +295,66 @@
 </div>
 
 <p>
-<div id="subgroup_diagram" style="display: block">
-  <h4>Classes of subgroups up to conjugation</h4>
-    {% if gp.diagram_ok and not gp.outer_equivalence%}
-      <script>
-        show_info("diagram");
-      </script>
-      {% if info.wide %}
-        <canvas id="subdiagram" width="1000" height="300" style="border: 0px solid black">
-           Sorry, your browser does not support the subgroup diagram.
-        </canvas>
 
-        <script type="text/javascript">
-          {{ info.dojs|safe }}
-        </script>
-        {% if user_is_authenticated and BETA %}
-          <button onclick="getpositions()">Get positions</button>
-          <br>
-          <p>
-          <div id="positions">
-          </div>
-        {% endif %}
-        <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
-        <h4>Subgroup information</h4>
+{# Just header information for the diagrams #}
+
+<div class="subgroup_autdiagram" style="display: none">
+  <h4>Classes of subgroups up to automorphism</h4>
+  <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+</div>
+
+<div class="subgroup_diagram" style="display: block">
+  <h4>Classes of subgroups up to conjugation</h4>
+</div>
+
+{# now the canvas #}
+
+<div class="subgroup_diagram subgroup_autdiagram">
+{% if info.wide %}
+    <canvas id="subdiagram" width="1000" height="300" style="border: 0px solid black">
+       Sorry, your browser does not support the subgroup diagram.
+    </canvas>
+
+    {% if user_is_authenticated and BETA %}
+      <button onclick="getpositions()">Get positions</button>
+      <br>
+      <p>
+      <div id="positions">
+      </div>
+    {% endif %}
+    <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+
+    <h4>Subgroup information</h4>
+    <div class="selectedsub">
+      Click on a subgroup in the diagram to see information about it.
+    </div>
+  {% else %} {# not wide #}
+    <table>
+    <tr><td>
+      <canvas id="subdiagram" width="500" height="300" style="border: 0px solid black">
+        Sorry, your browser does not support the subgroup diagram.
+      </canvas>
+    <td valign="top">
+      <script type="text/javascript">
+        {{ info.dojs|safe }}
+      </script>
+      <h4>Subgroup information</h4>
         <div class="selectedsub">
           Click on a subgroup in the diagram to see information about it.
         </div>
-      {% else %}
-        <table>
-        <tr><td>
-          <canvas id="subdiagram" width="500" height="300" style="border: 0px solid black">
-            Sorry, your browser does not support the subgroup diagram.
-          </canvas>
-        <td valign="top">
-          <script type="text/javascript">
-            {{ info.dojs|safe }}
-          </script>
-          <h4>Subgroup information</h4>
-            <div class="selectedsub">
-              Click on a subgroup in the diagram to see information about it.
-            </div>
-        </table>
-        {% if user_is_authenticated and BETA %}
-          <button onclick="getpositions()">Get positions</button>
-          <br>
-          <p>
-          <div id="positions">
-          </div>
-        {% endif %}
-        <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
-      {% endif %}
+     </table>
+    {% if user_is_authenticated and BETA %}
+      <button onclick="getpositions()">Get positions</button>
+      <br>
+      <p>
+      <div id="positions">
+      </div>
+    {% endif %}
+    <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+  {% endif %}
+</div>
+
+{% if 1 == 1 %}
     {% else %}
       There are too many classes of subgroups to display.
       {% if not gp.outer_equivalence %}
@@ -344,26 +363,30 @@
     {% endif %}
 </div>
 
-<div id="subgroup_autdiagram" style="display: none">
-  <h4>Classes of subgroups up to automorphism</h4>
-  <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
-</div>
+<script type="text/javascript">
+  {{ info.dojs|safe }}
+</script>
 
-<div id="subgroup_profile" style="display: none">
+
+<div class="subgroup_profile" style="display: none">
   <h4>Classes of subgroups up to conjugation</h4>
 {% for ordline in info.subgroup_profile %}
 Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
 {% endfor %}
 </div>
 
-<div id="subgroup_autprofile" style="display: none">
+<div class="subgroup_autprofile" style="display: none">
   <h4>Classes of subgroups up to automorphism</h4>
   {% for ordline in info.subgroup_autprofile %}
     Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
   {% endfor %}
 </div>
 
-{% if not gp.diagram_ok or gp.outer_equivalence %}
+{% if gp.diagram_ok and not gp.outer_equivalence%}
+  <script>
+    show_info("diagram");
+  </script>
+{% else %}
   <script>
     show_info("profile");
   </script>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -333,8 +333,13 @@
       <div id="positions">
       </div>
     {% endif %}
+  <div class="subgroup_diagram">
     <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+  </div>
 
+  <div class="subgroup_autdiagram">
+    <a href="{{url_for('.aut_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+  </div>
     <h4>Subgroup information</h4>
     <div class="selectedsub">
       Click on a subgroup in the diagram to see information about it.
@@ -358,7 +363,13 @@
       <div id="positions">
       </div>
     {% endif %}
+  <div class="subgroup_diagram">
     <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+  </div>
+
+  <div class="subgroup_autdiagram">
+    <a href="{{url_for('.aut_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+  </div>
   {% endif %}
 </div>
 
@@ -386,6 +397,7 @@ Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
 {% if gp.diagram_ok and not gp.outer_equivalence%}
   <script>
     show_info("diagram");
+    sdiagram.setSize();
   </script>
 {% else %}
   <script>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -346,37 +346,6 @@
 
 <div id="subgroup_autdiagram" style="display: none">
   <h4>Classes of subgroups up to automorphism</h4>
-  {% if info.autwide %}
-    <canvas id="autdiagram" width="1000" height="300" style="border: 0px solid black">
-      Sorry, your browser does not support the subgroup diagram.
-    </canvas>
-
-    <script type="text/javascript">
-      {{ info.doautjs|safe }}
-    </script>
-  {% else %}
-    <table>
-      <tr><td>
-        <canvas id="autdiagram" width="500" height="300" style="border: 0px solid black">
-            Sorry, your browser does not support the subgroup diagram.
-        </canvas>
-      <td valign="top">
-        <script type="text/javascript">
-          {{ info.doautjs|safe }}
-        </script>
-        <h4>Subgroup information</h4>
-          <div class="selectedsub">
-            Click on a subgroup in the diagram to see information about it.
-          </div>
-    </table>
-    {% if user_is_authenticated and BETA %}
-      <button onclick="getpositions()">Get positions</button>
-      <br>
-      <p>
-      <div id="positions">
-      </div>
-    {% endif %}
-  {% endif %}
   <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
 </div>
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -36,9 +36,11 @@
     $('.subgroup_autprofile').hide();
     if(style=="diagram") {
       sdiagram.newgraph(glist[0]);
+      type="C";
       $('.subgroup_diagram').show();
     } else if(style=="autdiagram") {
       sdiagram.newgraph(glist[1]);
+      type="A";
       $('.subgroup_autdiagram').show();
     } else {
       $('.subgroup_'+style).show();

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -300,16 +300,27 @@
 
 <div class="subgroup_autdiagram" style="display: none">
   <h4>Classes of subgroups up to automorphism</h4>
-  <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
 </div>
 
 <div class="subgroup_diagram" style="display: block">
   <h4>Classes of subgroups up to conjugation</h4>
+  {% if not gp.diagram_ok %}
+  <p>
+  There are too many subgroups to show.
+    {% if not gp.outer_equivalence%}
+      <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
+    {% endif %}
+  {% endif %}
 </div>
 
 {# now the canvas #}
 
-<div class="subgroup_diagram subgroup_autdiagram">
+{% if gp.diagram_ok and not gp.outer_equivalence%}
+  <div class="subgroup_diagram subgroup_autdiagram">
+{% else %}
+  <div class="subgroup_autdiagram">
+{% endif %}
+
 {% if info.wide %}
     <canvas id="subdiagram" width="1000" height="300" style="border: 0px solid black">
        Sorry, your browser does not support the subgroup diagram.
@@ -335,9 +346,6 @@
         Sorry, your browser does not support the subgroup diagram.
       </canvas>
     <td valign="top">
-      <script type="text/javascript">
-        {{ info.dojs|safe }}
-      </script>
       <h4>Subgroup information</h4>
         <div class="selectedsub">
           Click on a subgroup in the diagram to see information about it.
@@ -354,13 +362,6 @@
   {% endif %}
 </div>
 
-{% if 1 == 1 %}
-    {% else %}
-      There are too many classes of subgroups to display.
-      {% if not gp.outer_equivalence %}
-        <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
-      {% endif %}
-    {% endif %}
 </div>
 
 <script type="text/javascript">

--- a/lmfdb/groups/abstract/templates/diagram_page.html
+++ b/lmfdb/groups/abstract/templates/diagram_page.html
@@ -64,8 +64,10 @@
 
 {% if info.type == "aut" %}
   sdiagram.newgraph(glist[1]);
+  type="A";
   {% else %}
   sdiagram.newgraph(glist[0]);
+  type="C";
 {% endif %}
   sdiagram.setSize();
 </script>

--- a/lmfdb/groups/abstract/templates/diagram_page.html
+++ b/lmfdb/groups/abstract/templates/diagram_page.html
@@ -4,7 +4,6 @@
 {% block body %}
 
 
-
 {# An invisible span to get the select color in the diagram into the DOM #}
 <div>
 <span id="group-diagram-selected" style="display:none;">Hi</span>
@@ -53,12 +52,22 @@
 
 <script type="text/javascript" src="{{ url_for('static', filename='graphs/graph.js') }}"></script>
 
+<h3>{{title|safe}}<h3>
+
+
 <canvas id="subdiagram" width="{{ info.w }}" height="{{ info.h }}" style="border: 0px solid black">
   Sorry, your browser does not support the subgroup diagram.
 </canvas>
 
 <script type="text/javascript">
 {{ info.dojs|safe }}
+
+{% if info.type == "aut" %}
+  sdiagram.newgraph(glist[1]);
+  {% else %}
+  sdiagram.newgraph(glist[0]);
+{% endif %}
+  sdiagram.setSize();
 </script>
 
 <div>
@@ -74,7 +83,7 @@ Subgroups can be dragged in all directions?
 </div>
 
 <h4>Subgroup information</h4>
-<div id="selectedsub">
+<div class="selectedsub">
 Click on a subgroup in the diagram to see information about it.
 </div>
 

--- a/lmfdb/static/graphs/graph.js
+++ b/lmfdb/static/graphs/graph.js
@@ -87,6 +87,7 @@ Graph = class {
     addNodes(values, orders) {
         for(var j=0, item; item = values[j]; j++) {
                 var myx = Math.max(j, item[6]);
+//console.log("Node ", myx, " ", item);
                 this.addNode(item, myx, orders, {});
         }
     }
@@ -211,6 +212,16 @@ class Renderer {
       this.graph = g;
       this.reposition();
       this.draw();
+      var found = false;
+      for (var i = 0; i < g.nodes.length; i++) {
+        if(g.nodes[i].selected) {
+          showsubinfo(g.nodes[i], g.ambient);
+          found = true;
+        }
+      }
+      if (! found) {
+        clearsubinfo();
+      }
     }
 
     clear() {
@@ -798,7 +809,6 @@ function make_sdiagram(canv, ambient, gdatalist) {
     [nodes, edges, orders] = gdatalist[j]
     glist[j] = new Graph(ambient);
     glist[j].addNodes(nodes, orders);
-    dbug=edges;
     for(var k=0, edge; edge=edges[k]; k++) {
       glist[j].addEdge(edge[0],edge[1]);
     }

--- a/lmfdb/static/graphs/graph.js
+++ b/lmfdb/static/graphs/graph.js
@@ -23,6 +23,7 @@
 */
 var ourg;
 var ambientlabel;
+var type="C"; // C for conjugacy class, A for up to aut
 
 /* The rest of the global variables are for debugging or page colors,
    so they should be ok when 2 diagrams are on the page */
@@ -212,6 +213,7 @@ class Renderer {
       this.graph = g;
       this.reposition();
       this.draw();
+      ourg = g;
       var found = false;
       for (var i = 0; i < g.nodes.length; i++) {
         if(g.nodes[i].selected) {
@@ -827,10 +829,10 @@ function make_sdiagram(canv, ambient, gdatalist) {
       layout.layout();
     }
   }
-  //ourg = g;
+  ourg = glist[glist.length-1];
   ambientlabel=ambient;
 
-  renderer = new Renderer(document.getElementById(canv),glist[glist.length-1]);
+  renderer = new Renderer(document.getElementById(canv),ourg);
 
   // Need to call Event.Handler here
   new EventHandler(renderer, {
@@ -856,7 +858,7 @@ function getpositions() {
   }
   mylist += "]]";
   var mydiv = document.getElementById("positions");
-  mydiv.innerHTML = mylist;
+  mydiv.innerHTML = type+"<br>"+mylist;
 
   return mylist;
 }

--- a/lmfdb/static/graphs/graph.js
+++ b/lmfdb/static/graphs/graph.js
@@ -805,8 +805,6 @@ function newheight(rendr, numrows) {
     var w = ctx.width;
     ctx.height = 50*numrows;
     ctx.width = w;
-    rendr.setSize();
-    rendr.draw();
   }
 }
 
@@ -833,7 +831,6 @@ function make_sdiagram(canv, ambient, gdatalist) {
   ambientlabel=ambient;
 
   renderer = new Renderer(document.getElementById(canv),glist[glist.length-1]);
-  renderer.draw();
 
   // Need to call Event.Handler here
   new EventHandler(renderer, {
@@ -842,6 +839,7 @@ function make_sdiagram(canv, ambient, gdatalist) {
       }
   });
   newheight(renderer, orders.length);
+  renderer.setSize();
   // The renderer is stored in sdiagram by the web page
   return [renderer,glist];
 }

--- a/lmfdb/static/graphs/graph.js
+++ b/lmfdb/static/graphs/graph.js
@@ -798,6 +798,17 @@ function clearsubinfo() {
     });
 }
 
+function newheight(rendr, numrows) {
+  if (numrows>6) {
+    var ctx = $("#subdiagram")[0].getContext('2d').canvas;
+    var h = ctx.height;
+    var w = ctx.width;
+    ctx.height = 50*numrows;
+    ctx.width = w;
+    rendr.setSize();
+    rendr.draw();
+  }
+}
 
 //function make_sdiagram(canv, ambient, nodes, edges, orders) {
 function make_sdiagram(canv, ambient, gdatalist) {
@@ -808,13 +819,15 @@ function make_sdiagram(canv, ambient, gdatalist) {
     var nodes, edges, orders;
     [nodes, edges, orders] = gdatalist[j]
     glist[j] = new Graph(ambient);
-    glist[j].addNodes(nodes, orders);
-    for(var k=0, edge; edge=edges[k]; k++) {
-      glist[j].addEdge(edge[0],edge[1]);
+    if(gdatalist[j].length>0) {
+      glist[j].addNodes(nodes, orders);
+      for(var k=0, edge; edge=edges[k]; k++) {
+        glist[j].addEdge(edge[0],edge[1]);
+      }
+      var layout = new Layout(glist[j]);
+      layout.setiter(nodes[0][0][7]==0);
+      layout.layout();
     }
-    var layout = new Layout(glist[j]);
-    layout.setiter(nodes[0][0][7]==0);
-    layout.layout();
   }
   //ourg = g;
   ambientlabel=ambient;
@@ -828,6 +841,7 @@ function make_sdiagram(canv, ambient, gdatalist) {
           renderer.draw();
       }
   });
+  newheight(renderer, orders.length);
   // The renderer is stored in sdiagram by the web page
   return [renderer,glist];
 }


### PR DESCRIPTION
This fixes:
  - dragging of subgroups is now reasonably fast for both the regular diagram and the up-to-aut diagram
  - both diagrams have links to their own full page versions
  - the diagram on the group home page will enlarge itself vertically if there are many orders dividing the order of the group.  This affected things like C_256 where the edges were not showing because it was all crammed together before.

Some samples to look at with the 3 variations of the layout

Basic example:
http://127.0.0.1:37777/Groups/Abstract/8.3

Has both diagrams, but CC one is wide, so the subgroup info is put below it
http://127.0.0.1:37777/Groups/Abstract/16.14

Too many subgroups for CC diagram, but there is an aut diagram with many levels:
http://127.0.0.1:37777/Groups/Abstract/256.56092

