### PR TITLE
p-adic field update

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -153,6 +153,12 @@ def show_slopes(sl):
         return "None"
     return(sl)
 
+def show_slopes2(sl):
+    # uses empty brackets with a space instead of None
+    if str(sl) == "[]":
+        return r'[\ ]'
+    return(sl)
+
 def show_slope_content(sl,t,u):
     sc = str(sl)
     if sc == '[]':
@@ -214,7 +220,7 @@ lf_columns = SearchColumns([
     MathCol("u", "lf.unramified_degree", "$u$", short_title="unramified degree"),
     MathCol("t", "lf.tame_degree", "$t$", short_title="tame degree"),
     ProcessedCol("visible", "lf.visible_slopes", "Visible slopes",
-                    show_slopes, mathmode=False),
+                    show_slopes2, mathmode=True),
     MultiProcessedCol("slopes", "lf.slope_content", "Slope content",
                       ["slopes", "t", "u"],
                       show_slope_content,

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -287,13 +287,12 @@ def render_field_webpage(args):
             ('Galois group', group_pretty_and_nTj(gn, gt)),
         ]
         # Look up the unram poly so we can link to it
-        unramlabel = db.lf_fields.lucky({'p': p, 'n': f, 'c': 0}, projection=0)
-        if unramlabel is None:
+        unramdata = db.lf_fields.lucky({'p': p, 'n': f, 'c': 0})
+        if unramdata is None:
             logger.fatal("Cannot find unramified field!")
             unramfriend = ''
         else:
-            unramfriend = url_for_label(unramlabel)
-            unramdata = db.lf_fields.lookup(unramlabel)
+            unramfriend = url_for_label(unramdata['label'])
 
         Px = PolynomialRing(QQ, 'x')
         Pt = PolynomialRing(QQ, 't')
@@ -304,7 +303,8 @@ def render_field_webpage(args):
             eisenp = raw_typeset(eisenp, web_latex(eisenp))
 
         else:
-            unramp = data['unram'].replace('t','x')
+            unramp = coeff_to_poly(unramdata['coeffs'])
+            #unramp = data['unram'].replace('t','x')
             unramp = raw_typeset(unramp, web_latex(Px(str(unramp))))
             unramp = prettyname(unramdata)+' $\\cong '+Qp+'(t)$ where $t$ is a root of '+unramp
             eisenp = Ptx(str(data['eisen']).replace('y','x'))

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -123,9 +123,10 @@ def format_lfield(label,p):
     return lf_display_knowl(label, name = prettyname(data))
 
 # Input is a list of pairs, coeffs of field as string and multiplicity
-def format_subfields(subdata, p):
-    if not subdata:
+def format_subfields(sublist, multdata, p):
+    if not sublist:
         return ''
+    subdata = zip(sublist, multdata)
     return display_multiset(subdata, format_lfield, p)
 
 
@@ -356,7 +357,7 @@ def render_field_webpage(args):
                     'gsm': gsm,
                     'galphrase': galphrase,
                     'autstring': autstring,
-                    'subfields': format_subfields(data['subs'],p),
+                    'subfields': format_subfields(data['subfield'],data['subfield_mult'],p),
                     'aut': data['aut'],
                     })
         friends = [('Galois group', "/GaloisGroup/%dT%d" % (gn, gt))]

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -213,11 +213,13 @@ lf_columns = SearchColumns([
                       default=True),
     MathCol("u", "lf.unramified_degree", "$u$", short_title="unramified degree"),
     MathCol("t", "lf.tame_degree", "$t$", short_title="tame degree"),
+    ProcessedCol("visible", "lf.visible_slopes", "Visible slopes",
+                    show_slopes, mathmode=False),
     MultiProcessedCol("slopes", "lf.slope_content", "Slope content",
                       ["slopes", "t", "u"],
                       show_slope_content,
                       default=True, mathmode=True)],
-    db_cols=["c", "coeffs", "e", "f", "gal", "label", "n", "p", "slopes", "t", "u"])
+    db_cols=["c", "coeffs", "e", "f", "gal", "label", "n", "p", "slopes", "t", "u", "visible"])
 
 def lf_postprocess(res, info, query):
     cache = knowl_cache(list(set(f"{rec['n']}T{rec['gal']}" for rec in res)))
@@ -342,6 +344,7 @@ def render_field_webpage(args):
                     'rf': lf_display_knowl( rflabel, name=printquad(data['rf'], p)),
                     'base': lf_display_knowl(str(p)+'.1.0.1', name='$%s$'%Qp),
                     'hw': data['hw'],
+                    'visible': show_slopes(data['visible']),
                     'slopes': show_slopes(data['slopes']),
                     'gal': group_pretty_and_nTj(gn, gt, True),
                     'gt': gt,

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -151,7 +151,7 @@ def ratproc(inp):
 def show_slopes(sl):
     if str(sl) == "[]":
         return "None"
-    return(sl)
+    return('$' + sl + '$')
 
 def show_slopes2(sl):
     # uses empty brackets with a space instead of None

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -352,6 +352,7 @@ def render_field_webpage(args):
                     'inertia': group_display_inertia(data['inertia']),
                     'wild_inertia': wild_inertia,
                     'unram': unramp,
+                    'ind_insep': show_slopes(str(data['ind_of_insep'])),
                     'eisen': eisenp,
                     'gms': data['gms'],
                     'gsm': gsm,

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -118,15 +118,9 @@ def ctx_local_fields():
             'local_algebra_data': local_algebra_data}
 
 # Utilities for subfield display
-def format_lfield(coefmult,p):
-    coefmult = [int(c) for c in coefmult.split(",")]
-    data = db.lf_fields.lucky({'coeffs':coefmult, 'p': p}, projection=1)
-    if data is None:
-        # This should not happen, what do we do?
-        # This is wrong
-        return ''
-    return lf_display_knowl(data['label'], name = prettyname(data))
-
+def format_lfield(label,p):
+    data = db.lf_fields.lookup(label)
+    return lf_display_knowl(label, name = prettyname(data))
 
 # Input is a list of pairs, coeffs of field as string and multiplicity
 def format_subfields(subdata, p):
@@ -362,7 +356,7 @@ def render_field_webpage(args):
                     'gsm': gsm,
                     'galphrase': galphrase,
                     'autstring': autstring,
-                    'subfields': format_subfields(data['subfields'],p),
+                    'subfields': format_subfields(data['subs'],p),
                     'aut': data['aut'],
                     })
         friends = [('Galois group', "/GaloisGroup/%dT%d" % (gn, gt))]

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -52,7 +52,7 @@
     <table>
       <tr><td>{{ KNOWL('lf.unramified_subfield', title='Unramified subfield')}}:</td><td>{{info.unram|safe}}</tr>
       <tr><td>Relative {{ KNOWL('lf.eisenstein_polynomial', 'Eisenstein polynomial')}}:</td><td>{{info.eisen|safe}}</tr>
-      <tr><td>{{ KNOWL('lf.indices_of_inseperability', 'Indices of inseperability')}}:</td><td>{{info.ind_insep|safe}}</tr>
+      <tr><td>{{ KNOWL('lf.indices_of_inseparability', 'Indices of inseparability')}}:</td><td>{{info.ind_insep|safe}}</tr>
     </table>
   </p>
   <p><h2>{{ KNOWL('lf.galois_invariants', title='Invariants of the Galois closure') }}</h2>

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -23,6 +23,7 @@
       <tr><td>{{ KNOWL('lf.root_number', title='Root number') }}:</td> <td>{{info.hw}}</td></tr>
       <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) }$:</td> <td>${{info.aut}}$</td></tr>
       <tr><td colspan="2">{{info.galphrase}}</td></tr>
+      <tr><td>{{ KNOWL('lf.visible_slopes', title='Visible slopes')}}:</td><td>{{info.visible}}</td></tr>
     </table>
   </p>
 

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -52,6 +52,7 @@
     <table>
       <tr><td>{{ KNOWL('lf.unramified_subfield', title='Unramified subfield')}}:</td><td>{{info.unram|safe}}</tr>
       <tr><td>Relative {{ KNOWL('lf.eisenstein_polynomial', 'Eisenstein polynomial')}}:</td><td>{{info.eisen|safe}}</tr>
+      <tr><td>{{ KNOWL('lf.indices_of_inseperability', 'Indices of inseperability')}}:</td><td>{{info.ind_insep|safe}}</tr>
     </table>
   </p>
   <p><h2>{{ KNOWL('lf.galois_invariants', title='Invariants of the Galois closure') }}</h2>


### PR DESCRIPTION
This adds "visible" slopes to the home page of each p-adic field (it is the last entry in the top area of a p-adic field home page).  One can also optionally display them in a search results
There are some other changes under the hood so that defining polynomials can be changed.  In particular, subfields are now stored in the database by label, and the unramified subfield of a field does not need to be stored since it is determined by "f".  The structure of the subfield information was also changed to facilitate a future feature where one can search for a field with a given subfield.

Before this goes to production, lf_fields should be copied to the cloud.

Because we have both old and new columns in the database table, some entries will be deleted once this code makes its way to production.