### PR TITLE
Very minor UI tweak to raw/typeset textarea

### DIFF
--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2494,7 +2494,7 @@ span.raw-tset-copy-btn:active, span.raw-tset-toggle:active {
 span.raw-tset-container > .raw-container {
     font-size: 95%;
     line-height: 1.25;
-    padding: 2px 3px 2px 1px;
+    padding: 1.5px 3px 1.5px 2px;
     border: 1px solid {{color.input_border}};
     vertical-align: middle;
     margin: 0px;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2494,7 +2494,7 @@ span.raw-tset-copy-btn:active, span.raw-tset-toggle:active {
 span.raw-tset-container > .raw-container {
     font-size: 95%;
     line-height: 1.25;
-    padding: 1.5px 3px 1.5px 2px;
+    padding: 1px 3px 1.5px 2px;
     border: 1px solid {{color.input_border}};
     vertical-align: middle;
     margin: 0px;

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2468,7 +2468,7 @@ span.raw-tset-copy-btn > img {
     content: url({{url_for('static', filename='images/copy.svg')}});
 }
 span.raw-tset-copy-btn > img, span.raw-tset-toggle > img {
-    vertical-align: middle;
+    vertical-align: top;
     height: 11px;
 }
 span.raw-tset-copy-btn, span.raw-tset-toggle {
@@ -2493,9 +2493,10 @@ span.raw-tset-copy-btn:active, span.raw-tset-toggle:active {
 /* textarea/pre */
 span.raw-tset-container > .raw-container {
     font-size: 95%;
-    line-height: 1;
-    padding: 1.5px;
+    line-height: 1.25;
+    padding: 2px 3px 2px 1px;
     border: 1px solid {{color.input_border}};
+    vertical-align: middle;
     margin: 0px;
     font-family: monospace;
 }


### PR DESCRIPTION
With this change you should not see vertical changes on chrome/firefox/opera/brave/safari when switching between raw/typeset if all the text areas are one line (the most common case), and you should not see partial lines.  Some pages where you can try this

https://blue.lmfdb.xyz/ModularForm/GL2/Q/holomorphic/1/118/a/a/
https://blue.lmfdb.xyz/NumberField/3.1.2688652.1