### PR TITLE
Fix issues 4884 and 5077

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -361,7 +361,7 @@ def render_field_webpage(args):
             friends.append(('Unramified subfield', unramfriend))
         if rffriend != '':
             friends.append(('Discriminant root field', rffriend))
-        if db.nf_fields.exists({'local_algs': {'$contains': label}}):
+        if data['is_completion']:
             friends.append(('Number fields with this completion',
                 url_for('number_fields.number_field_render_webpage')+"?completions={}".format(label) ))
         downloads = [('Underlying data', url_for('.lf_data', label=label))]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -880,7 +880,7 @@ def number_field_search(info, query):
     parse_primes(info,query,'ram_primes',name='Ramified primes',
                  qfield='ramps',mode=info.get('ram_quantifier'),radical='disc_rad',cardinality='num_ram')
     parse_subfield(info, query, 'subfield', qfield='subfields', name='Intermediate field')
-    parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions')
+    parse_padicfields(info, query, 'completions', qfield='local_algs', name='$p$-adic completions', flag_unramified=True)
     parse_bool_unknown(info,query,'monogenic')
     parse_posints(info,query,'index')
     parse_primes(info,query,'inessentialp',name='Inessential primes',

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -4,7 +4,7 @@
 import re
 import sys
 from collections import Counter
-from lmfdb.utils.utilities import flash_error
+from lmfdb.utils.utilities import flash_error, flash_info
 from sage.all import ZZ, QQ, prod, PolynomialRing, pari
 from sage.misc.decorators import decorator_keywords
 from sage.repl.preparse import implicit_mul
@@ -1138,11 +1138,17 @@ def parse_inertia(inp, query, qfield, err_msg=None):
 
 # see SearchParser.__call__ for actual arguments when calling
 @search_parser(clean_info=True, error_is_safe=True)
-def parse_padicfields(inp, query, qfield):
+def parse_padicfields(inp, query, qfield, flag_unramified=False):
     labellist = inp.split(",")
+    doflash = False
     for label in labellist:
         if not LF_LABEL_RE.match(label):
             raise SearchParsingError('It needs to be a <a title = "$p$-adic field label" knowl="lf.field.label">$p$-adic field label</a> or a list of local field labels')
+        splitlab = label.split('.')
+        if splitlab[2] == '0':
+            doflash = True
+    if flag_unramified and doflash:
+        flash_info("Search results may be incomplete.  Given $p$-adic completions contain an <a title='unramified' knowl='nf.unramified_prime'>unramified</a> field and completions are only searched for <a title='ramified' knowl='nf.ramified_primes'>ramified primes</a>.")
     query[qfield] = {"$contains": labellist}
 
 def input_string_to_poly(FF):


### PR DESCRIPTION
These (possibly duplicate) issues are that p-adic field pages are slow to load.

To test, just ask for random fields from the p-adic field index page.  Random is good to avoid accidentally getting a quick result due to caching.

The mechanism is that I added a boolean column to the p-adic field database to say whether or not the p-adic field is a completion and filled it in.  lf_fields would need to be copied to the cloud before this code gets there.  This solution does nothing about searches on the number field page where the user specifies one or more completions.  For some reason, those do not seem to be as slow.

This also addresses another minor issue.  We only precompute local algebras of number fields at ramified primes.  If the user searches the number field database for a particular unramified p-adic field, we return the results we know, but this typically misses many other fields.  There is a check added to the search parser for p-adic fields to determine whether or not to show a warning to the user.  The two options are shown by

http://127.0.0.1:37777/NumberField/?completions=3.4.2.1  (ramified field, no warning)

http://127.0.0.1:37777/NumberField/?completions=3.4.0.1 (unramified field, so warning is given)
