### PR TITLE
Temporarily hide characters for cyclic automorphism groups on higher genus passport pages

### DIFF
--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -795,6 +795,7 @@ def render_passport(args):
 
         gp_string=str(gn) + '.' + str(gt)
         pretty_group=sg_pretty(gp_string)
+        info['cyclic'] = db.gps_small.lookup(gp_string,projection="cyclic")
 
         if gp_string == pretty_group:
             spname=False

--- a/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
+++ b/lmfdb/higher_genus_w_automorphisms/templates/hgcwa-show-passport.html
@@ -29,7 +29,9 @@ The full automorphism group for this family is ${{info.fullauto}}$ with signatur
 
 {% if info.jacobian_decomp %}
   <table><tr><td>{{KNOWL('ag.jacobian',title='Jacobian variety')}} {{KNOWL('curve.highergenus.aut.groupalgebradecomp', title='group algebra decomposition')}}:</td><td>${{info.jacobian_decomp}}$</td></tr>
+{% if not info.cyclic %}{# temporarily hide characters for cyclic groups pending recomputation of this data (some of which is incorrect) #}
     <tr><td >Corresponding {{KNOWL('curve.highergenus.aut.characters',title="character(s)")}}:</td><td> ${{info.corrChar}}$</td></tr>
+{% endif %}
   </table>
  {% endif %}
 


### PR DESCRIPTION
There is a data issue with some of the character computations associated to passports for cyclic automorphism gorups on some of the hgcwa pages (the wrong character is listed in some cases).  This data is all in the process of being recomputed, but in the mean time this PR will hide the erroneous character information.