### PR TITLE
Big abelian groups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -663,7 +663,12 @@ def by_abelian_label(label):
             {"abelian": True, "primary_abelian_invariants": primary}, "label"
         )
     if dblabel is None:
-        return render_abstract_group("ab/" + label, data=primary)
+        snf = primary_to_smith(primary)
+        canonical_label = '.'.join([str(z) for z in snf])
+        if canonical_label != label:
+            return redirect(url_for(".by_abelian_label", label=canonical_label))
+        else:
+            return render_abstract_group("ab/" + canonical_label, data=primary)
     else:
         return redirect(url_for(".by_label", label=dblabel))
 

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -53,7 +53,6 @@ from .web_groups import (
     WebAbstractRationalCharacter,
     WebAbstractSubgroup,
     group_names_pretty,
-    LiveAbelianGroup,
     primary_to_smith
 )
 from .stats import GroupStats

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -53,6 +53,8 @@ from .web_groups import (
     WebAbstractRationalCharacter,
     WebAbstractSubgroup,
     group_names_pretty,
+    LiveAbelianGroup,
+    primary_to_smith
 )
 from .stats import GroupStats
 
@@ -653,11 +655,16 @@ def by_abelian_label(label):
             label,
         )
         return redirect(url_for(".index"))
+    print("************************************")
+    print(" here ")
     primary = canonify_abelian_label(label)
+    print(" canon ")
     dblabel = db.gps_groups.lucky(
         {"abelian": True, "primary_abelian_invariants": primary}, "label"
     )
+    print(" dblabel ")
     if dblabel is None:
+        print("doing render_abstr_group")
         return render_abstract_group("ab/" + label, data=primary)
     else:
         return redirect(url_for(".by_label", label=dblabel))
@@ -1017,20 +1024,40 @@ def diagram_js_string(gp, conj, aut):
         num_layers = 0
     return f'var [sdiagram,glist] = make_sdiagram("subdiagram", "{gp.label}", {glist}, {order_lookup}, {num_layers});', display_opts
 
+def abelian_get_elementary(snf):
+    plist = ZZ(snf[0]).prime_factors()
+    if len(snf)==1:  # cyclic group, all primes are good
+        return prod(plist)
+    ppossible = ZZ(snf[1]).prime_factors()
+    if len(ppossible)>1:
+        return 1
+    return ppossible[0]
+
 # Writes individual pages
 def render_abstract_group(label, data=None):
     info = {}
+    print("Data is ")
+    print(data)
     if data is None:
         label = clean_input(label)
         gp = WebAbstractGroup(label)
     elif isinstance(data, list): # abelian group
         gp = WebAbstractGroup(label, data=data)
+        snf = primary_to_smith(data)
+        gp.elementary = abelian_get_elementary(snf)
+        gp.hyperelementary = gp.elementary
+        gp.Zgroup = len(snf)==1
+        gp.Agroup = True
+        gp.G = LiveAbelianGroup(snf)
+        print("SNF: ", snf)
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     # check if it fails to be a potential label even
 
+    print(gp)
     info["boolean_characteristics_string"] = create_boolean_string(gp)
+    print("post bool string")
 
     if gp.live():
         title = f"Abstract group {label}"

--- a/lmfdb/groups/abstract/test_abstract_groups.py
+++ b/lmfdb/groups/abstract/test_abstract_groups.py
@@ -66,7 +66,7 @@ class AbGpsTest(LmfdbTest):
             "4432676798593", # factor of aut_order
         ])
         self.check_args("/Groups/Abstract/ab/3000", [ # large cyclic group
-            r"C_2^3\times C_{100}", # automorphism group structure
+            r"C_{2}^{3} \times C_{100}", # automorphism group structure
         ])
 
     def test_underlying_data(self):

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -17,7 +17,6 @@ from sage.all import (
     prod,
     is_prime,
     cartesian_product_iterator,
-    gap,
 )
 from sage.libs.gap.libgap import libgap
 from sage.libs.gap.element import GapElement

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1601,7 +1601,7 @@ class LiveAbelianGroup():
             return []
         plist = ZZ(self.snf[-1]).prime_factors()
         def get_sylow(snf, p):
-            ppart = [z.p_primary_part(p) for z in snf]
+            ppart = [p**z.ord(p) for z in snf]
             return [z for z in ppart if z>1]
         sylows = [get_sylow(self.snf,p) for p in plist]
         return [LiveAbelianGroup(syl) for syl in sylows]


### PR DESCRIPTION
This fixes issue #5078 and should now handle pretty large abelian groups on the fly.  There will still be some limitations, e.g., if you ask for a cyclic group where the order cannot be readily factored by sage.

It changes the behavior a little in that it will rewrite the url and label for a big abelian group to use invariant factors (which meshes with how we show smaller abelian groups).

Some examples to see:

From the issue:
http://127.0.0.1:37777/Groups/Abstract/ab/1000000007 

even bigger:
http://127.0.0.1:37777/Groups/Abstract/ab/10000123451234500007

not cyclic:
http://127.0.0.1:37777/Groups/Abstract/ab/2.2.4.10.100.1000.10000

multiple factors which need to be canonified:
http://127.0.0.1:37777/Groups/Abstract/ab/10.6.14.15.35.21