### PR TITLE
fix for #4982 (ss Iwasawa invariants)

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -495,7 +495,7 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <tr style="border-bottom: 1px solid #000;">
 <th>$p$</th>
 {% for pdata in data.iw.data %}
-<td>
+<td align=center>
 {{pdata[0]}}
 </td>
 {% endfor %}
@@ -504,10 +504,8 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <tr>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
 {% for pdata in data.iw.data %}
-<td>
-{% if pdata[1] == "ss" %}&nbsp;{% endif %}
+<td align=center>
 {{ KNOWL('ec.q.reduction_type', title=pdata[1]) }}
-{% if pdata[1] == "ss" %}<br>$+$, $-${% endif %}
 </td>
 {% endfor %}
 </tr>
@@ -515,7 +513,7 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <tr>
 <th>{{ KNOWL('ec.lambda_invariant', title='$\lambda$-invariant(s)')  }} </th>
 {% for pdata in data.iw.data %}
-<td>
+<td align=center>
 {{ pdata[2] }}
 </td>
 {% endfor %}
@@ -524,7 +522,7 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <tr>
 <th>{{ KNOWL('ec.mu_invariant', title='$\mu$-invariant(s)') }} </th>
 {% for pdata in data.iw.data %}
-<td>
+<td align=center>
 {{ pdata[3] }}
 </td>
 {% endfor %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -505,7 +505,9 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
 {% for pdata in data.iw.data %}
 <td>
+{% if pdata[1] == "ss" %}&nbsp;{% endif %}
 {{ KNOWL('ec.q.reduction_type', title=pdata[1]) }}
+{% if pdata[1] == "ss" %}<br>$+$, $-${% endif %}
 </td>
 {% endfor %}
 </tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -505,7 +505,7 @@ $p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-opti
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
 {% for pdata in data.iw.data %}
 <td align=center>
-{{ KNOWL('ec.q.reduction_type', title=pdata[1]) }}
+{{ KNOWL(pdata[4], title=pdata[1]) }}
 </td>
 {% endfor %}
 </tr>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -561,34 +561,43 @@ class WebEC(object):
         iw['missing_flag'] = False # flags that there is at least one "?" in the table
         iw['additive_shown'] = False # flags that there is at least one additive prime in table
         for p in sorted(pp):
-            rtype = ""
+            rtype = ''
+            rtknowl = 'ec.q.reduction_type'
             if p in badp:
                 red = rtypes[badp.index(p)]
                 # Additive primes are excluded from the table
-                rtype = ["nonsplit","add", "split"][1+red]
+                rtype = ['nonsplit', 'add', 'split'][1+red]
+                rtknowl = ['ec.nonsplit_multiplicative_reduction', 'ec.additive_reduction', 'ec.split_multiplicative_reduction'][1+red]
             p = str(p)
             pdata = iwdata[p]
             if isinstance(pdata, type(u'?')):
                 if not rtype:
-                    rtype = "ord" if pdata=="o?" else "ss"
+                    if pdata=="o?":
+                        rtype = "ord"
+                        rtknowl = "ec.good_ordinary_reduction"
+                    else:
+                        rtype = "ss"
+                        rtknowl = "ec.good_supersingular_reduction"
                 if rtype == "add":
-                    iw['data'] += [[p,rtype,"-","-"]]
+                    iw['data'] += [[p, rtype, "-", "-", rtknowl]]
                     iw['additive_shown'] = True
                 else:
-                    iw['data'] += [[p,rtype,"?","?"]]
+                    iw['data'] += [[p, rtype, "?", "?", rtknowl]]
                     iw['missing_flag'] = True
             else:
                 if len(pdata)==2:
                     if not rtype:
                         rtype = "ord"
+                        rtknowl = "ec.good_ordinary_reduction"
                     lambdas = str(pdata[0])
                     mus = str(pdata[1])
                 else:
                     rtype = "ss"
+                    rtknowl = "ec.good_supersingular_reduction"
                     lambdas = ",".join([str(pdata[0]), str(pdata[1])])
                     mus = str(pdata[2])
                     mus = ",".join([mus,mus])
-                iw['data'] += [[p,rtype,lambdas,mus]]
+                iw['data'] += [[p, rtype, lambdas, mus, rtknowl]]
 
     def make_torsion_growth(self):
         # The torsion growth table has one row per extension field

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -570,7 +570,7 @@ class WebEC(object):
             pdata = iwdata[p]
             if isinstance(pdata, type(u'?')):
                 if not rtype:
-                    rtype = "ordinary" if pdata=="o?" else "ss"
+                    rtype = "ord" if pdata=="o?" else "ss"
                 if rtype == "add":
                     iw['data'] += [[p,rtype,"-","-"]]
                     iw['additive_shown'] = True
@@ -580,7 +580,7 @@ class WebEC(object):
             else:
                 if len(pdata)==2:
                     if not rtype:
-                        rtype = "ordinary"
+                        rtype = "ord"
                     lambdas = str(pdata[0])
                     mus = str(pdata[1])
                 else:


### PR DESCRIPTION
This adds "+,-" under the table header when that is "ss" (for supersingular), to make it clear that in the pairs of numbers below, the first is the lambda^+ (or mu^+) and the second is the -.

For example: http://localhost:37777/EllipticCurve/Q/43a1/

There may be a better way of making the alignment work: the table headers are left-justified which does not look right here as that puts the + under ss, so I cheated by inserting a hard space before the ss.  I'm sure that it could have been done using a custom css style, and I am happy to do it that way if someone else tells me what to do.