### PR TITLE
Fix list of knowls for source/ack

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -144,7 +144,7 @@ def source():
     bread = bread_prefix() + [('Source', ' ')]
     return render_template("multi.html", kids=['rcs.source.nf',
                                                'rcs.ack.nf',
-                                               'rcs.ack.nf'],
+                                               'rcs.cite.nf'],
         title=t, bread=bread, learnmore=learnmore)
 
 


### PR DESCRIPTION
On the source and acknowlegments page for number fields, the extra acknowledgments appears twice and the "how to cite" not at all.  This fixes that.

http://127.0.0.1:37777/NumberField/Source
http://beta.lmfdb.org/NumberField/Source