### PR TITLE
final cm code fixes for #5004

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -368,7 +368,6 @@ class ECNF(object):
         self.End = r"\(\Z\)"
         self.rational_cm = self.cm_type>0
         if self.cm:
-            self.cm = -abs(self.cm) # this line can be deleted when we no longer store abs(-D) for rational CM by -D
             self.cm_sqf = integer_squarefree_part(ZZ(self.cm))
             self.cm_bool = r"yes (\(%s\))" % self.cm
             if self.cm % 4 == 0:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -473,9 +473,6 @@ def make_cm_query(cm_disc_str):
     for d in cm_list:
         if not ((d < 0) and (d % 4 in [0,1])):
             raise ValueError("CM discriminants are negative and congruent to 0 or 1 mod 4.")
-    # the next line is because actual CM with disc -D is stored as +D in the table;
-    # it can be removed once we only store -D itself.
-    cm_list += [-el for el in cm_list]
     return cm_list
 
 @search_parser


### PR DESCRIPTION
Two tiny changes, now that (on the beta database) the 'cm' column of ec_nfcurves now always contains 0 or the actual negative discriminant, as the 'cm_status' column holds the sign of the old 'cm' column (+1 for actual CM and -1 for potential).  Specifically, 
   1. in processing the search for specific discriminants we no longer need to append the negatives of the ones requested;
   2. in preparing the web page data we no longer have to replace positive 'cm' value by  their negatives
It will be safe to push this to prod *after* ec_nfcurves has been copied over, and at that opint#5004 can be closed.
