### PR TITLE
Fix duplicate heading in EC/Q

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -21,6 +21,10 @@ curve:
   pari:  E = ellinit(%s)
   magma: E := EllipticCurve(%s);
 
+simple_curve:
+  sage: E.short_weierstrass_model()
+  magma: WeierstrassModel(E);
+
 gens:
   sage:  E.gens()
   magma: Generators(E);

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -65,12 +65,8 @@ white-space: pre in order to keep line breaks! #}
     </div>
 #}
 
-    <h2 style="margin-top:0px;"> {{ KNOWL('ec.q.minimal_weierstrass_equation', title='Minimal Weierstrass equation') }} </h2>
-
-    {{ place_code('curve') }}
-
-    <h2 class='min_eqn' style='margin-top:0px;'>            {{ KNOWL('ec.minimal_equation', 'Minimal equation') }} </h2>
-    <h2 class='proj_eqn nodisplay' style='margin-top:0px;'> {{ KNOWL('ec.minimal_equation', 'Minimal equation') }} </h2>
+    <h2 class='min_eqn' style='margin-top:0px;'>            {{ KNOWL('ec.q.minimal_weierstrass_equation', 'Minimal Weierstrass equation') }} </h2>
+    <h2 class='proj_eqn nodisplay' style='margin-top:0px;'> {{ KNOWL('ec.q.minimal_weierstrass_equation', 'Minimal Weierstrass equation') }} </h2>
     <h2 class='simp_eqn nodisplay' style='margin-top:0px;'> {{ KNOWL('ec.simple_equation',  'Simplified equation') }} </h2>
 
     <table>
@@ -88,8 +84,7 @@ white-space: pre in order to keep line breaks! #}
     <tr>
     </table>
 
-    {# <p> {{ data.data.equation | safe }} </p> #}
-
+    {{ place_code('curve') }}
 
     <h2> {{ KNOWL('ec.mordell_weil_group', title='Mordell-Weil group') }} structure</h2>
     <p>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -84,7 +84,7 @@ white-space: pre in order to keep line breaks! #}
     <tr>
     </table>
 
-    {{ place_code('curve') }}
+    <p>{{ place_code('curve') }}{{ place_code('simple_curve') }}</p>
 
     <h2> {{ KNOWL('ec.mordell_weil_group', title='Mordell-Weil group') }} structure</h2>
     <p>


### PR DESCRIPTION
This fixes a minor layout bug introduced when the simpify equation option was added to EC/Q (the minimal equation heading appears twice, once with the wrong knowl link).  I will merge this and push it to prod once tests pass.