### PR TITLE
Fix parsing of positive integers

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -17,6 +17,7 @@ from lmfdb.utils import (
     flash_error, display_knowl, CountBox, prop_int_pretty,
     SearchArray, TextBox, YesNoBox, SubsetNoExcludeBox, TextBoxWithSelect,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
+    parse_posints,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, parse_padicfields,
     raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly, 
@@ -857,13 +858,13 @@ def nf_postprocess(res, info, query):
                            ('Search results', '.')],
              learnmore=learnmore_list)
 def number_field_search(info, query):
-    parse_ints(info,query,'degree')
+    parse_posints(info,query,'degree')
     parse_galgrp(info,query, qfield=('galois_label', 'degree'))
     parse_bracketed_posints(info,query,'signature',qfield=('degree','r2'),exactlength=2, allow0=True, extractor=lambda L: (L[0]+2*L[1],L[1]))
     parse_signed_ints(info,query,'discriminant',qfield=('disc_sign','disc_abs'))
     parse_floats(info, query, 'rd')
     parse_floats(info, query, 'regulator')
-    parse_ints(info,query,'class_number')
+    parse_posints(info,query,'class_number')
     parse_ints(info,query,'num_ram')
     parse_bool(info,query,'cm_field',qfield='cm')
     parse_bool(info,query,'is_galois')

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -20,8 +20,8 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'Pagination', 'to_ordinal',
            'debug', 'flash_error', 'flash_warning', 'flash_info',
            'image_callback', 'encode_plot',
-           'parse_ints', 'parse_signed_ints', 'parse_floats', 'parse_mod1',
-           'parse_rational', 'parse_padicfields',
+           'parse_ints', 'parse_posints', 'parse_signed_ints', 'parse_floats',
+           'parse_mod1', 'parse_rational', 'parse_padicfields',
            'parse_rational_to_list', 'parse_inertia',
            'parse_rats', 'parse_bracketed_posints', 'parse_bracketed_rats', 'parse_bool',
            'parse_bool_unknown', 'parse_primes', 'parse_element_of', 'parse_not_element_of',
@@ -125,7 +125,8 @@ from .web_display import (
 )
 
 from .search_parsing import (
-    parse_ints, parse_signed_ints, parse_floats, parse_mod1, parse_rational,
+    parse_ints, parse_signed_ints, parse_posints, parse_floats, parse_mod1, 
+    parse_rational,
     parse_rational_to_list, parse_padicfields, parse_rats, parse_inertia,
     parse_bracketed_posints, parse_bracketed_rats, parse_bool, parse_bool_unknown, parse_primes,
     parse_element_of, parse_not_element_of, parse_subset, parse_submultiset, parse_list,

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -26,7 +26,7 @@ QQ_RE = re.compile(r"^-?\d+(/\d+)?$")
 QQ_LIST_RE = re.compile(r"^-?\d+(/\d+)?(,-?\d+(/\d+)?)*$")
 # Single non-negative rational, allowing decimals, used in parse_range2rat
 QQ_DEC_RE = re.compile(r"^\d+((\.\d+)|(/\d+))?$")
-LIST_POSINT_RE = re.compile(r"^(0*[1-9]\d*)(,0*[1-9]\d*)*$")
+LIST_POSINT_RE = re.compile(r"^(0*[1-9]\d*|(\d*-(0*[1-9]\d*)?))(,(0*[1-9]\d*|(\d*-(0*[1-9]\d*)?)))*$")
 LIST_RAT_RE = re.compile(r"^((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-((\d+((\.\d+)|(/\d+))?))?))(,((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-(\d+((\.\d+)|(/\d+))?)?)))*$")
 # to check if a string is comprised of just multiplication and exponentiation symbols
 MULT_PARSE = re.compile(r"^[0-9()*^]*$")

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -19,14 +19,14 @@ SPACES_RE = re.compile(r"\d\s+\d")
 LIST_RE = re.compile(r"^(\d+|(\d*-(\d+)?))(,(\d+|(\d*-(\d+)?)))*$")
 FLOAT_STR = r"(-?(((\d+([.]\d*)?)|([.]\d+))(e[-+]?\d+)?)|(-?\d+/\d+))"
 LIST_FLOAT_RE = re.compile(r"^({0}|{0}-|{0}-{0})(,({0}|{0}-|{0}-{0}))*$".format(FLOAT_STR))
-BRACKETED_POSINT_RE = re.compile(r"^\[\]|\[[1-9]\d*(,[1-9]\d*)*\]$")
+BRACKETED_POSINT_RE = re.compile(r"^\[\]|\[0*[1-9]\d*(,0*[1-9]\d*)*\]$")
 BRACKETED_NN_RE = re.compile(r"^\[\]|\[\d+(,\d+)*\]$")
 BRACKETED_RAT_RE = re.compile(r"^\[\]|\[-?(\d+|\d+/\d+)(,-?(\d+|\d+/\d+))*\]$")
 QQ_RE = re.compile(r"^-?\d+(/\d+)?$")
 QQ_LIST_RE = re.compile(r"^-?\d+(/\d+)?(,-?\d+(/\d+)?)*$")
 # Single non-negative rational, allowing decimals, used in parse_range2rat
 QQ_DEC_RE = re.compile(r"^\d+((\.\d+)|(/\d+))?$")
-LIST_POSINT_RE = re.compile(r"^(\d+)(,\d+)*$")
+LIST_POSINT_RE = re.compile(r"^(0*[1-9]\d*)(,0*[1-9]\d*)*$")
 LIST_RAT_RE = re.compile(r"^((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-((\d+((\.\d+)|(/\d+))?))?))(,((\d+((\.\d+)|(/\d+))?)|((\d+((\.\d+)|(/\d+))?)-(\d+((\.\d+)|(/\d+))?)?)))*$")
 # to check if a string is comprised of just multiplication and exponentiation symbols
 MULT_PARSE = re.compile(r"^[0-9()*^]*$")


### PR DESCRIPTION
The regex for parsing positive integers was changed to not allow 0.  It then uses this function for searching the degree and class number of a number field.

This also changes the regex for bracketed lists of positive integers (e.g., for entering a class group structure).  Before, [02] would be rejected, but now it is accepted as equivalent to [2], but [00] or [0,2] are rejected.