### PR TITLE
Add label to dirchar values tables

### DIFF
--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -31,9 +31,15 @@
 <div style='overflow:auto'>
   <table class="values">
     <thead>
-      <tr>{% for a in groupelts %}<td style="text-align:center">\({{a}}\)</td>{%endfor%}</tr>
+      <tr>
+        <td style="text-align:center">\(a\)</td>
+        {% for a in groupelts %}<td style="text-align:center">\({{a}}\)</td>{%endfor%}
+      </tr>
     </thead>
-    <tr>{% for v in values %}<td style="text-align:center">{{v}}</td>{%endfor%}</tr>
+    <tr>
+      <td style="text-align:center">\( \chi_{ {{modulus}} }({{number}}, a) \)</td>
+      {% for v in values %}<td style="text-align:center">{{v}}</td>{%endfor%}
+    </tr>
   </table>
 </div>
 {{ place_code('jacobi') }}


### PR DESCRIPTION
This is a small change that adds a first column to the values table
shown on Dirichlet character pages. This came out of a conversation
where we went to the LMFDB to see a Dirichlet character and its
L-function, and we went to

https://www.lmfdb.org/Character/Dirichlet/4/3

The values table makes much less obvious sense when there are only two
values, and it was confusing. This adds a first column containing
labels.