### PR TITLE
show labels in download output, make_data() function in output

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-import ast
 import os
 import re
-from ast import literal_eval
-from io import BytesIO
 import time
 
 from flask import render_template, url_for, request, redirect, make_response, send_file, abort


### PR DESCRIPTION
Downloading elliptic curve data now includes the labels of the elliptic curve as well as a function make_data() turning the downloaded data into elliptic curves in Magma, Sage, and PARI/gp.
This is issue https://github.com/LMFDB/lmfdb/issues/4810