### PR TITLE
Automatic style fixing after PR's are merged

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -1,6 +1,7 @@
 name: Format python code
-on: push
-  branches: [ 'master' ]
+on:
+  push:
+    branches: [ 'master' ]
 jobs:
   autopep8:
     runs-on: ubuntu-latest

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -41,7 +41,7 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W503,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -8,7 +8,7 @@ jobs:
         id: checkout
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: ${{ github.repository }} == 'LMFDB/lmfdb'
+        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
           # see generate_autopep8codes.py
           # E241 - Fix extraneous whitespace around keywords.
@@ -25,7 +25,7 @@ jobs:
           # W391 - Remove trailing blank lines.
           # E401 - Put imports on separate lines.
           # E502 - Remove extraneous escape of newline.
-          # W504 - Fix line break after binary operator.
+          # W503 - Fix line break before binary operator.
           # W601 - Use "in" rather than "has_key()".
           # W602 - Fix deprecated form of raising exception.
           # W603 - Use "!=" instead of "<>"
@@ -40,7 +40,7 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W503,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -53,3 +53,4 @@ jobs:
           labels: autopep8, automated pr
           branch: autopep8-patches
           branch-sufix: timestamp
+          delete-branch: true

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -8,7 +8,7 @@ jobs:
         id: checkout
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
+        if: ${{ github.repository }} == 'LMFDB/lmfdb'
         with:
           # see generate_autopep8codes.py
           # E241 - Fix extraneous whitespace around keywords.
@@ -25,7 +25,6 @@ jobs:
           # W391 - Remove trailing blank lines.
           # E401 - Put imports on separate lines.
           # E502 - Remove extraneous escape of newline.
-          # W503 - Fix line break before binary operator.
           # W504 - Fix line break after binary operator.
           # W601 - Use "in" rather than "has_key()".
           # W602 - Fix deprecated form of raising exception.
@@ -41,7 +40,7 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -8,6 +8,10 @@ jobs:
         id: checkout
         with:
           repository: ${{github.event.push.repository}}
+      - name: foo
+          env:
+            FOO: ${{ steps.checkout.repository.full_name }}
+        run: echo "$FOO"
       - name: autopep8
         uses: peter-evans/autopep8@v1
         if: steps.checkout.repository.full_name == 'edgarcosta/lmfdb'

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -11,7 +11,7 @@ jobs:
           organization: ${{github.event.push.organization}}
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: steps.checkout.organization == 'LMFDB'
+        if: steps.checkout.organization == 'edgarcosta'
         with:
           args: --recursive --in-place --aggressive --aggressive lmfdb/
       - name: Create Pull Request

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -9,8 +9,8 @@ jobs:
         with:
           repository: ${{github.event.push.repository}}
       - name: foo
-          env:
-            FOO: ${{ steps.checkout.repository.full_name }}
+        env:
+          FOO: ${{ steps.checkout.repository.full_name }}
         run: echo "$FOO"
       - name: autopep8
         uses: peter-evans/autopep8@v1

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -50,6 +50,5 @@ jobs:
           title: Fixes by autopep8 action
           body: This is an auto-generated PR with fixes by autopep8.
           labels: autopep8, automated pr
-          branch: autopep8-patches
           branch-sufix: timestamp
           delete-branch: true

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -10,39 +10,40 @@ jobs:
         uses: peter-evans/autopep8@v1
         if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
+          # see generate_autopep8codes.py
+          # E241 - Fix extraneous whitespace around keywords.
+          # E242 - Remove extraneous whitespace around operator.
+          # E251 - Remove whitespace around parameter '=' sign.
+          # E252 - Missing whitespace around parameter equals.
+          # E26 -  Fix spacing after comment hash for inline comments.
+          # E27 -  Fix extraneous whitespace around keywords.
           # W291 - Remove trailing whitespace.
+          # W292 - Add a single newline at the end of the file.
+          # W293 - Remove trailing whitespace on blank line.
+          # E301 - Add missing blank line.
           # E303 - Remove extra blank lines.
           # E304 - Remove blank line following function decorator.
-          # E722 - Fix bare except.
-          # E252 - Missing whitespace around parameter equals.
-          # E241 - Fix extraneous whitespace around keywords.
-          # W602 - Fix deprecated form of raising exception.
           # E306 - Expected 1 blank line before a nested definition.
-          # E714 - Use 'is not' test for object identity.
-          # W690 - Fix various deprecated code (via lib2to3).
-          # E301 - Add missing blank line.
-          # E721 - Use "isinstance()" instead of comparing types directly.
-          # W293 - Remove trailing whitespace on blank line.
-          # E27 -  Fix extraneous whitespace around keywords.
-          # W604 - Use "repr()" instead of backticks.
+          # W391 - Remove trailing blank lines.
           # E401 - Put imports on separate lines.
+          # E502 - Remove extraneous escape of newline.
           # W503 - Fix line break before binary operator.
           # W504 - Fix line break after binary operator.
-          # E701 - Put colon-separated compound statement on separate lines.
-          # E242 - Remove extraneous whitespace around operator.
           # W601 - Use "in" rather than "has_key()".
-          # E251 - Remove whitespace around parameter '=' sign.
-          # E712 - Fix comparison with boolean.
-          # W292 - Add a single newline at the end of the file.
-          # E26 -  Fix spacing after comment hash for inline comments.
-          # W605 - Fix invalid escape sequence 'x'.
-          # E711 - Fix comparison with None.
-          # E502 - Remove extraneous escape of newline.
+          # W602 - Fix deprecated form of raising exception.
           # W603 - Use "!=" instead of "<>"
+          # W604 - Use "repr()" instead of backticks.
+          # W605 - Fix invalid escape sequence 'x'.
+          # W690 - Fix various deprecated code (via lib2to3).
           # E70 -  Put semicolon-separated compound statement on separate lines.
+          # E701 - Put colon-separated compound statement on separate lines.
+          # E711 - Fix comparison with None.
+          # E712 - Fix comparison with boolean.
           # E713 - Use 'not in' for test for membership.
-          # W391 - Remove trailing blank lines.
-          args: --recursive --in-place --aggressive --select=W291,E303,E304,E722,E252,E241,W602,E306,E714,W690,E301,E721,W293,E27,W604,E401,W503,W504,E701,E242,W601,E251,E712,W292,E26,W605,E711,E502,W603,E70,E713,W391 lmfdb/
+          # E714 - Use 'is not' test for object identity.
+          # E721 - Use "isinstance()" instead of comparing types directly.
+          # E722 - Fix bare except.
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E26,E27,W291,W292,W293,E301,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -6,11 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         id: checkout
-        with:
-          repository: ${{github.event.push.repository}}
       - name: foo
         env:
-          FOO: ${{ steps.checkout.repository.full_name }}
+          FOO: ${{ steps.checkout.repository }}
         run: echo "$FOO"
       - name: autopep8
         uses: peter-evans/autopep8@v1

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -50,5 +50,6 @@ jobs:
           title: Fixes by autopep8 action
           body: This is an auto-generated PR with fixes by autopep8.
           labels: autopep8, automated pr
-          branch-sufix: timestamp
+          branch: autopep8-patches
+          branch-suffix: timestamp
           delete-branch: true

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -7,9 +7,7 @@ jobs:
       - uses: actions/checkout@v2
         id: checkout
       - name: foo
-        env:
-          FOO: ${{ steps.checkout.repository }}
-        run: echo "$FOO"
+        run: echo "${{ steps.checkout.repository }}"
       - name: autopep8
         uses: peter-evans/autopep8@v1
         if: steps.checkout.repository.full_name == 'edgarcosta/lmfdb'

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -11,7 +11,7 @@ jobs:
           organization: ${{github.event.push.organization}}
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: checkout.organization == 'LMFDB'
+        if: steps.checkout.organization == 'LMFDB'
         with:
           args: --recursive --in-place --aggressive --aggressive lmfdb/
       - name: Create Pull Request

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -19,7 +19,6 @@ jobs:
           # W291 - Remove trailing whitespace.
           # W292 - Add a single newline at the end of the file.
           # W293 - Remove trailing whitespace on blank line.
-          # E301 - Add missing blank line.
           # E303 - Remove extra blank lines.
           # E304 - Remove blank line following function decorator.
           # E306 - Expected 1 blank line before a nested definition.
@@ -42,7 +41,7 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E301,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -8,7 +8,7 @@ jobs:
         id: checkout
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
+        if: ${{ github.repository }} == 'LMFDB/lmfdb'
         with:
           # see generate_autopep8codes.py
           # E241 - Fix extraneous whitespace around keywords.

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -8,7 +8,7 @@ jobs:
         id: checkout
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: ${{ github.repository }} == 'LMFDB/lmfdb'
+        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
           # see generate_autopep8codes.py
           # E241 - Fix extraneous whitespace around keywords.

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -17,6 +17,7 @@ jobs:
           # E251 - Remove whitespace around parameter '=' sign.
           # E252 - Missing whitespace around parameter equals.
           # E27 -  Fix extraneous whitespace around keywords.
+          # E266 - Fix too many leading '#' for block comments.
           # W291 - Remove trailing whitespace.
           # W292 - Add a single newline at the end of the file.
           # W293 - Remove trailing whitespace on blank line.
@@ -42,7 +43,7 @@ jobs:
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
           # E731 - Use a def when use do not assign a lambda expression.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722,E731 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E266,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722,E731 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -7,11 +7,10 @@ jobs:
       - uses: actions/checkout@v2
         id: checkout
         with:
-          ref: ${{github.event.push.head.ref}}
-          organization: ${{github.event.push.organization}}
+          repository: ${{github.event.push.repository}}
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: steps.checkout.organization == 'edgarcosta'
+        if: steps.checkout.repository.full_name == 'edgarcosta/lmfdb'
         with:
           args: --recursive --in-place --aggressive --aggressive lmfdb/
       - name: Create Pull Request

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -41,7 +41,8 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          # E731 - Use a def when use do not assign a lambda expression.
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E303,E304,E306,W391,E401,E502,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722,E731 lmfdb/
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -1,6 +1,6 @@
 name: Format python code
 on: push
-  #  branches: [ 'master' ]
+  branches: [ 'master' ]
 jobs:
   autopep8:
     runs-on: ubuntu-latest
@@ -9,7 +9,7 @@ jobs:
         id: checkout
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
+        if: ${{ github.repository }} == 'LMFDB/lmfdb'
         with:
           # see generate_autopep8codes.py
           # E241 - Fix extraneous whitespace around keywords.

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -1,5 +1,6 @@
 name: Format python code
 on: push
+  #  branches: [ 'master' ]
 jobs:
   autopep8:
     runs-on: ubuntu-latest
@@ -25,7 +26,7 @@ jobs:
           # W391 - Remove trailing blank lines.
           # E401 - Put imports on separate lines.
           # E502 - Remove extraneous escape of newline.
-          # W503 - Fix line break before binary operator.
+          # W504 - Fix line break after binary operator.
           # W601 - Use "in" rather than "has_key()".
           # W602 - Fix deprecated form of raising exception.
           # W603 - Use "!=" instead of "<>"
@@ -50,5 +51,5 @@ jobs:
           body: This is an auto-generated PR with fixes by autopep8.
           labels: autopep8, automated pr
           branch: autopep8-patches
-          branch-suffix: timestamp
+            # branch-suffix: timestamp
           delete-branch: true

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -6,11 +6,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         id: checkout
-      - name: foo
-        run: echo "${{ github.repository }}"
       - name: autopep8
         uses: peter-evans/autopep8@v1
-        if: steps.checkout.repository.full_name == 'edgarcosta/lmfdb'
+        if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
           args: --recursive --in-place --aggressive --aggressive lmfdb/
       - name: Create Pull Request

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -1,0 +1,24 @@
+name: Format python code
+on: push
+jobs:
+  autopep8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+        with:
+          ref: ${{github.event.push.head.ref}}
+          organization: ${{github.event.push.organization}}
+      - name: autopep8
+        uses: peter-evans/autopep8@v1
+        if: checkout.organization == 'LMFDB'
+        with:
+          args: --recursive --in-place --aggressive --aggressive lmfdb/
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: autopep8 action fixes
+          title: Fixes by autopep8 action
+          body: This is an auto-generated PR with fixes by autopep8.
+          labels: autopep8, automated pr
+          branch: autopep8-patches

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
         id: checkout
       - name: foo
-        run: echo "${{ steps.checkout.repository }}"
+        run: echo "${{ github.repository }}"
       - name: autopep8
         uses: peter-evans/autopep8@v1
         if: steps.checkout.repository.full_name == 'edgarcosta/lmfdb'

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -52,3 +52,4 @@ jobs:
           body: This is an auto-generated PR with fixes by autopep8.
           labels: autopep8, automated pr
           branch: autopep8-patches
+          branch-sufix: timestamp

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -15,7 +15,6 @@ jobs:
           # E242 - Remove extraneous whitespace around operator.
           # E251 - Remove whitespace around parameter '=' sign.
           # E252 - Missing whitespace around parameter equals.
-          # E26 -  Fix spacing after comment hash for inline comments.
           # E27 -  Fix extraneous whitespace around keywords.
           # W291 - Remove trailing whitespace.
           # W292 - Add a single newline at the end of the file.
@@ -43,7 +42,8 @@ jobs:
           # E714 - Use 'is not' test for object identity.
           # E721 - Use "isinstance()" instead of comparing types directly.
           # E722 - Fix bare except.
-          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E26,E27,W291,W292,W293,E301,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+          args: --recursive --in-place --aggressive --select=E241,E242,E251,E252,E27,W291,W292,W293,E301,E303,E304,E306,W391,E401,E502,W503,W504,W601,W602,W603,W604,W605,W690,E70,E701,E711,E712,E713,E714,E721,E722 lmfdb/
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -10,7 +10,17 @@ jobs:
         uses: peter-evans/autopep8@v1
         if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
-          args: --recursive --in-place --aggressive --aggressive lmfdb/
+          # E203 whitespace before ‘,’, ‘;’, or ‘:’
+          # E222 multiple spaces after operator
+          # E241 multiple spaces after ‘,’
+          # E251 unexpected spaces around keyword / parameter equals
+          # E301 expected 1 blank line, found 0
+          # E302 expected 2 blank lines, found 0
+          # E303 too many blank lines
+          # E304 blank lines found after function decorator
+          # E702 multiple statements on one line (semicolon)
+
+          args: --recursive --in-place --aggressive --select=E203,E222,E241,E251,E301,E302,E303,E304,E702 lmfdb/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -10,17 +10,39 @@ jobs:
         uses: peter-evans/autopep8@v1
         if: ${{ github.repository }} == 'edgarcosta/lmfdb'
         with:
-          # E203 whitespace before ‘,’, ‘;’, or ‘:’
-          # E222 multiple spaces after operator
-          # E241 multiple spaces after ‘,’
-          # E251 unexpected spaces around keyword / parameter equals
-          # E301 expected 1 blank line, found 0
-          # E302 expected 2 blank lines, found 0
-          # E303 too many blank lines
-          # E304 blank lines found after function decorator
-          # E702 multiple statements on one line (semicolon)
-
-          args: --recursive --in-place --aggressive --select=E203,E222,E241,E251,E301,E302,E303,E304,E702 lmfdb/
+          # W291 - Remove trailing whitespace.
+          # E303 - Remove extra blank lines.
+          # E304 - Remove blank line following function decorator.
+          # E722 - Fix bare except.
+          # E252 - Missing whitespace around parameter equals.
+          # E241 - Fix extraneous whitespace around keywords.
+          # W602 - Fix deprecated form of raising exception.
+          # E306 - Expected 1 blank line before a nested definition.
+          # E714 - Use 'is not' test for object identity.
+          # W690 - Fix various deprecated code (via lib2to3).
+          # E301 - Add missing blank line.
+          # E721 - Use "isinstance()" instead of comparing types directly.
+          # W293 - Remove trailing whitespace on blank line.
+          # E27 -  Fix extraneous whitespace around keywords.
+          # W604 - Use "repr()" instead of backticks.
+          # E401 - Put imports on separate lines.
+          # W503 - Fix line break before binary operator.
+          # W504 - Fix line break after binary operator.
+          # E701 - Put colon-separated compound statement on separate lines.
+          # E242 - Remove extraneous whitespace around operator.
+          # W601 - Use "in" rather than "has_key()".
+          # E251 - Remove whitespace around parameter '=' sign.
+          # E712 - Fix comparison with boolean.
+          # W292 - Add a single newline at the end of the file.
+          # E26 -  Fix spacing after comment hash for inline comments.
+          # W605 - Fix invalid escape sequence 'x'.
+          # E711 - Fix comparison with None.
+          # E502 - Remove extraneous escape of newline.
+          # W603 - Use "!=" instead of "<>"
+          # E70 -  Put semicolon-separated compound statement on separate lines.
+          # E713 - Use 'not in' for test for membership.
+          # W391 - Remove trailing blank lines.
+          args: --recursive --in-place --aggressive --select=W291,E303,E304,E722,E252,E241,W602,E306,E714,W690,E301,E721,W293,E27,W604,E401,W503,W504,E701,E242,W601,E251,E712,W292,E26,W605,E711,E502,W603,E70,E713,W391 lmfdb/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -2,7 +2,6 @@ import subprocess
 
 pro = subprocess.run('pycodestyle lmfdb', shell=True, capture_output=True)
 failedcodes = {line.split(':', 4)[3].lstrip().split(' ', 1)[0]  for line in pro.stdout.decode().splitlines()}
-failedcodes.discard('E26')
 
 autopep8 = r"""
 E241 - Fix extraneous whitespace around keywords.
@@ -45,6 +44,7 @@ W604 - Use "repr()" instead of backticks.
 W605 - Fix invalid escape sequence 'x'.
 W690 - Fix various deprecated code (via lib2to3).
 """
+allcodes.pop('E26')
 
 pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
 allcodes = dict(elt for elt in pairs if len(elt) == 2)

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -47,6 +47,7 @@ W690 - Fix various deprecated code (via lib2to3).
 allcodes.pop('E26')
 allcodes.pop('E301')
 allcodes.pop('W503')
+failedcodes.discard('E266') # autopep8 doesn't really fully fix this one
 
 pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
 allcodes = dict(elt for elt in pairs if len(elt) == 2)

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -1,6 +1,9 @@
 import subprocess
+
 pro = subprocess.run('pycodestyle lmfdb', shell=True, capture_output=True)
 failedcodes = {line.split(':', 4)[3].lstrip().split(' ', 1)[0]  for line in pro.stdout.decode().splitlines()}
+failedcodes.discard('E26')
+
 autopep8 = r"""
 E241 - Fix extraneous whitespace around keywords.
 E242 - Remove extraneous whitespace around operator.
@@ -42,9 +45,11 @@ W604 - Use "repr()" instead of backticks.
 W605 - Fix invalid escape sequence 'x'.
 W690 - Fix various deprecated code (via lib2to3).
 """
+
 pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
 allcodes = dict(elt for elt in pairs if len(elt) == 2)
-passingcodes = set(allcodes).difference(failedcodes)
+
+passingcodes = sorted(set(allcodes).difference(failedcodes), key=lambda x:x[1:])
 for elt in passingcodes:
     print(f"          # {elt} - {allcodes[elt]}")
 print(f"          args: --recursive --in-place --aggressive --select={','.join(passingcodes)} lmfdb/")

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -45,6 +45,7 @@ W605 - Fix invalid escape sequence 'x'.
 W690 - Fix various deprecated code (via lib2to3).
 """
 allcodes.pop('E26')
+allcodes.pop('E301')
 
 pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
 allcodes = dict(elt for elt in pairs if len(elt) == 2)

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -1,0 +1,50 @@
+import subprocess
+pro = subprocess.run('pycodestyle lmfdb', shell=True, capture_output=True)
+failedcodes = {line.split(':', 4)[3].lstrip().split(' ', 1)[0]  for line in pro.stdout.decode().splitlines()}
+autopep8 = r"""
+E241 - Fix extraneous whitespace around keywords.
+E242 - Remove extraneous whitespace around operator.
+E251 - Remove whitespace around parameter '=' sign.
+E252 - Missing whitespace around parameter equals.
+E26  - Fix spacing after comment hash for inline comments.
+E265 - Fix spacing after comment hash for block comments.
+E266 - Fix too many leading '#' for block comments.
+E27  - Fix extraneous whitespace around keywords.
+E301 - Add missing blank line.
+E302 - Add missing 2 blank lines.
+E303 - Remove extra blank lines.
+E304 - Remove blank line following function decorator.
+E305 - Expected 2 blank lines after end of function or class.
+E306 - Expected 1 blank line before a nested definition.
+E401 - Put imports on separate lines.
+E402 - Fix module level import not at top of file
+E501 - Try to make lines fit within --max-line-length characters.
+E502 - Remove extraneous escape of newline.
+E701 - Put colon-separated compound statement on separate lines.
+E70  - Put semicolon-separated compound statement on separate lines.
+E711 - Fix comparison with None.
+E712 - Fix comparison with boolean.
+E713 - Use 'not in' for test for membership.
+E714 - Use 'is not' test for object identity.
+E721 - Use "isinstance()" instead of comparing types directly.
+E722 - Fix bare except.
+E731 - Use a def when use do not assign a lambda expression.
+W291 - Remove trailing whitespace.
+W292 - Add a single newline at the end of the file.
+W293 - Remove trailing whitespace on blank line.
+W391 - Remove trailing blank lines.
+W503 - Fix line break before binary operator.
+W504 - Fix line break after binary operator.
+W601 - Use "in" rather than "has_key()".
+W602 - Fix deprecated form of raising exception.
+W603 - Use "!=" instead of "<>"
+W604 - Use "repr()" instead of backticks.
+W605 - Fix invalid escape sequence 'x'.
+W690 - Fix various deprecated code (via lib2to3).
+"""
+pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
+allcodes = dict(elt for elt in pairs if len(elt) == 2)
+passingcodes = set(allcodes).difference(failedcodes)
+for elt in passingcodes:
+    print(f"          # {elt} - {allcodes[elt]}")
+print(f"          args: --recursive --in-place --aggressive --select={','.join(passingcodes)} lmfdb/")

--- a/.github/workflows/generate_autopep8codes.py
+++ b/.github/workflows/generate_autopep8codes.py
@@ -46,6 +46,7 @@ W690 - Fix various deprecated code (via lib2to3).
 """
 allcodes.pop('E26')
 allcodes.pop('E301')
+allcodes.pop('W503')
 
 pairs = [tuple(elt.strip().replace(' - ', ' ').split(' ', 1)) for elt in autopep8.strip('\n').split('\n')]
 allcodes = dict(elt for elt in pairs if len(elt) == 2)


### PR DESCRIPTION
Note, we will not be enforcing any new style, just keeping the styles that we already satisfy.
If some style got broken, it creates a PR to fix it.
To see the kind of PR that this creates see https://github.com/edgarcosta/lmfdb/pull/12

In particular, when we merge this PR, we will get exactly the same PR submitted here.


This resolves #5224