### PR TITLE
remove extraneous space at end of links in knowls, resolves #5086

### DIFF
--- a/lmfdb/templates/knowl-defs.html
+++ b/lmfdb/templates/knowl-defs.html
@@ -12,9 +12,7 @@
     * title: to overwrite the knowl's title, usually just leave it
              to its default None.
 #}
-{% macro LINK_EXT(title, href) %}
-<a href="{{href}}" target="_blank">{{title}}</a>
-{% endmacro %}
+{% macro LINK_EXT(title, href) %}<a href="{{href}}" target="_blank">{{title}}</a>{% endmacro %}
 
 {% macro KNOWL(kid, title=none) -%}
 {% with ktitle = knowl_title(kid) -%}


### PR DESCRIPTION
Newline in LINK_EXT macro was adding an extra space after ever href (including in citations in knowls).