### PR TITLE
Resolves #4886

### DIFF
--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -214,6 +214,8 @@ class ECNF_stats(StatsDisplay):
     def signature_summary(self, sig):
         r, s = sig
         d = r+2*s
+        if sig not in self.sig_normstats:
+            return f'The database contains no curves defined over number fields of degree {d} and signature ({r},{s}).'
         stats = self.sig_normstats[r,s]
         ncurves = stats['ncurves']
         nclasses = stats['nclasses']

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -215,7 +215,7 @@ class ECNF_stats(StatsDisplay):
         r, s = sig
         d = r+2*s
         if sig not in self.sig_normstats:
-            return f'The database contains no curves defined over number fields of degree {d} and signature ({r},{s}).'
+            return ''
         stats = self.sig_normstats[r,s]
         ncurves = stats['ncurves']
         nclasses = stats['nclasses']

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -744,11 +744,11 @@ def statistics_by_signature(d,r):
     else:
         info['degree'] = d
 
-    if r not in range(d%2,d+1,2):
-        info['error'] = "Invalid signature %s" % info['sig']
     s = (d-r)//2
     sig = (r,s)
     info['sig'] = '%s,%s' % sig
+    if r not in range(d%2,d+1,2):
+        info['error'] = "Invalid signature %s" % info['sig']
     info['summary'] = ECNF_stats().signature_summary(sig)
 
     fields_by_sig = ECNF_stats().fields_by_sig

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -750,6 +750,8 @@ def statistics_by_signature(d,r):
     if r not in range(d%2,d+1,2):
         info['error'] = "Invalid signature %s" % info['sig']
     info['summary'] = ECNF_stats().signature_summary(sig)
+    if not info['summary']:
+        info['error'] = "The database does not contain any curves defined over fields of signature %s" % info['sig']
 
     fields_by_sig = ECNF_stats().fields_by_sig
     counts_by_field = ECNF_stats().field_normstats


### PR DESCRIPTION
Gracefully handle errors that occur when attempting to browse elliptic curves over number fields of a given signature when there are none in the database.