### PR TITLE
Fix shadows/jumping on initial display of the subgroup diagram.

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -440,6 +440,7 @@ Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
   <script>
     show_info("diagram");
     sdiagram.setSize();
+    sdiagram.draw();
   </script>
 {% else %}
   <script>

--- a/lmfdb/groups/abstract/templates/diagram_page.html
+++ b/lmfdb/groups/abstract/templates/diagram_page.html
@@ -70,6 +70,7 @@
   type="C";
 {% endif %}
   sdiagram.setSize();
+  sdiagram.draw();
 </script>
 
 <div>

--- a/lmfdb/static/graphs/graph.js
+++ b/lmfdb/static/graphs/graph.js
@@ -156,7 +156,6 @@ class Renderer {
     this.factorX = (this.ctx.canvas.width - 2 * this.radius) / (this.graph.layoutMaxX - this.graph.layoutMinX+1);
     this.factorY = (this.ctx.canvas.height - 2 * this.radius) / (this.graph.layoutMaxY - this.graph.layoutMinY+1);
     this.reposition();
-    this.draw();
   }
 
 


### PR DESCRIPTION
Sometimes the initial display of the subgroup diagram looks like there are shadows (or double images) of some of the subgroups.  When you move the mouse over it or click, it fixes itself (sometimes involving subgroups moving a little).  This fixes that problem.  

Detailed explaination (if you care):  I think it was caused by us having the code draw a diagram, and then maybe redrawing with the correct one.  But, images used for subgroups fetched asynchronously and I think the redisplay call may happen before all of the first ones get drawn leading to double versions being drawn on the canvas.  This eliminates the initial draw so that the diagram is just drawn once to start with.

To see the problem, compare

http://beta.lmfdb.org/Groups/Abstract/16.5

http://127.0.0.1:37777/Groups/Abstract/16.5