### PR TITLE
fix mw test to account for data change

### DIFF
--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -195,15 +195,10 @@ class Genus2Test(LmfdbTest):
         assert "\\infty" in L.get_data(as_text=True)
         assert "6.2.1658432.2" in L.get_data(as_text=True)
         L = self.tc.get("/Genus2Curve/Q/969306/a/969306/1")
-        assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.get_data(
-            as_text=True
-        )
-        assert "16y" in L.get_data(as_text=True) and "2xz^2 + 11z^3" in L.get_data(
-            as_text=True
-        )
+        assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.get_data(as_text=True)
+        assert "16y" in L.get_data(as_text=True) and "2xz^2 + 11z^3" in L.get_data(as_text=True)
         assert "3.259671" in L.get_data(as_text=True)
         assert "\\infty" in L.get_data(as_text=True)
-        assert "D_4\\times C_2" in L.get_data(as_text=True)
         L = self.tc.get("/Genus2Curve/Q/461/a/461/2")
         assert "trivial" in L.get_data(as_text=True)
 


### PR DESCRIPTION
Removed a test that would succeed only if the two torsion field is not in the database (which it now is).