### PR TITLE
Fix display of transitive inertia groups

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -533,7 +533,7 @@ def resolve_display(resolves):
 
 def group_display_inertia(code):
     if str(code[0]) == "t":
-        return transitive_group_display_knowl(base_label(*code[1]))
+        return group_pretty_and_nTj(code[1][0], code[1][1], useknowls=True)
     if code[1] == [1,1]:
         return "trivial"
     ans = "Intransitive group isomorphic to "+abstract_group_display_knowl(f"{code[1][0]}.{code[1][1]}")


### PR DESCRIPTION
This fixes an inconsistency.  On the page of a p-adic field with residue field degree 1, we have the inertia group as a transitive permutation group.  This displays it just like the Galois group by giving the abstract group knowl followed by (as nTj).

http://beta.lmfdb.org/padicField/2.6.8.3
http://127.0.0.1:37777/padicField/2.6.8.3
