### PR TITLE
#3358 more dirichlet characters and group knowl again

### DIFF
--- a/lmfdb/characters/templates/CharGroup.html
+++ b/lmfdb/characters/templates/CharGroup.html
@@ -29,7 +29,7 @@
   <tr> <td>{{KNOWL('character.dirichlet.group.order',title='Order')}}</td> <td>=</td> <td>{{ order }}</td> </tr>
 {% if order > 1 %}
   <tr> <td colspan="3"> {{ place_code('struct') }} </td> </tr>
-  <tr> <td>{{KNOWL('character.dirichlet.group.structure',title='Structure')}}</td> <td>=</td> <td>{{ structure }}</td> </tr>
+  <tr> <td>{{KNOWL('character.dirichlet.group.structure',title='Structure')}}</td> <td>=</td> <td>{{ structure_group_knowl | safe }}</td> </tr>
   <tr> <td colspan="3"> {{ place_code('gen') }} </td> </tr>
   <tr> <td>{{KNOWL('character.dirichlet.group.generators',title='Generators')}}</td> <td>=</td> <td>{{ generators | safe }}</td> </tr>
 {% endif %}
@@ -81,6 +81,10 @@ and several values of the character.
     {% endfor %}
   </tbody>
 </table>
+
+{%if rowtruncate%}
+Click <a href="{{url_for('characters.render_DirichletNavigation')}}?modulus={{modulus}}">here</a> to search among the remaining {{order - contents|count}} characters.
+{% endif %}
 {% endif %}
 
 {% endblock %}

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -44,7 +44,8 @@ The design is the following:
 """
 
 from flask import url_for
-from sage.all import (gcd, Rational, Integers, cached_method,
+from collections import defaultdict
+from sage.all import (gcd, ZZ, Rational, Integers, cached_method,
                       euler_phi, latex)
 from sage.databases.cremona import cremona_letter_code
 from sage.misc.lazy_attribute import lazy_attribute
@@ -56,7 +57,7 @@ from lmfdb.number_fields.web_number_field import WebNumberField, formatfield, nf
 from lmfdb.characters.TinyConrey import (ConreyCharacter, kronecker_symbol,
                 symbol_numerator, PariConreyGroup, get_sage_genvalues)
 from lmfdb.characters.utils import url_character, complex2str
-
+from lmfdb.groups.abstract.main import abstract_group_display_knowl, render_abstract_group
 logger = make_logger("DC")
 
 def parity_string(n):
@@ -704,7 +705,7 @@ class WebCharGroup(WebCharObject):
     headers = [ 'order', 'primitive']
     _keys = [ 'title', 'codelangs', 'type', 'nf', 'nflabel',
             'nfpol', 'modulus', 'modlabel', 'texname', 'codeinit', 'previous',
-            'prevmod', 'next', 'nextmod', 'structure', 'codestruct', 'order',
+            'prevmod', 'next', 'nextmod', 'structure', 'structure_group_knowl', 'codestruct', 'order',
             'codeorder', 'gens', 'generators', 'codegen', 'valuefield', 'vflabel',
             'vfpol', 'headers', 'groupelts', 'contents',
             'properties', 'friends', 'rowtruncate', 'coltruncate']
@@ -718,7 +719,33 @@ class WebCharGroup(WebCharObject):
     @lazy_attribute
     def structure(self):
         inv = self.H.invariants()
-        return r'\(%s\)' % ('\\times '.join('C_{%s}' % d for d in inv))
+        inv_list = list(inv)
+        inv_list.sort()
+        return r"\(%s\)" % ("\\times ".join("C_{%s}" % d for d in inv_list))
+
+    @lazy_attribute
+    def structure_group_knowl(self):
+        inv = self.H.invariants()
+        label = ".".join(str(v) for v in inv)
+        parts = defaultdict(list)
+        for piece in label.split("."):
+            if "_" in piece:
+                base, exp = map(ZZ, piece.split("_"))
+            else:
+                base = ZZ(piece)
+                exp = 1
+            for p, e in base.factor():
+                parts[p].extend([p ** e] * exp)
+        for v in parts.values():
+            v.sort()
+        primary = sum((parts[p] for p in sorted(parts)), [])
+        dblabel = db.gps_groups.lucky(
+            {"abelian": True, "primary_abelian_invariants": primary}, "label"
+        )
+        if dblabel is None:
+            abgp_url = url_for('abstract.by_abelian_label', label=label)
+            return f'<a href= %s >{self.structure}</a>' % abgp_url
+        return abstract_group_display_knowl(dblabel, f"{self.structure}")
 
     @lazy_attribute
     def codestruct(self):

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -57,7 +57,7 @@ from lmfdb.number_fields.web_number_field import WebNumberField, formatfield, nf
 from lmfdb.characters.TinyConrey import (ConreyCharacter, kronecker_symbol,
                 symbol_numerator, PariConreyGroup, get_sage_genvalues)
 from lmfdb.characters.utils import url_character, complex2str
-from lmfdb.groups.abstract.main import abstract_group_display_knowl, render_abstract_group
+from lmfdb.groups.abstract.main import abstract_group_display_knowl
 logger = make_logger("DC")
 
 def parity_string(n):


### PR DESCRIPTION
This redoes PR #4950, addresses #3358, there is now a link to the abstract group instead of a knowl; on sage-9.2 it doesn't work, but does on sage-9.4.