### PR TITLE
Debug fix

### DIFF
--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -96,6 +96,14 @@ class Configuration(_Configuration):
         )
 
         parser.add_argument(
+            "-r",
+            "--restart",
+            action="store_true",
+            dest="core_restart",
+            help="enable restart mode",
+        )
+
+        parser.add_argument(
             "--color",
             dest="core_color",
             metavar="COLOR",
@@ -254,6 +262,7 @@ class Configuration(_Configuration):
             "port": opts["web"]["port"],
             "host": opts["web"]["bindip"],
             "debug": opts["core"]["debug"],
+            "use_reloader": opts["core"]["restart"],
         }
         for opt in ["use_debugger", "use_reloader", "profiler"]:
             if opt in extopts:


### PR DESCRIPTION
Our debugger has been broken for a while.  There has been [recent progress](https://github.com/sagemath/cypari2/pull/116) in Cypari toward fixing it for real, but that still hasn't been achieved.  However, there is a workaround that can get some of the functionality back.

There are two features that using `--debug` gives you:  it gives you an in-browser traceback and debug prompt, and it makes it so that the application automatically restarts if source files are changed.  It's actually this second feature that conflicts with Pari's threading, and it's possible to separate the two.  This PR adds a new command line argument, `--restart`, for this second feature (off by default).  As a consequence, if you're working on parts of the LMFDB that use pari you can use `--debug` successfully, but you'll have to restart manually if there are code changes.  If you're working on a part of the LMFDB where pari isn't being called you can use `--debug --restart` to get the original behavior.

To test, you can use the fact that http://localhost:37777/NumberField/8.0.97571192547662768845333987328.43
is currently causing server errors.