### PR TITLE
Taming the A_17 field

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -219,7 +219,7 @@ def group_pretty_and_nTj(n, t, useknowls=False, skip_nTj=False, cache={}):
     pretty = group_obj.display_short(True) if group else ''
     if pretty != '':
         # modify if we use knowls and have the gap id
-        if useknowls:
+        if useknowls and group['gapid']:
             gp_label = f"{group['order']}.{group['gapid']}"
             pretty = abstract_group_display_knowl(gp_label, cache=cache)
         if skip_nTj:

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -504,7 +504,6 @@ def render_field_webpage(args):
         ram_primes = r'\textrm{None}'
     data['phrase'] = group_phrase(n, t)
     zkraw = nf.zk()
-    Ra = PolynomialRing(QQ, 'a')
     zk = [compress_poly_Q(x, 'a') for x in zkraw]
     zk = ['$%s$' % x for x in zk]
     zk = ', '.join(zk)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -523,14 +523,16 @@ def render_field_webpage(args):
     rootofunity = raw_typeset(rootof1raw, nf.root_of_1_gen(),
         extra='&nbsp;(order ${}$)'.format(nf.root_of_1_order()))
 
-    myunits = [unlatex(z) for z in nf.units()]
-    Ra = PolynomialRing(QQ,'a')
-    myunits = [Ra(z) for z in myunits]
-    unit_compress = [compress_poly_Q(x, 'a') for x in myunits]
-    unit_compress = ['$%s$' % x for x in unit_compress]
-    unit_compress = ', '.join(unit_compress)
-    myunits = str(myunits)[1:-1] # remove brackets
-    myunits = raw_typeset(myunits, unit_compress)
+    myunits = nf.units()
+    if 'not' not in myunits: 
+        myunits = [unlatex(z) for z in myunits]
+        Ra = PolynomialRing(QQ,'a')
+        myunits = [Ra(z) for z in myunits]
+        unit_compress = [compress_poly_Q(x, 'a') for x in myunits]
+        unit_compress = ['$%s$' % x for x in unit_compress]
+        unit_compress = ', '.join(unit_compress)
+        myunits = str(myunits)[1:-1] # remove brackets
+        myunits = raw_typeset(myunits, unit_compress)
 
     if ram_primes != 'None':
         ram_primes = raw_typeset(ram_primes_raw, ram_primes)

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -18,7 +18,7 @@ from lmfdb.utils import (
     SearchArray, TextBox, YesNoBox, SubsetNoExcludeBox, TextBoxWithSelect,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
-    parse_floats, parse_subfield, search_wrap, parse_padicfields, bigint_knowl,
+    parse_floats, parse_subfield, search_wrap, parse_padicfields,
     raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, CheckCol, MathCol, ProcessedCol, MultiProcessedCol
@@ -79,11 +79,13 @@ def nf_label_pretty(label):
 
 # fixed precision display of float, rounding off
 def fixed_prec(r, digs=3):
+    if r>10**10:
+        return prop_int_pretty(r)
     n = RealField(200)(r)*(10**digs)
     n = str(n.round())
     head = int(n[:-digs])
     if head >= 10**4:
-        head = comma(head)
+        head = comma(head, r'\\,')
     return str(head) + '.' + n[-digs:]
 
 
@@ -437,9 +439,9 @@ def render_field_webpage(args):
     D = nf.disc()
     data['disc_factor'] = nf.disc_factored_latex()
     if D.abs().is_prime() or D == 1:
-        data['discriminant'] = bigint_knowl(D,cutoff=60,sides=3)
+        data['discriminant'] = raw_typeset_poly(D, compress_threshold=150)
     else:
-        data['discriminant'] = bigint_knowl(D,cutoff=60,sides=3) + r"\(\medspace = %s\)" % data['disc_factor']
+        data['discriminant'] = raw_typeset_poly(D, compress_threshold=150)
     if nf.frobs():
         data['frob_data'], data['seeram'] = see_frobs(nf.frobs())
     else:  # fallback in case we haven't computed them in a case
@@ -616,7 +618,7 @@ def render_field_webpage(args):
                   ('Degree', prop_int_pretty(data['degree'])),
                   ('Signature', '$%s$' % data['signature']),
                   ('Discriminant', prop_int_pretty(D)),
-                  ('Root discriminant', '%s' % data['rd']),
+                  ('Root discriminant', data['rd']),
                   ('Ramified ' + primes + '', ram_primes),
                   ('Class number', '%s %s' % (data['class_number'], grh_lab)),
                   ('Class group', '%s %s' % (data['class_group_invs'], grh_lab)),

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -8,7 +8,7 @@ from io import BytesIO
 import time
 
 from flask import render_template, request, url_for, redirect, send_file, make_response, Markup
-from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, prime_range, RealField
+from sage.all import ZZ, QQ, PolynomialRing, NumberField, latex, prime_range, RealField, log
 
 from lmfdb import db
 from lmfdb.app import app
@@ -81,13 +81,15 @@ def nf_label_pretty(label):
 
 # fixed precision display of float, rounding off
 def fixed_prec(r, digs=3):
-    if r>10**10:
-        return prop_int_pretty(r)
+    if r>10**7:
+        e = int(log(abs(r),10))
+        return r'%.3f\times 10^{%d}' % (r/10**e, e)
     n = RealField(200)(r)*(10**digs)
     n = str(n.round())
     head = int(n[:-digs])
     if head >= 10**4:
-        head = comma(head, r'\\,')
+        head = comma(head, r'\,')
+    print(head)
     return str(head) + '.' + n[-digs:]
 
 
@@ -449,7 +451,7 @@ def render_field_webpage(args):
     else:  # fallback in case we haven't computed them in a case
         data['frob_data'], data['seeram'] = frobs(nf)
     # This could put commas in the rd, we don't want to trigger spaces
-    data['rd'] = ('%s' % fixed_prec(nf.rd(),2)).replace(',','{,}')
+    data['rd'] = '\(%s\)' % fixed_prec(nf.rd(),2)
     # Bad prime information
     npr = len(ram_primes)
     ramified_algebras_data = nf.ramified_algebras_data()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -522,11 +522,15 @@ def render_field_webpage(args):
     rootof1raw = unlatex(nf.root_of_1_gen())
     rootofunity = raw_typeset(rootof1raw, nf.root_of_1_gen(),
         extra='&nbsp;(order ${}$)'.format(nf.root_of_1_order()))
-    safe_units = nf.units_safe()
-    if 'too long' in safe_units:
-        myunits = safe_units
-    else:
-        myunits = raw_typeset(unlatex(safe_units), safe_units)
+
+    myunits = [unlatex(z) for z in nf.units()]
+    Ra = PolynomialRing(QQ,'a')
+    myunits = [Ra(z) for z in myunits]
+    unit_compress = [compress_poly_Q(x, 'a') for x in myunits]
+    unit_compress = ['$%s$' % x for x in unit_compress]
+    unit_compress = ', '.join(unit_compress)
+    myunits = str(myunits)[1:-1] # remove brackets
+    myunits = raw_typeset(myunits, unit_compress)
 
     if ram_primes != 'None':
         ram_primes = raw_typeset(ram_primes_raw, ram_primes)
@@ -960,7 +964,7 @@ def unlatex(s):
     s = re.sub(r'\\frac{(.+?)}{(.+?)}', r'(\1)/(\2)', s)
     s = s.replace(r'{',r'(')
     s = s.replace(r'}',r')')
-    s = re.sub(r'([^\s+-,])\s*a', r'\1*a',s)
+    s = re.sub(r'([^\s+,-])\s*a', r'\1*a',s)
     return s
 
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -20,7 +20,7 @@ from lmfdb.utils import (
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, parse_padicfields,
     raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly, 
-    raw_typeset_int)
+    raw_typeset_int, compress_poly_Q)
 from lmfdb.utils.web_display import compress_int
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, CheckCol, MathCol, ProcessedCol, MultiProcessedCol
@@ -505,7 +505,7 @@ def render_field_webpage(args):
     data['phrase'] = group_phrase(n, t)
     zkraw = nf.zk()
     Ra = PolynomialRing(QQ, 'a')
-    zk = [latex(Ra(x)) for x in zkraw]
+    zk = [compress_poly_Q(x, 'a') for x in zkraw]
     zk = ['$%s$' % x for x in zk]
     zk = ', '.join(zk)
     zkraw = ', '.join(zkraw)

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -28,7 +28,7 @@ table.ntdata a {
       <tr><td>{{ KNOWL('nf.signature', title="Signature") }}:<td>&nbsp;&nbsp;<td>${{info.signature}}$<td>{{ place_code('signature') }}
        <tr><td>{{ KNOWL('nf.discriminant', title="Discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.discriminant|safe}}<td>{{ place_code('discriminant') }}
        <tr><td>{{ KNOWL('nf.root_discriminant', title="Root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.rd}}<td>{{ place_code('rd') }}
-      <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>${{info.ram_primes}}$<td>{{ place_code('ramified_primes') }}
+      <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>{{info.ram_primes|safe}}<td>{{ place_code('ramified_primes') }}
       <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q) }$:<td>&nbsp;&nbsp;<td>${{info.auts}}$</td></tr>
 {% if info.is_abelian %}
     <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -692,23 +692,19 @@ class WebNumberField:
             return 1
         return na_text()
 
-    def units_safe(self):  # fundamental units, if they are not too long
+    def units_raw(self):  # fundamental units, if they are not too long
         units = self.units()
-        if len(units) > 500:
-            return "Units are too long to display, but can be downloaded with other data for this field from 'Stored data to gp' link to the right"
         return units
 
     def units(self):  # fundamental units
         res = None
         if self.haskey('units'):
-            res = ',&nbsp; '.join(self._data['units'])
+            return self._data['units']
         elif self.unit_rank() == 0:
-            res = ''
+            res = []
         elif self.haskey('class_number'):
             K = self.K()
-            units = [web_latex(u) for u in K.unit_group().fundamental_units()]
-            units = ',&nbsp; '.join(units)
-            res = units
+            res = K.unit_group().fundamental_units()
         if res:
             res = res.replace('\\\\', '\\')
             return res

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -10,7 +10,8 @@ from sage.all import (
 
 from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html, 
-        raw_typeset_poly, display_multiset, factor_base_factor, integer_squarefree_part, integer_is_squarefree,
+        raw_typeset_poly, display_multiset, factor_base_factor, 
+        integer_squarefree_part, integer_is_squarefree,
         factor_base_factorization_latex)
 from lmfdb.logger import make_logger
 from lmfdb.galois_groups.transitive_group import WebGaloisGroup, transitive_group_display_knowl, galois_module_knowl, group_pretty_and_nTj
@@ -739,7 +740,7 @@ class WebNumberField:
         s = ''
         if D < 0:
             s = r'-\,'
-        return s + factor_base_factorization_latex(factor_base_factor(D,self.ramified_primes()))
+        return s + factor_base_factorization_latex(factor_base_factor(D,self.ramified_primes()), cutoff=30)
 
     def web_poly(self):
         return pol_to_html(str(coeff_to_poly(self.coeffs())))

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -692,10 +692,6 @@ class WebNumberField:
             return 1
         return na_text()
 
-    def units_raw(self):  # fundamental units, if they are not too long
-        units = self.units()
-        return units
-
     def units(self):  # fundamental units
         res = None
         if self.haskey('units'):

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -47,7 +47,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'TraceHash', 'TraceHashClass',
            'redirect_no_cache', 'letters2num', 'num2letters',
            'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor', 
-           'raw_typeset_qexp', 'raw_typeset_int',
+           'raw_typeset_qexp', 'raw_typeset_int', 'compress_poly_Q',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat']
 
 from flask import (request, make_response, flash, url_for,
@@ -108,6 +108,7 @@ from .web_display import (
     polyquo_knowl,
     raw_typeset,
     raw_typeset_poly,
+    compress_poly_Q,
     raw_typeset_poly_factor,
     raw_typeset_qexp,
     raw_typeset_int,

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -46,7 +46,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'datetime_to_timestamp_in_ms', 'timestamp_in_ms_to_datetime',
            'TraceHash', 'TraceHashClass',
            'redirect_no_cache', 'letters2num', 'num2letters',
-           'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor', 'raw_typeset_qexp',
+           'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor', 
+           'raw_typeset_qexp', 'raw_typeset_int',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat']
 
 from flask import (request, make_response, flash, url_for,
@@ -109,6 +110,7 @@ from .web_display import (
     raw_typeset_poly,
     raw_typeset_poly_factor,
     raw_typeset_qexp,
+    raw_typeset_int,
     sparse_cyclotomic_to_latex,
     teXify_pol,
     to_ordinal,

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -553,16 +553,18 @@ def splitcoeff(coeff):
 #  display and formatting utilities
 ################################################################################
 
-def comma(x):
+def comma(x, sep=","):
     """
     Input is an integer. Output is a string of that integer with commas.
     CAUTION: this misbehaves if the input is not an integer.
+
+    sep is an optional separator other than a comma
 
     Example:
     >>> comma("12345")
     '12,345'
     """
-    return x < 1000 and str(x) or ('%s,%03d' % (comma(x // 1000), (x % 1000)))
+    return x < 1000 and str(x) or ('%s%s%03d' % (comma(x // 1000), sep, (x % 1000)))
 
 def latex_comma(x):
     """

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -564,7 +564,7 @@ def comma(x, sep=","):
     >>> comma("12345")
     '12,345'
     """
-    return x < 1000 and str(x) or ('%s%s%03d' % (comma(x // 1000), sep, (x % 1000)))
+    return x < 1000 and str(x) or ('%s%s%03d' % (comma(x // 1000, sep), sep, (x % 1000)))
 
 def latex_comma(x):
     """

--- a/lmfdb/utils/web_display.py
+++ b/lmfdb/utils/web_display.py
@@ -177,19 +177,26 @@ def bigpoly_knowl(f, nterms_cutoff=8, bigint_cutoff=12, var='x'):
     else:
         return lng
 
-def factor_base_factorization_latex(fbf):
+def factor_base_factorization_latex(fbf, cutoff=0):
+    """
+    cutoff is the threshold for compressing large integers
+    cutoff = 0 means we do not compress them
+    """
     if len(fbf) == 0:
         return '1'
     ans = ''
     sign = 1
     for p, e in fbf:
+        pdisp = str(p)
+        if cutoff:
+            pdisp = compress_int(p, cutoff)[0]
         if p == -1:
             if (e % 2) == 1:
                 sign *= -1
         elif e == 1:
-            ans += r'\cdot %d' % p
+            ans += r'\cdot %s' % pdisp
         elif e != 0:
-            ans += r'\cdot %d^{%d}' % (p, e)
+            ans += r'\cdot %s^{%d}' % (pdisp, e)
     # get rid of the initial '\cdot '
     ans = ans[6:]
     return '- ' + ans if sign == -1 else ans
@@ -418,6 +425,12 @@ def compress_polynomial(poly, threshold, decreasing=True):
         tset = tset[len(plus):]
     return tset
 
+def raw_typeset_int(n, cutoff=80, sides=3, extra=''):
+    """
+    Raw/typeset for integers with configurable parameters
+    """
+    compv, compb = compress_int(n, cutoff=cutoff, sides=sides)
+    return raw_typeset(n, rf'\({compv}\)', extra=extra, compressed=compb)
 
 
 def raw_typeset_poly(coeffs,

--- a/lmfdb/utils/web_display.py
+++ b/lmfdb/utils/web_display.py
@@ -5,6 +5,7 @@ from sage.all import (
     Factorization,
     latex,
     ZZ,
+    QQ,
     factor,
     PolynomialRing,
     TermOrder,
@@ -621,6 +622,41 @@ def raw_typeset_qexp(coeffs_list,
     raw = raw.replace(rawvar, final_rawvar)
 
     return raw_typeset(raw, rf'\( {tset} \)', compressed=r'\cdots' in tset, **kwargs)
+
+def compress_poly_Q(rawpoly,
+                     var='x',
+                     compress_threshold=100):
+    """
+    Generate a raw_typeset string a polynomial over Q
+    The typeset compresses each numerator and denominator
+    """
+    R = PolynomialRing(QQ, var)
+    sagepol = R(rawpoly)
+    coefflist = sagepol.coefficients(sparse=False)
+    d = len(coefflist)
+
+    def frac_string(frac):
+        if frac.denominator()==1:
+            return compress_int(frac.numerator())[0]
+        return r'\frac{%s}{%s}'%(compress_int(frac.numerator())[0], compress_int(frac.denominator())[0])
+
+    tset = ''
+    for j in range(1,d+1):
+        csign = coefflist[d-j].sign()
+        if csign:
+            cabs = coefflist[d-j].abs()
+            if csign>0:
+                tset += '+'
+            else:
+                tset += '-'
+            if cabs != 1 or d-j==0:
+                tset += frac_string(cabs)
+            if d-j>0:
+                if d-j == 1:
+                    tset += var
+                else:
+                    tset += r'%s^{%s}'%(var,d-j)
+    return tset[1:]
 
 
 


### PR DESCRIPTION
This addresses issue #5034 

The page which reflects many of the changes is

http://127.0.0.1:37777/NumberField/17.17.13202363705223218603863184487755024630582383374680032800435939704158233027841788543229812635151072074455438626669432759450899735549243294921243306854586939663055181335880903211540683502950935087551803286773305471032026037990460071805978402769130092019752634101527352693814943791414905342572852579428180829030727661698750961477408713596845181881409326113271279701186934711912924535979375368089471422837282452421683506180048924876364820225210846226099372878635447796099920054239935070472348193791925328690838569369798938742618818040823435236370214291386195573062935332270993039421387687573397220106241394348907347636983408333263308765625.1

The small group knowl is now just a typeset name of the Galois group if we do not have a gap ID for the Galois group.  If we do have the gap ID, then it is still a small group knowl, as in

  http://127.0.0.1:37777/NumberField/4.0.125.1

 - The discriminant is abbreviated if it is too long
 - Ramified primes are abbreviated if they are too long, both in the list of ramified primes and in the factored form of the discriminant.
 - Note, in this case the factored form of the discriminant has a shortened prime.  When you go to raw mode, only the discriminant is put in a textarea.  The prime is available in raw mode in the list of ramifying primes (but not in the factorization).
 - In the local algebras (bottom of page), the giant prime is abbreviated both in the left column of the table and where it appears in a Q_p (one of the factors for that prime)
 - The integral basis is sort of shown in full, but every numerator or denominator deemed to be too big gets the ... treatment.

The page above does not have fund. units.  If we like the treatment of the basis, we can do the analogous thing with the units for pages which have them.
