### PR TITLE
Upgrade to flask 2.2.2

### DIFF
--- a/lmfdb/local_fields/__init__.py
+++ b/lmfdb/local_fields/__init__.py
@@ -27,7 +27,6 @@ def redirect_local():
 
 
 app.register_blueprint(local_fields_page, url_prefix="/padicField")
-app.register_blueprint(local_fields_page, url_prefix="/LocalNumberField")
 
 # API2 has been disabled for now
 #from lmfdb.api2.searchers import register_search_function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 bcrypt
 cython
-flask<=1.1.4
+flask
 flask-cache
 flask-login
 flask-markdown
-markupsafe<=2.0.1
-itsdangerous<=2.0.1
+markupsafe
+itsdangerous
 psycopg2-binary
 pyflakes
 pytest


### PR DESCRIPTION
To upgrade your sage appropriately, do
```
sage -pip install flask -U
sage -pip install flask-login -U
```
In my tests, both http://localhost:37777/padicField/ and http://localhost:37777/LocalNumberField still work because of a redirect.

This should resolve #5177