### PR TITLE
Tiny tweak to typeset/raw box size

### DIFF
--- a/lmfdb/static/raw_typeset.js
+++ b/lmfdb/static/raw_typeset.js
@@ -5,7 +5,7 @@ function setraw(elt) {
     raw = $(raw);
     var ta = $(raw[0]); // the textarea element
     ta.width($this.width() - (21 + 2 + 2 + 5)); // icon + 2*border + ws +  (x->x)
-    ta.height($this.height() - 8); // 2*padding + 2*border
+    ta.height($this.height() - 8);
   }
 
   $this.attr("tset", $this.html());

--- a/lmfdb/static/raw_typeset.js
+++ b/lmfdb/static/raw_typeset.js
@@ -5,7 +5,7 @@ function setraw(elt) {
     raw = $(raw);
     var ta = $(raw[0]); // the textarea element
     ta.width($this.width() - (21 + 2 + 2 + 5)); // icon + 2*border + ws +  (x->x)
-    ta.height($this.height() - (2 + 2)); // 2*padding + 2*border
+    ta.height($this.height() - 8); // 2*padding + 2*border
   }
 
   $this.attr("tset", $this.html());

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2460,7 +2460,7 @@ span.activesubgp {
 
 textarea.tset-raw {
     font-size: 95%;
-    padding: 1px;
+    padding: 1.5px;
     border: 1px solid {{color.input_border}};
 }
 


### PR DESCRIPTION
This prevents the screen from moving when you click the x->x button on Chrome and shows exactly one line in raw mode (rather than one line plus a few pixels of the line below).
