### PR TITLE
Search by signature in ECNF searches

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -493,6 +493,8 @@ ecnf_columns = SearchColumns([
     MathCol("class_size", "ec.isogeny", "Class size", short_title="isogeny class size"),
     MathCol("class_deg", "ec.isogeny", "Class degree", short_title="isogeny class degree"),
     ProcessedCol("field_label", "nf", "Base field", lambda field: nf_display_knowl(field, field_pretty(field)), default=True, align="center"),
+    MathCol("degree", "nf.degree", "Field degree", short_title="base field degree", align="center"),
+    MathCol("signature", "nf.signature", "Field signature", short_title="base field signature", align="center"),
     SearchCol("conductor_label", "ec.conductor_label", "Conductor", align="center"),
     ProcessedCol("conductor_norm", "ec.conductor", "Conductor norm", lambda v: web_latex_factored_integer(ZZ(v)), default=True, align="center"),
     ProcessedCol("normdisc", "ec.discriminant", "Discriminant norm", lambda v: web_latex_factored_integer(ZZ(v)), align="center"),
@@ -669,7 +671,12 @@ def elliptic_curve_search(info, query):
     parse_primes(info, query, 'conductor_norm_factors', name='bad primes',
              qfield='conductor_norm_factors',mode=info.get('bad_quantifier'))
     info['field_pretty'] = field_pretty
-    parse_ints(info,query,'bf_deg',name='Base field degree',qfield='degree')
+    if info.get('deg_sig'):
+        sig = ast.literal_eval(info['deg_sig'])
+        if len(sig) == 1:
+            query['degree'] = sig[0]
+        else:
+            query['signature'] = sig
 
 @ecnf_page.route("/browse/")
 def browse():
@@ -907,11 +914,12 @@ class ECNFSearchArray(SearchArray):
             label="Torsion order",
             knowl="ec.torsion_order",
             example="2")
-        bf_deg = SelectBox(
-            name="bf_deg",
-            label="Base field degree",
-            knowl="nf.degree",
-            options=[("",""),("2", "2"),("3", "3"),("4", "4"),("5", "5"),("6", "6")]
+        deg_sig = SelectBox(
+            name="deg_sig",
+            label="Base field degree/signature",
+            knowl="nf.signature",
+            options=[("",""),("[2]", "quadratic"),("[3]", "cubic"),("[4]", "quartic"),("[5]", "quintic"),("[6]", "sextic"),
+                     ("[2,0]", "real quadratic"), ("[0,1]", "imaginary quadratic"), ("[3,0]", "real cubic"), ("[1,1]", "mixed cubic") ]
             )
 
         tor_opts = ([("", ""),
@@ -985,7 +993,7 @@ class ECNFSearchArray(SearchArray):
         count = CountBox()
 
         self.browse_array = [
-            [field, bf_deg],
+            [field, deg_sig],
             [conductor_norm, bad_primes],
             [rank, Qcurves],
             [torsion, torsion_structure],
@@ -1000,7 +1008,7 @@ class ECNFSearchArray(SearchArray):
 
         self.refine_array = [
             [field, conductor_norm, rank, torsion, cm_disc],
-            [bf_deg, bad_primes, Qcurves, torsion_structure, include_cm],
+            [deg_sig, bad_primes, Qcurves, torsion_structure, include_cm],
             [sha, isodeg, class_size, reduction, galois_image],
             [jinv, regulator, one, class_deg, nonmax_primes],
             ]


### PR DESCRIPTION
This PR resolves #5035 by adding options to search for real/imaginary quadratic fields and real/mixed cubic fields to the base field degree selector (which is now the base field degree/signature selector).  Also adds signature as a column you can include in the search results table.