### PR TITLE
fix handling of cm columns for ECNF (issue #5004)

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -366,14 +366,9 @@ class ECNF(object):
         # CM and End(E)
         self.cm_bool = "no"
         self.End = r"\(\Z\)"
+        self.rational_cm = self.cm_type>0
         if self.cm:
-            # When we switch to storing rational cm by having |D| in
-            # the column, change the following lines:
-            if self.cm>0:
-                self.rational_cm = True
-                self.cm = -self.cm
-            else:
-                self.rational_cm = K(self.cm).is_square()
+            self.cm = -abs(self.cm) # this line can be deleted when we no longer store abs(-D) for rational CM by -D
             self.cm_sqf = integer_squarefree_part(ZZ(self.cm))
             self.cm_bool = r"yes (\(%s\))" % self.cm
             if self.cm % 4 == 0:
@@ -392,7 +387,7 @@ class ECNF(object):
                 self.cm_ramp = ", ".join([str(p) for p in self.cm_ramp])
 
         # Sato-Tate:
-        self.ST = st_display_knowl('1.2.A.1.1a' if not self.cm else ('1.2.B.2.1a' if self.cm < 0 else '1.2.B.1.1a'))
+        self.ST = st_display_knowl('1.2.A.1.1a' if not self.cm_type else ('1.2.B.2.1a' if self.cm_type < 0 else '1.2.B.1.1a'))
 
         # Q-curve / Base change
         try:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -472,7 +472,9 @@ def make_cm_query(cm_disc_str):
     cm_list = parse_ints_to_list_flash(cm_disc_str, "CM discriminant", max_val=None)
     for d in cm_list:
         if not ((d < 0) and (d % 4 in [0,1])):
-            raise ValueError("A CM discriminant must be a fundamental discriminant of an imaginary quadratic field.")
+            raise ValueError("CM discriminants are negative and congruent to 0 or 1 mod 4.")
+    # the next line is because actual CM with disc -D is stored as +D in the table;
+    # it can be removed once we only store -D itself.
     cm_list += [-el for el in cm_list]
     return cm_list
 
@@ -506,12 +508,12 @@ ecnf_columns = SearchColumns([
     ProcessedCol("torsion_structure", "ec.torsion_subgroup", "Torsion",
                  lambda tors: r"\oplus".join([r"\Z/%s\Z"%n for n in tors]) if tors else r"\mathsf{trivial}", default=True, mathmode=True, align="center"),
     ProcessedCol("has_cm", "ec.complex_multiplication", "CM", lambda v: r"$\textsf{%s}$"%("no" if v == 0 else ("potential" if v < 0 else "yes")),
-                 default=lambda info: info.get("include_cm") and info.get("include_cm") != "noPCM", short_title="Has CM", align="center", orig="cm"),
+                 default=lambda info: info.get("include_cm") and info.get("include_cm") != "noPCM", short_title="Has CM", align="center", orig="cm_type"),
     ProcessedCol("cm", "ec.complex_multiplication", "CM", lambda v: "" if v == 0 else -abs(v),
                  default=True, short_title="CM discriminant", mathmode=True, align="center"),
     ProcessedCol("sato_tate_group", "st_group.definition", "Sato-Tate",
                  lambda v: st_display_knowl('1.2.A.1.1a' if v==0 else ('1.2.B.2.1a' if v < 0 else '1.2.B.1.1a')),
-                 short_title="Sato-Tate group", align="center", orig="cm"),
+                 short_title="Sato-Tate group", align="center", orig="cm_type"),
     CheckCol("q_curve", "ec.q_curve", r"$\Q$-curve", short_title="Q-curve"),
     CheckCol("base_change", "ec.base_change", "Base change"),
     CheckCol("semistable", "ec.semistable", "Semistable"),


### PR DESCRIPTION
I have checked all the possible input combinations (I think), but would like someone else to check that the handling of ST group type and Galois images is still OK.  The changes are in fact very minor: we now check the sign of 'cm_type' instead of that of 'cm' to distinguish the three cases.

The code is actually simpler (probably a sign that this was a good change anyway).  There are two places where lines can be deleted once all netries in the 'cm' column are back to being negative.

I also corrected an incorrect error message (try entering an integer which is not a negative discriminant into the CM discriminant search box to see it):  CM discriminants do *not* have ti be fundamental discriminats, just negative disriminants!
