### PR TITLE
Resolves #5159

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -93,6 +93,10 @@ def fixed_prec(r, digs=3):
     print(head)
     return str(head) + '.' + n[-digs:]
 
+@app.context_processor
+def ctx_raw_typeset():
+    return {'raw_typeset': raw_typeset}
+
 
 @app.context_processor
 def ctx_galois_groups():


### PR DESCRIPTION
As @edgarcosta noted, the raw_typeset errors in #5159 are the caused by not exposing raw_typeset to jinja (via `app.context_processor`).  I'm not sure why no one has noticed/encountered it before, but this fixes the problem (at least for number fields).