### PR TITLE
Make unit group rank be in math mode in nf search pages

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -805,7 +805,7 @@ nf_columns = SearchColumns([
     SearchCol("galois", "nf.galois_group", "Galois group", default=True),
     SearchCol("class_group_desc", "nf.ideal_class_group", "Class group", default=True),
     MathCol("torsion_order", "nf.unit_group", "Unit group torsion", align="center"),
-    MultiProcessedCol("unit_rank", "nf.rank", "Unit group rank", ["r2", "degree"], lambda r2, degree: degree - r2 + - 1, align="center"),
+    MultiProcessedCol("unit_rank", "nf.rank", "Unit group rank", ["r2", "degree"], lambda r2, degree: degree - r2 + - 1, align="center", mathmode=True),
     MathCol("regulator", "nf.regulator", "Regulator", align="left")],
     db_cols=["class_group", "coeffs", "degree", "r2", "disc_abs", "disc_sign", "galois_label", "label", "ramps", "used_grh", "cm", "is_galois", "torsion_order", "regulator"])
 


### PR DESCRIPTION
On the number field search pages, if you add unit rank as a display column, it was not in math mode even though it is just an integer.  This puts it in math mode like other integers in the search columns.

Seeing it involves clicking to show the extra columns, so a single url can't do it, but any number field search should do.