### PR TITLE
Datapage

### DIFF
--- a/Postgres_FAQ.md
+++ b/Postgres_FAQ.md
@@ -658,7 +658,7 @@ Statistics
    refresh them manually using, for example, `db.g2c_curves.stats.refresh_statistics()`.
    Sometimes this isn't sufficient (if there are extra stats that shouldn't
    be present for example).  A more drastic option is to call
-   `db.g2c_curves._clear_stats_counts()`.  If you do this, make sure to
+   `db.g2c_curves.stats._clear_stats_counts()`.  If you do this, make sure to
    visit the relevant statistics page while logged in as editor,
    in order to regenerate the statistics used there.
 

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -204,7 +204,7 @@ def download_search(info):
 
 @abvarfq_page.route("/data/<label>")
 def AV_data(label):
-    bread = get_bread((f"Data - {label}", " "))
+    bread = get_bread((label, url_for_label(label)), ("Data", " "))
     extension_labels = list(db.av_fq_endalg_factors.search({"base_label": label}, "extension_label", sort=["extension_degree"]))
     tables = ["av_fq_isog", "av_fq_endalg_factors"] + ["av_fq_endalg_data"] * len(extension_labels)
     labels = [label, label] + extension_labels

--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -18,6 +18,7 @@ from lmfdb.utils import (
     search_wrap, count_wrap, YesNoMaybeBox, CountBox, SubsetBox, SelectBox
 )
 from lmfdb.utils.interesting import interesting_knowls
+from lmfdb.api import datapage
 from . import abvarfq_page
 from .search_parsing import parse_newton_polygon, parse_nf_string, parse_galgrp
 from .isog_class import validate_label, AbvarFq_isoclass
@@ -130,6 +131,7 @@ def abelian_varieties_by_gqi(g, q, iso):
 
     if hasattr(cl, "curves") and cl.curves:
         downloads.append(('Curves to text', url_for('.download_curves', label=label)))
+    downloads.append(("Underlying data", url_for('.AV_data', label=label)))
 
     return render_template(
         "show-abvarfq.html",
@@ -198,6 +200,16 @@ def download_search(info):
     strIO.write(s.encode('utf-8'))
     strIO.seek(0)
     return send_file(strIO, attachment_filename=filename, as_attachment=True, add_etags=False)
+
+@abvarfq_page.route("/data/<label>")
+def AV_data(label):
+    bread = get_bread((f"Data - {label}", " "))
+    extension_labels = list(db.av_fq_endalg_factors.search({"base_label": label}, "extension_label", sort=["extension_degree"]))
+    tables = ["av_fq_isog", "av_fq_endalg_factors"] + ["av_fq_endalg_data"] * len(extension_labels)
+    labels = [label, label] + extension_labels
+    label_cols = ["label", "base_label"] + ["extension_label"] * len(extension_labels)
+    sorts = [[], ["extension_degree"]] + [[]] * len(extension_labels)
+    return datapage(labels, tables, title=f"Abelian variety isogeny class data - {label}", bread=bread, label_cols=label_cols, sorts=sorts)
 
 class AbvarSearchArray(SearchArray):
     jump_example = "2.16.am_cn"

--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -138,6 +138,9 @@ class AVTest(LmfdbTest):
         page = self.tc.get('Variety/Abelian/Fq/download_all/3.17.d_b_act', follow_redirects=True)
         assert '"curve_counts": [21, 283, 4719, 84395' in page.get_data(as_text=True)
 
+        text = self.tc.get('Variety/Abelian/Fq/data/3.17.d_b_act', follow_redirects=True).get_data(as_text=True)
+        assert 'dim4_factors' in text and 'multiplicity' in text and 'brauer_invariants' in text
+
     def test_download_curves(self):
         r"""
         Test downloading all stored data to text

--- a/lmfdb/api/__init__.py
+++ b/lmfdb/api/__init__.py
@@ -14,4 +14,6 @@ def body_class():
 from . import api
 assert api # silence pyflakes
 
+from .api import datapage
+
 app.register_blueprint(api_page, url_prefix="/api")

--- a/lmfdb/api/__init__.py
+++ b/lmfdb/api/__init__.py
@@ -15,5 +15,6 @@ from . import api
 assert api # silence pyflakes
 
 from .api import datapage
+assert datapage
 
 app.register_blueprint(api_page, url_prefix="/api")

--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -339,8 +339,8 @@ def api_query(table, id = None):
                         for col in sorted(coll.extra_cols)]
         return render_template("collection.html",
                                title=title,
-                               search_schema=search_schema,
-                               extra_schema=extra_schema,
+                               search_schema={table: search_schema},
+                               extra_schema={table: extra_schema},
                                single_object=single_object,
                                query_unquote = query_unquote,
                                url_args = url_args,
@@ -380,8 +380,8 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
         else:
             return abort(code, msg % tuple(flash_extras))
     data = []
-    search_schemas = []
-    extra_schemas = []
+    search_schema = {}
+    extra_schema = {}
     for label, table, col, sort in zip(labels, tables, label_cols, sorts):
         q = {col: label}
         coll = db[table]
@@ -393,10 +393,10 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
             return apierror("No key %s in table %s", [err, table], table=table)
         except Exception as err:
             return apierror(str(err), table=table)
-        search_schemas.append([(col, coll.col_type[col])
-                               for col in sorted(coll.search_cols)])
-        extra_schemas.append([(col, coll.col_type[col])
-                              for col in sorted(coll.extra_cols)])
+        search_schema[table] = [(col, coll.col_type[col])
+                                for col in sorted(coll.search_cols)]
+        extra_schema[table] = [(col, coll.col_type[col])
+                               for col in sorted(coll.extra_cols)]
     data = Json.prep(data)
 
     # the collected result
@@ -418,8 +418,8 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
     else:
         return render_template("apidata.html",
                                title=title,
-                               search_schemas=search_schemas,
-                               extra_schemas=extra_schemas,
+                               search_schema=search_schema,
+                               extra_schema=extra_schema,
                                bread=bread,
                                pretty=pretty_document,
                                **data)

--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -346,3 +346,80 @@ def api_query(table, id = None):
                                url_args = url_args,
                                bread=bc,
                                **data)
+
+# This function is used to show the data associated to a given homepage, which could possibly be from multiple tables.
+def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
+    """
+    INPUT:
+
+    - ``labels`` -- a string giving a label used in the tables (e.g. '11.a1' for an elliptic curve), or a list of strings (one per table)
+    - ``tables`` -- a search table or list of search tables (as strings)
+    - ``title`` -- title for the page
+    - ``bread`` -- bread for the page
+    - ``label_cols`` -- a list of column names of the same length; defaults to using ``label`` everywhere
+    - ``sorts`` -- lists for sorting each table; defaults to None
+    """
+    format = request.args.get("_format", "html")
+    if not isinstance(tables, list):
+        tables = [tables]
+    if not isinstance(labels, list):
+        labels = [labels for table in tables]
+    if label_cols is None:
+        label_cols = ["label" for table in tables]
+    if sorts is None:
+        sorts = [None for table in tables]
+    assert len(labels) == len(tables) == len(label_cols)
+
+    def apierror(msg, flash_extras=[], code=404, table=False):
+        if format == "html":
+            flash_error(msg, *flash_extras)
+            if table:
+                return redirect(url_for("API.api_query", table=table))
+            else:
+                return redirect(url_for("API.index"))
+        else:
+            return abort(code, msg % tuple(flash_extras))
+    data = []
+    search_schemas = []
+    extra_schemas = []
+    for label, table, col, sort in zip(labels, tables, label_cols, sorts):
+        q = {col: label}
+        coll = db[table]
+        try:
+            data.append(list(coll.search(q, projection=3, sort=sort)))
+        except QueryCanceledError:
+            return apierror("Query %s exceeded time limit.", [q], code=500, table=table)
+        except KeyError as err:
+            return apierror("No key %s in table %s", [err, table], table=table)
+        except Exception as err:
+            return apierror(str(err), table=table)
+        search_schemas.append([(col, coll.col_type[col])
+                               for col in sorted(coll.search_cols)])
+        extra_schemas.append([(col, coll.col_type[col])
+                              for col in sorted(coll.extra_cols)])
+    data = Json.prep(data)
+
+    # the collected result
+    data = {
+        "labels": labels,
+        "tables": tables,
+        "label_cols": label_cols,
+        "timestamp": datetime.utcnow().isoformat(),
+        "data": data,
+    }
+    if format.lower() == "json":
+        return current_app.response_class(json.dumps(data, indent=2), mimetype='application/json')
+    elif format.lower() == "yaml":
+        y = yaml.dump(data,
+                      default_flow_style=False,
+                      canonical=False,
+                      allow_unicode=True)
+        return Response(y, mimetype='text/plain')
+    else:
+        return render_template("apidata.html",
+                               title=title,
+                               search_schemas=search_schemas,
+                               extra_schemas=extra_schemas,
+                               bread=bread,
+                               pretty=pretty_document,
+                               **data)

--- a/lmfdb/api/templates/apidata.html
+++ b/lmfdb/api/templates/apidata.html
@@ -28,10 +28,10 @@ Formats:
       {% if (recs|length) == 0 %}
         {{ label_col }} {{ label }} does not appear in <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a>
       {% elif (recs|length) == 1 %}
-        <a href="{{ url_for('API.api_query_id', table=table, id=recs[0].get('id')) }}">{{ table }}</a></br/>
+        <a href="{{ url_for('API.api_query_id', table=table, id=recs[0].get('id')) }}">{{ table }}</a> &bull; {% include "apischema.html" %} </br/>
         <code>{{ pretty(recs[0], id=False) }}</code>
       {% else %}
-        <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a></br/>
+        <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a> &bull; {% include "apischema.html" %} </br/>
         <ul>
           {% for entry in recs %}
             <li>

--- a/lmfdb/api/templates/apidata.html
+++ b/lmfdb/api/templates/apidata.html
@@ -1,0 +1,48 @@
+{% extends "homepage.html" %}
+
+{% block content %}
+
+<style>
+  .api-entries > li { margin-bottom: 14px; }
+  #schema-table {
+    width: 95%;
+  }
+  div.schema-holder {
+    height: 300px;
+    width: 97%;
+    overflow-y: scroll;
+  }
+</style>
+
+<div>
+Formats:
+- <a href="{{ url }}">HTML</a>
+- <a href="{{ url }}?_format=yaml">YAML</a>
+- <a href="{{ url }}?_format=json">JSON</a>
+- {{ timestamp }}
+</div>
+
+<ul class="api-entries">
+  {% for table, recs, label, label_col in zip(tables, data, labels, label_cols) %}
+    <li>
+      {% if (recs|length) == 0 %}
+        {{ label_col }} {{ label }} does not appear in <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a>
+      {% elif (recs|length) == 1 %}
+        <a href="{{ url_for('API.api_query_id', table=table, id=recs[0].get('id')) }}">{{ table }}</a></br/>
+        <code>{{ pretty(recs[0], id=False) }}</code>
+      {% else %}
+        <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a></br/>
+        <ol>
+          {% for entry in recs %}
+            <li>
+              id: <a href="{{ url_for('API.api_query_id', table=table, id=entry.get('id')) }}">{{ entry.get('id') }}</a></br/>
+              <code>{{ pretty(entry, id=False) }}</code>
+            </li>
+          {% endfor %}
+        </ol>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+
+{% endblock %}

--- a/lmfdb/api/templates/apidata.html
+++ b/lmfdb/api/templates/apidata.html
@@ -32,14 +32,14 @@ Formats:
         <code>{{ pretty(recs[0], id=False) }}</code>
       {% else %}
         <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a></br/>
-        <ol>
+        <ul>
           {% for entry in recs %}
             <li>
               id: <a href="{{ url_for('API.api_query_id', table=table, id=entry.get('id')) }}">{{ entry.get('id') }}</a></br/>
               <code>{{ pretty(entry, id=False) }}</code>
             </li>
           {% endfor %}
-        </ol>
+        </ul>
       {% endif %}
     </li>
   {% endfor %}

--- a/lmfdb/api/templates/apischema.html
+++ b/lmfdb/api/templates/apischema.html
@@ -1,0 +1,24 @@
+  <a id="{{table}}-schema-shower" onclick="return show_schema('{{table}}');" href="#">Show schema</a>
+  <a id="{{table}}-schema-hider" onclick="return hide_schema('{{table}}');" href="#" style="display: none;">Hide schema</a>
+  <div class="{{table}}-schema-holder" style="display: none;">
+    <table id="schema-table" class="ntdata">
+      <tr>
+        <th>Column</th>
+        <th>Type</th>
+      </tr>
+      {% for col, typ in search_schema[table] %}
+        <tr>
+          <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
+          <td>{{typ}}</td>
+        </tr>
+      {% endfor %}
+      {% if extra_schema %}
+        {% for col, typ in extra_schema[table] %}
+          <tr{% if loop.index == 1 %} class="toplined"{% endif %}>
+            <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
+            <td>{{typ}}</td>
+          </tr>
+        {% endfor %}
+      {% endif %}
+    </table>
+  </div>

--- a/lmfdb/api/templates/collection.html
+++ b/lmfdb/api/templates/collection.html
@@ -2,21 +2,6 @@
 
 {% block content %}
 
-<script type="text/javascript">
-  function show_schema() {
-    $("div.schema-holder").show();
-    $("#schema-hider").show();
-    $("#schema-shower").hide();
-    return false;
-  }
-  function hide_schema() {
-    $("div.schema-holder").hide();
-    $("#schema-hider").hide();
-    $("#schema-shower").show();
-    return false;
-  }
-</script>
-
 <style>
   .api-entries > li { margin-bottom: 14px; }
   #schema-table {
@@ -43,30 +28,7 @@ Formats:
 Query: <code><a href="{{ query }}">{{ query_unquote }}</a></code>
 </div>
 <div>
-  <a id="schema-shower" onclick="return show_schema();" href="#">Show schema</a>
-  <a id="schema-hider" onclick="return hide_schema();" href="#" style="display: none;">Hide schema</a>
-  <div class="schema-holder" style="display: none;">
-    <table id="schema-table" class="ntdata">
-      <tr>
-        <th>Column</th>
-        <th>Type</th>
-      </tr>
-      {% for col, typ in search_schema %}
-        <tr>
-          <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
-          <td>{{typ}}</td>
-        </tr>
-      {% endfor %}
-      {% if extra_schema %}
-        {% for col, typ in extra_schema %}
-          <tr{% if loop.index == 1 %} class="toplined"{% endif %}>
-            <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
-            <td>{{typ}}</td>
-          </tr>
-        {% endfor %}
-      {% endif %}
-    </table>
-  </div>
+  {% include "apischema.html" %}
 </div>
 
 {% if single_object %}

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -145,6 +145,7 @@ def ctx_proc_userdata():
         urlparts = urlparts._replace(**replace)
         return urlunparse(urlparts)
     vars['modify_url'] = modify_url
+    vars['zip'] = zip
 
     return vars
 

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -434,7 +434,7 @@ def artin_data(label):
     poly = db.artin_reps.lookup(label, "NFGal")
     if poly is None:
         return abort(404)
-    bread = get_bread([(f"Data - {label}", " ")])
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     return datapage([label, poly], ["artin_reps", "artin_field_data"], bread=bread, title=f"Artin representation data - {label}", label_cols=["Baselabel", "Polynomial"])
 
 @artin_representations_page.route("/random")

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -5,7 +5,7 @@
 import re
 import random
 
-from flask import render_template, request, url_for, redirect
+from flask import render_template, request, url_for, redirect, abort
 from sage.all import ZZ, cached_function
 
 from lmfdb import db
@@ -19,6 +19,7 @@ from lmfdb.utils.display_stats import StatsDisplay, totaler, proportioners, rang
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_parsing import search_parser
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, MathCol
+from lmfdb.api import datapage
 from lmfdb.number_fields.web_number_field import WebNumberField
 from lmfdb.galois_groups.transitive_group import (
     complete_group_code, knowl_cache, galdata, galunformatter,
@@ -405,6 +406,7 @@ def render_artin_representation_webpage(label):
             wnf=wnf,
             proj_wnf=proj_wnf,
             properties=properties,
+            downloads=[("Underlying data", url_for(".artin_data", label=orblabel))],
             info=info,
             learnmore=learnmore_list(),
             KNOWL_ID="artin.%s" % label,
@@ -421,10 +423,19 @@ def render_artin_representation_webpage(label):
         wnf=wnf,
         proj_wnf=proj_wnf,
         properties=properties,
+        downloads=[("Underlying data", url_for(".artin_data", label=label))],
         info=info,
         learnmore=learnmore_list(),
         KNOWL_ID="artin.%s" % label,
     )
+
+@artin_representations_page.route("/data/<label>")
+def artin_data(label):
+    poly = db.artin_reps.lookup(label, "NFGal")
+    if poly is None:
+        return abort(404)
+    bread = get_bread([(f"Data - {label}", " ")])
+    return datapage([label, poly], ["artin_reps", "artin_field_data"], bread=bread, title=f"Artin representation data - {label}", label_cols=["Baselabel", "Polynomial"])
 
 @artin_representations_page.route("/random")
 @redirect_no_cache

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -28,3 +28,7 @@ class ArtinRepTest(LmfdbTest):
     def test_big_degree_new(self):
         L = self.tc.get('/ArtinRepresentation/2.3806401.120.b.a')
         assert '24T201' in L.get_data(as_text=True) # Galois group
+
+    def test_underlying_data(self):
+        data = self.tc.get('/ArtinRepresentation/data/2.3806401.120.b').get_data(as_text=True)
+        assert 'ArtinReps' in data and 'GalConjSigns' in data

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -30,6 +30,7 @@ from lmfdb.utils import (
 )
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, MathCol, LinkCol, MultiProcessedCol
+from lmfdb.api import datapage
 from . import belyi_page
 from .web_belyi import (
     WebBelyiGalmap,
@@ -581,6 +582,21 @@ def belyi_galmap_sage_download(label):
 @belyi_page.route("/download_galmap_to_text/<label>")
 def belyi_galmap_text_download(label):
     return Belyi_download().download_galmap_text(label)
+
+@belyi_page.route("/data/<label>")
+def belyi_data(label):
+    bread = get_bread(f"Data - {label}")
+    if label.count("-") == 1: # passport label length
+        labels = [label, label]
+        label_cols = ["plabel", "plabel"]
+        tables = ["belyi_passports_fixed", "belyi_galmaps_fixed"]
+    elif label.count("-") == 2: # galmap label length
+        labels = [label, "-".join(label.split("-")[:-1]), label]
+        label_cols = ["label", "plabel", "label"]
+        tables = ["belyi_galmaps_fixed", "belyi_passports_fixed", "belyi_galmap_portraits"]
+    else:
+        return abort(404)
+    return datapage(labels, tables, title=f"Belyi map data - {label}", bread=bread, label_cols=label_cols)
 
 def url_for_label(label):
     return url_for(".by_url_belyi_search_url", smthorlabel=label)

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -585,7 +585,7 @@ def belyi_galmap_text_download(label):
 
 @belyi_page.route("/data/<label>")
 def belyi_data(label):
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     if label.count("-") == 1: # passport label length
         labels = [label, label]
         label_cols = ["plabel", "plabel"]

--- a/lmfdb/belyi/test_belyi.py
+++ b/lmfdb/belyi/test_belyi.py
@@ -153,7 +153,7 @@ class BelyiTest(LmfdbTest):
         data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
         assert "maxdegbf" in data and "orbit_size" in data
 
-        data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
+        data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1-a", follow_redirects=True).get_data(as_text=True)
         assert "friends" in data and "maxdegbf" in data and "portrait" in data
 
     # friends

--- a/lmfdb/belyi/test_belyi.py
+++ b/lmfdb/belyi/test_belyi.py
@@ -151,7 +151,7 @@ class BelyiTest(LmfdbTest):
 
         # Underlying data link
         data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
-        assert "maxdegbf" in data and "'map'" in data
+        assert "maxdegbf" in data and "orbit_size" in data
 
         data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
         assert "friends" in data and "maxdegbf" in data and "portrait" in data

--- a/lmfdb/belyi/test_belyi.py
+++ b/lmfdb/belyi/test_belyi.py
@@ -149,6 +149,13 @@ class BelyiTest(LmfdbTest):
             in page.get_data(as_text=True)
         )
 
+        # Underlying data link
+        data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
+        assert "maxdegbf" in data and "'map'" in data
+
+        data = self.tc.get("/Belyi/data/7T5-7_7_3.3.1", follow_redirects=True).get_data(as_text=True)
+        assert "friends" in data and "maxdegbf" in data and "portrait" in data
+
     # friends
     def test_friends(self):
         for url, friends in [

--- a/lmfdb/belyi/web_belyi.py
+++ b/lmfdb/belyi/web_belyi.py
@@ -261,8 +261,8 @@ class WebBelyiGalmap(object):
                     data["curve_url"] = url
 
         # Downloads
+        data_label = data["label"]
         if galmap["g"] <= 2:
-            data_label = data["label"]
             if triple:
                 spl = data_label.split("-")
                 data_label = "-".join(spl[0:-1])
@@ -283,6 +283,7 @@ class WebBelyiGalmap(object):
             ]
         else:
             self.downloads = []
+        self.downloads.append(("Underlying data", url_for(".belyi_data", label=data_label)))
 
         # Breadcrumbs
         label_spl = data["label"].split("-")

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -314,6 +314,7 @@ def render_bmf_space_webpage(field_label, level_label):
         (level_label, '')])
     friends = []
     properties = []
+    downloads = []
 
     if not field_label_regex.match(field_label):
         flash_error("%s is not a valid label for an imaginary quadratic field", field_label)
@@ -370,8 +371,9 @@ def render_bmf_space_webpage(field_label, level_label):
                 info['nnf_missing'] = dim_data['2']['new_dim'] - info['nnf1'] # - 2*info['nnf2']
                 properties = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
+                downloads = [('Underlying data', url_for("API.api_query", table="bmf_dims") + f"?label={info['label']}")]
 
-    return render_template("bmf-space.html", info=info, title=t, bread=bread, properties=properties, friends=friends, learnmore=learnmore_list())
+    return render_template("bmf-space.html", info=info, title=t, bread=bread, properties=properties, friends=friends, downloads=downloads, learnmore=learnmore_list())
 
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/download/<download_type>')

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -600,8 +600,9 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
         properties = data.properties
         friends = data.friends
         info['downloads'] = [
-        ('Modular form to Magma', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='magma')),
-        ('Eigenvalues to Sage', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='sage'))
+            ('Modular form to Magma', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='magma')),
+            ('Eigenvalues to Sage', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='sage')),
+            ('Underlying data', url_for("API.api_query", table="bmf_forms") + f"?label={label}"),
         ]
     except ValueError:
         flash_error("No Bianchi modular form in the database has label %s", label)

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 
-from flask import render_template, url_for, request, redirect, make_response
+from flask import render_template, url_for, request, redirect, make_response, abort
 from sage.all import latex, QQ, PolynomialRing
 
 from lmfdb import db

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -13,6 +13,7 @@ from lmfdb.utils import (
 from lmfdb.utils.display_stats import StatsDisplay, totaler, proportioners
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.number_fields.web_number_field import WebNumberField, nf_display_knowl, field_pretty
 from lmfdb.nfutils.psort import ideal_from_label, primes_iter
 from lmfdb.bianchi_modular_forms import bmf_page
@@ -371,9 +372,25 @@ def render_bmf_space_webpage(field_label, level_label):
                 info['nnf_missing'] = dim_data['2']['new_dim'] - info['nnf1'] # - 2*info['nnf2']
                 properties = [('Base field', pretty_field_label), ('Level',info['level_label']), ('Norm',str(info['level_norm'])), ('New dimension',str(newdim))]
                 friends = [('Newform {}'.format(f['label']), f['url']) for f in info['nfdata'] ]
-                downloads = [('Underlying data', url_for("API.api_query", table="bmf_dims") + f"?label={info['label']}")]
+                downloads = [('Underlying data', url_for(".bmf_data", label=info['label']))]
 
     return render_template("bmf-space.html", info=info, title=t, bread=bread, properties=properties, friends=friends, downloads=downloads, learnmore=learnmore_list())
+
+@bmf_page.route('/data/<label>')
+def bmf_data(label):
+    pieces = label.split("-")
+    if len(pieces) == 2:
+        url = url_for(".render_bmf_space_webpage", field_label=pieces[0], level_label=pieces[1])
+        title = f"Bianchi modular space data - {label}"
+        table = "bmf_dims"
+    elif len(pieces) == 3:
+        url = url_for_label(label)
+        title = f"Bianchi modular form data - {label}"
+        table = "bmf_forms"
+    else:
+        return abort(404, f"Invalid label {label}")
+    bread = get_bread([(label, url), ("Data", " ")])
+    return datapage(label, table, title=title, bread=bread)
 
 
 @bmf_page.route('/<field_label>/<level_label>/<label_suffix>/download/<download_type>')
@@ -607,7 +624,7 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
         info['downloads'] = [
             ('Modular form to Magma', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='magma')),
             ('Eigenvalues to Sage', url_for(".render_bmf_webpage_download", field_label=field_label, label_suffix=label_suffix, level_label=level_label, download_type='sage')),
-            ('Underlying data', url_for("API.api_query", table="bmf_forms") + f"?label={label}"),
+            ('Underlying data', url_for(".bmf_data", label=label)),
         ]
     except ValueError:
         flash_error("No Bianchi modular form in the database has label %s", label)

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -169,3 +169,8 @@ class BMFTest(LmfdbTest):
             magma_code += 'for P in primes[1..15] do;\n if Valuation(NN,P) eq 0 then;\n  assert iso(heckeEigenvalues[P]) eq HeckeEigenvalue(f,P);\n end if;\nend for;\n'
             magma_code += 'f;\n'
             self.assert_if_magma('success', magma_code, mode='in')
+
+    def test_underlying_data(self):
+        # We just check for the existence of the link, since it use the api
+        page = self.tc.get("/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/88.5/a").get_data(as_text=True)
+        assert "Underlying data" in page and "api/bmf_forms/?label=2.0.7.1-88.5-a" in page

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -172,4 +172,4 @@ class BMFTest(LmfdbTest):
     def test_underlying_data(self):
         # We just check for the existence of the link, since it use the api
         page = self.tc.get("/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/88.5/a", follow_redirects=True).get_data(as_text=True)
-        assert "Underlying data" in page and "api/bmf_forms/?label=2.0.7.1-88.5-a" in page
+        assert "Underlying data" in page and "data/2.0.7.1-88.5-a" in page

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -171,5 +171,5 @@ class BMFTest(LmfdbTest):
 
     def test_underlying_data(self):
         # We just check for the existence of the link, since it use the api
-        page = self.tc.get("/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/88.5/a").get_data(as_text=True)
+        page = self.tc.get("/ModularForm/GL2/ImaginaryQuadratic/2.0.7.1/88.5/a", follow_redirects=True).get_data(as_text=True)
         assert "Underlying data" in page and "api/bmf_forms/?label=2.0.7.1-88.5-a" in page

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -442,7 +442,7 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
                     return redirect(url_for(".render_DirichletNavigation"))
 
                 info['show_orbit_label'] = True
-                info['downloads'] = [('Underlying data', url_for('API.api_query', table="char_dir_orbits") + f"?label={modulus}.{orbit_label}")]
+                info['downloads'] = [('Underlying data', url_for('.dirchar_data', label=f"{modulus}.{orbit_label}"))]
                 info['learnmore'] = learn()
                 info['code'] = dict([(k[4:], info[k]) for k in info if k[0:4] == "code"])
                 info['code']['show'] = {lang: '' for lang in info['codelangs']}  # use default show names
@@ -506,11 +506,18 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
 
 @characters_page.route("/Dirichlet/data/<label>")
 def dirchar_data(label):
-    if label.count(".") != 2:
-        return abort(404)
-    modulus, orbit_label, number = label.split(".")
-    title = f"Dirichlet character data - {modulus}.{number}"
-    return datapage([f"{modulus}.{orbit_label}", f"{modulus}.{number}"], ["char_dir_orbits", "char_dir_values"], title=title, bread=[], label_cols=["label", "label"])
+    if label.count(".") == 2:
+        modulus, orbit_label, number = label.split(".")
+        title = f"Dirichlet character data - {modulus}.{number}"
+        tail = [(f"{modulus}.{number}", url_for(".render_Dirichletwebpage", modulus=modulus, number=number)),
+                ("Data", " ")]
+        return datapage([f"{modulus}.{orbit_label}", f"{modulus}.{number}"], ["char_dir_orbits", "char_dir_values"], title=title, bread=bread(tail), label_cols=["label", "label"])
+    elif label.count(".") == 1:
+        modulus, orbit_label = label.split(".")
+        title = f"Dirichlet character data - {modulus}.{orbit_label}"
+        tail = [(label, url_for(".render_Dirichletwebpage", modulus=modulus, orbit_label=orbit_label)),
+                ("Data", " ")]
+        return datapage(label, "char_dir_orbits", title=title, bread=bread(tail))
 
 def _dir_knowl_data(label, orbit=False):
     modulus, number = label.split('.')

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -91,8 +91,8 @@ class DirichletCharactersTest(LmfdbTest):
         assert r'\chi_{999999999}(234567902,' in W.get_data(as_text=True) and r'\chi_{999999999}(432432433,' in W.get_data(as_text=True) and r'\chi_{999999999}(332999668,' in W.get_data(as_text=True)
 
     def test_dirichletgalorbs(self):
-        W = self.tc.get('/Character/Dirichlet/289/j')
-        assert r'&rarr; <a href="/Character/Dirichlet/289/j"> j</a>' in W.get_data(as_text=True)
+        W = self.tc.get('/Character/Dirichlet/289/j').get_data(as_text=True)
+        assert r'&rarr; <a href="/Character/Dirichlet/289/j"> j</a>' in W
         table_row = (r'<td class="center">\(-1\)</td>  '
                     r'<td class="center">\(1\)</td>  '
                     r'<td class="center">\(e\left(\frac{57}{136}\right)\)</td>  '
@@ -105,7 +105,8 @@ class DirichletCharactersTest(LmfdbTest):
                     r'<td class="center">\(e\left(\frac{55}{136}\right)\)</td>  '
                     r'<td class="center">\(e\left(\frac{61}{272}\right)\)</td>  '
                     r'<td class="center">\(e\left(\frac{41}{272}\right)\)</td>')
-        assert table_row in W.get_data(as_text=True)
+        assert table_row in W
+        assert "Underlying data" in W and "api/char_dir_orbits/?label=289.j" in W
 
         W = self.tc.get('/Character/Dirichlet/7145/da')
         assert r'&rarr; <a href="/Character/Dirichlet/7145/da"> da</a>' in W.get_data(as_text=True)
@@ -231,3 +232,7 @@ class DirichletCharactersTest(LmfdbTest):
         W = self.tc.get('/Character/Dirichlet/91/3')
         assert 'H = DirichletGroup(91, base_ring=CyclotomicField(6))' in W.get_data(as_text=True), "sage code group is wrong"
         assert 'chi = DirichletCharacter(H, M([1,2]))' in W.get_data(as_text=True), "sage code generator is wrong"
+
+    def test_underlying_data(self):
+        W = self.tc.get('/Character/Dirichlet/data/289.j.7').get_data(as_text=True)
+        assert 'is_minimal' in W and 'values_gens' in W

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -106,7 +106,7 @@ class DirichletCharactersTest(LmfdbTest):
                     r'<td class="center">\(e\left(\frac{61}{272}\right)\)</td>  '
                     r'<td class="center">\(e\left(\frac{41}{272}\right)\)</td>')
         assert table_row in W
-        assert "Underlying data" in W and "api/char_dir_orbits/?label=289.j" in W
+        assert "Underlying data" in W and "data/289.j" in W
 
         W = self.tc.get('/Character/Dirichlet/7145/da')
         assert r'&rarr; <a href="/Character/Dirichlet/7145/da"> da</a>' in W.get_data(as_text=True)
@@ -236,3 +236,5 @@ class DirichletCharactersTest(LmfdbTest):
     def test_underlying_data(self):
         W = self.tc.get('/Character/Dirichlet/data/289.j.7').get_data(as_text=True)
         assert 'is_minimal' in W and 'values_gens' in W
+        W = self.tc.get('/Character/Dirichlet/data/289.j').get_data(as_text=True)
+        assert 'is_minimal' in W

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -484,10 +484,10 @@ def mf_data(label):
         tables = ["mf_gamma1", "mf_gamma1_subspaces", "mf_gamma1_portraits"]
         labels = label
         label_cols = None
-        title = f"$Gamma_1$ data - {label}"
+        title = fr"$\Gamma_1$ data - {label}"
     else:
         return abort(404, "Invalid label")
-    bread = get_bread(other=f"Data - {label}")
+    bread = get_bread(other=[(label, url_for_label(label)), ("Data", " ")])
     return datapage(labels, tables, title=title, bread=bread, label_cols=label_cols)
 
 

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -451,7 +451,6 @@ def render_full_gamma1_space_webpage(label):
 @cmf.route("/data/<label>")
 def mf_data(label):
     slabel = label.split(".")
-    data = None
     if len(slabel) == 6:
         emb_label = label
         form_label = ".".join(slabel[:4])

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -25,6 +25,7 @@ from lmfdb.backend.utils import range_formatter
 from lmfdb.utils.search_parsing import search_parser
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol, FloatCol, CheckCol, ProcessedCol, MultiProcessedCol, ColGroup, SpacerCol
+from lmfdb.api import datapage
 from lmfdb.classical_modular_forms import cmf
 from lmfdb.classical_modular_forms.web_newform import (
     WebNewform, convert_newformlabel_from_conrey, LABEL_RE,
@@ -446,6 +447,50 @@ def render_full_gamma1_space_webpage(label):
                            learnmore=learnmore_list(),
                            title=space.title,
                            friends=space.friends)
+
+@cmf.route("/data/<label>")
+def mf_data(label):
+    slabel = label.split(".")
+    data = None
+    if len(slabel) == 6:
+        emb_label = label
+        form_label = ".".join(slabel[:4])
+        space_label = ".".join(slabel[:3])
+        ocode = db.mf_newforms.lookup(form_label, "hecke_orbit_code")
+        if ocode is None:
+            return abort(404, f"{label} not in database")
+        tables = ["mf_newforms", "mf_hecke_cc", "mf_newspaces", "mf_twists_cc", "mf_hecke_charpolys", "mf_newform_portraits", "mf_hecke_traces"]
+        labels = [form_label, emb_label, space_label, emb_label, ocode, form_label, ocode]
+        label_cols = ["label", "label", "label", "source_label", "hecke_orbit_code", "label", "hecke_orbit_code"]
+        title = f"Embedded newform data - {label}"
+    elif len(slabel) == 4:
+        form_label = label
+        space_label = ".".join(slabel[:3])
+        ocode = db.mf_newforms.lookup(form_label, "hecke_orbit_code")
+        if ocode is None:
+            return abort(404, f"{label} not in database")
+        tables = ["mf_newforms", "mf_hecke_nf", "mf_newspaces", "mf_twists_nf", "mf_hecke_charpolys", "mf_newform_portraits", "mf_hecke_traces"]
+        labels = [form_label, form_label, space_label, form_label, ocode, form_label, ocode]
+        label_cols = ["label", "label", "label", "source_label", "hecke_orbit_code", "label", "hecke_orbit_code"]
+        title = f"Newform data - {label}"
+    elif len(slabel) == 3:
+        ocode = db.mf_newspaces.lookup(label, "hecke_orbit_code")
+        if ocode is None:
+            return abort(404, f"{label} not in database")
+        tables = ["mf_newspaces", "mf_subspaces", "mf_newspace_portraits", "mf_hecke_newspace_traces"]
+        labels = [label, label, label, ocode]
+        label_cols = ["label", "label", "label", "hecke_orbit_code"]
+        title = f"Newspace data - {label}"
+    elif len(slabel) == 2:
+        tables = ["mf_gamma1", "mf_gamma1_subspaces", "mf_gamma1_portraits"]
+        labels = label
+        label_cols = None
+        title = f"$Gamma_1$ data - {label}"
+    else:
+        return abort(404, "Invalid label")
+    bread = get_bread(other=f"Data - {label}")
+    return datapage(labels, tables, title=title, bread=bread, label_cols=label_cols)
+
 
 @cmf.route("/<level>/")
 def by_url_level(level):

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -553,12 +553,12 @@ class CmfTest(LmfdbTest):
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)
         assert ('mf_gamma1' in data and 'newspace_dims' in data and
                 'mf_gamma1_subspaces' in data and 'sub_mult' in data and
-                'mf_gamma1_portraits' in data and "'portrait'" in data)
+                'mf_gamma1_portraits' in data and "data:image/png;base64" in data)
 
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e').get_data(as_text=True)
         assert ('mf_newspaces' in data and 'num_forms' in data and
                 'mf_subspaces' in data and 'sub_mult' in data and
-                'mf_newspace_portraits' in data and "'portrait'" in data and
+                'mf_newspace_portraits' in data and "data:image/png;base64" in data and
                 'mf_hecke_newspace_traces' in data and 'trace_an' in data)
 
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e.a').get_data(as_text=True)
@@ -567,7 +567,7 @@ class CmfTest(LmfdbTest):
                 'mf_newspaces' in data and 'num_forms' in data and
                 'mf_twists_nf' in data and 'twisting_char_label' in data and
                 'mf_hecke_charpolys' in data and 'charpoly_factorization' in data and
-                'mf_newform_portraits' in data and "'portrait'" in data and
+                'mf_newform_portraits' in data and "data:image/png;base64" in data and
                 'mf_hecke_traces' in data and 'trace_an' in data)
 
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e.a.4.1').get_data(as_text=True)
@@ -576,5 +576,5 @@ class CmfTest(LmfdbTest):
                 'mf_newspaces' in data and 'num_forms' in data and
                 'mf_twists_cc' in data and 'twisting_conrey_index' in data and
                 'mf_hecke_charpolys' in data and 'charpoly_factorization' in data and
-                'mf_newform_portraits' in data and "'portrait'" in data and
+                'mf_newform_portraits' in data and "data:image/png;base64" in data and
                 'mf_hecke_traces' in data and 'trace_an' in data)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -548,3 +548,33 @@ class CmfTest(LmfdbTest):
         assert 'Only' in page.get_data(as_text=True)
         assert 'up to 1000 are available' in page.get_data(as_text=True)
         assert 'a_{1000}' in page.get_data(as_text=True)
+
+    def test_underlying_data(self):
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)
+        assert ('mf_gamma1' in data and 'newspace_dims' in data and
+                'mf_gamma1_subspaces' in data and 'sub_mult' in data and
+                'mf_gamma1_portraits' in data and "'portrait'" in data)
+
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e').get_data(as_text=True)
+        assert ('mf_newspaces' in data and 'num_forms' in data and
+                'mf_subspaces' in data and 'sub_mult' in data and
+                'mf_newspace_portraits' in data and "'portrait'" in data and
+                'mf_hecke_newspace_traces' in data and 'trace_an' in data)
+
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e.a').get_data(as_text=True)
+        assert ('mf_newforms' in data and 'field_disc_factorization' in data and
+                'mf_hecke_nf' in data and 'hecke_ring_character_values' in data and
+                'mf_newspaces' in data and 'num_forms' in data and
+                'mf_twists_nf' in data and 'twisting_char_label' in data and
+                'mf_hecke_charpolys' in data and 'charpoly_factorization' in data and
+                'mf_newform_portraits' in data and "'portrait'" in data and
+                'mf_hecke_traces' in data and 'trace_an' in data)
+
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2.e.a.4.1').get_data(as_text=True)
+        assert ('mf_newforms' in data and 'field_disc_factorization' in data and
+                'mf_hecke_cc' in data and 'an_normalized' in data and
+                'mf_newspaces' in data and 'num_forms' in data and
+                'mf_twists_cc' in data and 'twisting_conrey_index' in data and
+                'mf_hecke_charpolys' in data and 'charpoly_factorization' in data and
+                'mf_newform_portraits' in data and "'portrait'" in data and
+                'mf_hecke_traces' in data and 'trace_an' in data)

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -369,17 +369,20 @@ class WebNewform(object):
     def downloads(self):
         downloads = []
         if self.embedding_label is None:
+            label = self.label
             if self.hecke_cutters or self.has_exact_qexp:
-                downloads.append(('Modular form to Magma', url_for('.download_newform_to_magma', label=self.label)))
+                downloads.append(('Modular form to Magma', url_for('.download_newform_to_magma', label=label)))
             if self.has_exact_qexp:
-                downloads.append(('q-expansion to Sage', url_for('.download_qexp', label=self.label)))
-            downloads.append(('Trace form to text', url_for('.download_traces', label=self.label)))
+                downloads.append(('q-expansion to Sage', url_for('.download_qexp', label=label)))
+            downloads.append(('Trace form to text', url_for('.download_traces', label=label)))
             #if self.has_complex_qexp:
-            #    downloads.append(('Embeddings to text', url_for('.download_cc_data', label=self.label)))
-            #    downloads.append(('Satake angles to text', url_for('.download_satake_angles', label=self.label)))
-            downloads.append(('All stored data to text', url_for('.download_newform', label=self.label)))
+            #    downloads.append(('Embeddings to text', url_for('.download_cc_data', label=label)))
+            #    downloads.append(('Satake angles to text', url_for('.download_satake_angles', label=label)))
+            downloads.append(('All stored data to text', url_for('.download_newform', label=label)))
         else:
-            downloads.append(('Coefficient data to text', url_for('.download_embedded_newform', label='%s.%s'%(self.label, self.embedding_label))))
+            label = '%s.%s'%(self.label, self.embedding_label)
+            downloads.append(('Coefficient data to text', url_for('.download_embedded_newform', label=label)))
+        downloads.append(('Underlying data', url_for('.mf_data', label=label)))
         return downloads
 
     @lazy_attribute

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -28,7 +28,10 @@ def get_bread(**kwds):
     bread = [('Modular forms', url_for('modular_forms')),
              ('Classical', url_for("cmf.index"))]
     if 'other' in kwds:
-        return bread + [(kwds['other'], ' ')]
+        if isinstance(kwds['other'], str):
+            return bread + [(kwds['other'], ' ')]
+        else:
+            return bread + kwds['other']
     url_kwds = {}
     for key, display, link in links:
         if key not in kwds:

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -264,6 +264,7 @@ class WebNewformSpace(object):
         self.downloads = [
             ('Trace form to text', url_for('cmf.download_traces', label=self.label)),
             ('All stored data to text', url_for('.download_newspace', label=self.label)),
+            ('Underlying data', url_for('.mf_data', label=self.label)),
         ]
 
         if self.conrey_indexes[0] == 1:
@@ -418,7 +419,8 @@ class WebGamma1Space(object):
         # Downloads
         self.downloads = [
             ('Trace form to text', url_for('cmf.download_traces', label=self.label)),
-            ('All stored data to text', url_for('cmf.download_full_space', label=self.label))
+            ('All stored data to text', url_for('cmf.download_full_space', label=self.label)),
+            ('Underlying data', url_for('.mf_data', label=self.label)),
         ]
         self.title = r"Space of modular forms of level %s and weight %s"%(self.level, self.weight)
         self.friends = []

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -652,7 +652,7 @@ class ECNF(object):
             self.downloads.append(('Code to {}'.format(lang[0]),
                                    url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
                                            class_label=self.iso_label, number=self.number, download_type=lang[1])))
-
+        self.downloads.append(('Underlying data', url_for("API.api_query", table="ec_nfcurves") + f"?label={self.label}"))
 
         if 'Lfunction' in self.urls:
             Lfun = get_lfunction_by_url(self.urls['Lfunction'].lstrip('/L').rstrip('/'), projection=['degree', 'trace_hash', 'Lhash'])

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -652,7 +652,7 @@ class ECNF(object):
             self.downloads.append(('Code to {}'.format(lang[0]),
                                    url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
                                            class_label=self.iso_label, number=self.number, download_type=lang[1])))
-        self.downloads.append(('Underlying data', url_for("API.api_query", table="ec_nfcurves") + f"?label={self.label}"))
+        self.downloads.append(('Underlying data', url_for(".ecnf_data", label=self.label)))
 
         if 'Lfunction' in self.urls:
             Lfun = get_lfunction_by_url(self.urls['Lfunction'].lstrip('/L').rstrip('/'), projection=['degree', 'trace_hash', 'Lhash'])

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -25,6 +25,7 @@ from lmfdb.utils.search_parsing import search_parser
 
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, MathCol, ProcessedCol, MultiProcessedCol, CheckCol, SearchCol
+from lmfdb.api import datapage
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberField
 from lmfdb.ecnf import ecnf_page
@@ -372,6 +373,12 @@ def show_ecnf(nf, conductor_label, class_label, number):
                            info=info,
                            KNOWL_ID="ec.%s"%label,
                            learnmore=learnmore_list())
+
+@ecnf_page.route("/data/<label>")
+def ecnf_data(label):
+    bread = get_bread((label, url_for_label(label)), ("Data", " "))
+    title = f"Elliptic curve data - {label}"
+    return datapage(label, "ec_nfcurves", title=title, bread=bread)
 
 def download_search(info):
     dltype = info['Submit']

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -17,6 +17,7 @@ from lmfdb.utils import (
     StatsDisplay, parse_element_of, parse_signed_ints, search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, MathCol, LinkCol, ProcessedCol, MultiProcessedCol, ColGroup
+from lmfdb.api import datapage
 from lmfdb.elliptic_curves import ec_page, ec_logger
 from lmfdb.elliptic_curves.isog_class import ECisog_class
 from lmfdb.elliptic_curves.web_ec import WebEC, match_lmfdb_label, match_cremona_label, split_lmfdb_label, split_cremona_label, weierstrass_eqn_regex, short_weierstrass_eqn_regex, class_lmfdb_label, curve_lmfdb_label, EC_ainvs, latex_sha, gl2_subgroup_data, CREMONA_BOUND
@@ -646,6 +647,22 @@ def render_curve_webpage_by_label(label):
     ec_logger.debug("Total cputime: %ss"%(cputime(cpt0)))
     return T
 
+@ec_page.route("/data/<label>")
+def EC_data(label):
+    bread = get_bread(f"Data - {label}")
+    if match_lmfdb_label(label):
+        conductor, iso_class, number = split_lmfdb_label(label)
+        if not number: # isogeny class
+            return datapage(label, ["ec_classdata", "ec_padic"], bread=bread, label_col="lmfdb_iso", sorts=[[], ["p"]])
+        iso_label = class_lmfdb_label(conductor, iso_class)
+        labels = [label] * 8
+        label_cols = ["lmfdb_label"] * 8
+        labels[1] = labels[7] = iso_label
+        label_cols[1] = label_cols[7] = "lmfdb_iso"
+        sorts = [[], [], [], [], ["degree", "field"], ["prime"], ["prime"], ["p"]]
+        return datapage(labels, ["ec_curvedata", "ec_classdata", "ec_mwbsd", "ec_iwasawa", "ec_torsion_growth", "ec_localdata", "ec_galrep", "ec_padic"], title=f"Elliptic curve data - {label}", bread=bread, label_cols=label_cols, sorts=sorts)
+    return abort(404)
+
 @ec_page.route("/padic_data/<label>/<int:p>")
 def padic_data(label, p):
     try:
@@ -687,7 +704,6 @@ def download_EC_qexp(label, limit):
     response = make_response(','.join(str(an) for an in E.anlist(int(limit), python_ints=True)))
     response.headers['Content-type'] = 'text/plain'
     return response
-
 
 #TODO: get all the data from all the relevant tables, not just the search table.
 

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -652,7 +652,7 @@ def render_curve_webpage_by_label(label):
 
 @ec_page.route("/data/<label>")
 def EC_data(label):
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     if match_lmfdb_label(label):
         conductor, iso_class, number = split_lmfdb_label(label)
         if not number: # isogeny class

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -188,3 +188,14 @@ class EllCurveTest(LmfdbTest):
         """
         L = self.tc.get('/EllipticCurve/Q/Completeness')
         assert 'Currently, the database includes' in L.get_data(as_text=True)
+
+    def test_underlying_data(self):
+        data = self.tc.get('/EllipticCurve/Q/data/65/a/1').get_data(as_text=True)
+        assert ('ec_curvedata' in data and 'stable_faltings_height' in data and
+                'ec_classdata' in data and 'isogeny_matrix' in data and
+                'ec_mwbsd' in data and 'torsion_generators' in data and
+                'ec_iwasawa' in data and 'iwdata' in data and
+                'ec_torsion_growth' in data and 'field' in data and
+                'ec_localdata' in data and 'tamagawa_number' in data and
+                'ec_galrep' in data and "'modell_image'" in data and
+                'ec_padic' in data and 'unit' in data)

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -190,12 +190,22 @@ class EllCurveTest(LmfdbTest):
         assert 'Currently, the database includes' in L.get_data(as_text=True)
 
     def test_underlying_data(self):
-        data = self.tc.get('/EllipticCurve/Q/data/65/a/1').get_data(as_text=True)
-        assert ('ec_curvedata' in data and 'stable_faltings_height' in data and
-                'ec_classdata' in data and 'isogeny_matrix' in data and
-                'ec_mwbsd' in data and 'torsion_generators' in data and
-                'ec_iwasawa' in data and 'iwdata' in data and
-                'ec_torsion_growth' in data and 'field' in data and
-                'ec_localdata' in data and 'tamagawa_number' in data and
-                'ec_galrep' in data and "'modell_image'" in data and
-                'ec_padic' in data and 'unit' in data)
+        #data = self.tc.get('/EllipticCurve/Q/data/65/a/1', follow_redirects=True).get_data(as_text=True)
+        self.check_args('/EllipticCurve/Q/data/65.a1', [
+            'ec_curvedata', 'stable_faltings_height',
+            'ec_classdata', 'isogeny_matrix',
+            'ec_mwbsd', 'torsion_generators',
+            'ec_iwasawa', 'iwdata',
+            'ec_torsion_growth', 'field',
+            'ec_localdata', 'tamagawa_number',
+            'ec_galrep', "modell_image",
+            'ec_padic', 'unit',
+        ])
+        #assert ('ec_curvedata' in data and 'stable_faltings_height' in data and
+        #        'ec_classdata' in data and 'isogeny_matrix' in data and
+        #        'ec_mwbsd' in data and 'torsion_generators' in data and
+        #        'ec_iwasawa' in data and 'iwdata' in data and
+        #        'ec_torsion_growth' in data and 'field' in data and
+        #        'ec_localdata' in data and 'tamagawa_number' in data and
+        #        'ec_galrep' in data and "'modell_image'" in data and
+        #        'ec_padic' in data and 'unit' in data)

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -21,6 +21,7 @@ CREMONA_BOUND    = 500000 # above this bound we have nor Cremona labels (no Clab
 
 cremona_label_regex = re.compile(r'(\d+)([a-z]+)(\d*)')
 lmfdb_label_regex = re.compile(r'(\d+)\.([a-z]+)(\d*)')
+lmfdb_label_regex = re.compile(r'(\d+)\.([a-z]+)(\d*)')
 sw_label_regex = re.compile(r'sw(\d+)(\.)(\d+)(\.*)(\d*)')
 weierstrass_eqn_regex = re.compile(r'\[(-?\d+),(-?\d+),(-?\d+),(-?\d+),(-?\d+)\]')
 short_weierstrass_eqn_regex = re.compile(r'\[(-?\d+),(-?\d+)\]')
@@ -422,7 +423,8 @@ class WebEC(object):
                           ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_label)),
                           ('Code to Magma', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
                           ('Code to SageMath', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
-                          ('Code to GP', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp'))
+                          ('Code to GP', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp')),
+                          ('Underlying data', url_for(".EC_data", label=self.lmfdb_label)),
         ]
 
         try:

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -17,6 +17,7 @@ from lmfdb.utils import (
     search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MultiProcessedCol, MathCol, CheckCol, SearchCol
+from lmfdb.api import datapage
 from lmfdb.number_fields.web_number_field import modules2string
 from lmfdb.galois_groups import galois_groups_page, logger
 from lmfdb.groups.abstract.main import abstract_group_display_knowl
@@ -308,7 +309,7 @@ def render_group_webpage(args):
         data['nilpotency'] = '$%s$' % data['nilpotency']
         if data['nilpotency'] == '$-1$':
             data['nilpotency'] += ' (not nilpotent)'
-        downloads = [('Underlying data', url_for("API.api_query", table="gps_transitive") + f"?label={label}")]
+        downloads = [('Underlying data', url_for(".gg_data", label=label))]
 
         bread = get_bread([(label, ' ')])
         return render_template(
@@ -322,6 +323,11 @@ def render_group_webpage(args):
             KNOWL_ID="gg.%s"%label,
             learnmore=learnmore_list())
 
+@galois_groups_page.route("/data/<label>")
+def gg_data(label):
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
+    title = f"Transitive group data - {label}"
+    return datapage(label, "gps_transitive", title=title, bread=bread)
 
 @galois_groups_page.route("/random")
 @redirect_no_cache

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -308,9 +308,19 @@ def render_group_webpage(args):
         data['nilpotency'] = '$%s$' % data['nilpotency']
         if data['nilpotency'] == '$-1$':
             data['nilpotency'] += ' (not nilpotent)'
+        downloads = [('Underlying data', url_for("API.api_query", table="gps_transitive") + f"?label={label}")]
 
         bread = get_bread([(label, ' ')])
-        return render_template("gg-show-group.html", title=title, bread=bread, info=data, properties=prop2, friends=friends, KNOWL_ID="gg.%s"%label, learnmore=learnmore_list())
+        return render_template(
+            "gg-show-group.html",
+            title=title,
+            bread=bread,
+            info=data,
+            properties=prop2,
+            friends=friends,
+            downloads=downloads,
+            KNOWL_ID="gg.%s"%label,
+            learnmore=learnmore_list())
 
 
 @galois_groups_page.route("/random")

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -42,3 +42,7 @@ class GalGpTest(LmfdbTest):
         L = self.tc.get('/GaloisGroup/12345T678', follow_redirects=True)
         assert 'was not found in the database' in L.get_data(as_text=True)
 
+    def test_underlying_data(self):
+        data = self.tc.get('/GaloisGroup/8T44').get_data(as_text=True)
+        assert "Underlying data" in data and "api/gps_transitive/?label=8T44" in data
+

--- a/lmfdb/galois_groups/test_galoisgroup.py
+++ b/lmfdb/galois_groups/test_galoisgroup.py
@@ -44,5 +44,5 @@ class GalGpTest(LmfdbTest):
 
     def test_underlying_data(self):
         data = self.tc.get('/GaloisGroup/8T44').get_data(as_text=True)
-        assert "Underlying data" in data and "api/gps_transitive/?label=8T44" in data
+        assert "Underlying data" in data and "data/8T44" in data
 

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -384,7 +384,7 @@ def class_from_curve_label(label):
 
 @g2c_page.route("/Q/data/<label>")
 def G2C_data(label):
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_curve_label(label)), ("Data", " ")])
     sorts = [[], [], [], ["prime"], ["p"], []]
     label_cols = ["label", "label", "label", "lmfdb_label", "label", "label"]
     return datapage(label, ["g2c_curves", "g2c_endomorphisms", "g2c_ratpts", "g2c_galrep", "g2c_tamagawa", "g2c_plots"], title=f"Genus 2 curve data - {label}", bread=bread, sorts=sorts, label_cols=label_cols)

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -342,7 +342,6 @@ def render_curve_webpage(label):
         learnmore=learnmore_list(),
         title=g2c.title,
         friends=g2c.friends,
-        downloads=g2c.downloads,
         KNOWL_ID="g2c.%s" % label,
     )
 

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -34,6 +34,7 @@ from lmfdb.utils import (
 )
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, MathCol, CheckCol, LinkCol, ProcessedCol, ProcessedLinkCol
+from lmfdb.api import datapage
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.genus2_curves import g2c_page
 from lmfdb.genus2_curves.web_g2c import WebG2C, min_eqn_pretty, st0_group_name, end_alg_name, geom_end_alg_name
@@ -310,6 +311,7 @@ def render_curve_webpage(label):
     return render_template(
         "g2c_curve.html",
         properties=g2c.properties,
+        downloads=g2c.downloads,
         info={"aut_grp_dict": aut_grp_dict, "geom_aut_grp_dict": geom_aut_grp_dict},
         data=g2c.data,
         code=g2c.code,
@@ -357,6 +359,12 @@ def url_for_isogeny_class_label(label):
 def class_from_curve_label(label):
     return ".".join(label.split(".")[:2])
 
+@g2c_page.route("/data/<label>")
+def G2C_data(label):
+    bread = get_bread(f"Data - {label}")
+    sorts = [[], [], [], ["prime"], ["p"], []]
+    label_cols = ["label", "label", "label", "lmfdb_label", "label", "label"]
+    return datapage(label, ["g2c_curves", "g2c_endomorphisms", "g2c_ratpts", "g2c_galrep", "g2c_tamagawa", "g2c_plots"], title=f"Genus 2 curve data - {label}", bread=bread, sorts=sorts, label_cols=label_cols)
 
 ################################################################################
 # Searching

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -361,7 +361,7 @@ def url_for_isogeny_class_label(label):
 def class_from_curve_label(label):
     return ".".join(label.split(".")[:2])
 
-@g2c_page.route("/data/<label>")
+@g2c_page.route("/Q/data/<label>")
 def G2C_data(label):
     bread = get_bread(f"Data - {label}")
     sorts = [[], [], [], ["prime"], ["p"], []]

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -358,4 +358,4 @@ class Genus2Test(LmfdbTest):
                 'g2c_ratpts' in data and 'mw_gens_v' in data and
                 'g2c_galrep' in data and 'modell_image' in data and
                 'g2c_tamagawa' in data and 'tamagawa_number' in data and
-                'g2c_plots' in data and "'plot'" in data)
+                'g2c_plots' in data and "data:image/png;base64" in data)

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -350,3 +350,12 @@ class Genus2Test(LmfdbTest):
             data = self.tc.get(url).get_data(as_text=True)
             for friend in friends:
                 assert friend in data
+
+    def test_underlying_data(self):
+        data = self.tc.get("/Genus2Curve/Q/data/576.a.576.1").get_data(as_text=True)
+        assert ('g2c_curves' in data and 'bad_lfactors' in data and
+                'g2c_endomorphisms' in data and 'factorsQQ_base' in data and
+                'g2c_ratpts' in data and 'mw_gens_v' in data and
+                'g2c_galrep' in data and 'modell_image' in data and
+                'g2c_tamagawa' in data and 'tamagawa_number' in data and
+                'g2c_plots' in data and "'plot'" in data)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -876,6 +876,10 @@ class WebG2C(object):
             (r'\(\overline{\Q}\)-simple', bool_pretty(data['is_simple_geom'])),
             (r'\(\mathrm{GL}_2\)-type', bool_pretty(data['is_gl2_type'])),
             ]
+        if is_curve:
+            self.downloads = [("Underlying data", url_for(".G2C_data", label=data['label']))]
+        else:
+            self.downloads = []
 
         # Friends
         self.friends = friends = []

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1266,13 +1266,13 @@ def how_computed_page():
 
 @abstract_page.route("/data/<label>")
 def gp_data(label):
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     title = f"Abstract group data - {label}"
     return datapage(label, ["gps_groups", "gps_groups_cc", "gps_qchar", "gps_char", "gps_subgroups"], bread=bread, title=title, label_cols=["label", "group", "group", "group", "ambient"])
 
 @abstract_page.route("/sdata/<label>")
 def sgp_data(label):
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_subgroup_label(label)), ("Data", " ")])
     title = f"Abstract subgroup data - {label}"
     data = db.gps_subgroups.lookup(label, ["ambient", "subgroup", "quotient"])
     if data is None:

--- a/lmfdb/groups/abstract/test_abstract_groups.py
+++ b/lmfdb/groups/abstract/test_abstract_groups.py
@@ -68,3 +68,16 @@ class AbGpsTest(LmfdbTest):
         self.check_args("/Groups/Abstract/ab/3000", [ # large cyclic group
             r"C_2^3\times C_{100}", # automorphism group structure
         ])
+
+    def test_underlying_data(self):
+        self.check_args("/Groups/Abstract/data/256.33517", [
+            "gps_groups", "number_normal_subgroups",
+            "gps_groups_cc", "representative",
+            "gps_qchar", "cdim",
+            "gps_char", "indicator",
+            "gps_subgroups", "mobius_sub"])
+        self.check_args("/Groups/Abstract/sdata/16.8.2.b1.a1", [
+            "gps_subgroups", "'label': '16.8.2.b1.a1'",
+            "gps_groups", "'label': '8.4'",
+            "'label': '16.8'",
+            "'label': '2.1'"])

--- a/lmfdb/groups/abstract/test_abstract_groups.py
+++ b/lmfdb/groups/abstract/test_abstract_groups.py
@@ -77,7 +77,7 @@ class AbGpsTest(LmfdbTest):
             "gps_char", "indicator",
             "gps_subgroups", "mobius_sub"])
         self.check_args("/Groups/Abstract/sdata/16.8.2.b1.a1", [
-            "gps_subgroups", "'label': '16.8.2.b1.a1'",
-            "gps_groups", "'label': '8.4'",
-            "'label': '16.8'",
-            "'label': '2.1'"])
+            "gps_subgroups", "16.8.2.b1.a1",
+            "gps_groups", "[28776, 16577, 5167]", # perm_gens
+            "[16582, 136, 5167, 40176]", # perm_gens
+            "[[1, 1, 1]]"]) # faithful_reps

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -769,15 +769,15 @@ def render_family(args):
 
         if len(Ltopo_rep) == 0 or len(dataz) == 1:
             downloads = [('Code to Magma', url_for(".hgcwa_code_download", label=label, download_type='magma')),
-                             ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
+                         ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
         else:
             downloads = [('Code to Magma', None),
-                             (u'\u2003 All vectors', url_for(".hgcwa_code_download",  label=label, download_type='magma')),
-                             (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_magma')),
-                             ('Code to Gap', None),
-                             (u'\u2003 All vectors', url_for(".hgcwa_code_download",  label=label, download_type='gap')),
-                             (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_gap'))]
-
+                         (u'\u2003 All vectors', url_for(".hgcwa_code_download",  label=label, download_type='magma')),
+                         (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_magma')),
+                         ('Code to Gap', None),
+                         (u'\u2003 All vectors', url_for(".hgcwa_code_download",  label=label, download_type='gap')),
+                         (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_gap'))]
+        downloads.append(('Underlying data', url_for("API.api_query", table="hgcwa_passports") + f"?label={label}"))
         return render_template("hgcwa-show-family.html",
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
@@ -975,6 +975,7 @@ def render_passport(args):
                              ('Code to Gap', None),
                              (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
                              (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_gap'))]
+        downloads.append(('Underlying data', url_for("API.api_query", table="hgcwa_passports") + f"?passport_label={label}"))
 
 
         return render_template("hgcwa-show-passport.html",

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -22,6 +22,7 @@ from lmfdb.utils import (
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_parsing import (search_parser, collapse_ors)
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol, ProcessedCol
+from lmfdb.api import datapage
 from lmfdb.sato_tate_groups.main import sg_pretty
 from lmfdb.higher_genus_w_automorphisms import higher_genus_w_automorphisms_page
 from lmfdb.higher_genus_w_automorphisms.hgcwa_stats import HGCWAstats
@@ -777,13 +778,25 @@ def render_family(args):
                          ('Code to Gap', None),
                          (u'\u2003 All vectors', url_for(".hgcwa_code_download",  label=label, download_type='gap')),
                          (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_gap'))]
-        downloads.append(('Underlying data', url_for("API.api_query", table="hgcwa_passports") + f"?label={label}"))
+        downloads.append(('Underlying data', url_for(".hgcwa_data", label=label)))
         return render_template("hgcwa-show-family.html",
                                title=title, bread=bread, info=info,
                                properties=prop2, friends=friends,
                                KNOWL_ID="curve.highergenus.aut.%s" % label,
                                learnmore=learnmore_list(), downloads=downloads)
 
+@higher_genus_w_automorphisms_page.route("/data/<label>")
+def hgcwa_data(label):
+    if label_is_one_family(label):
+        label_col = "label"
+        title = f"Higher genus family - {label}"
+    elif label_is_one_passport(label):
+        label_col = "passport_label"
+        title = f"Higher genus passport - {label}"
+    else:
+        return abort(404, f"Invalid label {label}")
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
+    return datapage(label, "hgcwa_passports", title=title, bread=bread, label_cols=[label_col])
 
 def render_passport(args):
     info = {}
@@ -975,7 +988,7 @@ def render_passport(args):
                              ('Code to Gap', None),
                              (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
                              (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_gap'))]
-        downloads.append(('Underlying data', url_for("API.api_query", table="hgcwa_passports") + f"?passport_label={label}"))
+        downloads.append(('Underlying data', url_for(".hgcwa_data", label=label)))
 
 
         return render_template("hgcwa-show-passport.html",

--- a/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
+++ b/lmfdb/higher_genus_w_automorphisms/test_hgcwa.py
@@ -78,3 +78,9 @@ class HigherGenusWithAutomorphismsTest(LmfdbTest):
     def braid_summary_pages(self):
         L = self.tc.get('/HigherGenus/C/Aut/3.8-3.0.2-2-4-4/T.1.1')
         assert 'braid inequivalent' in L.get_data(as_text=True)
+
+    def underlying_data(self):
+        page = self.tc.get('/HigherGenus/C/Aut/3.8-3.0.2-2-4-4.1').get_data(as_text=True)
+        assert 'Underlying data' in page and 'api/hgcwa_passports/?passport_label=3.8-3.0.2-2-4-4.1' in page
+        page = self.tc.get('/HigherGenus/C/Aut/3.8-3.0.2-2-4-4').get_data(as_text=True)
+        assert 'Underlying data' in page and 'api/hgcwa_passports/?label=3.8-3.0.2-2-4-4' in page

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -537,7 +537,7 @@ def render_hmf_webpage(**args):
 def hmf_data(label):
     field_label = label.split("-")[0]
     title = f"Hilbert modular form data - {label}"
-    bread = get_bread(f"Data - {label}")
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     return datapage([label, label, field_label, field_label], ["hmf_forms", "hmf_hecke", "hmf_fields", "nf_fields"], title=title, bread=bread)
 
 #data quality pages

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from flask import render_template, url_for, request, redirect, make_response, abort
+from flask import render_template, url_for, request, redirect, make_response
 
 from lmfdb import db
 from lmfdb.utils import (

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from flask import render_template, url_for, request, redirect, make_response
+from flask import render_template, url_for, request, redirect, make_response, abort
 
 from lmfdb import db
 from lmfdb.utils import (
@@ -17,6 +17,7 @@ from lmfdb.hilbert_modular_forms.hmf_stats import HMFstats
 from lmfdb.utils import names_and_urls, prop_int_pretty
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, MathCol, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.lfunctions.LfunctionDatabase import get_lfunction_by_url, get_instances_by_Lhash_and_trace_hash
 
 def get_bread(tail=[]):
@@ -394,7 +395,8 @@ def render_hmf_webpage(**args):
 
     info['downloads'] = [
         ('Modular form to Magma', url_for(".render_hmf_webpage_download", field_label=info['field_label'], label=info['label'], download_type='magma')),
-        ('Eigenvalues to Sage', url_for(".render_hmf_webpage_download", field_label=info['field_label'], label=info['label'], download_type='sage'))
+        ('Eigenvalues to Sage', url_for(".render_hmf_webpage_download", field_label=info['field_label'], label=info['label'], download_type='sage')),
+        ('Underlying data', url_for(".hmf_data", label=info['label'])),
         ]
 
 
@@ -530,6 +532,13 @@ def render_hmf_webpage(**args):
         learnmore=learnmore_list(),
         KNOWL_ID="mf.hilbert.%s"%label,
     )
+
+@hmf_page.route("/data/<label>")
+def hmf_data(label):
+    field_label = label.split("-")[0]
+    title = f"Hilbert modular form data - {label}"
+    bread = get_bread(f"Data - {label}")
+    return datapage([label, label, field_label, field_label], ["hmf_forms", "hmf_hecke", "hmf_fields", "nf_fields"], title=title, bread=bread)
 
 #data quality pages
 @hmf_page.route("/Source")

--- a/lmfdb/hilbert_modular_forms/test_hmf.py
+++ b/lmfdb/hilbert_modular_forms/test_hmf.py
@@ -161,3 +161,9 @@ class HMFTest(LmfdbTest):
             magma_code += 'assert(&and([iso(heckeEigenvalues[P]) eq HeckeEigenvalue(f,P): P in primes[1..10]]));\n'
             magma_code += 'f;\n'
             self.assert_if_magma('success', magma_code, mode='in')
+
+    def test_underlying_data(self):
+        data = self.tc.get('/ModularForm/GL2/TotallyReal/data/2.2.5.1-31.1-a').get_data(as_text=True)
+        assert ('hmf_forms' in data and 'level_bad_primes' in data and
+                'hmf_hecke' in data and 'AL_eigenvalues' in data and
+                'hmf_fields' in data and 'ideals' in data)

--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -533,12 +533,13 @@ def render_hgm_webpage(label):
 
 @hypergm_page.route("/data/<label>")
 def hgm_data(label):
-    title = f"Hypergeometric motive data - {label}"
-    bread = get_bread([(f"Data - {label}", " ")])
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
     if "_t" in label:
+        title = f"Hypergeometric motive data - {label}"
         fam_label = label.split("_t")[0]
         return datapage([label, fam_label], ["hgm_motives", "hgm_families"], bread=bread, title=title)
     else:
+        title = f"Hypergeometric motive family data - {label}"
         return datapage(label, "hgm_families", bread=bread, title=title)
 
 

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -272,7 +272,9 @@ class WebHyperGeometricFamily(object):
                  url_for('hypergm.index') +
                  "?A={}&B={}".format(str(self.A), str(self.B)))]
 
-
+    @lazy_attribute
+    def downloads(self):
+        return [("Underlying data", url_for("API.api_query", table="hgm_families") + f"?label={self.label}")]
 
     @lazy_attribute
     def title(self):

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -274,7 +274,7 @@ class WebHyperGeometricFamily(object):
 
     @lazy_attribute
     def downloads(self):
-        return [("Underlying data", url_for("API.api_query", table="hgm_families") + f"?label={self.label}")]
+        return [("Underlying data", url_for(".hgm_data", label=self.label))]
 
     @lazy_attribute
     def title(self):

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -15,6 +15,7 @@ from lmfdb.utils import (
     search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol
+from lmfdb.api import datapage
 from lmfdb.lattice import lattice_page
 from lmfdb.lattice.isom import isom
 from lmfdb.lattice.lattice_stats import Lattice_stats
@@ -324,7 +325,7 @@ str([1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3]), str([1,-2,-2
     else:
         info['properties']=[('Class number', prop_int_pretty(info['class_number']))]+info['properties']
     info['properties']=[('Label', '%s' % info['label'])]+info['properties']
-    downloads = [("Underlying data", url_for("API.api_query", table="lat_lattices") + f"?label={lab}")]
+    downloads = [("Underlying data", url_for(".lattice_data", label=lab))]
 
     if info['name'] != "" :
         info['properties']=[('Name','%s' % info['name'] )]+info['properties']
@@ -351,6 +352,11 @@ def vect_to_sym(v):
             k=k+1
     return [[int(M[i,j]) for i in range(n)] for j in range(n)]
 
+@lattice_page.route('/data/<label>')
+def lattice_data(label):
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
+    title = f"Lattice data - {label}"
+    return datapage(label, "lat_lattices", title=title, bread=bread)
 
 #auxiliary function for displaying more coefficients of the theta series
 @lattice_page.route('/theta_display/<label>/<number>')

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -324,11 +324,20 @@ str([1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3]), str([1,-2,-2
     else:
         info['properties']=[('Class number', prop_int_pretty(info['class_number']))]+info['properties']
     info['properties']=[('Label', '%s' % info['label'])]+info['properties']
+    downloads = [("Underlying data", url_for("API.api_query", table="lat_lattices") + f"?label={lab}")]
 
     if info['name'] != "" :
         info['properties']=[('Name','%s' % info['name'] )]+info['properties']
 #    friends = [('L-series (not available)', ' ' ),('Half integral weight modular forms (not available)', ' ')]
-    return render_template("lattice-single.html", info=info, title=t, bread=bread, properties=info['properties'], learnmore=learnmore_list(), KNOWL_ID="lattice.%s"%info['label'])
+    return render_template(
+        "lattice-single.html",
+        info=info,
+        title=t,
+        bread=bread,
+        properties=info['properties'],
+        downloads=downloads,
+        learnmore=learnmore_list(),
+        KNOWL_ID="lattice.%s"%info['label'])
 #friends=friends
 
 def vect_to_sym(v):

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -79,7 +79,7 @@ class HomePageTest(LmfdbTest):
     def test_downloadstring2(self):
         L = self.tc.get("/Lattice/2.156.312.1.2").get_data(as_text=True)
         assert 'vector' in L
-        assert 'Underlying data' in L and 'api/lat_lattices/?label=2.156.312.1.2' in L
+        assert 'Underlying data' in L and 'data/2.156.312.1.2' in L
 
     def test_downloadstring_search(self):
         L = self.tc.get("/Lattice/?class_number=8").get_data(as_text=True)

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -79,6 +79,7 @@ class HomePageTest(LmfdbTest):
     def test_downloadstring2(self):
         L = self.tc.get("/Lattice/2.156.312.1.2").get_data(as_text=True)
         assert 'vector' in L
+        assert 'Underlying data' in L and 'api/lat_lattices/?label=2.156.312.1.2' in L
 
     def test_downloadstring_search(self):
         L = self.tc.get("/Lattice/?class_number=8").get_data(as_text=True)
@@ -104,7 +105,3 @@ class HomePageTest(LmfdbTest):
                     "/Lattice/{}".format(elt),
                     follow_redirects=True)
             assert elt in L.get_data(as_text=True)
-
-
-
-

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -44,6 +44,7 @@ from lmfdb.utils import (
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.names_and_urls import names_and_urls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol, CheckCol, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.backend.utils import SearchParsingError
 from lmfdb.app import is_debug_mode, _single_knowl
 from lmfdb import db
@@ -1285,6 +1286,8 @@ def set_bread_and_friends(info, L, request):
         info['factors_origins'] = L.factors_origins
         info['Linstances'] = L.instances
         info['downloads'] = L.downloads
+        info['downloads'].append(("Underlying data", url_for(".lfunc_data", label=L.label)))
+
 
         for elt in [info['origins'], info['friends'], info['factors_origins'], info['Linstances']]:
             if elt is not None:
@@ -1564,8 +1567,11 @@ def download(label, L=None): # the wrapper populates the L
     assert label
     return L.download()
 
-
-
+@l_function_page.route("/data/<label>")
+def lfunc_data(label):
+    title = f"Lfunction data - {label}"
+    bread = get_bread([(f"Data - {label}", " ")])
+    return datapage(label, ["lfunc_lfunctions", "lfunc_search", "lfunc_instances"], title=title, bread=bread)
 
 
 ################################################################################

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1580,7 +1580,7 @@ def download(label, L=None): # the wrapper populates the L
 @l_function_page.route("/data/<label>")
 def lfunc_data(label):
     title = f"Lfunction data - {label}"
-    bread = get_bread([(f"Data - {label}", " ")])
+    bread = get_bread([(label, url_for_lfunction(label)), ("Data", " ")])
     return datapage(label, ["lfunc_lfunctions", "lfunc_search", "lfunc_instances"], title=title, bread=bread)
 
 

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -621,3 +621,8 @@ class LfunctionTest(LmfdbTest):
         svg = paintSvgFileAll([["GSp4", 1]])
         assert "12.4687" in svg
 
+    def test_underlying_data(self):
+        data = self.tc.get("/L/data/2-289379-1.1-c1-0-0").get_data(as_text=True)
+        assert ("lfunc_lfunctions" in data and "st_group" in data and
+                "lfunc_search" in data and "euler19" in data and
+                "lfunc_instances" in data and "Lhash_array" in data)

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -358,6 +358,7 @@ def render_field_webpage(args):
         if db.nf_fields.exists({'local_algs': {'$contains': label}}):
             friends.append(('Number fields with this completion',
                 url_for('number_fields.number_field_render_webpage')+"?completions={}".format(label) ))
+        downloads = [('Underlying data', url_for('API.api_query', table='lf_fields') + f'?label={label}')]
 
         bread = get_bread([(label, ' ')])
         return render_template(
@@ -368,6 +369,7 @@ def render_field_webpage(args):
             info=info,
             properties=prop2,
             friends=friends,
+            downloads=downloads,
             learnmore=learnmore_list(),
             KNOWL_ID="lf.%s" % label,
         )

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -17,6 +17,7 @@ from lmfdb.utils import (
     redirect_no_cache, raw_typeset)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.local_fields import local_fields_page, logger
 from lmfdb.groups.abstract.main import abstract_group_display_knowl
 from lmfdb.galois_groups.transitive_group import (
@@ -358,7 +359,7 @@ def render_field_webpage(args):
         if db.nf_fields.exists({'local_algs': {'$contains': label}}):
             friends.append(('Number fields with this completion',
                 url_for('number_fields.number_field_render_webpage')+"?completions={}".format(label) ))
-        downloads = [('Underlying data', url_for('API.api_query', table='lf_fields') + f'?label={label}')]
+        downloads = [('Underlying data', url_for('.lf_data', label=label))]
 
         bread = get_bread([(label, ' ')])
         return render_template(
@@ -398,6 +399,11 @@ def printquad(code, p):
         s = str(s) + r'\cdot '+str(u)
     return(r'$\Q_{' + str(p) + r'}(\sqrt{' + str(s) + '})$')
 
+@local_fields_page.route("/data/<label>")
+def lf_data(label):
+    title = f"Local field data - {label}"
+    bread = get_bread([(label, url_for_label(label)), ("Data", " ")])
+    return datapage(label, "lf_fields", title=title, bread=bread)
 
 @local_fields_page.route("/random")
 @redirect_no_cache

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -32,4 +32,4 @@ class LocalFieldTest(LmfdbTest):
 
     def test_underlying_data(self):
         page = self.tc.get('/padicField/11.6.4.2').get_data(as_text=True)
-        assert 'Underlying data' in page and 'api/lf_fields/?label=11.6.4.2' in page
+        assert 'Underlying data' in page and 'data/11.6.4.2' in page

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -29,3 +29,7 @@ class LocalFieldTest(LmfdbTest):
         assert 'Not computed' in L.get_data(as_text=True)
         L = self.tc.get('/padicField/2.8.0.1')
         assert 'Does not exist' in L.get_data(as_text=True)
+
+    def test_underlying_data(self):
+        page = self.tc.get('/padicField/11.6.4.2').get_data(as_text=True)
+        assert 'Underlying data' in page and 'api/lf_fields/?label=11.6.4.2' in page

--- a/lmfdb/maass_forms/main.py
+++ b/lmfdb/maass_forms/main.py
@@ -271,7 +271,8 @@ def maass_data(label):
     title = f"Maass form data - {label}"
     bread = [("Modular forms", url_for("modular_forms")),
              ("Maass", url_for(".index")),
-             (f"Data - {label}", " ")]
+             (label, url_for(".by_label", label=label)),
+             ("Data", " ")]
     tables = ["maass_newforms", "maass_portraits"]
     label_cols = ["maass_id", "maass_id"]
     return datapage(label, tables, bread=bread, title=title, label_cols=label_cols)

--- a/lmfdb/maass_forms/main.py
+++ b/lmfdb/maass_forms/main.py
@@ -12,6 +12,7 @@ from lmfdb.utils.search_parsing import search_parser
 from lmfdb.utils.display_stats import StatsDisplay, proportioners, totaler
 from lmfdb.utils.utilities import display_knowl
 from lmfdb.utils.search_columns import SearchColumns, MathCol, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.maass_forms.plot import paintSvgMaass
 from lmfdb.maass_forms.web_maassform import WebMaassForm, MaassFormDownloader, character_link, symmetry_pretty, fricke_pretty
 from sage.all import gcd
@@ -264,6 +265,16 @@ def search_by_label(label):
                            title=mf.title,
                            friends=mf.friends,
                            KNOWL_ID="mf.maass.mwf.%s"%mf.label)
+
+@maass_page.route("/data/<label>")
+def maass_data(label):
+    title = f"Maass form data - {label}"
+    bread = [("Modular forms", url_for("modular_forms")),
+             ("Maass", url_for(".index")),
+             (f"Data - {label}", " ")]
+    tables = ["maass_newforms", "maass_portraits"]
+    label_cols = ["maass_id", "maass_id"]
+    return datapage(label, tables, bread=bread, title=title, label_cols=label_cols)
 
 class MaassStats(StatsDisplay):
     table = db.maass_newforms

--- a/lmfdb/maass_forms/test_maass.py
+++ b/lmfdb/maass_forms/test_maass.py
@@ -49,4 +49,4 @@ class MaassTest(LmfdbTest):
     def test_underlying_data(self):
         data = self.tc.get("/ModularForm/GL2/Q/Maass/data/54119c4cacf7560af58dd8ba").get_data(as_text=True)
         assert ("maass_newforms" in data and "symmetry" in data and
-                "maass_portraits" in data and "'portrait'" in data)
+                "maass_portraits" in data and "data:image/png;base64" in data)

--- a/lmfdb/maass_forms/test_maass.py
+++ b/lmfdb/maass_forms/test_maass.py
@@ -11,37 +11,42 @@ class MaassTest(LmfdbTest):
         assert 'database currently contains' in L.get_data(as_text=True)
 
     def test_browse_1_10_0_10(self):
-        L = self.tc.get("https://blue.lmfdb.xyz/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/BrowseGraph/1/10/0/10/")
         assert 'In the plot below each dot is linked' in L.get_data(as_text=True)
 
     def test_browse_1_15_0_15(self):
-        L = self.tc.get("https://blue.lmfdb.xyz/ModularForm/GL2/Q/Maass/BrowseGraph/1/15/0/15/")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/BrowseGraph/1/15/0/15/")
         assert 'In the plot below each dot is linked' in L.get_data(as_text=True)
 
     def test_browse_10_100_0_4(self):
-        L = self.tc.get("https://blue.lmfdb.xyz/ModularForm/GL2/Q/Maass/BrowseGraph/10/100/0/4/")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/BrowseGraph/10/100/0/4/")
         assert 'In the plot below each dot is linked' in L.get_data(as_text=True)
 
     def test_browse_100_1000_0_1(self):
-        L = self.tc.get("https://blue.lmfdb.xyz/ModularForm/GL2/Q/Maass/BrowseGraph/100/1000/0/1/")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/BrowseGraph/100/1000/0/1/")
         assert 'In the plot below each dot is linked' in L.get_data(as_text=True)
 
     def test_search_all(self):
-        L = self.tc.get("http://127.0.0.1:37778/ModularForm/GL2/Q/Maass/?search_type=List&all=1")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/?search_type=List&all=1")
         assert "9.533695" in L.get_data(as_text=True) and "19.48471" in L.get_data(as_text=True)
 
     def test_search_N_101(self):
-        L = self.tc.get("http://127.0.0.1:37778/ModularForm/GL2/Q/Maass/?hst=List&level=101&search_type=List")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/?hst=List&level=101&search_type=List")
         assert "0.453759" in L.get_data(as_text=True) and "1.11356" in L.get_data(as_text=True)
 
     def test_search_R_40_50(self):
-        L = self.tc.get("http://127.0.0.1:37778/ModularForm/GL2/Q/Maass/?spectral_parameter=40-50&search_type=List")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/?spectral_parameter=40-50&search_type=List")
         assert "40.54335" in L.get_data(as_text=True) and "49.961696" in L.get_data(as_text=True)
 
     def test_search_R_1234(self):
-        L = self.tc.get("http://127.0.0.1:37778/ModularForm/GL2/Q/Maass/?hst=List&spectral_parameter=12.34&search_type=List")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/?hst=List&spectral_parameter=12.34&search_type=List")
         assert "12.34000" in L.get_data(as_text=True)
 
     def test_form_1234(self):
-        L = self.tc.get("http://127.0.0.1:37778/ModularForm/GL2/Q/Maass/541192fdacf756021f2c6e39")
+        L = self.tc.get("/ModularForm/GL2/Q/Maass/541192fdacf756021f2c6e39")
         assert "coefficients" in L.get_data(as_text=True) and "-1.236693" in L.get_data(as_text=True) and "1.858211" in L.get_data(as_text=True)
+
+    def test_underlying_data(self):
+        data = self.tc.get("/ModularForm/GL2/Q/Maass/data/54119c4cacf7560af58dd8ba").get_data(as_text=True)
+        assert ("maass_newforms" in data and "symmetry" in data and
+                "maass_portraits" in data and "'portrait'" in data)

--- a/lmfdb/maass_forms/web_maassform.py
+++ b/lmfdb/maass_forms/web_maassform.py
@@ -127,6 +127,7 @@ class WebMaassForm(object):
     def downloads(self):
         return [("Coefficients to text", url_for (".download_coefficients", label=self.label)),
                 ("All stored data to text", url_for (".download", label=self.label)),
+                ("Underlying data", url_for(".maass_data", label=self.label)),
                 ]
 
     @property

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -22,6 +22,7 @@ from lmfdb.utils import (
     raw_typeset, flash_info, input_string_to_poly)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, CheckCol, MathCol, ProcessedCol, MultiProcessedCol
+from lmfdb.api import datapage
 from lmfdb.galois_groups.transitive_group import (
     cclasses_display_knowl,character_table_display_knowl,
     group_phrase, galois_group_data, transitive_group_display_knowl,
@@ -628,7 +629,7 @@ def render_field_webpage(args):
     for lang in [["Magma","magma"], ["SageMath","sage"], ["Pari/GP", "gp"]]:
         downloads.append(('Download {} code'.format(lang[0]),
                           url_for(".nf_download", nf=label, download_type=lang[1])))
-    downloads.append(('Underlying data', url_for("API.api_query", table="nf_fields") + f"?label={label}"))
+    downloads.append(('Underlying data', url_for(".nf_datapage", label=label)))
     from lmfdb.artin_representations.math_classes import NumberFieldGaloisGroup
     from lmfdb.artin_representations.math_classes import artin_label_pretty
     try:
@@ -687,6 +688,11 @@ def by_label(label):
         flash_error("%s is not a valid input for a <span style='color:black'>label</span>.  %s", label, str(err))
         return redirect(url_for(".number_field_render_webpage"))
 
+@nf_page.route("/data/<label>")
+def nf_datapage(label):
+    title = f"Number field data - {label}"
+    bread = bread_prefix() + [(label, url_for(".by_label", label=label)), ("Data", " ")]
+    return datapage(label, "nf_fields", title=title, bread=bread)
 
 @nf_page.route("/interesting")
 def interesting():

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -628,6 +628,7 @@ def render_field_webpage(args):
     for lang in [["Magma","magma"], ["SageMath","sage"], ["Pari/GP", "gp"]]:
         downloads.append(('Download {} code'.format(lang[0]),
                           url_for(".nf_download", nf=label, download_type=lang[1])))
+    downloads.append(('Underlying data', url_for("API.api_query", table="nf_fields") + f"?label={label}"))
     from lmfdb.artin_representations.math_classes import NumberFieldGaloisGroup
     from lmfdb.artin_representations.math_classes import artin_label_pretty
     try:

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -91,4 +91,4 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=5-6%2C3','4.4.485809.1')
 
     def test_underlying_data(self):
-        self.check_args('NumberField/2.2.10069.1', ['Underlying data', 'api/nf_fields/?label=2.2.10069.1'])
+        self.check_args('NumberField/2.2.10069.1', ['Underlying data', 'data/2.2.10069.1'])

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -89,3 +89,6 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=3%2C6','4.4.1311025.1')
         self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=6%2C3','4.4.1311025.1')
         self.check_args('/NumberField/?signature=[4%2C0]&galois_group=C2xC2&class_number=5-6%2C3','4.4.485809.1')
+
+    def test_underlying_data(self):
+        self.check_args('NumberField/2.2.10069.1', ['Underlying data', 'api/nf_fields/?label=2.2.10069.1'])

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -942,7 +942,7 @@ def st_data(label):
     data = db.gps_st.lookup(label)
     if data is None:
         return abort(404)
-    bread = get_bread([(f"Data - {label}", "")])
+    bread = get_bread([(label, url_for('.by_label', label=label)), ("Data", "")])
     title = f"Sato-Tate group data - {label}"
     return datapage([label, data["identity_component"], data["component_group"]], ["gps_st", "gps_st0", "gps_groups"], bread=bread, title=title, label_cols=["label", "name", "label"])
 

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -111,3 +111,10 @@ class SatoTateGroupTest(LmfdbTest):
             L = self.tc.get('/SatoTateGroup/'+label)
             assert "Moment sequences" in L.get_data(as_text=True)
 
+    def test_underlying_data(self):
+        data = self.tc.get('/SatoTateGroup/data/1.6.L.8.3j').get_data(as_text=True)
+        assert ('gps_st0' in data and 'character_diagonal' in data and
+                'symplectic_form' in data and
+                'gps_groups' in data and 'number_normal_subgroups' in data)
+        page = self.tc.get('/SatoTateGroup/0.1.2').get_data(as_text=True)
+        assert 'Underlying data' not in page

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -671,3 +671,16 @@ function show_moreless(ml) {
   $('.'+ml).show();
 }
 
+function show_schema(tbl) {
+  $("div."+tbl+"-schema-holder").show();
+  $("#"+tbl+"-schema-hider").show();
+  $("#"+tbl+"-schema-shower").hide();
+  return false;
+}
+
+function hide_schema(tbl) {
+  $("div."+tbl+"-schema-holder").hide();
+  $("#"+tbl+"-schema-hider").hide();
+  $("#"+tbl+"-schema-shower").show();
+  return false;
+}


### PR DESCRIPTION
This PR adds "Underlying data links" to most homepages in the lmfdb, as described in #4662.  It is available at [purple](https://purple.lmfdb.xyz) for experimentation.

When the page depends only one table, we just give a link to the appropriate `api_query` search result.  When there are multiple underlying tables (e.g. elliptic curves, classical modular forms, abstract groups), there is a new page which shows the entries in these different that contribute to the page.

Some things I'd like feedback on:
* I ignored the links that were already present and just added "Underlying data" at the bottom.  In some cases, this may overlap with links like "Download all stored data to text".  I'm not sure whether to include both or to remove one or the other.
* There are some homepages where I didn't add "Underlying data" links, mainly isogeny classes of various kinds where there was no separate table (e.g. isogeny classes of elliptic curves).  I'm open to adding something here, either giving just one entry from the isogeny class or all entries.
* I chose not to include data from things that felt more like "friends" than part of the object.  So, for example, I don't include an entry from `nf_fields` for the coefficient field of a modular form.  I also may have missed tables that should have been included.  I'm happy to add more tables.

Since it was a simple fix, this PR also resolves #4969 and fixes a bug in the "Random subgroup" button [here](https://purple.lmfdb.xyz/Groups/Abstract/?search_type=Subgroups).