### PR TITLE
Fix bug when hiding ColGroups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -887,8 +887,8 @@ subgroup_columns = SearchColumns([
                           ["ambient", "ambient_tex"],
                           lambda amb, tex: '<a href="%s">$%s$</a>' % (get_url(amb), tex),
                           default=True, short_title="Ambient name"),
-        ProcessedCol("ambient_order", "group.order", "Order", show_factor, default=True, align="center")],
-             default=True, short_title="Ambient order"),
+        ProcessedCol("ambient_order", "group.order", "Order", show_factor, default=True, align="center", short_title="Ambient order")],
+             default=True),
     SpacerCol("", default=True, th_class=" border-right", td_class=" border-right", td_style="padding:0px;", th_style="padding:0px;"),
     ColGroup("quotient_cols", None, "Quotient", [
         MultiProcessedCol("quotient_name", "group.name", "Name",

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -430,6 +430,24 @@ function control_columns(S) {
     var label = S.options[S.selectedIndex].text;
     label = label.slice(2, label.length);
     $('.col-'+S.value).toggle();
+    // For column groups, have to adjust the width of the top column
+    $('th.col-'+S.value).each(function(i, obj) {
+      // We need to adjust the column width for any colgroup header containing this column.
+      // there should only be one in the list, but doing this more than once won't hurt.
+      var classes = $(this).attr('class').split(' ');
+      for (i = 0; i < classes.length; i++) {
+        if (classes[i].startsWith("colgroup-")) {
+          var colspan = $('th.'+classes[i]+':visible').length;
+          var header = $('.col-' + classes[i].slice(9));
+          if (colspan == 0) {
+            header.hide();
+          } else {
+            header.show();
+            header.prop("colSpan", $('th.'+classes[i]+':visible').length);
+          }
+        }
+      }
+    })
     if ($('.col-'+S.value+':visible').length > 0) {
       S.options[S.selectedIndex].text = '✓ ' + label; // note that the space after the checkbox is unicode, the size of an en-dash
       var i = hidden_cols.indexOf(S.value);
@@ -450,7 +468,6 @@ function control_columns(S) {
         shown_cols.splice(i, 1);
         show.val(shown_cols.join("."));
       }
-      console.log(hidden_cols);
     }
     S.value = '';
   }

--- a/lmfdb/utils/search_columns.py
+++ b/lmfdb/utils/search_columns.py
@@ -158,20 +158,24 @@ class ColGroup(SearchCol):
             orig = sum([sub.orig for sub in subcols], [])
         self.orig = orig
         self.height = 2
-        if not callable(subcols):
-            self.th_content = f" colspan={len(subcols)}"
 
     def show(self, info, rank=None):
         if self.contingent(info):
             if callable(self.subcols):
                 subcols = self.subcols(info)
-                self.th_content = f" colspan={len(subcols)}"
+            else:
+                subcols = self.subcols
+            n = 0
+            for sub in subcols:
+                if sub.name != self.name and "colgroup" not in sub.th_class:
+                    sub.th_class += f" colgroup-{self.name}"
+                if sub.default(info):
+                    n += 1
+            self.th_content = f" colspan={n}"
             if rank == 0:
                 yield self
-            elif callable(self.subcols):
-                yield from subcols
             else:
-                yield from self.subcols
+                yield from subcols
 
 class SearchColumns:
     above_results = "" # Can add text above the Results (1-50 of ...) if desired


### PR DESCRIPTION
This bug is apparent when you try to hide a column that is part of a column group (previously, the colspan of the header was not updated).  To review, try hiding columns in the three sections of the LMFDB that have column groups:

[beta subgroups](https://beta.lmfdb.org/Groups/Abstract/?search_type=Subgroups) vs [purple subgroups](https://purple.lmfdb.xyz/Groups/Abstract/?search_type=Subgroups)
[beta EC](https://beta.lmfdb.org/EllipticCurve/Q/?search_type=List&all=1) vs [purple EC](https://purple.lmfdb.xyz/EllipticCurve/Q/?search_type=List&all=1)
[beta CMF](https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/?search_type=List&all=1) vs [purple CMF](https://purple.lmfdb.xyz/ModularForm/GL2/Q/holomorphic/?search_type=List&all=1)