### PR TITLE
Fix rewrite so that it no longer deletes rows not matching query

### DIFF
--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -925,8 +925,7 @@ class PostgresTable(PostgresBase):
         restat=True,
         tostr_func=None,
         commit=True,
-        searchfile=None,
-        extrafile=None,
+        datafile=None,
         progress_count=10000,
         **kwds
     ):
@@ -945,8 +944,7 @@ class PostgresTable(PostgresBase):
         - ``tostr_func`` -- a function to be used when writing data to the temp file
             defaults to copy_dumps from encoding
         - ``commit`` -- whether to actually execute the rewrite
-        - ``searchfile`` -- a filename to use for the temp file holding the search table
-        - ``extrafile`` -- a filename to use for the temp file holding the extra table
+        - ``datafile`` -- a filename to use for the temp file holding the data
         - ``progress_count`` -- (default 10000) how frequently to print out status reports as the rewrite proceeds
         - ``**kwds`` -- any other keyword arguments are passed on to the ``reload`` method
 
@@ -962,79 +960,51 @@ class PostgresTable(PostgresBase):
             ....:     return rec
             sage: db.artin_reps.rewrite(add_signs)
         """
-        search_cols = ["id"] + self.search_cols
-        if self.extra_table is None:
-            projection = search_cols
-        else:
-            projection = search_cols + self.extra_cols
-            extra_cols = ["id"] + self.extra_cols
+        data_cols = projection = ["id"] + self.search_cols + self.extra_cols
         # It would be nice to just use Postgres' COPY TO here, but it would then be hard
         # to give func access to the data to process.
         # An alternative approach would be to use COPY TO and have func and filter both
         # operate on the results, but then func would have to process the strings
         if tostr_func is None:
             tostr_func = copy_dumps
-        if searchfile is None:
-            searchfile = tempfile.NamedTemporaryFile("w", delete=False)
-        elif os.path.exists(searchfile):
-            raise ValueError("Search file %s already exists" % searchfile)
+        if datafile is None:
+            datafile = tempfile.NamedTemporaryFile("w", delete=False)
+        elif os.path.exists(datafile):
+            raise ValueError("Data file %s already exists" % datafile)
         else:
-            searchfile = open(searchfile, "w")
-        if self.extra_table is None:
-            extrafile = EmptyContext()
-        elif extrafile is None:
-            extrafile = tempfile.NamedTemporaryFile("w", delete=False)
-        elif os.path.exists(extrafile):
-            raise ValueError("Extra file %s already exists" % extrafile)
-        else:
-            extrafile = open(extrafile, "w")
+            datafile = open(datafile, "w")
         start = time.time()
         count = 0
         tot = self.count(query)
         sep = kwds.get("sep", u"|")
         try:
-            with searchfile:
-                with extrafile:
-                    # write headers
-                    searchfile.write(sep.join(search_cols) + u"\n")
-                    searchfile.write(
-                        sep.join(self.col_type.get(col) for col in search_cols)
-                        + u"\n\n"
-                    )
-                    if self.extra_table is not None:
-                        extrafile.write(sep.join(extra_cols) + u"\n")
-                        extrafile.write(
-                            sep.join(self.col_type.get(col) for col in extra_cols)
-                            + u"\n\n"
-                        )
+            with datafile:
+                # write headers
+                datafile.write(sep.join(data_cols) + u"\n")
+                datafile.write(
+                    sep.join(self.col_type.get(col) for col in data_cols)
+                    + u"\n\n"
+                )
 
-                    for rec in self.search(query, projection=projection, sort=[]):
-                        processed = func(rec)
-                        searchfile.write(
-                            sep.join(
-                                tostr_func(processed.get(col), self.col_type[col])
-                                for col in search_cols
-                            )
-                            + u"\n"
+                for rec in self.search(query, projection=projection, sort=[]):
+                    processed = func(rec)
+                    datafile.write(
+                        sep.join(
+                            tostr_func(processed.get(col), self.col_type[col])
+                            for col in data_cols
                         )
-                        if self.extra_table is not None:
-                            extrafile.write(
-                                sep.join(
-                                    tostr_func(processed.get(col), self.col_type[col])
-                                    for col in extra_cols
-                                )
-                                + u"\n"
-                            )
-                        count += 1
-                        if (count % progress_count) == 0:
-                            print(
-                                "%d of %d records (%.1f percent) dumped in %.3f secs"
-                                % (count, tot, 100.0 * count / tot, time.time() - start)
-                            )
+                        + u"\n"
+                    )
+                    count += 1
+                    if (count % progress_count) == 0:
+                        print(
+                            "%d of %d records (%.1f percent) dumped in %.3f secs"
+                            % (count, tot, 100.0 * count / tot, time.time() - start)
+                        )
             print("All records dumped in %.3f secs" % (time.time() - start))
-            self.reload(
-                searchfile.name,
-                extrafile.name,
+            self.update_from_file(
+                datafile.name,
+                label_col="id",
                 resort=resort,
                 reindex=reindex,
                 restat=restat,
@@ -1044,9 +1014,7 @@ class PostgresTable(PostgresBase):
             )
             self.log_db_change("rewrite", query=query, projection=projection)
         finally:
-            os.unlink(searchfile.name)
-            if self.extra_table is not None:
-                os.unlink(extrafile.name)
+            os.unlink(datafile.name)
 
     def update_from_file(
         self,

--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -8,7 +8,7 @@ from psycopg2.sql import SQL, Identifier, Placeholder, Literal
 
 from .encoding import Json, copy_dumps
 from .base import PostgresBase, _meta_table_name
-from .utils import DelayCommit, EmptyContext, IdentifierWrapper, LockError, psycopg2_version
+from .utils import DelayCommit, IdentifierWrapper, LockError, psycopg2_version
 from .base import (
     _meta_indexes_cols,
     _meta_constraints_cols,


### PR DESCRIPTION
We now use `update_from_file` under the hood rather than `reload`.