### PR TITLE
fixing riemann-zeta-zeros url to parent directory

### DIFF
--- a/lmfdb/zeros/zeta/zetazeros.py
+++ b/lmfdb/zeros/zeta/zetazeros.py
@@ -21,7 +21,7 @@ def friends_list():
     return [('L-function', url_for("l_functions.l_function_riemann_page"))]
 
 def downloads():
-    return [('Bulk download', "https://beta.lmfdb.org/data/riemann-zeta-zeros/")]
+    return [('Bulk download', "https://beta.lmfdb.org/riemann-zeta-zeros/")]
 
 # Return the learnmore list with the matchstring entry removed
 def learnmore_list_remove(matchstring):


### PR DESCRIPTION
Before we were pointing to 
https://beta.lmfdb.org/riemann-zeta-zeros/data/ == https://beta.lmfdb.org/data/riemann-zeta-zeros/
now we point to
https://beta.lmfdb.org/riemann-zeta-zeros/
which contains the missing `index.db`

I would like also to point out that we are actively using https://github.com/LMFDB/lmfdb/blob/master/lmfdb/zeros/zeta/platt_zeros.py to display the zeros https://github.com/LMFDB/lmfdb/blob/master/lmfdb/zeros/zeta/zetazeros.py#L10=

Resolves #5111

