### PR TITLE
Two heights in subgroup diagrams

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -983,6 +983,7 @@ def diagram_js(gp, layers, display_opts, aut=False):
             grp.subgroup_order,
             gp.tex_images.get(grp.subgroup_tex, gp.tex_images["?"]),
             grp.diagramx[0] if aut else (grp.diagramx[2] if grp.normal else grp.diagramx[1]),
+            grp.diagram_aut_x if aut else grp.diagram_x
         ]
         for grp in layers[0]
     ]

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -29,19 +29,32 @@
     }
   }
 
+  var heightstyle='div'; // alternative is 'order'
   function show_info(style) {
     $('.subgroup_diagram').hide();
     $('.subgroup_profile').hide();
     $('.subgroup_autdiagram').hide();
     $('.subgroup_autprofile').hide();
     if(style=="diagram") {
-      sdiagram.newgraph(glist[0]);
       type="C";
+      whoisshowing=0;
+      if(heightstyle=='order') {
+        whoisshowing += 2;
+      }
+      sdiagram.newgraph(glist[whoisshowing]);
       $('.subgroup_diagram').show();
+      sdiagram.setSize();
+      sdiagram.draw();
     } else if(style=="autdiagram") {
-      sdiagram.newgraph(glist[1]);
       type="A";
+      whoisshowing=1;
+      if(heightstyle=='order') {
+        whoisshowing += 2;
+      }
+      sdiagram.newgraph(glist[whoisshowing]);
       $('.subgroup_autdiagram').show();
+      sdiagram.setSize();
+      sdiagram.draw();
     } else {
       $('.subgroup_'+style).show();
     }
@@ -54,6 +67,11 @@
   }
   function toggleheight()
   {
+    if (heightstyle=='div') {
+      heightstyle = 'order';
+    } else {
+      heightstyle = 'div';
+    }
     mytoggleheights($("#orderForHeight").prop('checked'));
   }
 
@@ -413,6 +431,10 @@
       <div id="positions">
       </div>
     {% endif %}
+  <div>
+    Each subgroup order has its own line?
+    <input type="checkbox" id="orderForHeight" onchange="toggleheight()" />
+  </div>
   <div class="subgroup_diagram">
     <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
   </div>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -52,6 +52,10 @@
     button_on(style);
     other_buttons_off(style);
   }
+  function toggleheight()
+  {
+    mytoggleheights($("#orderForHeight").prop('checked'));
+  }
 
 </script>
 
@@ -375,6 +379,10 @@
       <div id="positions">
       </div>
     {% endif %}
+  <div>
+    Each subgroup order has its own line?
+    <input type="checkbox" id="orderForHeight" onchange="toggleheight()" />
+  </div>
   <div class="subgroup_diagram">
     <a href="{{url_for('.sub_diagram', label=gp.label)}}">See a full page version of the diagram</a>
   </div>

--- a/lmfdb/groups/abstract/templates/diagram_page.html
+++ b/lmfdb/groups/abstract/templates/diagram_page.html
@@ -48,6 +48,10 @@
   {
     can_move_vertically = $("#allMove").prop('checked');
   }
+  function toggleheight()
+  {
+    mytoggleheights($("#orderForHeight").prop('checked'));
+  }
 </script>
 
 <script type="text/javascript" src="{{ url_for('static', filename='graphs/graph.js') }}"></script>
@@ -63,12 +67,13 @@
 {{ info.dojs|safe }}
 
 {% if info.type == "aut" %}
-  sdiagram.newgraph(glist[1]);
+  whoisshowing=1;
   type="A";
   {% else %}
-  sdiagram.newgraph(glist[0]);
+  whoisshowing=0;
   type="C";
 {% endif %}
+  sdiagram.newgraph(glist[whoisshowing]);
   sdiagram.setSize();
   sdiagram.draw();
 </script>
@@ -83,6 +88,10 @@
 <div>
 Subgroups can be dragged in all directions?
 <input type="checkbox" id="allMove" onchange="togglemovement()" />
+</div>
+<div>
+Each subgroup order has its own line?
+<input type="checkbox" id="orderForHeight" onchange="toggleheight()" />
 </div>
 
 <h4>Subgroup information</h4>


### PR DESCRIPTION
A while ago, there was an idea to allow the user to switch between the two ways of layout out subgroup diagram graphs, where heights on the diagram are determined by the number of prime factors in the order of the subgroup and by the order itself.  This allows the user to toggle between them.  If a subgroup has been selected (so that its info is being shown), that stays when the toggle is made.

A good group to look at is

  http://127.0.0.1:37777/Groups/Abstract/56.3
  http://beta.lmfdb.org/Groups/Abstract/56.3

and/or the corresponding page where just the diagram is shown

  http://127.0.0.1:37777/Groups/Abstract/diagram/56.3
  http://beta.lmfdb.org/Groups/Abstract/diagram/56.3

If reading the code changes, there are some extra changes.  This is the start of implementing an added feature which turned out to be harder than it looked.  It has been commented out, so is only visible if looking at the code.