### PR TITLE
Modify title of Riemann zeta page and add zeros to Learn more

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -482,6 +482,8 @@ class Lfunction_from_db(Lfunction):
         self.label = self.lfunc_data['label']
         self.info = self.general_webpagedata()
         self.info['title'] = "L-function " + self.label
+        if self.info['label'] == '1-1-1.1-r0-0-0':
+          self.info['title'] = "L-function " + self.label + ": Riemann zeta function"
 
     @lazy_attribute
     def _Ltype(self):

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -1169,6 +1169,8 @@ def render_single_Lfunction(Lclass, args, request):
             return render_lfunction_exception(err)
 
     info = initLfunction(L, temp_args, request)
+    if info['label']=='1-1-1.1-r0-0-0':
+        info['learnmore'].append(("$\zeta$ zeros", url_for("zeta zeros.zetazeros")))
     return render_template('Lfunction.html', **info)
 
 def render_lfunction_exception(err):


### PR DESCRIPTION
Fixes issue #5107 by adding "Riemann zeta function to the title and a link to the zeta zeros page in the learnmore.  The style of the title matches that of special number fields and the learnmore is the same as on the general L-function page.  To test:

http://127.0.0.1:37777/L/1/1/1.1/r0/0/0
http://beta.lmfdb.org/L/1/1/1.1/r0/0/0
