### PR TITLE
Hide dimension 2 BMFs

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -172,6 +172,7 @@ def bianchi_modular_form_search(info, query):
     parse_nf_string(info, query, 'field_label', name='base number field')
     parse_noop(info, query, 'label')
     #parse_ints(info, query, 'dimension')
+    query['dimension'] = 1
     parse_ints(info, query, 'level_norm')
     parse_primes(info, query, 'field_bad_primes', name='field bad primes',
          qfield='field_bad_primes',mode=info.get('field_bad_quantifier'))

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -12,7 +12,7 @@ from lmfdb.utils import (
     teXify_pol, search_wrap)
 from lmfdb.utils.display_stats import StatsDisplay, totaler, proportioners
 from lmfdb.utils.interesting import interesting_knowls
-from lmfdb.utils.search_columns import SearchColumns, MathCol, ProcessedCol, MultiProcessedCol
+from lmfdb.utils.search_columns import SearchColumns, ProcessedCol, MultiProcessedCol
 from lmfdb.number_fields.web_number_field import WebNumberField, nf_display_knowl, field_pretty
 from lmfdb.nfutils.psort import ideal_from_label, primes_iter
 from lmfdb.bianchi_modular_forms import bmf_page
@@ -145,7 +145,8 @@ bmf_columns = SearchColumns([
                                   label_suffix=suff),
                           short),
                       default=True),
-    MathCol("dimension", "mf.bianchi.newform", "Dimension", default=True),
+    # See Issue #4170
+    #MathCol("dimension", "mf.bianchi.newform", "Dimension", default=True),
     ProcessedCol("sfe", "mf.bianchi.sign", "Sign",
                  lambda v: "$+1$" if v == 1 else ("$-1$" if v == -1 else "?"),
                  default=True, align="center"),
@@ -170,7 +171,7 @@ def bianchi_modular_form_search(info, query):
     """
     parse_nf_string(info, query, 'field_label', name='base number field')
     parse_noop(info, query, 'label')
-    parse_ints(info, query, 'dimension')
+    #parse_ints(info, query, 'dimension')
     parse_ints(info, query, 'level_norm')
     parse_primes(info, query, 'field_bad_primes', name='field bad primes',
          qfield='field_bad_primes',mode=info.get('field_bad_quantifier'))
@@ -360,9 +361,10 @@ def render_bmf_space_webpage(field_label, level_label):
                     } for f in newforms]
                 info['nnewforms'] = len(info['nfdata'])
                 # currently we have newforms of dimension 1 and 2 only (mostly dimension 1)
+                # but the dimension 2 data is untrustworthy so is ignored here
                 info['nnf1'] = sum(1 for f in info['nfdata'] if f['dim']==1)
-                info['nnf2'] = sum(1 for f in info['nfdata'] if f['dim']==2)
-                info['nnf_missing'] = dim_data['2']['new_dim'] - info['nnf1'] - 2*info['nnf2']
+                #info['nnf2'] = sum(1 for f in info['nfdata'] if f['dim']==2)
+                info['nnf_missing'] = dim_data['2']['new_dim'] - info['nnf1'] # - 2*info['nnf2']
                 properties = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
 
@@ -687,12 +689,14 @@ class BMFSearchArray(SearchArray):
             knowl='mf.bianchi.level',
             example='1',
             example_span='e.g. 1 or 1-100')
-        dimension = TextBox(
-            name='dimension',
-            label='Dimension',
-            knowl='mf.bianchi.spaces',
-            example='1',
-            example_span='e.g. 1 or 2')
+
+        # See Issue #4170
+        # dimension = TextBox(
+        #     name='dimension',
+        #     label='Dimension',
+        #     knowl='mf.bianchi.spaces',
+        #     example='1',
+        #     example_span='e.g. 1 or 2')
 
         sign = SelectBox(
             name='sfe',
@@ -704,7 +708,8 @@ class BMFSearchArray(SearchArray):
         base_change = ExcludeOnlyBox(
             name='include_base_change',
             label='Base change',
-            knowl='mf.bianchi.base_change'
+            knowl='mf.bianchi.base_change',
+            example="exclude"
         )
         CM = ExcludeOnlyBox(
             name='include_cm',
@@ -732,13 +737,13 @@ class BMFSearchArray(SearchArray):
         self.browse_array = [
             [field],
             [level, sign],
-            [dimension, base_change],
-            [count, CM],
-            [field_bad_primes, level_bad_primes]
+            [base_change, CM],
+            [field_bad_primes, level_bad_primes],
+            [count]
         ]
         self.refine_array = [
-            [field, level, dimension, field_bad_primes],
-            [sign, base_change, CM, level_bad_primes]
+            [field, level, CM],
+            [sign, base_change, field_bad_primes, level_bad_primes]
         ]
 
 label_finder = re.compile(r"label=([0-9.]+)")
@@ -765,6 +770,7 @@ class BianchiStats(StatsDisplay):
                            "Bianchi modular forms"),
              display_knowl('nf', 'base field'),
              display_knowl('mf.bianchi.level', 'level norm')),
+         'constraint': {"dimension": 1},
          'totaler': totaler(),
          'proportioner': proportioners.per_row_total},
         {'cols': ['field_label', 'level_norm'],
@@ -792,12 +798,12 @@ class BianchiStats(StatsDisplay):
          'table': db.bmf_dims,
          'totaler': totaler(col_counts=False),
          'proportioner': proportioners.per_row_total},
-        {'cols': ['dimension', 'level_norm'],
-         'totaler': totaler(),
-         'proportioner': proportioners.per_col_total},
-        {'cols': ['dimension', 'field_label'],
-         'totaler': totaler(),
-         'proportioner': proportioners.per_col_total},
+        # {'cols': ['dimension', 'level_norm'],
+        #  'totaler': totaler(),
+        #  'proportioner': proportioners.per_col_total},
+        # {'cols': ['dimension', 'field_label'],
+        #  'totaler': totaler(),
+        #  'proportioner': proportioners.per_col_total},
     ]
 
     buckets = {'level_norm': ['1-100', '101-1000', '1001-10000', '10001-50000', '50001-100000', '100001-150000']}

--- a/lmfdb/bianchi_modular_forms/templates/bmf-space.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-space.html
@@ -61,12 +61,12 @@
 {%if info.nnewforms > 0 %}
 This space contains the following
 {%if info.nnewforms == 1 %}
-newform.
+newform of {{ KNOWL('mf.bianchi.newform', title='dimension') }} 1.
 {%else%}
-newforms.
+newforms of {{ KNOWL('mf.bianchi.newform', title='dimension') }} 1.
 {%endif%}
 {%if info.nnf_missing>0 %}
-Newforms of higher dimension are not yet in the database.
+Newforms of higher {{ KNOWL('mf.bianchi.newform', title='dimension') }} are not yet in the database.
 {%endif%}
 
 {#
@@ -77,20 +77,14 @@ is one newform
 are {{info.nnewforms}} newforms
 {%endif%}
 at this level,
-{%if info.nnf2 == 0 %}
 {%if info.nnf1 == 1 %}which has{%else%}all of which have{%endif%} rational coefficients.
-{%elif info.nnf1 == 0 %}
-{%if info.nnf2 == 1 %}which has{%else%}all of which have{%endif%} quadratic coefficients.
-{%else%}
-{{info.nnf1}} with rational coefficients and
-{{info.nnf2}} with quadratic coefficients.
 {%endif%}
 #}
 <table border=1 class="ntdata">
   <tr>
     <th>{{ KNOWL('mf.bianchi.labels', title='label') }}
     <th>{{ KNOWL('mf.bianchi.weight', title='weight') }}
-    <th>{{ KNOWL('mf.bianchi.newform', title='dimension') }}
+    {#<th>{{ KNOWL('mf.bianchi.newform', title='dimension') }}#}
     <th>{{ KNOWL('mf.bianchi.sign', title='sign') }}
     <th>{{ KNOWL('mf.bianchi.base_change', title='base change') }}
     <th>{{ KNOWL('mf.bianchi.cm', title='CM') }}
@@ -99,7 +93,7 @@ at this level,
   <tr>
     <td><a href={{nf.url}}>{{nf.label}}</a>
       <td align='center'>{{nf.wt}}
-      <td align='center'>{{nf.dim}}
+    {#<td align='center'>{{nf.dim}}#}
       <td align='center'>{{nf.sfe}}</td>
       <td align='center'>{{nf.bc}}
       <td align='center'>{{nf.cm}}


### PR DESCRIPTION
This addresses issue #4170.  I have not deleted the (small number of) dimension 2 BMFs from the table bmf_forms, but I have 
   - removed Dimension from the search options
   - adjusted the stats page (the last two tables are now deleted)
   - adjusted the wording in the description of newform spaces.
I just realised that after removing the Dimension from the search options I should still add the constraint dimension=1 to the search.  I will fix that and update the PR shortly
