### PR TITLE
Monogenic fields etc.

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -452,7 +452,7 @@ def render_field_webpage(args):
     else:  # fallback in case we haven't computed them in a case
         data['frob_data'], data['seeram'] = frobs(nf)
     # This could put commas in the rd, we don't want to trigger spaces
-    data['rd'] = '\(%s\)' % fixed_prec(nf.rd(),2)
+    data['rd'] = r'\(%s\)' % fixed_prec(nf.rd(),2)
     # Bad prime information
     npr = len(ram_primes)
     ramified_algebras_data = nf.ramified_algebras_data()
@@ -551,7 +551,10 @@ def render_field_webpage(args):
         'fund_units': myunits,
         'cnf': nf.cnf(),
         'grh_label': grh_label,
-        'loc_alg': loc_alg
+        'loc_alg': loc_alg,
+        'monogenic': nf.monogenic(),
+        'index': nf.index(),
+        'inessential': nf.inessentialp()
     })
 
     bread.append(('%s' % nf_label_pretty(info['label_raw']), ' '))
@@ -826,6 +829,7 @@ nf_columns = SearchColumns([
     MathCol("rd", "nf.root_discriminant", "Root discriminant"),
     CheckCol("cm", "nf.cm_field", "Is CM field?"),
     CheckCol("is_galois", "nf.galois_group", "Is Galois?"),
+    CheckCol("monogenic", "nf.monogenic", "Is monogenic?"),
     SearchCol("galois", "nf.galois_group", "Galois group", default=True),
     SearchCol("class_group_desc", "nf.ideal_class_group", "Class group", default=True),
     MathCol("torsion_order", "nf.unit_group", "Unit group torsion", align="center"),
@@ -875,6 +879,10 @@ def number_field_search(info, query):
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad',cardinality='num_ram')
     parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
     parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions')
+    parse_bool(info,query,'monogenic')
+    parse_ints(info,query,'index')
+    parse_primes(info,query,'inessentialp',name='Inessential primes',
+                 qfield='inessentialp')
     info['wnf'] = WebNumberField.from_data
     info['gg_display'] = group_pretty_and_nTj
 
@@ -1164,6 +1172,20 @@ class NFSearchArray(SearchArray):
             knowl="nf.padic_completion.search",
             example_span="2.4.10.7 or 2.4.10.7,3.2.1.2",
             example="2.4.10.7")
+        monogenic = YesNoBox(
+            name="monogenic",
+            label="Monogenic",
+            knowl="nf.monogenic")
+        index = TextBox(
+            name="index",
+            label="Index",
+            knowl="nf.zk_index",
+            example='2')
+        inessentialprimes = TextBox(
+            name="inessentialp",
+            label="Inessential primes",
+            knowl="nf.inessential_prime",
+            example="2,3")
         count = CountBox()
 
         self.browse_array = [
@@ -1174,9 +1196,12 @@ class NFSearchArray(SearchArray):
             [num_ram, cm_field],
             [ram_primes, ur_primes],
             [regulator, subfield],
-            [count, completion]]
+            [completion, monogenic],
+            [index, inessentialprimes],
+            [count]]
 
         self.refine_array = [
             [degree, signature, class_number, class_group, cm_field],
             [num_ram, ram_primes, ur_primes, gal, is_galois],
-            [discriminant, rd, regulator, subfield, completion]]
+            [discriminant, rd, regulator, subfield, completion],
+            [monogenic, index, inessentialprimes]]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -18,7 +18,6 @@ from lmfdb.utils import (
     SearchArray, TextBox, YesNoBox, YesNoMaybeBox, SubsetNoExcludeBox, 
     TextBoxWithSelect, parse_bool_unknown, parse_posints,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
-    parse_posints,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, parse_padicfields,
     raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly, 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -16,7 +16,7 @@ from lmfdb.utils import (
     web_latex, to_dict, coeff_to_poly, pol_to_html, comma, format_percentage,
     flash_error, display_knowl, CountBox, prop_int_pretty,
     SearchArray, TextBox, YesNoBox, YesNoMaybeBox, SubsetNoExcludeBox, 
-    TextBoxWithSelect, parse_bool_unknown,
+    TextBoxWithSelect, parse_bool_unknown, parse_posints,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_posints,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
@@ -881,7 +881,7 @@ def number_field_search(info, query):
     parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
     parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions')
     parse_bool_unknown(info,query,'monogenic')
-    parse_ints(info,query,'index')
+    parse_posints(info,query,'index')
     parse_primes(info,query,'inessentialp',name='Inessential primes',
                  qfield='inessentialp')
     info['wnf'] = WebNumberField.from_data

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -15,7 +15,8 @@ from lmfdb.app import app
 from lmfdb.utils import (
     web_latex, to_dict, coeff_to_poly, pol_to_html, comma, format_percentage,
     flash_error, display_knowl, CountBox, prop_int_pretty,
-    SearchArray, TextBox, YesNoBox, SubsetNoExcludeBox, TextBoxWithSelect,
+    SearchArray, TextBox, YesNoBox, YesNoMaybeBox, SubsetNoExcludeBox, 
+    TextBoxWithSelect, parse_bool_unknown,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_posints,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
@@ -879,7 +880,7 @@ def number_field_search(info, query):
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad',cardinality='num_ram')
     parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
     parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions')
-    parse_bool(info,query,'monogenic')
+    parse_bool_unknown(info,query,'monogenic')
     parse_ints(info,query,'index')
     parse_primes(info,query,'inessentialp',name='Inessential primes',
                  qfield='inessentialp')
@@ -1172,7 +1173,7 @@ class NFSearchArray(SearchArray):
             knowl="nf.padic_completion.search",
             example_span="2.4.10.7 or 2.4.10.7,3.2.1.2",
             example="2.4.10.7")
-        monogenic = YesNoBox(
+        monogenic = YesNoMaybeBox(
             name="monogenic",
             label="Monogenic",
             knowl="nf.monogenic")

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -65,6 +65,13 @@ table.ntdata a {
             {{ info.integral_basis | safe }}
             {{ place_code('integral_basis') }}
         </p>
+        <p>
+          <table>
+            <tr><td>{{ KNOWL('nf.monogenic', title='Monogenic')}}:<td>&nbsp;&nbsp;<td>{{info.monogenic}}
+            <tr><td>{{ KNOWL('nf.zk_index', title='Index')}}:<td>&nbsp;&nbsp;<td>{{info.index}}
+            <tr><td>{{ KNOWL('nf.inessential_prime', title='Inessential primes')}}:<td>&nbsp;&nbsp;<td>{{info.inessential}}
+           </table>
+           </p>
 
         <h2> {{ KNOWL('nf.ideal_class_group', title='Class group') }} and  {{ KNOWL('nf.class_number', title='class number') }}</h2>
         <p>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -503,6 +503,26 @@ class WebNumberField:
             return [str(u) for u in zkstrings]
         return list(pari(self.poly()).nfbasis())
 
+    def monogenic(self):
+        if self.haskey('monogenic'):
+            return 'Yes' if self._data['monogenic'] else 'No'
+        return 'Not computed'
+
+    def index(self):
+        if self.haskey('index'):
+            return r'$%d$'%self._data['index']
+        return 'Not computed'
+
+    def inessentialp(self):
+        if self.haskey('inessentialp'):
+            inep = self._data['inessentialp']
+            if inep:
+                return(', '.join([r'$%s$' % z for z in inep]))
+            else:
+                return('None')
+        return 'Not computed'
+
+
     # 2018-4-1: is this actually used?  grep -r doesn't find anywhere it's called....
     # Used by subfields and resolvent functions to
     # take coefficients for fields and either return

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -505,7 +505,12 @@ class WebNumberField:
 
     def monogenic(self):
         if self.haskey('monogenic'):
-            return 'Yes' if self._data['monogenic'] else 'No'
+            if self._data['monogenic']==1:
+                return 'Yes' 
+            if self._data['monogenic']==0:
+                return 'Not computed'
+            if self._data['monogenic']==-1:
+                return 'No' 
         return 'Not computed'
 
     def index(self):

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -125,8 +125,8 @@ from .web_display import (
 )
 
 from .search_parsing import (
-    parse_ints, parse_signed_ints, parse_posints, parse_floats, parse_mod1, 
-    parse_rational,
+    parse_ints, parse_signed_ints, parse_posints,
+    parse_floats, parse_mod1, parse_rational,
     parse_rational_to_list, parse_padicfields, parse_rats, parse_inertia,
     parse_bracketed_posints, parse_bracketed_rats, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_not_element_of, parse_subset, parse_submultiset, parse_list,


### PR DESCRIPTION
Addressing issue #5044, this adds the display and search for number fields for whether or not a field is monogenic, its index, and the list of inessential primes.

Searching is visible on the main number field page

http://127.0.0.1:37777/NumberField/

and the display can be seen on any particular field page, e.g., 

where we have data
http://127.0.0.1:37777/NumberField/2.0.567764.1

and where we (currently) do not have data

http://127.0.0.1:37777/NumberField/3.1.244.1
