### PR TITLE
Add the ability to dynamically create things like aut_weyl_group

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1714,6 +1714,9 @@ class WebAbstractSubgroup(WebObj):
                 return Wtype(label, rec)
             elif rec.get("short_label") == label:
                 return Wtype(rec["label"], rec)
+        # It's possible that the label refers to a small group that is not in the database
+        # but that we can create dynamically
+        return Wtype(label)
 
     @lazy_attribute
     def _full(self):


### PR DESCRIPTION
Resolves some recent errors in the flasklog (which occurred when we were storing labels for automorphism groups and the like that were outside the range included in the database).  To see this change in effect, compare https://beta.lmfdb.org/Groups/Abstract/sub/80.11.1.a1.a1 and http://localhost:37777/Groups/Abstract/sub/80.11.1.a1.a1.