### PR TITLE
update for congruent number data

### DIFF
--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -236,8 +236,7 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
 </p>
 
 <p>
-  In eight cases ($n = 378953, 462073, 548953, 764593, 799657, 822722,
-  937121$, and $998617$), all of rank $2$, only one generator is
+  In three cases ($n = 799657, 937121$, and $998617$), all of rank $2$, only one generator is
   known, and hence neither the regulator nor &#1064; are known.
 </p>
 
@@ -261,7 +260,7 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
 <p>
 The data files were created by Randall L. Rathbun on February 14, 2013
 with updates on May 18, 2014.  Some data was provided by Allan J
-MacLeod, the rest computed by Rathbun using <tt>PARI/GP</tt>
+MacLeod, Ralph Buchholz and Brett Wittby, the rest computed by Rathbun using <tt>PARI/GP</tt>
 and <tt>eclib</tt> (in particular <tt>mwrank</tt>).
 </p>
 


### PR DESCRIPTION
Our data on congruent number curves includes 8 N under a million for which the curve had rank 2 but ony one generator was known.  Rathbun has recently provided the missing generators.

This PR  updates the congruent number curve web page to (1) change the list of 8 missing cases to a list of 3; (2) adds an acknowledgement to the two people who found these last generators (as communicated by Rathbun).

In addition, there are 3 data files which need updating from my home directory on legendre to wherever they are stored for beta and prod.  My directory is /scratch/home/jcremona/data/congruent-number-curves (with hyphens) and the database directory is data/congruent_number_curves (with uderscores), and the 3 files to be updated are:

 - CN.MWgroup
 - CN.height
 - CN.Tate-Sha

Of these, the last two are only provided for users to download, while the first is used in displaying on congruent number curve pages (e.g. https://beta.lmfdb.org/EllipticCurve/Q/CongruentNumber/378953).  In each case just 3 lines have changed, namely for N= 378953, 462073, 548953, 764593 and 822722.  And the last 3 cases are N=799657, 937121, 998617.

I suggest that the data is copied first.

