### PR TITLE
all trailing whitespaces removed

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -108,7 +108,7 @@ def stats():
             else:
                 link = '<a href = "' + url_for(".api_query", table=tablename) + '">' + tablename + '</a>'
             if not sizes['toast_bytes']:
-                sizes['toast_bytes'] = 0 
+                sizes['toast_bytes'] = 0
             if sizes['nrows']:
                 avg_size = int(round(float(sizes['table_bytes'] + sizes['toast_bytes'] + sizes['extra_bytes']) / sizes['nrows']))
             else:
@@ -152,7 +152,7 @@ def api_query_id(table, id):
         </tr>
         """
         for c in sorted(col_type.keys()):
-            out += "<tr><td>%s</td><td> %s </td>\n" % (c, col_type[c]) 
+            out += "<tr><td>%s</td><td> %s </td>\n" % (c, col_type[c])
         return out
     else:
         return api_query(table, id=id)

--- a/lmfdb/api2/utils.py
+++ b/lmfdb/api2/utils.py
@@ -40,7 +40,7 @@ def create_search_dict(table='', query=None, view_start=0, request = None):
     else:
         query_alpha = query
 
-    search = {'table':table, 'query':query_alpha, 'view_start':view_start, 
+    search = {'table':table, 'query':query_alpha, 'view_start':view_start,
         'max_count':100, 'correct_count':False, 'count_only':False}
 
     if request:
@@ -61,7 +61,7 @@ def build_api_wrapper(api_key, api_type, data, request = None):
     request -- Flask request object to query for needed data
     """
 
-    return json.dumps({"key":api_key, 'built_at':str(datetime.datetime.now()), 
+    return json.dumps({"key":api_key, 'built_at':str(datetime.datetime.now()),
         'api_version':api_version, 'type':api_type, 'data':data},
         indent=4, sort_keys=False, cls = APIEncoder)
 
@@ -122,7 +122,7 @@ def build_api_search(api_key, mddtuple, max_count=None, request=None):
     search_dict = mddtuple[2]
     if metadata.get('error_string', None):
         return build_api_error(metadata['error_string'], request = request)
-    return build_api_records(api_key, metadata['record_count'], metadata['correct_count'], 
+    return build_api_records(api_key, metadata['record_count'], metadata['correct_count'],
         search_dict['view_start'], metadata['view_count'], data, max_count = max_count, request = request)
 
 def build_api_searchers(names, human_names, descriptions, request = None):
@@ -135,7 +135,7 @@ def build_api_searchers(names, human_names, descriptions, request = None):
     request -- Flask request object to query for needed data
     """
     item_list = [{n:{ 'human_name':h, 'desc':d}} for n, h, d in zip(names, human_names, descriptions)]
-    
+
     return build_api_wrapper('GLOBAL', api_type_searchers, item_list, request)
 
 
@@ -340,7 +340,7 @@ def interpret(query, qkey, qval, type_info):
     if type_info and not qval.startswith("|"):
         user_infer = False
         qval, comparator = trim_comparator(qval, [(">","$gt"),("<","$lt"), ("%","$in"), ("<=","$le"), (">=","$ge")])
-        
+
         try:
             if type_info == 'string':
                 pass #Already a string
@@ -433,7 +433,7 @@ def simple_search_postgres(search_dict, projection=None):
     C = db[search_dict['table']]
     info = {}
     try:
-        data = C.search(search_dict['query'], projection = projection, limit = rcount, 
+        data = C.search(search_dict['query'], projection = projection, limit = rcount,
             offset = offset, info = info)
     except Exception as e:
         data = []

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -39,7 +39,7 @@ class ReverseProxied(object):
         scheme = environ.get('HTTP_X_FORWARDED_PROTO')
         if scheme:
             environ['wsgi.url_scheme'] = scheme
-        
+
         return self.app(environ, start_response)
 
 app = Flask(__name__)
@@ -258,7 +258,7 @@ def netloc_redirect():
         Redirect non-whitelisted routes from www.lmfdb.org to beta.lmfdb.org
     """
     from urllib.parse import urlparse, urlunparse
-    
+
     urlparts = urlparse(request.url)
 
     if urlparts.netloc in ["lmfdb.org", "lmfdb.com", "www.lmfdb.com"]:

--- a/lmfdb/artin_representations/math_classes.py
+++ b/lmfdb/artin_representations/math_classes.py
@@ -840,7 +840,7 @@ class NumberFieldGaloisGroup(object):
         self.lowered = self.lower_precision()
         def help_padic(n,p, prec):
             """
-              Take an integer n, prime p, and precision prec, and return a 
+              Take an integer n, prime p, and precision prec, and return a
               prec-tuple of the p-adic coefficients of j
             """
             n = ZZ(n)
@@ -860,7 +860,7 @@ class NumberFieldGaloisGroup(object):
         p = self._data['QpRts-p']
         prec = self._data['QpRts-prec']
         myroots = [[help_padic(z, p, prec) for z in t] for t in myroots]
-        myroots = [[[getel(root[j], r) 
+        myroots = [[[getel(root[j], r)
             for j in range(len(self._data['QpRts-minpoly'])-1)]
             for r in range(prec)]
             for root in myroots]

--- a/lmfdb/artin_representations/test_artin_representation.py
+++ b/lmfdb/artin_representations/test_artin_representation.py
@@ -5,7 +5,7 @@ from lmfdb.tests import LmfdbTest
 class ArtinRepTest(LmfdbTest):
 
     # All tests should pass
-    # 
+    #
     def test_search_deg_condrange(self):
         L = self.tc.get('/ArtinRepresentation/?dimension=3&conductor=1988-2015&group=&ramified=&unramified=&root_number=&frobenius_schur_indicator=&count=15')
         assert '41' in L.get_data(as_text=True) # Only 1 result at the time this test was written, which has conductor 2009 = 7^2.41

--- a/lmfdb/characters/HeckeCharacters.py
+++ b/lmfdb/characters/HeckeCharacters.py
@@ -156,7 +156,7 @@ class HeckeChar(DualAbelianGroupElement):
         F = self.exponents()
         D = self.parent().gens_orders()
         return tuple( f/d for f,d in zip( F, D) )
-        
+
     def __call__(self, x):
         try:
             logx = self.parent().group()(x)

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -66,7 +66,7 @@ def pretty_ideal(Kgen, s, enclose=True):
     if Kgen == 'phi':
         gens = gens.replace(Kgen, r"\phi")
     return r"\(" + gens + r"\)" if enclose else gens
-    
+
 def latex_factorization(plist, exponents, sign=+1):
     """plist is a list of strings representing prime ideals P (or other things) in latex without math delimiters.
     exponents is a list (of the same length) of non-negative integer exponents e, possibly  0.
@@ -99,7 +99,7 @@ def inflate_interval(a,b,r):
 def plot_zone_union(R,S):
     return(min(R[0],S[0]),max(R[1],S[1]),min(R[2],S[2]),max(R[3],S[3]))
 
-# Finds a suitable plotting zone for the component a <= x <= b of the EC y**2+h(x)*y=f(x) 
+# Finds a suitable plotting zone for the component a <= x <= b of the EC y**2+h(x)*y=f(x)
 def EC_R_plot_zone_piece(f,h,a,b):
     npts=50
     Y=[]
@@ -118,7 +118,7 @@ def EC_R_plot_zone_piece(f,h,a,b):
     (a,b)=inflate_interval(a,b,1.3)
     return (a,b,ymin,ymax)
 
-# Finds a suitable plotting zone for the EC y**2+h(x)*y=f(x) 
+# Finds a suitable plotting zone for the EC y**2+h(x)*y=f(x)
 def EC_R_plot_zone(f,h):
     F=f+h**2/4
     F1=F.derivative()
@@ -151,7 +151,7 @@ def EC_nf_plot(K, ainvs, base_field_gen_name):
         S=K.embeddings(RDF)
         for s in S:
             A=[s(c) for c in ainvs]
-            R.append(EC_R_plot_zone(Rx([A[4],A[3],A[1],1]),Rx([A[2],A[0]]))) 
+            R.append(EC_R_plot_zone(Rx([A[4],A[3],A[1],1]),Rx([A[2],A[0]])))
         xmin = min([r[0] for r in R])
         xmax = max([r[1] for r in R])
         ymin = min([r[2] for r in R])
@@ -258,7 +258,7 @@ class ECNF(object):
         #sys.stdout.flush()
         K = self.field.K()
         Kgen = str(K.gen())
-        
+
         # a-invariants
         # NB Here we construct the ai as elements of K, which are used as follows:
         # (1) to compute the model discriminant (if not stored)
@@ -502,7 +502,7 @@ class ECNF(object):
             self.Lvalue = web_latex(self.Lvalue)
         except (TypeError, AttributeError):
             self.Lvalue = "not available"
-            
+
         # Tamagawa product
         tamagawa_numbers = [ZZ(_ld['cp']) for _ld in self.local_data]
         cp_fac = [cp.factor() for cp in tamagawa_numbers]
@@ -518,8 +518,8 @@ class ECNF(object):
             self.sha = web_latex(self.sha) + " (rounded)"
         except AttributeError:
             self.sha = "not available"
-            
-        
+
+
         # Local data
 
         # The Kodaira symbol is stored as an int in pari encoding. The
@@ -700,11 +700,11 @@ def make_code(label, lang=None):
     all_langs = ['magma', 'pari', 'sage']
 
     # Get the base field label and a-invariants:
-    
+
     E = db.ec_nfcurves.lookup(label, projection = ['field_label', 'ainvs'])
-   
+
     # Look up the defining polynomial of the base field:
-    
+
     from lmfdb.utils import coeff_to_poly
     poly = coeff_to_poly(db.nf_fields.lookup(E['field_label'], projection = 'coeffs'))
 

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask import url_for
 from lmfdb import db
-from lmfdb.utils import encode_plot, names_and_urls, web_latex 
+from lmfdb.utils import encode_plot, names_and_urls, web_latex
 from lmfdb.logger import make_logger
 from lmfdb.ecnf.WebEllipticCurve import web_ainvs, FIELD
 from lmfdb.number_fields.web_number_field import field_pretty, nf_display_knowl

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -123,7 +123,7 @@ class EllCurveTest(LmfdbTest):
         """
         self.check_args('/EllipticCurve/?cm_disc=-4','1024.1-a1')
         self.not_check_args('/EllipticCurve/?cm_disc=-4','1.0.1-a1')
-        
+
         # make sure it works with 4-way PCM, CM, PCMnoCM, noCM switch
         self.check_args('/EllipticCurve/?cm_disc=-11&include_cm=PCMnoCM','14641.1-a1')
         self.not_check_args('/EllipticCurve/?cm_disc=-11&include_cm=PCMnoCM','9.1-CMa1')

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -637,7 +637,7 @@ def local_table(N,D,tama,bad_lpolys,cluster_pics):
     loctab.extend(['</tbody>', '</table>'])
     return '\n'.join(loctab)
 
-def galrep_table(galrep):  
+def galrep_table(galrep):
     galtab = ['<table class="ntdata">', '<thead>', '<tr>',
               th_wrap('', r'Prime \(\ell\)'),
               th_wrap('g2c.galois_rep_image', r'mod-\(\ell\) image'),
@@ -1059,7 +1059,7 @@ class WebG2C(object):
             self._code =  yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
 
             # Fill in placeholders for this specific curve:
-            for lang in ['magma']: #TODO: 'sage', 'pari', 
+            for lang in ['magma']: #TODO: 'sage', 'pari',
                 self._code['curve'][lang] = self._code['curve'][lang] % (self.data['min_eqn'])
 
         return self._code

--- a/lmfdb/groups/abstract/test_browse_page.py
+++ b/lmfdb/groups/abstract/test_browse_page.py
@@ -18,7 +18,7 @@ class AbGpsHomeTest(LmfdbTest):
     #  def test_stats_page(self):
     #  self.check_args("/Groups/Abstract/stats","Abstract groups: Statistics")
 
- 
+
     def test_completeness_page(self):
         r"""
         Check that Groups/Abstract/Completeness works

--- a/lmfdb/hecke_algebras/main.py
+++ b/lmfdb/hecke_algebras/main.py
@@ -419,7 +419,7 @@ def render_hecke_algebras_webpage_download(**args):
         response = make_response(download_hecke_algebras_full_lists_op(**args))
         response.headers['Content-type'] = 'text/plain'
         return response
-    elif args['obj'] == 'gen': 
+    elif args['obj'] == 'gen':
         response = make_response(download_hecke_algebras_full_lists_gen(**args))
         response.headers['Content-type'] = 'text/plain'
         return response
@@ -468,10 +468,10 @@ def download_hecke_algebras_full_lists_gen(**args):
 @hecke_algebras_page.route('/<orbit_label>/<index>/<prime>/download/<lang>/<obj>')
 def render_hecke_algebras_webpage_ell_download(**args):
     if args['obj'] == 'operators':
-        response = make_response(download_hecke_algebras_full_lists_mod_op(**args)) 
+        response = make_response(download_hecke_algebras_full_lists_mod_op(**args))
         response.headers['Content-type'] = 'text/plain'
         return response
-    elif args['obj'] == 'idempotents': 
+    elif args['obj'] == 'idempotents':
         response = make_response(download_hecke_algebras_full_lists_id(**args))
         response.headers['Content-type'] = 'text/plain'
         return response
@@ -488,7 +488,7 @@ def download_hecke_algebras_full_lists_mod_op(**args):
     lang = args['lang']
     c = download_comment_prefix[lang]
     field='GF(%s), %s, %s, '%(res['ell'], sqrt(len(res['operators'][0])), sqrt(len(res['operators'][0])))
-    mat_start = "Mat("+field if lang == 'gp' else "Matrix("+field 
+    mat_start = "Mat("+field if lang == 'gp' else "Matrix("+field
     mat_end = "~)" if lang == 'gp' else ")"
     entry = lambda r: "".join([mat_start,str(r),mat_end])
 

--- a/lmfdb/higher_genus_w_automorphisms/hgcwa_stats.py
+++ b/lmfdb/higher_genus_w_automorphisms/hgcwa_stats.py
@@ -22,7 +22,7 @@ class HGCWAstats(StatsDisplay):
         self.dim_max = db.hgcwa_passports.max('dim')
         self.g0_max = db.hgcwa_passports.max('g0')
         self.refined_passports_knowl = display_knowl(
-            'curve.highergenus.aut.refinedpassport', 
+            'curve.highergenus.aut.refinedpassport',
             title='refined passports')
         self.generating_vectors_knowl = display_knowl(
             'curve.highergenus.aut.generatingvector',
@@ -42,9 +42,9 @@ class HGCWAstats(StatsDisplay):
             r'has genus 0, as well as genus 2 through 4 with quotient genus '
             r'greater than 0. There are %s distinct %s in the database. The '
             r'number of distinct %s is %s. Here are some '
-            r'<a href="%s">further statistics</a>.' % 
+            r'<a href="%s">further statistics</a>.' %
             (2, self.genus_max, self.distinct_refined_passports,
-            self.refined_passports_knowl, self.generating_vectors_knowl, 
+            self.refined_passports_knowl, self.generating_vectors_knowl,
             self.distinct_generating_vectors, stats_url)
         )
 

--- a/lmfdb/hypergm/plot.py
+++ b/lmfdb/hypergm/plot.py
@@ -11,8 +11,8 @@ from sage.functions.log import exp
 def circle_drops(A,B):
     # Drops going around the unit circle for those A and B.
     # See http://user.math.uzh.ch/dehaye/thesis_students/Nicolas_Wider-Integrality_of_factorial_ratios.pdf
-    # for longer description (not original, better references exist)    
-    marks = lcm(lcm(A),lcm(B))    
+    # for longer description (not original, better references exist)
+    marks = lcm(lcm(A),lcm(B))
     tmp = [0 for i in range(marks)]
     for a in A:
 #        print tmp
@@ -26,7 +26,7 @@ def circle_drops(A,B):
                 tmp[i*marks/b] += 1
 #    print tmp
     return [sum(tmp[:j]) for j in range(marks)]
-    
+
 def piecewise_constant_image(A,B):
     # Jumps up and down going around circle, not used
     v = circle_drops(A,B)
@@ -44,11 +44,11 @@ def piecewise_linear_image(A,B):
     for pt in w:
         G += line([(pt[0],pt[1]),(pt[0]+Rational(1)/len(w),pt[1])])
     return G
-    
+
 def circle_image(A,B):
     G = Graphics()
     G += circle((0,0), 1 , color = 'black',thickness = 3)
-    G += circle((0,0), 1.4, color = 'black',alpha = 0) #This adds an invisible framing circle to the plot, which protects the aspect ratio from being skewed. 
+    G += circle((0,0), 1.4, color = 'black',alpha = 0) #This adds an invisible framing circle to the plot, which protects the aspect ratio from being skewed.
     from collections import defaultdict
     tmp = defaultdict(int)
     for a in A:
@@ -56,7 +56,7 @@ def circle_image(A,B):
             if gcd(j,a) == 1:
                 rational = Rational(j)/Rational(a)
                 tmp[(rational.numerator(),rational.denominator())] += 1
-    
+
     for b in B:
         for j in range(b):
             if gcd(j,b) == 1:

--- a/lmfdb/hypergm/web_family.py
+++ b/lmfdb/hypergm/web_family.py
@@ -139,7 +139,7 @@ class WebHyperGeometricFamily(object):
     @lazy_attribute
     def h1_latex(self):
         return(latex(self.h1))
-    
+
     @lazy_attribute
     def bezout_latex(self):
         return latex(self.bezout)

--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -59,7 +59,7 @@ def get_bread(tail=[]):
 def learnmore_list():
     return [('Source and acknowledgments', url_for(".how_computed_page")),
             ('Completeness of the data', url_for(".completeness_page")),
-            ('Reliability of the data', url_for(".reliability_page")),            
+            ('Reliability of the data', url_for(".reliability_page")),
             ('Labels for integral lattices', url_for(".labels_page")),
             ('History of lattices', url_for(".history_page"))]
 
@@ -276,7 +276,7 @@ def render_lattice_webpage(**args):
             (i, url_for(".render_lattice_webpage_download", label=info['label'], lang=i, obj='shortest_vectors')) for i in ['gp', 'magma','sage']]
 
     if f['name']==['Leech']:
-        info['shortest']=[str([1,-2,-2,-2,2,-1,-1,3,3,0,0,2,2,-1,-1,-2,2,-2,-1,-1,0,0,-1,2]), 
+        info['shortest']=[str([1,-2,-2,-2,2,-1,-1,3,3,0,0,2,2,-1,-1,-2,2,-2,-1,-1,0,0,-1,2]),
 str([1,-2,-2,-2,2,-1,0,2,3,0,0,2,2,-1,-1,-2,2,-1,-1,-2,1,-1,-1,3]), str([1,-2,-2,-1,1,-1,-1,2,2,0,0,2,2,0,0,-2,2,-1,-1,-1,0,-1,-1,2])]
         info['all_shortest']="no"
         info['download_shortest'] = [

--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -88,10 +88,10 @@ class HomePageTest(LmfdbTest):
     def test_download_shortest(self):
         L = self.tc.get("/Lattice/13.14.28.8.1/download/magma/shortest_vectors").get_data(as_text=True)
         assert 'data := ' in L
- 
+
     def test_download_genus(self):
         L = self.tc.get("/Lattice/4.5.5.1.1/download/gp/genus_reps").get_data(as_text=True)
-        assert ']~)' in L 
+        assert ']~)' in L
 
 
     def test_favorite(self):

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -511,7 +511,7 @@ class LfunctionTest(LmfdbTest):
 
         L = self.tc.get('/L/lhash/dirichlet_L_6253.458/', follow_redirects=True)
         assert '1.0612' in L.get_data(as_text=True), "Missing data in /L/lhash/dirichlet_L_6253.458/"
-        assert '1-6253-6253.458-r1-0-0' in L.get_data(as_text=True) 
+        assert '1-6253-6253.458-r1-0-0' in L.get_data(as_text=True)
         assert 'Dual L-function' in L.get_data(as_text=True)
         assert 'Character/Dirichlet/6253/458' in L.get_data(as_text=True)
 

--- a/lmfdb/maass_forms/plot.py
+++ b/lmfdb/maass_forms/plot.py
@@ -5,11 +5,12 @@ from lmfdb import db
 from lmfdb.utils import signtocolour
 from flask import url_for
 
+
 def paintSvgMaass(min_level, max_level, min_R, max_R, width=1000, heightfactor=20, L=""):
     ''' Returns the contents (as a string) of the svg-file for
         all Maass forms in the database of the specified weight.
         Takes all levels from min_level to max_level
-        Spectral parameter in [min_R, max_R] 
+        Spectral parameter in [min_R, max_R]
         Set L="/L" to make link go to the L-function
     '''
     xMax = int(max_R)
@@ -47,7 +48,7 @@ def paintSvgMaass(min_level, max_level, min_R, max_R, width=1000, heightfactor=2
         s = f.get('symmetry',0)
         y -= s    # Shifting even slightly up and odd slightly down
         color = signtocolour(s)
-            
+
         ans += "<a xlink:href='{0}' target='_top'>".format(linkurl)
         ans += "<circle cx='{0}' cy='{1}' ".format(str(x)[0:6],str(y))
         ans += "r='{0}'  style='fill:{1}'>".format(str(radius),color)
@@ -108,7 +109,7 @@ def paintCSMaass(width, height, xMin, xMax, yMin, yMax, xfactor, yfactor, ticlen
     # ----------- Values and gridlines y axis
     for i in range(yMin , yMax + 1, 2):
         yvalue = (i - yMin + 1) * yfactor
-        ans += "<text x='5' y='{0}' ".format(str(yvalue + 3)) 
+        ans += "<text x='5' y='{0}' ".format(str(yvalue + 3))
         ans += "style='fill:rgb(102,102,102);font-size:11px;'>"
         ans += "{0}</text>\n".format(str(i))
 

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -15,12 +15,12 @@ from lmfdb.app import app
 from lmfdb.utils import (
     web_latex, to_dict, coeff_to_poly, pol_to_html, comma, format_percentage,
     flash_error, display_knowl, CountBox, prop_int_pretty,
-    SearchArray, TextBox, YesNoBox, YesNoMaybeBox, SubsetNoExcludeBox, 
+    SearchArray, TextBox, YesNoBox, YesNoMaybeBox, SubsetNoExcludeBox,
     SubsetBox, TextBoxWithSelect, parse_bool_unknown, parse_posints,
     clean_input, nf_string_to_label, parse_galgrp, parse_ints, parse_bool,
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, parse_padicfields,
-    raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly, 
+    raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly,
     raw_typeset_int, compress_poly_Q)
 from lmfdb.utils.web_display import compress_int
 from lmfdb.utils.interesting import interesting_knowls
@@ -527,7 +527,7 @@ def render_field_webpage(args):
         extra='&nbsp;(order ${}$)'.format(nf.root_of_1_order()))
 
     myunits = nf.units()
-    if 'not' not in myunits: 
+    if 'not' not in myunits:
         myunits = [unlatex(z) for z in myunits]
         Ra = PolynomialRing(QQ,'a')
         myunits = [Ra(z) for z in myunits]

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -9,8 +9,8 @@ from sage.all import (
     QQ, NumberField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
-from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html, 
-        raw_typeset_poly, display_multiset, factor_base_factor, 
+from lmfdb.utils import (web_latex, coeff_to_poly, pol_to_html,
+        raw_typeset_poly, display_multiset, factor_base_factor,
         integer_squarefree_part, integer_is_squarefree,
         factor_base_factorization_latex)
 from lmfdb.logger import make_logger
@@ -506,11 +506,11 @@ class WebNumberField:
     def monogenic(self):
         if self.haskey('monogenic'):
             if self._data['monogenic']==1:
-                return 'Yes' 
+                return 'Yes'
             if self._data['monogenic']==0:
                 return 'Not computed'
             if self._data['monogenic']==-1:
-                return 'No' 
+                return 'No'
         return 'Not computed'
 
     def index(self):
@@ -908,7 +908,7 @@ class WebNumberField:
                 LF = db.lf_fields.lookup(lab)
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
-                thisdat = [lab, f, LF['e'], LF['f'], LF['c'], 
+                thisdat = [lab, f, LF['e'], LF['f'], LF['c'],
                     transitive_group_display_knowl(LF['galois_label']),
                     LF['t'], LF['u'], LF['slopes']]
                 if str(p) not in local_algebra_dict:

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -10,7 +10,7 @@ class SatoTateGroupTest(LmfdbTest):
     def test_main(self):
         L = self.tc.get('/SatoTateGroup/')
         assert 'Browse' in L.get_data(as_text=True) and 'U(1)' in L.get_data(as_text=True) and 'U(1)_2' in L.get_data(as_text=True) and 'SU(2)' in L.get_data(as_text=True) and 'Rational' in L.get_data(as_text=True)
-        
+
     def test_by_label(self):
         L = self.tc.get('/SatoTateGroup/?jump=1.4.A.1.1a', follow_redirects=True)
         assert 'USp(4)' in L.get_data(as_text=True) and '223412' in L.get_data(as_text=True)

--- a/lmfdb/siegel_modular_forms/dimensions.py
+++ b/lmfdb/siegel_modular_forms/dimensions.py
@@ -112,7 +112,7 @@ def dimension_Gamma0_2(wt_range, j):
       <li><span class="emph">Non cusp</span>: The codimension of the subspace of cusp forms.</li>
       <li><span class="emph">Cusp</span>: The subspace of cusp forms.</li>
     </ul>
-    """    
+    """
     return _dimension_Gamma_2(wt_range, j, group = 'Gamma0(2)')
 
 def dimension_Sp4Z(wt_range):
@@ -179,14 +179,14 @@ def _dimension_Sp4Z(wt_range):
     H_MS = (x ** 10 + x ** 12) / (1 - x ** 4) / (1 - x ** 6)
 
     dct = dict((k,
-                 { 'Total': H_all[k], 
+                 { 'Total': H_all[k],
                    'Eisenstein': 1 if k >= 4 else 0,
                    'Klingen': H_Kl[k],
                    'Maass': H_MS[k],
                    'Interesting': H_all[k]-(1 if k >= 4 else 0)-H_Kl[k]-H_MS[k]
                    }
                  if is_even(k) else
-                 { 'Total': H_all[k-35], 
+                 { 'Total': H_all[k-35],
                    'Eisenstein': 0,
                    'Klingen': 0,
                    'Maass': 0,
@@ -220,7 +220,7 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
     if 'Sp4(Z)' == group and 2 == j and wt_range[0] < 4:
         wt_range1 = [ k for k in wt_range if k < 4]
         wt_range2 = [ k for k in wt_range if k >= 4]
-        if wt_range2 != []: 
+        if wt_range2 != []:
             headers, dct = _dimension_Gamma_2(wt_range2, j, group)
         else:
             headers, dct = ['Total', 'Non cusp', 'Cusp'], {}
@@ -239,7 +239,7 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
     db_cusp = db.smf_dims.lucky(query)
     if not db_cusp:
         raise NotImplementedError(r'Dimensions of \(M_{k,j}\) for \(j=%d\) not implemented' % j)
-    
+
     P = PowerSeriesRing(ZZ,  default_prec =wt_range[-1] + 1,  names = ('t'))
     Qt = FunctionField(QQ, names=('t'))
     total = dict()
@@ -249,13 +249,13 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
         total[p] = P(f.numerator())/P(f.denominator())
         f = Qt(str(db_cusp[p]))
         cusp[p] = P(f.numerator())/P(f.denominator())
-    
+
     if 'Gamma(2)' == group:
         dct = dict((k, dict((p, [total[p][k], total[p][k]-cusp[p][k], cusp[p][k]])
                               for p in partitions)) for k in wt_range)
         for k in dct:
             dct[k]['All'] = [sum(dct[k][p][i] for p in dct[k]) for i in range(3)]
-            
+
         partitions.insert(0,'All')
         headers = partitions
 
@@ -263,14 +263,14 @@ def _dimension_Gamma_2(wt_range, j, group = 'Gamma(2)'):
         ps = { '3': ['6', '42', '222'],
                '21': ['51', '42', '321'],
                '111': ['411', '33']}
-        
+
         dct = dict((k, dict((p,[
                             sum(total[q][k] for q in ps[p]),
                             sum(total[q][k]-cusp[q][k] for q in ps[p]),
                             sum(cusp[q][k] for q in ps[p]),
-                            ]) for p in ps)) for k in wt_range) 
+                            ]) for p in ps)) for k in wt_range)
         for k in dct:
-            dct[k]['All'] = [sum(dct[k][p][i] for p in dct[k]) for i in range(3)]       
+            dct[k]['All'] = [sum(dct[k][p][i] for p in dct[k]) for i in range(3)]
 
         headers = list(ps)
         headers.sort(reverse=True)

--- a/lmfdb/siegel_modular_forms/family.py
+++ b/lmfdb/siegel_modular_forms/family.py
@@ -52,10 +52,10 @@ class SiegelFamily (SageObject):
             self.__dimension_glossary = None
         self.__samples = None
         self.order = doc.get('order')
-        
+
     def computes_dimensions(self):
         return True if self.__dimension else False
-    
+
     def dimension(self, *args, **kwargs):
         return self.__dimension(*args, **kwargs) if self.__dimension else None
 

--- a/lmfdb/siegel_modular_forms/family_data.py
+++ b/lmfdb/siegel_modular_forms/family_data.py
@@ -5,18 +5,18 @@ families = [
     "name": "Gamma0_2",
     "degree": int(2),
     "dim_args_default": {"k": "4..24", "j": "2"},
-    "latex_name": "M_{k,j}\\left(\\Gamma_0(2)\\right)", 
+    "latex_name": "M_{k,j}\\left(\\Gamma_0(2)\\right)",
     "order": int(50)
 },
 {
-    "name": "Gamma0_3", 
+    "name": "Gamma0_3",
     "degree": int(2),
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left(\\Gamma_0(3)\\right)",
     "order": int(80)
 },
 {
-    "name": "Gamma0_3_psi_3", 
+    "name": "Gamma0_3_psi_3",
     "degree": int(2),
     "dim_args_default": { "k": "0..20" },
     "latex_name": "M_k\\left(\\Gamma_0(3),\\psi_3\\right)",
@@ -33,7 +33,7 @@ families = [
     "name": "Gamma0_4",
     "degree": int(2),
     "dim_args_default": { "k": "0..20" },
-    "latex_name": "M_k\\left(\\Gamma_0(4)\\right)", 
+    "latex_name": "M_k\\left(\\Gamma_0(4)\\right)",
     "order": int(100)
 },
 {
@@ -47,55 +47,55 @@ families = [
     "name": "Gamma1_2",
     "degree": int(2),
     "dim_args_default": { "k": "4..10", "j": "2" },
-    "latex_name": "M_{k,j}\\left(\\Gamma_1(2)\\right)", 
+    "latex_name": "M_{k,j}\\left(\\Gamma_1(2)\\right)",
     "order": int(60)
 },
 {
-    "name": "Gamma_2", 
+    "name": "Gamma_2",
     "degree": int(2),
     "dim_args_default": { "k": "4..10", "j": "2" },
-    "latex_name": "M_{k,j}\\left(\\Gamma(2)\\right)", 
+    "latex_name": "M_{k,j}\\left(\\Gamma(2)\\right)",
     "order": int(70)
 },
 {
-    "name": "Kp", 
+    "name": "Kp",
     "degree": int(2),
-    "latex_name": "M_2\\left(K(p)\\right)", 
+    "latex_name": "M_2\\left(K(p)\\right)",
     "order": int(110)
 },
 {
-    "name": "Sp4Z_2", 
+    "name": "Sp4Z_2",
     "degree": int(2),
     "dim_args_default": { "k": "4..24" },
-    "latex_name": "M_{k,2}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)", 
+    "latex_name": "M_{k,2}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)",
     "order": int(30)
 },
 {
-    "name": "Sp4Z_j", 
+    "name": "Sp4Z_j",
     "degree": int(2),
     "dim_args_default": { "k": "4..24", "j": "4" },
-    "latex_name": "M_{k,j}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)", 
+    "latex_name": "M_{k,j}\\left(\\textrm{Sp}(4,\\mathbb{Z})\\right)",
     "order": int(40)
 },
 {
-    "name": "Sp4Z", 
+    "name": "Sp4Z",
     "degree": int(2),
     "dim_args_default": { "k": "0..20" },
-    "latex_name": "M_k\\left({\\textrm{Sp}}(4,\\mathbb{Z})\\right)", 
+    "latex_name": "M_k\\left({\\textrm{Sp}}(4,\\mathbb{Z})\\right)",
     "order": int(10)
 },
 {
     "name": "Sp6Z",
     "degree": int(3),
     "dim_args_default": { "k": "0..20" },
-    "latex_name": "M_{k}\\left(\\textrm{Sp}(6,\\mathbb{Z})\\right)", 
+    "latex_name": "M_{k}\\left(\\textrm{Sp}(6,\\mathbb{Z})\\right)",
     "order": int(130)
 },
 {
-    "name": "Sp8Z", 
+    "name": "Sp8Z",
     "degree": int(4),
     "dim_args_default": { "k": "0..16" },
-    "latex_name": "M_k\\left(\\textrm{Sp}(8,\\mathbb{Z})\\right)", 
+    "latex_name": "M_k\\left(\\textrm{Sp}(8,\\mathbb{Z})\\right)",
     "order": int(140)
 },
 ]

--- a/lmfdb/siegel_modular_forms/sample.py
+++ b/lmfdb/siegel_modular_forms/sample.py
@@ -33,7 +33,7 @@ class Sample_class (SageObject):
         self.__is_integral = doc.get('is_integral')
         self.__representation = doc.get('representation')
         self.__id = doc.get('id_link')
- 
+
     def collection(self):
         return self.__collection
 

--- a/lmfdb/siegel_modular_forms/siegel_modular_form.py
+++ b/lmfdb/siegel_modular_forms/siegel_modular_form.py
@@ -322,11 +322,11 @@ def render_sample_page(family, sam, args, bread):
         info['reduce'] = safe_reduce
     else:
         info['reduce'] = latex
-        
+
     # check that explicit formula is not ridiculously big
     if sam.explicit_formula():
         info['explicit_formula_bytes'] = len(sam.explicit_formula())
         if len(sam.explicit_formula()) < 100000:
             info['explicit_formula'] = sam.explicit_formula()
-        
+
     return render_template("ModularForm_GSp4_Q_sample.html", title=title, bread=bread, properties=properties, info=info)

--- a/lmfdb/tensor_products/galois_reps.py
+++ b/lmfdb/tensor_products/galois_reps.py
@@ -78,7 +78,7 @@ sage: VW.algebraic_coefficients(38)[36] == -38
 #
 
 #* This code is specific to tensor products of dimension \leq 2.  To handle
-# higher dimension there are several pieces of code which one must check 
+# higher dimension there are several pieces of code which one must check
 # still hold true.
 ########################################################################
 # (C) Alberto Camara, Martin Dickson, Mark Watkins, Chris Wuthrich 2014
@@ -256,7 +256,6 @@ class GaloisRepresentation( Lfunction):
     def init_artin_rep(self, rho):
         """
         Initiate with an Artin representation
- 
         """
         self.original_object = [rho]
         self.object_type = "Artin representation"
@@ -615,7 +614,7 @@ class GaloisRepresentation( Lfunction):
 
         self.texname = "L(s,\\rho)"
         self.texnamecompleteds = "\\Lambda(s,\\rho)"
-        self.texnamecompleted1ms = "\\Lambda(1-s, \\widehat{\\rho})" 
+        self.texnamecompleted1ms = "\\Lambda(1-s, \\widehat{\\rho})"
         self.title = "$L(s,\\rho)$, where $\\rho$ is a Galois representation"
 
         self.credit = 'Workshop in Besancon, 2014'

--- a/lmfdb/tests/test_tensor_products.py
+++ b/lmfdb/tests/test_tensor_products.py
@@ -2,10 +2,11 @@
 import unittest2
 from lmfdb.tests import LmfdbTest
 
+
 class TensorProductTest(LmfdbTest):
     """
     These tests check whether we can still take tensor products of the things
-    we're supposed to be able to take tensor products of.  If naming 
+    we're supposed to be able to take tensor products of.  If naming
     conventions are changed for the objects we're forming tensor products of
     then these tests will fail.  The test is the assertion that the correct
     conductor is displayed somewhere on the page.

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -46,7 +46,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'datetime_to_timestamp_in_ms', 'timestamp_in_ms_to_datetime',
            'TraceHash', 'TraceHashClass',
            'redirect_no_cache', 'letters2num', 'num2letters',
-           'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor', 
+           'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor',
            'raw_typeset_qexp', 'raw_typeset_int', 'compress_poly_Q',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat']
 

--- a/lmfdb/utils/trace_hash.py
+++ b/lmfdb/utils/trace_hash.py
@@ -112,7 +112,7 @@ def TraceHash(E):
     QQ or a number field.
 
     """
-    K = E.base_field() 
+    K = E.base_field()
     if K == QQ:
         E_pari = pari(E.a_invariants()).ellinit()
         return TraceHash_from_ap([E_pari.ellap(p) for p in TH_P])


### PR DESCRIPTION
this was scripted using

    pep -q --select=W293 lmfdb | xargs autopep8  --select W293 --in-place

and the same for W291.

One could activate these checks, or not, at your choice.
