### PR TITLE
ST groups in database for search results

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -687,7 +687,8 @@ def mu_data(n):
         rec['supgroups'] = []
         rec['maximal'] = True
     elif n > 2:
-        rec['supgroups'] = ["0.1.%d"%(p*n) for p in [2,3,5]]
+        if n <= 200000:
+            rec['supgroups'] = ["0.1.%d"%(p*n) for p in [2,3,5]]
         rec['maximal'] = False
     rec['moments'] = [['a_1'] + [1 if m % n == 0 else 0 for m in range(13)]]
     rec['second_trace_moment'] = 1 if 2 % n == 0 else 0
@@ -840,7 +841,6 @@ def render_by_label(label):
     info['st0_name']=st0['name']
     info['identity_component']=st0['pretty']
     info['st0_description']=st0['description']
-    print("hi there")
     if data['component_group'][:2] == "ab":
         info['component_group'] = r"C_{%s}"%info['components']
         info['cyclic']=boolean_name(True)
@@ -872,6 +872,11 @@ def render_by_label(label):
         else:
             mults = ["" for s in data['supgroups']]
         info['supgroups'] = comma_separated_list([st_link(data['supgroups'][i]) + mults[i] for i in range(len(mults))])
+    if not data['rational']:
+        if info.get("supgroups"):
+            info['supgroups'] += ", $\\cdots$"
+        else:
+            info['supgroups'] = "$\\cdots$"
     if data.get('moments'):
         info['moments'] = [['x'] + [ '\\mathrm{E}[x^{%d}]'%m for m in range(len(data['moments'][0])-1)]]
         info['moments'] += data['moments']

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -600,7 +600,7 @@ st_columns = SearchColumns([
     MathCol("weight", "st_group.weight", "Wt", default=True),
     MathCol("degree", "st_group.degree", "Deg", default=True),
     MathCol("real_dimension", "st_group.real_dimension", r"$\mathrm{dim}_{\mathbb{R}}$", short_title="dim_R", default=True),
-    ProcessedCol("identity_component", "st_group.identity_component", r"$\mathrm{G}^0$", lambda v: st0_pretty(v), short_title="G^0", mathmode=True, default=True, align="center"),
+    ProcessedCol("identity_component", "st_group.identity_component", r"$\mathrm{G}^0$", st0_pretty, short_title="G^0", mathmode=True, default=True, align="center"),
     MathCol("pretty", "st_group.name", "Name", default=True),
     MathCol("components", "st_group.component_group", r"$\mathrm{G}/\mathrm{G}^0$", short_title="G/G^0", default=True),
     MathCol("trace_zero_density", "st_group.trace_zero_density", r"$\mathrm{Pr}[t\!=\!0]$", short_title="Pr[t=0]", default=True),

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -840,14 +840,21 @@ def render_by_label(label):
     info['st0_name']=st0['name']
     info['identity_component']=st0['pretty']
     info['st0_description']=st0['description']
-    G = db.gps_groups.lookup(data['component_group'])
-    if not G:
-        flash_error ("%s is not the label of a Sato-Tate component group currently in the database.", data['component_group'])
-        return redirect(url_for(".index"))
-    info['component_group']=G['tex_name']
-    info['cyclic']=boolean_name(G['cyclic'])
-    info['abelian']=boolean_name(G['abelian'])
-    info['solvable']=boolean_name(G['solvable'])
+    print("hi there")
+    if data['component_group'][:2] == "ab":
+        info['component_group'] = r"C_{%s}"%info['components']
+        info['cyclic']=boolean_name(True)
+        info['abelian']=boolean_name(True)
+        info['solvable']=boolean_name(True)
+    else:
+        G = db.gps_groups.lookup(data['component_group'])
+        if not G:
+            flash_error ("%s is not the label of a Sato-Tate component group currently in the database.", data['component_group'])
+            return redirect(url_for(".index"))
+        info['component_group']=G['tex_name']
+        info['cyclic']=boolean_name(G['cyclic'])
+        info['abelian']=boolean_name(G['abelian'])
+        info['solvable']=boolean_name(G['solvable'])
     if data.get('gens'):
         info['gens'] = comma_separated_list([string_matrix(m) for m in data['gens']]) if type(data['gens']) == list else data['gens']
         info['numgens'] = len(info['gens'])

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -12,15 +12,15 @@ class SatoTateGroupTest(LmfdbTest):
         assert 'Browse' in L.get_data(as_text=True) and 'U(1)' in L.get_data(as_text=True) and 'U(1)_2' in L.get_data(as_text=True) and 'SU(2)' in L.get_data(as_text=True) and 'Rational' in L.get_data(as_text=True)
         
     def test_by_label(self):
-        L = self.tc.get('/SatoTateGroup/?label=1.4.A.1.1a', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/?jump=1.4.A.1.1a', follow_redirects=True)
         assert 'USp(4)' in L.get_data(as_text=True) and '223412' in L.get_data(as_text=True)
-        L = self.tc.get('/SatoTateGroup/?label=1.4.USp(4)', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/?jump=1.4.USp(4)', follow_redirects=True)
         assert '1.4.A.1.1a' in L.get_data(as_text=True) and '223412' in L.get_data(as_text=True)
-        L = self.tc.get('/SatoTateGroup/?label=1.2.N(U(1))', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/?jump=1.2.N(U(1))', follow_redirects=True)
         assert '1.2.B.2.1a' in L.get_data(as_text=True) and '462' in L.get_data(as_text=True)
-        L = self.tc.get('/SatoTateGroup/?label=0.1.37', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/?jump=0.1.37', follow_redirects=True)
         assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.get_data(as_text=True)
-        L = self.tc.get('/SatoTateGroup/?label=0.1.mu(37)', follow_redirects=True)
+        L = self.tc.get('/SatoTateGroup/?jump=0.1.mu(37)', follow_redirects=True)
         assert '0.1.37' in L.get_data(as_text=True) and 'mu(185)' in L.get_data(as_text=True)
 
     def test_direct_access(self):
@@ -46,10 +46,10 @@ class SatoTateGroupTest(LmfdbTest):
         assert 'both matches' in L.get_data(as_text=True)
         L = self.tc.get('/SatoTateGroup/?weight=1&degree=4&include_irrational=yes&components=48')
         assert 'unique match' in L.get_data(as_text=True)
-        L = self.tc.get('SatoTateGroup/?components=48&include_irrational=yes')
-        assert '27 matches' in L.get_data(as_text=True)
-        L = self.tc.get('SatoTateGroup/?degree=1&start=1000&count=25&include_irrational=yes')
-        assert 'matches 1001-1025' in L.get_data(as_text=True)
+        # L = self.tc.get('SatoTateGroup/?components=48&include_irrational=yes') # temporarily disable, reenable once irrational groups have been added to db
+        # assert '27 matches' in L.get_data(as_text=True)
+        # L = self.tc.get('SatoTateGroup/?degree=1&start=1000&count=25&include_irrational=yes')
+        # assert 'matches 1001-1025' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?degree=1')
         assert 'both matches' in L.get_data(as_text=True)
         L = self.tc.get('SatoTateGroup/?count=47')
@@ -90,8 +90,8 @@ class SatoTateGroupTest(LmfdbTest):
             sys.stdout.flush()
             L = self.tc.get('/SatoTateGroup/' + label)
             assert label in L.get_data(as_text=True) and 'Moment sequences' in L.get_data(as_text=True)
-        L = self.tc.get('/SatoTateGroup/?components=999999999&include_irrational=yes')
-        assert 'unique match' in L.get_data(as_text=True) and 'mu(999999999)' in L.get_data(as_text=True)
+        # L = self.tc.get('/SatoTateGroup/?components=99999&include_irrational=yes') # temporarily disable, reenable once irrational groups have been added to db
+        # assert 'unique match' in L.get_data(as_text=True) and 'mu(99999)' in L.get_data(as_text=True)
 
     def test_trace_zero_density(self):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=1')


### PR DESCRIPTION
This PR is the first step in addressing #5012.  At the moment only the two rational weight 0 groups are in the database -- I don't want to add all the others yet because it will break beta even worse than it already is (right now 0.1.1 and 0.1.2 show up twice).  Once this PR is merged I will add the first 100,000 mu groups (and when char_orbits is extended to 1,000,000 I will extend the mu groups as well).

It will still happily render pages and knowls for groups that are not in the database as it did before, but with this PR the only groups that will appear in the search results are those in the database.

I also added a label_components column that can be used for sorting if we wish to.