### PR TITLE
Lmfdb#3946 cite each section separately

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -786,9 +786,10 @@ def how_computed_page():
     t = "Source and acknowledgments for Weil polynomial data"
     bread = get_bread(("Source", " "))
     return render_template(
-        "double.html",
-        kid="rcs.source.av.fq",
-        kid2="rcs.ack.av.fq",
+        "multi.html",
+        kids=["rcs.source.av.fq",
+              "rcs.ack.av.fq",
+              "rcs.cite.av.fq"],
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Source"),

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -348,7 +348,7 @@ def render_artin_representation_webpage(label):
     if proj_wnf.is_in_db():
         proj_coefs = [int(z) for z in proj_wnf.coeffs()]
         if proj_coefs != the_nf.polynomial():
-            friends.append(("Field {}".format(proj_wnf.get_label()), 
+            friends.append(("Field {}".format(proj_wnf.get_label()),
                 str(url_for("number_fields.by_label", label=proj_wnf.get_label()))))
     if case == 'rep':
         cc = the_rep.central_character()
@@ -464,9 +464,11 @@ def source():
     t = 'Source and acknowledgments for Artin representation pages'
     bread = get_bread([("Source", '')])
     learnmore = learnmore_list_remove('Source')
-    return render_template("double.html", kid='rcs.source.artin',
-                           kid2='rcs.ack.artin',
-                           title=t, bread=bread, 
+    return render_template("multi.html",
+                           kids=['rcs.source.artin',
+                                 'rcs.ack.artin',
+                                 'rcs.cite.artin'],
+                           title=t, bread=bread,
                            learnmore=learnmore)
 
 @artin_representations_page.route("/Reliability")
@@ -475,7 +477,7 @@ def reliability():
     bread = get_bread([("Reliability", '')])
     learnmore = learnmore_list_remove('Reliability')
     return render_template("single.html", kid='rcs.rigor.artin',
-                           title=t, bread=bread, 
+                           title=t, bread=bread,
                            learnmore=learnmore)
 
 @artin_representations_page.route("/Completeness")
@@ -484,7 +486,7 @@ def cande():
     bread = get_bread([("Completeness", '')])
     learnmore = learnmore_list_remove('Completeness')
     return render_template("single.html", kid='rcs.cande.artin',
-                           title=t, bread=bread, 
+                           title=t, bread=bread,
                            learnmore=learnmore)
 
 class ArtinSearchArray(SearchArray):

--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -647,7 +647,7 @@ def belyi_search(info, query):
 
     parse_bool(info, query, "is_primitive", name="is_primitive")
     if info.get("primitivization"):
-        primitivization = info["primitivization"] 
+        primitivization = info["primitivization"]
         if re.match(GALMAP_RE, primitivization):
             # 7T6-7_4.2.1_4.2.1-b
             query["primitivization"] = primitivization
@@ -726,9 +726,10 @@ def how_computed_page():
     t = "Source and acknowledgments for Belyi map data"
     bread = get_bread("Source")
     return render_template(
-        "double.html",
-        kid="rcs.source.belyi",
-        kid2="rcs.ack.belyi",
+        "multi.html",
+        kids=["rcs.source.belyi",
+              "rcs.ack.belyi",
+              "rcs.cite.belyi"],
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Source"),

--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -592,7 +592,7 @@ def render_bmf_webpage(field_label, level_label, label_suffix):
     except Exception:
         numeigs = 20
     info['numeigs'] = numeigs
-    
+
     try:
         data = WebBMF.by_label(label, max_eigs=numeigs)
         title = "Bianchi cusp form {} over {}".format(data.short_label,field_pretty(data.field_label))
@@ -646,8 +646,12 @@ def bianchi_modular_form_by_label(lab):
 def how_computed_page():
     t = 'Source of Bianchi modular form data'
     bread = get_bread("Source")
-    return render_template("double.html", kid='rcs.source.mf.bianchi', kid2='rcs.ack.mf.bianchi',
-                           title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
+    return render_template("multi.html", kids=['rcs.source.mf.bianchi',
+                            'rcs.ack.mf.bianchi',
+                            'rcs.cite.mf.bianchi'],
+                            title=t,
+                            bread=bread,
+                            learnmore=learnmore_list_remove('Source'))
 
 @bmf_page.route("/Completeness")
 def completeness_page():

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -331,7 +331,9 @@ def how_computed_page():
     info['title'] = 'Source and acknowledgments for Dirichlet character data'
     info['bread'] = bread('Source')
     info['learnmore'] = learn('source')
-    return render_template("double.html", kid='rcs.source.character.dirichlet', kid2='rcs.ack.character.dirichlet',
+    return render_template("multi.html", kids=['rcs.source.character.dirichlet',
+                            'rcs.ack.character.dirichlet',
+                            'rcs.cite.character.dirichlet'],
                            **info)
 
 

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1142,8 +1142,9 @@ def space_search(info, query):
 @cmf.route("/Source")
 def how_computed_page():
     t = 'Source of classical modular form data'
-    return render_template("double.html", kid='rcs.source.cmf',
-                           kid2='rcs.ack.cmf', title=t,
+    return render_template("multi.html", kids=['rcs.source.cmf',
+                           'rcs.ack.cmf',
+                           'rcs.cite.cmf'], title=t,
                            bread=get_bread(other='Source'),
                            learnmore=learnmore_list_remove('Source'))
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -140,7 +140,9 @@ def how_computed_page():
     t = 'Source of elliptic curve data over number fields'
     bread = [('Elliptic curves', url_for("ecnf.index")),
              ('Source', '')]
-    return render_template("double.html", kid='rcs.source.ec', kid2='rcs.ack.ec',
+    return render_template("multi.html", kids=['rcs.source.ec',
+                                               'rcs.ack.ec',
+                                               'rcs.cite.ec'],
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ecnf_page.route("/Reliability")

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -173,7 +173,7 @@ class ECstats(StatsDisplay):
     @property
     def summary(self):
         return r'Currently, the database includes ${}$ {} over $\Q$ in ${}$ {}, with {} at most ${}$.'.format(self.ncurves_c, self.ec_knowl, self.nclasses_c, self.cl_knowl, self.cond_knowl, self.max_N_c)
-    
+
     table = db.ec_curvedata
     baseurl_func = ".rational_elliptic_curves"
 
@@ -204,7 +204,7 @@ class ECstats(StatsDisplay):
         #
         # It's a theorem that the complete set of possible degrees is this:
         return list(range(1,20)) + [21,25,27,37,43,67,163]
-        
+
 # NB the context processor wants something callable and the summary is a *property*
 
 @app.context_processor
@@ -680,7 +680,7 @@ def download_EC_qexp(label, limit):
     else:
         ainvs = db.ec_curvedata.lookup(label, 'ainvs', 'lmfdb_iso')
     if ainvs is None:
-        return elliptic_curve_jump_error(label, {})        
+        return elliptic_curve_jump_error(label, {})
     if limit > 100000:
         return redirect(url_for('.download_EC_qexp',label=label,limit=10000), 301)
     E = EllipticCurve(ainvs)
@@ -715,7 +715,10 @@ def download_EC_all(label):
 def how_computed_page():
     t = r'Source and acknowledgments for elliptic curve data over $\Q$'
     bread = get_bread('Source')
-    return render_template("double.html", kid='rcs.source.ec.q', kid2='rcs.ack.ec.q',
+    return render_template("multi.html",
+                           kids=['rcs.source.ec.q',
+                           'rcs.ack.ec.q',
+                           'rcs.cite.ec.q'],
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @ec_page.route("/Completeness")

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -161,24 +161,24 @@ def galois_group_search(info, query):
     if info.get('jump','').strip():
         jump_list = ["1T1", "2T1", "3T1", "4T1", "4T2", "5T1", "6T1", "7T1",
           "8T1", "8T2", "8T3", "8T5", "9T1", "9T2", "10T1", "11T1", "12T1",
-          "12T2", "12T5", "13T1", "14T1", "15T1", "16T1", "16T2", "16T3", 
-          "16T4", "16T5", "16T7", "16T8", "16T14", "17T1", "18T1", "18T2", 
-          "19T1", "20T1", "20T2", "20T3", "21T1", "22T1", "23T1", "24T1", 
-          "24T2", "24T3", "24T4", "24T5", "24T6", "24T8", "25T1", "25T2", 
-          "26T1", "27T1", "27T2", "27T4", "28T1", "28T2", "28T3", "29T1", 
-          "30T1", "31T1", "32T32", "32T33", "32T34", "32T35", "32T36", 
-          "32T37", "32T38", "32T39", "32T40", "32T41", "32T42", "32T43", 
-          "32T44", "32T45", "32T46", "32T47", "32T48", "32T49", "32T50", 
-          "32T51", "33T1", "34T1", "35T1", "36T1", "36T2", "36T3", "36T4", 
-          "36T7", "36T9", "37T1", "38T1", "39T1", "40T1", "40T2", "40T3", 
-          "40T4", "40T5", "40T7", "40T8", "40T13", "41T1", "42T1", "43T1", 
+          "12T2", "12T5", "13T1", "14T1", "15T1", "16T1", "16T2", "16T3",
+          "16T4", "16T5", "16T7", "16T8", "16T14", "17T1", "18T1", "18T2",
+          "19T1", "20T1", "20T2", "20T3", "21T1", "22T1", "23T1", "24T1",
+          "24T2", "24T3", "24T4", "24T5", "24T6", "24T8", "25T1", "25T2",
+          "26T1", "27T1", "27T2", "27T4", "28T1", "28T2", "28T3", "29T1",
+          "30T1", "31T1", "32T32", "32T33", "32T34", "32T35", "32T36",
+          "32T37", "32T38", "32T39", "32T40", "32T41", "32T42", "32T43",
+          "32T44", "32T45", "32T46", "32T47", "32T48", "32T49", "32T50",
+          "32T51", "33T1", "34T1", "35T1", "36T1", "36T2", "36T3", "36T4",
+          "36T7", "36T9", "37T1", "38T1", "39T1", "40T1", "40T2", "40T3",
+          "40T4", "40T5", "40T7", "40T8", "40T13", "41T1", "42T1", "43T1",
           "44T1", "44T2", "44T3", "45T1", "45T2", "46T1", "47T1"]
         strip_label = info.get('jump','').strip().upper()
         # If the user entered a simple label
         if re.match(r'^\d+T\d+$',strip_label):
             return redirect(url_for_label(strip_label), 301)
         try:
-            parse_galgrp(info, query, qfield=['label','n'], 
+            parse_galgrp(info, query, qfield=['label','n'],
                 name='a Galois group label', field='jump', list_ok=False,
                 err_msg="It needs to be a transitive group in nTj notation, such as 5T1, a GAP id, such as [4,1], or a <a title = 'Galois group labels' knowl='nf.galois_group.name'>group label</a>")
         except ValueError:
@@ -341,7 +341,7 @@ def cande():
     bread = get_bread([("Completeness", )])
     learnmore = learnmore_list_remove('Completeness')
     return render_template("single.html", kid='rcs.cande.gg',
-                           title=t, bread=bread, 
+                           title=t, bread=bread,
                            learnmore=learnmore)
 
 @galois_groups_page.route("/Labels")
@@ -349,15 +349,17 @@ def labels_page():
     t = 'Labels for Galois groups'
     bread = get_bread([("Labels", '')])
     return render_template("single.html", kid='gg.label',
-           learnmore=learnmore_list_remove('label'), 
+           learnmore=learnmore_list_remove('label'),
            title=t, bread=bread)
 
 @galois_groups_page.route("/Source")
 def source():
     t = 'Source and acknowledgments for Galois group pages'
     bread = get_bread([("Source", '')])
-    return render_template("double.html", kid='rcs.source.gg', kid2='rcs.ack.gg',
-                           title=t, bread=bread, 
+    return render_template("multi.html", kids=['rcs.source.gg',
+                                               'rcs.ack.gg',
+                                               'rcs.cite.gg'],
+                           title=t, bread=bread,
                            learnmore=learnmore_list_remove('Source'))
 
 @galois_groups_page.route("/Reliability")
@@ -365,7 +367,7 @@ def reliability():
     t = 'Reliability of Galois group data'
     bread = get_bread([("Reliability", '')])
     return render_template("single.html", kid='rcs.rigor.gg',
-                           title=t, bread=bread, 
+                           title=t, bread=bread,
                            learnmore=learnmore_list_remove('Reliability'))
 
 class GalSearchArray(SearchArray):

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -743,9 +743,10 @@ def source_page():
     t = r"Source and acknowledgments for genus 2 curve data over $\Q$"
     bread = get_bread("Source")
     return render_template(
-        "double.html",
-        kid="rcs.source.g2c",
-        kid2="rcs.ack.g2c",
+        "multi.html",
+        kids=["rcs.source.g2c",
+              "rcs.ack.g2c",
+              "rcs.cite.g2c"],
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Source"),

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1248,9 +1248,10 @@ def how_computed_page():
     t = "Source of the abstract group data"
     bread = get_bread("Source")
     return render_template(
-        "double.html",
-        kid="rcs.source.groups.abstract",
-        kid2="rcs.ack.groups.abstract",
+        "multi.html",
+        kids=["rcs.source.groups.abstract",
+              "rcs.ack.groups.abstract",
+              "rcs.cite.groups.abstract"],
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Source"),

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -1091,7 +1091,7 @@ def reliability_page():
 def how_computed_page():
     t = 'Source of higher genus curve with automorphisms data'
     bread = get_bread("Source")
-    return render_template("double.html",
+    return render_template("multi.html",
                            kids=['rcs.source.curve.highergenus.aut',
                                  'rcs.ack.curve.highergenus.aut',
                                  'rcs.cite.curve.highergenus.aut'],

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -1092,8 +1092,9 @@ def how_computed_page():
     t = 'Source of higher genus curve with automorphisms data'
     bread = get_bread("Source")
     return render_template("double.html",
-                           kid='rcs.source.curve.highergenus.aut',
-                           kid2='rcs.ack.curve.highergenus.aut',
+                           kids=['rcs.source.curve.highergenus.aut',
+                                 'rcs.ack.curve.highergenus.aut',
+                                 'rcs.cite.curve.highergenus.aut'],
                            title=t,
                            bread=bread,
                            learnmore=learnmore_list_remove('Source'))

--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -536,7 +536,9 @@ def render_hmf_webpage(**args):
 def how_computed_page():
     t = 'Source and acknowledgments for Hilbert modular form data'
     bread = get_bread("Source")
-    return render_template("double.html", kid='rcs.source.mf.hilbert', kid2='rcs.ack.mf.hilbert',
+    return render_template("multi.html", kids=['rcs.source.mf.hilbert',
+                                               'rcs.ack.mf.hilbert',
+                                               'rcs.cite.mf.hilbert'],
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @hmf_page.route("/Completeness")

--- a/lmfdb/hypergm/main.py
+++ b/lmfdb/hypergm/main.py
@@ -127,7 +127,7 @@ def ab2gammas(A,B):
             if d in ab[wh]:
                 subdict(ab[wh],d)
             else:
-                incdict(ab[1-wh], d) 
+                incdict(ab[1-wh], d)
     gamma[1] = [-1*z for z in gamma[1]]
     gamma = gamma[1]+gamma[0]
     gamma.sort()
@@ -293,7 +293,7 @@ def hgm_family_circle_image(AB):
     A, B = AB.split("_")
     from .plot import circle_image
     A = [int(n) for n in A[1:].split(".")]
-    B = [int(n) for n in B[1:].split(".")]    
+    B = [int(n) for n in B[1:].split(".")]
     G = circle_image(A, B)
     return image_callback(G)
 
@@ -303,7 +303,7 @@ def hgm_family_linear_image(AB):
     A, B = AB.split("_")
     from .plot import piecewise_linear_image
     A = [int(n) for n in A[1:].split(".")]
-    B = [int(n) for n in B[1:].split(".")]    
+    B = [int(n) for n in B[1:].split(".")]
     G = piecewise_linear_image(A, B)
     return image_callback(G)
 
@@ -313,7 +313,7 @@ def hgm_family_constant_image(AB):
     A, B = AB.split("_")
     from .plot import piecewise_constant_image
     A = [int(n) for n in A[1:].split(".")]
-    B = [int(n) for n in B[1:].split(".")]    
+    B = [int(n) for n in B[1:].split(".")]
     G = piecewise_constant_image(A, B)
     return image_callback(G)
 
@@ -615,7 +615,9 @@ def interesting_motives():
 def how_computed_page():
     t = r'Source and acknowledgments for hypergeometric motives over $\Q$'
     bread = get_bread(('Source',''))
-    return render_template("double.html", kid='rcs.source.hgm', kid2='rcs.ack.hgm',
+    return render_template("multi.html", kids=['rcs.source.hgm',
+                                               'rcs.ack.hgm',
+                                               'rcs.cite.hgm'],
            title=t, bread=bread,
            learnmore=learnmore_list_remove('Source'))
 

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -184,7 +184,7 @@ def process_euler(res, info, query):
 
 def url_for_lfunction(label):
     try:
-        kwargs = dict(zip(('degree', 'conductor', 'character', 'gamma_real', 'gamma_imag', 'index'), 
+        kwargs = dict(zip(('degree', 'conductor', 'character', 'gamma_real', 'gamma_imag', 'index'),
 label.split('-')))
         kwargs['degree'] = int(kwargs['degree'])
     except Exception:
@@ -1911,8 +1911,11 @@ def processSymPowerEllipticCurveNavigation(startCond, endCond, power):
 def generic_source():
     t = 'Source and acknowledgments for L-function data'
     bread = get_bread(breads=[('Source', ' ')])
-    return render_template("double.html", kid='rcs.source.lfunction', kid2='rcs.ack.lfunction', title=t, 
-        bread=bread)
+    return render_template("multi.html", kids=['rcs.source.lfunction',
+                                               'rcs.ack.lfunction',
+                                               'rcs.cite.lfunction'],
+                                         title=t,
+                                         bread=bread)
 
 @l_function_page.route("/Completeness")
 def generic_completeness():

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -443,8 +443,9 @@ def source():
     t = 'Source and acknowledgments for $p$-adic field pages'
     ttag = 'Source and acknowledgments for p-adic field pages'
     bread = get_bread([("Source", '')])
-    return render_template("double.html", kid='rcs.source.lf',
-                           kid2='rcs.ack.lf', title=t,
+    return render_template("multi.html", kids=['rcs.source.lf',
+                           'rcs.ack.lf','rcs.cite.lf'],
+                           title=t,
                            titletag=ttag, bread=bread,
                            learnmore=learnmore_list_remove('Source'))
 
@@ -548,10 +549,10 @@ class LFSearchArray(SearchArray):
             )
         results = CountBox()
 
-        self.browse_array = [[degree], [qp], [c], [e], [f], [topslope], [u], 
+        self.browse_array = [[degree], [qp], [c], [e], [f], [topslope], [u],
             [t], [gal], [inertia], [wild], [results]]
-        self.refine_array = [[degree, qp, gal, u], 
-            [e, c, inertia, t], 
+        self.refine_array = [[degree, qp, gal, u],
+            [e, c, inertia, t],
             [f, topslope, wild]]
 
 def ramdisp(p):

--- a/lmfdb/maass_forms/main.py
+++ b/lmfdb/maass_forms/main.py
@@ -125,7 +125,9 @@ def download_coefficients(label):
 def source_page():
     t = 'Source of Maass form data'
     bread = bread_prefix() + [('Source','')]
-    return render_template('double.html', kid='rcs.source.maass',kid2='rcs.ack.maass',
+    return render_template('multi.html', kids=['rcs.source.maass',
+                                               'rcs.ack.maass',
+                                               'rcs.cite.maass'],
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @maass_page.route('/Completeness')
@@ -145,7 +147,7 @@ def reliability_page():
 class MaassSearchArray(SearchArray):
     noun = "Maass form"
     plural_noun = "Maass forms"
-    def __init__(self):       
+    def __init__(self):
         level = TextBox(name="level", label="Level", knowl="mf.maass.mwf.level", example="1", example_span="997 or 1-10")
         weight = TextBox(name="weight", label="Weight", knowl="mf.maass.mwf.weight", example="0", example_span="0 (only weight 0 currently available)")
         character = TextBox(name="character", label="Character", knowl="mf.maass.mwf.character", example="1.1", example_span="1.1 or 5.1 (only trivial character currently available)")

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -135,7 +135,9 @@ def source():
     learnmore = learnmore_list_remove('Source')
     t = 'Source and acknowledgments for number field pages'
     bread = bread_prefix() + [('Source', ' ')]
-    return render_template("double.html", kid='rcs.source.nf', kid2='rcs.ack.nf',
+    return render_template("multi.html", kids=['rcs.source.nf',
+                                               'rcs.ack.nf',
+                                               'rcs.ack.nf'],
         title=t, bread=bread, learnmore=learnmore)
 
 
@@ -797,7 +799,7 @@ nf_columns = SearchColumns([
                  lambda label: '<a href="%s">%s</a>' % (url_for_label(label), nf_label_pretty(label)),
                  default=True),
     SearchCol("poly", "nf.defining_polynomial", "Polynomial", default=True),
-    MathCol("degree", "nf.degree", "Degree", align="center"), 
+    MathCol("degree", "nf.degree", "Degree", align="center"),
     MultiProcessedCol("signature", "nf.signature", "Signature", ["r2", "degree"], lambda r2, degree: '[%s,%s]' % (degree - 2*r2, r2 ), align="center"),
     MathCol("disc", "nf.discriminant", "Discriminant", default=True, align="left"),
     CheckCol("cm", "nf.cm_field", "Is CM field?"),

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -938,7 +938,9 @@ def render_st_group(info, portrait=None):
 def source_page():
     t = 'Source and acknowledgments for Sato-Tate group data'
     bread = get_bread("Source")
-    return render_template('double.html', kid='rcs.source.st_group', kid2='rcs.ack.st_group',
+    return render_template('multi.html', kids=['rcs.source.st_group',
+                                               'rcs.ack.st_group',
+                                               'rcs.cite.st_group'],
                            title=t, bread=bread, learnmore=learnmore_list_remove('Source'))
 
 @st_page.route('/Completeness')

--- a/lmfdb/templates/citation.html
+++ b/lmfdb/templates/citation.html
@@ -27,42 +27,4 @@ function update_date_tags() {
 update_date_tags()
 </script>
 
-{{ KNOWL_INC('rcs.cite.av.fq') }}
-
-{{ KNOWL_INC('rcs.cite.groups.abstract') }}
-
-{{ KNOWL_INC('rcs.cite.artin') }}
-
-{{ KNOWL_INC('rcs.cite.belyi') }}
-
-{{ KNOWL_INC('rcs.cite.mf.bianchi') }}
-
-{{ KNOWL_INC('rcs.cite.cmf') }}
-
-{{ KNOWL_INC('rcs.cite.highergenus.aut') }}
-
-{{ KNOWL_INC('rcs.cite.character.dirichlet') }}
-
-{{ KNOWL_INC('rcs.cite.ec.q') }}
-
-{{ KNOWL_INC('rcs.cite.ec') }}
-
-{{ KNOWL_INC('rcs.cite.gg') }}
-
-{{ KNOWL_INC('rcs.cite.g2c') }}
-
-{{ KNOWL_INC('rcs.cite.mf.hilbert') }}
-
-{{ KNOWL_INC('rcs.cite.hgm') }}
-
-{{ KNOWL_INC('rcs.cite.lfunction') }}
-
-{{ KNOWL_INC('rcs.cite.maass') }}
-
-{{ KNOWL_INC('rcs.cite.nf') }}
-
-{{ KNOWL_INC('rcs.cite.lf') }}
-
-{{ KNOWL_INC('rcs.cite.st_group') }}
-
 {% endblock %}

--- a/lmfdb/templates/citation.html
+++ b/lmfdb/templates/citation.html
@@ -27,8 +27,42 @@ function update_date_tags() {
 update_date_tags()
 </script>
 
+{{ KNOWL_INC('rcs.cite.av.fq') }}
 
-</div>
+{{ KNOWL_INC('rcs.cite.groups.abstract') }}
 
+{{ KNOWL_INC('rcs.cite.artin') }}
+
+{{ KNOWL_INC('rcs.cite.belyi') }}
+
+{{ KNOWL_INC('rcs.cite.mf.bianchi') }}
+
+{{ KNOWL_INC('rcs.cite.cmf') }}
+
+{{ KNOWL_INC('rcs.cite.highergenus.aut') }}
+
+{{ KNOWL_INC('rcs.cite.character.dirichlet') }}
+
+{{ KNOWL_INC('rcs.cite.ec.q') }}
+
+{{ KNOWL_INC('rcs.cite.ec') }}
+
+{{ KNOWL_INC('rcs.cite.gg') }}
+
+{{ KNOWL_INC('rcs.cite.g2c') }}
+
+{{ KNOWL_INC('rcs.cite.mf.hilbert') }}
+
+{{ KNOWL_INC('rcs.cite.hgm') }}
+
+{{ KNOWL_INC('rcs.cite.lfunction') }}
+
+{{ KNOWL_INC('rcs.cite.maass') }}
+
+{{ KNOWL_INC('rcs.cite.nf') }}
+
+{{ KNOWL_INC('rcs.cite.lf') }}
+
+{{ KNOWL_INC('rcs.cite.st_group') }}
 
 {% endblock %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -76,6 +76,8 @@
             </span>
 -->
           <div class="undertopright">
+            <a href="{{ url_for('citation') }}" >Citation</a>
+              &middot;
             <a href="{{ url_for('contact') }}" target="_blank">Feedback</a>
               &middot;
             <a href="#" id="menutoggle">

--- a/lmfdb/templates/multi.html
+++ b/lmfdb/templates/multi.html
@@ -1,0 +1,8 @@
+{% extends "homepage.html" %}
+{% block content %}
+
+{% for kid in kids%}
+{{ KNOWL_INC(kid) }}
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
This addresses #3946.

1. New 'How to cite' knowls for each section of the LMFDB which had existing "rcs.source" and "rcs.ack" knowls. These are currently empty, when content is added to them they will show up on the "Source and acknowledgements" pages as well as the "Citation" page
2. A new "Citation" link in the top banner of every page. This was discussed last week with Sam Schiavone and John Voight.