### PR TITLE
Use oplus consistently in EC/ECNF/G2C

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -409,7 +409,7 @@ class ECNF():
         if self.tr == 1:
             self.tor_struct_pretty = r"\(\Z/%s\Z\)" % self.torsion_structure[0]
         if self.tr == 2:
-            self.tor_struct_pretty = r"\(\Z/%s\Z\times\Z/%s\Z\)" % tuple(self.torsion_structure)
+            self.tor_struct_pretty = r"\(\Z/%s\Z\oplus\Z/%s\Z\)" % tuple(self.torsion_structure)
 
         self.torsion_gens = [web_point(parse_point(K,P)) for P in self.torsion_gens]
 

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -38,7 +38,7 @@ def latex_tor(t):
     elif len(t) == 1:
         return r"$\Z/{%s}\Z$" % t
     else:
-        return r"$\Z{%s}\Z \oplus \Z/{%s}\Z$" % t
+        return r"$\Z/{%s}\Z \oplus \Z/{%s}\Z$" % t
 
 def tor_invs(t):
     if isinstance(t, str):

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -36,9 +36,9 @@ def latex_tor(t):
     if len(t) == 0:
         return "trivial"
     elif len(t) == 1:
-        return "$C_{%s}$" % t
+        return r"$\Z/{%s}\Z$" % t
     else:
-        return r"$C_{%s} \times C_{%s}$" % t
+        return r"$\Z{%s}\Z \oplus \Z/{%s}\Z$" % t
 
 def tor_invs(t):
     if isinstance(t, str):

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -830,9 +830,9 @@ def ecnf_code(**args):
 
 def disp_tor(t):
     if len(t) == 1:
-        return "[%s]" % t, "C%s" % t
+        return "[%s]" % t, "ℤ/%sℤ" % t
     else:
-        return "[%s,%s]" % t, "C%s&times;C%s" % t
+        return "[%s,%s]" % t, "ℤ/%sℤ&oplus;ℤ/%sℤ" % t
 
 class ECNFSearchArray(SearchArray):
     noun = "curve"

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -72,25 +72,7 @@ white-space: pre in order to keep line breaks! #}
     ($r \le {{data.mwbsd.rank_bounds.1}}$)
     {%endif%}
     {% else %}
-    {% if data.mwbsd.rank == 0 %}
-      {% if data.mwbsd.torsion == 1 %}
-        trivial
-      {% else %}
-        ${{data.mwbsd.tor_struct}}$
-      {%endif%}
-    {% elif data.mwbsd.rank==1 %}
-      {% if data.mwbsd.torsion == 1 %}
-        $\Z$
-      {% else %}
-        $\Z\times {{data.mwbsd.tor_struct}}$
-      {%endif%}
-    {% else %}
-      {% if data.mwbsd.torsion == 1 %}
-        $\Z^{{data.mwbsd.rank}}$
-      {% else %}
-        $\Z^{{data.mwbsd.rank}} \times {{data.mwbsd.tor_struct}}$
-      {% endif %}
-    {%endif%}
+    {{ data.mwbsd.mw_struct}}
     {%endif%}
     </p>
 

--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -59,8 +59,8 @@ class HomePageTest(LmfdbTest):
         """
         self.check_args("/EllipticCurve/Q/?jump=11.a2", r'y^2+y=x^3-x^2-10x-20')
         self.check_args("/EllipticCurve/Q/?jump=389.a", 'Elliptic curves in class 389.a')
-        self.check_args("/EllipticCurve/Q/?jump=%5B0%2C1%2C1%2C-2%2C0%5D", r'\Z^2')
-        self.check_args("/EllipticCurve/Q/?jump=%5B-3024%2C+46224%5D+", r'\Z^2')
+        self.check_args("/EllipticCurve/Q/?jump=%5B0%2C1%2C1%2C-2%2C0%5D", '0.15246')
+        self.check_args("/EllipticCurve/Q/?jump=%5B-3024%2C+46224%5D+", '0.15246')
 
     #
     # Various search combinations

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -520,12 +520,16 @@ class WebEC():
         mwbsd['generators'] = [raw_typeset(weighted_proj_to_affine_point(P)) for P in mwbsd['gens']] if mwbsd['ngens'] else ''
         mwbsd['heights'] = [RR(h) for h in mwbsd['heights']]
 
+        # Mordell-Weil group
+        invs = [0 for a in range(self.rank)] + [n for n in self.torsion_structure]
+        mwbsd['mw_struct'] = "trivial" if len(invs) == 0 else r'\(' + r' \oplus '.join((r'\Z' if n == 0 else r'\Z/{%s}\Z' % n) for n in invs) + r'\)'
+
         # Torsion structure and generators:
         if mwbsd['torsion'] == 1:
             mwbsd['tor_struct'] = ''
             mwbsd['tor_gens'] = ''
         else:
-            mwbsd['tor_struct'] = r' \times '.join(r'\Z/{%s}\Z' % n for n in self.torsion_structure)
+            mwbsd['tor_struct'] = r' \oplus '.join(r'\Z/{%s}\Z' % n for n in self.torsion_structure)
             tor_gens_tmp = [weighted_proj_to_affine_point(P) for P in mwbsd['torsion_generators']]
             mwbsd['tor_gens'] = raw_typeset(', '.join(str(P) for P in tor_gens_tmp),
                 ', '.join(web_latex(P) for P in tor_gens_tmp))
@@ -626,7 +630,7 @@ class WebEC():
             if "missing" in tg1['f']:
                 tg['fields_missing'] = True
             T = tgd['torsion']
-            tg1['t'] = r'\(' + r' \times '.join(r'\Z/{}\Z'.format(n) for n in T) + r'\)'
+            tg1['t'] = r'\(' + r' \oplus '.join(r'\Z/{}\Z'.format(n) for n in T) + r'\)'
             bcc = next((lab for lab, pol in zip(bcs, bc_pols) if pol==F), None)
             if bcc:
                 from lmfdb.ecnf.main import split_full_label

--- a/lmfdb/genus2_curves/test_genus2_curves.py
+++ b/lmfdb/genus2_curves/test_genus2_curves.py
@@ -189,13 +189,13 @@ class Genus2Test(LmfdbTest):
 
     def test_mwgroup(self):
         L = self.tc.get("/Genus2Curve/Q/25913/a/25913/1")
-        assert "\\Z \\times \\Z \\times \\Z" in L.get_data(as_text=True)
+        assert "\\Z \\oplus \\Z \\oplus \\Z" in L.get_data(as_text=True)
         assert "-x^3 - z^3" in L.get_data(as_text=True)
         assert "0.375585" in L.get_data(as_text=True)
         assert "\\infty" in L.get_data(as_text=True)
         assert "6.2.1658432.2" in L.get_data(as_text=True)
         L = self.tc.get("/Genus2Curve/Q/969306/a/969306/1")
-        assert "\\Z \\times \\Z \\times \\Z \\times \\Z/{2}\\Z" in L.get_data(as_text=True)
+        assert "\\Z \\oplus \\Z \\oplus \\Z \\oplus \\Z/{2}\\Z" in L.get_data(as_text=True)
         assert "16y" in L.get_data(as_text=True) and "2xz^2 + 11z^3" in L.get_data(as_text=True)
         assert "3.259671" in L.get_data(as_text=True)
         assert "\\infty" in L.get_data(as_text=True)

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -834,7 +834,7 @@ class WebG2C():
             if len(invs) == 0:
                 data['mw_group'] = 'trivial'
             else:
-                data['mw_group'] = r'\(' + r' \times '.join((r'\Z' if n == 0 else r'\Z/{%s}\Z' % n) for n in invs) + r'\)'
+                data['mw_group'] = r'\(' + r' \oplus '.join((r'\Z' if n == 0 else r'\Z/{%s}\Z' % n) for n in invs) + r'\)'
             if lower >= upper:
                 data['mw_gens_table'] = mw_gens_table (ratpts['mw_invs'], ratpts['mw_gens'], ratpts['mw_heights'], ratpts['rat_pts'])
                 data['mw_gens_simple_table'] = mw_gens_simple_table (ratpts['mw_invs'], ratpts['mw_gens'], ratpts['mw_heights'], ratpts['rat_pts'], data['min_eqn'])


### PR DESCRIPTION
Per the discussion on issue #5130, this PR includes changes to ensure the we use \oplus rather than \times whenever we display the structure of the torsion subgroup or Mordell Weil group of an elliptic curve over Q or a number field, or a genus 2 curve over Q.  This was already true in search results, but has been changed in the drop down lists for torsion structure, on the object pages, and in relevant headings on statistics pages.  See, for example,

http://127.0.0.1:37777/Genus2Curve/Q/6400/f/64000/1 vs https://www.lmfdb.org/Genus2Curve/Q/6400/f/64000/1
http://127.0.0.1:37777/EllipticCurve/Q/356730/by/4 vs  https://www.lmfdb.org/EllipticCurve/Q/356730/by/4
http://127.0.0.1:37777/EllipticCurve/Q/stats vs https://www.lmfdb.org/EllipticCurve/Q/stats http://127.0.0.1:37777/EllipticCurve/stats vs https://www.lmfdb.org/EllipticCurve/stats
http://127.0.0.1:37777/EllipticCurve/4.4.7225.1/81.3/c/7 vs https://www.lmfdb.org/EllipticCurve/4.4.7225.1/81.3/c/7
