### PR TITLE
Inertia subgroup not computed

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -534,6 +534,8 @@ def group_display_inertia(code):
         return group_pretty_and_nTj(code[1][0], code[1][1], useknowls=True)
     if code[1] == [1,1]:
         return "trivial"
+    if code[1][1] < 0:
+        ans = "intransitive group not computed"
     ans = "Intransitive group isomorphic to "+abstract_group_display_knowl(f"{code[1][0]}.{code[1][1]}")
     return ans
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -535,9 +535,8 @@ def group_display_inertia(code):
     if code[1] == [1,1]:
         return "trivial"
     if code[1][1] < 0:
-        ans = "intransitive group not computed"
-    ans = "Intransitive group isomorphic to "+abstract_group_display_knowl(f"{code[1][0]}.{code[1][1]}")
-    return ans
+        return "intransitive group not computed"
+    return "Intransitive group isomorphic to "+abstract_group_display_knowl(f"{code[1][0]}.{code[1][1]}")
 
 def cclasses(n, t):
     group = WebGaloisGroup.from_nt(n,t)


### PR DESCRIPTION
This deals with the display when the inertia subgroup of a p-adic field has not been computed.  This can only happen when the field is not totally ramified and the inertia group has large degree, and so far only in some fields which were just uploaded.

http://127.0.0.1:37777/padicField/2.16.54.316
http://beta.lmfdb.org/padicField/2.16.54.316