### PR TITLE
Fix gp download

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1003,8 +1003,6 @@ def nf_data(**args):
     Ra = PolynomialRing(QQ, 'a')
     zk = [str(Ra(x)) for x in zk]
     zk = ', '.join(zk)
-    units = str(unlatex(nf.units()))
-    units = units.replace('&nbsp;', ' ')
     subs = nf.subfields()
     subs = [[coeff_to_poly(string2list(z[0])),z[1]] for z in subs]
 
@@ -1018,6 +1016,7 @@ def nf_data(**args):
     data += '[%s], '%zk
     data += '%s, '%str(1 if nf.is_cm_field() else 0)
     if nf.can_class_number():
+        units = ','.join(unlatex(z) for z in nf.units())
         data += '%s, '%nf.class_number()
         data += '%s, '%nf.class_group_invariants_raw()
         data += '%s, '%(1 if nf.used_grh() else 0)

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -723,9 +723,6 @@ class WebNumberField:
             return self._data['units']
         elif self.unit_rank() == 0:
             res = []
-        elif self.haskey('class_number'):
-            K = self.K()
-            res = K.unit_group().fundamental_units()
         if res:
             res = res.replace('\\\\', '\\')
             return res


### PR DESCRIPTION
Fixes issue #5070.

Can try the link there, or go to any number field page and pick "Stored data to gp" from the right panel.

This also removes a bit of code which would try to compute fundamental units if they were not in the database (but the class number was).  There are no examples currently where this code would be triggered, but we would not want to try to compute fundamental units on the fly in any case.
