### PR TITLE
Change wording

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -202,7 +202,7 @@
   {% endif %}
   {% if gp.semidirect_products %}
     <tr>
-      <td >{{KNOWL('group.semidirect_product', 'Semidirect product')}}:</td>
+      <td >{{KNOWL('group.semidirect_product', 'Nontrivial semidirect product')}}:</td>
       {% for sub, count, labels in gp.semidirect_products[:4] %}
         <td>${{sub.subgroup_tex_parened}}~\rtimes~{{sub.quotient_tex_parened}}$ {% if count > 1 %} ({{count}}){% endif %}</td>
       {% endfor %}


### PR DESCRIPTION
On the page for an individual group, the label for the line listing semidirect products says semidirect product.  This is technically not right since direct products are semidirect products.  This pull request just adds the word nontrivial, which is now explained in the knowl.

http://127.0.0.1:37777/Groups/Abstract/32.37
http://beta.lmfdb.org/Groups/Abstract/32.37