### PR TITLE
Fix search on residue field degree

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -243,6 +243,7 @@ def local_field_search(info,query):
     parse_galgrp(info,query,'gal',qfield=('galois_label','n'))
     parse_ints(info,query,'c',name='Discriminant exponent c')
     parse_ints(info,query,'e',name='Ramification index e')
+    parse_ints(info,query,'f',name='Residue field degree f')
     parse_rats(info,query,'topslope',qfield='top_slope',name='Top slope', process=ratproc)
     parse_inertia(info,query,qfield=('inertia_gap','inertia'))
     parse_inertia(info,query,qfield=('wild_gap','wild_gap'), field='wild_gap')


### PR DESCRIPTION
This fixes a bug reported in the feedback.  When setting "f" in a search of p-adic fields, before it was ignored:

https://beta.lmfdb.org/padicField/?f=3&search_type=List
http://127.0.0.1:37777/padicField/?f=3&search_type=List