### PR TITLE
Add adelic image invariants to non-CM E/Q pages

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -466,6 +466,10 @@ The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {
   </p>
 {% endif %}
 
+{% if data.adelic_level %}
+<p> The image of the {{KNOWL('ec.galois_rep', title='adelic Galois representation')}} has {{KNOWL('ec.galois_rep_adelic_image', title='level')}} ${{data.adelic_level}}$, {{KNOWL('ec.galois_rep_adelic_image', title='index')}} ${{data.adelic_index}}$, and {{KNOWL('ec.galois_rep_adelic_image', title='genus')}} ${{data.adelic_genus}}$.</p>
+{% endif %}
+
 <h2>$p$-adic regulators</h2>
 
     {{ place_code('padicreg') }}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -310,9 +310,11 @@ class WebEC():
         data['an'] = classdata['anlist']
         data['ap'] = classdata['aplist']
 
-        # mod-p Galois images:
+        # ell-adic Galois images:
 
-        data['galois_data'] = list(db.ec_galrep.search({'lmfdb_label': lmfdb_label}))
+        # remove adelic image record (prime set to 0) from ell-adic data if present
+        data['galois_data'] = [r for r in list(db.ec_galrep.search({'lmfdb_label': lmfdb_label})) if r["prime"] > 0]
+
         # CM and Endo ring:
 
         data['CMD'] = self.cm


### PR DESCRIPTION
This PR adds information about the image of the adelic Galois representation of non-CM elliptic curves over Q to their home pages (we will want to add a know to display generators and the ability to search on adelic level and image, but that can wait, I want to merge this PR now because the data changes to ec_galrep to add the adelic image data have resulted in a spurios line being displayed in the ell-adic image data).

Once this PR is merged I will copy the updated ec_curvedata and ec_galrep tables to prod.  The data was computed using the `FindOpenImage` function you can find in [Zywina's OpenImage repo](https://github.com/davidzywina/OpenImage).  We will want to incorporate this into our pipeline for adding new E/Q to the LMFDB.