### PR TITLE
New data for BMF and ECNF

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -65,10 +65,10 @@ def index():
     """
     info = to_dict(request.args, search_array=BMFSearchArray(), stats=BianchiStats())
     if not request.args:
-        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,7,11,19,43,67,163, 23,31]]
-        sl2_fields = gl2_fields + ["2.0.{}.1".format(d) for d in [20]]
-        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,7,11,19,43,67,163, 23,31]]
-        sl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [4,8,3,7,11,19,43,67,163,5]]
+        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,20,24,7,40,11,52,56,15,68,19,84,88,23]]#,31,35,39,43,47,51,53,55,59,67,71,79,83,87,91,95,163]]
+        sl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,20,7,11,19,43,67,163]]
+        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,5,6,7,10,11,13,14,15,17,19,21,22,23]]#,31,35,39,43,47,51,53,55,59,67,71,79,83,87,91,95,163]]
+        sl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,5,7,11,19,43,67,163]]
         info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
@@ -866,4 +866,4 @@ class BianchiStats(StatsDisplay):
 
     @property
     def short_summary(self):
-        return r'The database currently contains %s %s of weight 2 over the nine imaginary quadratic fields of class number one.  Here are some <a href="%s">further statistics</a>.' % (comma(self.nforms), display_knowl("mf.bianchi.bianchimodularforms", "Bianchi modular forms"), url_for(".statistics"))
+        return r'The database currently contains %s %s of weight 2 over %s imaginary quadratic fields.  Here are some <a href="%s">further statistics</a>.' % (comma(self.nforms), display_knowl("mf.bianchi.bianchimodularforms", "Bianchi modular forms"), self.nformfields, url_for(".statistics"))

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -10,10 +10,10 @@
 <table class="browse">
   <tr>
     <td>{{ KNOWL('mf.bianchi.newform', 'Newforms')}} by base field:</td>
-    <td>{% for f in info.field_forms %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {%-endfor %}</td>
+    <td>{% for f in info.field_forms %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {%-endfor %} ...</td>
   </tr><tr>
     <td>{{ KNOWL('mf.bianchi.level', '\(\GL_2\)')}} {{ KNOWL('mf.bianchi.spaces', 'newform spaces')}} by base field:</td>
-    <td>{% for f in info.gl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {% endfor %}</td>
+    <td>{% for f in info.gl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {% endfor %} ...</td>
   </tr><tr>
     <td>{{ KNOWL('mf.bianchi.level', '\(\SL_2\)')}}  {{ KNOWL('mf.bianchi.spaces', 'newform spaces')}} by base field:</td>
     <td>{% for f in info.sl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {% endfor %}</td>

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -54,7 +54,7 @@ class BMFTest(LmfdbTest):
         Check that various search combinations work.
         """
         self.check_args(base_url+"?field_label=2.0.7.1&level_norm=322&count=10", 'Results (4 matches)')
-        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", '/ModularForm/GL2/ImaginaryQuadratic/2.0.19.1/2025.1/a/')
+        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", 'ModularForm/GL2/ImaginaryQuadratic/2.0.95.1/16.5/a/')
 
     # tests for newspace pages
     def test_newspace(self):

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -21,10 +21,10 @@ logger = make_logger("bmf")
 # Schembri.  At some point we will want to list these abelian surfaces
 # as friends when there is no curve.
 
-# TO (after adding 31 more for 2.0.43.1): make this list into a table,
-# OR add a column to the bmf_forms table to indicate whether or not a
-# curve exists (which could be because we have not foud one, but is
-# normally because there really is not curve).
+# TODO: make this list into a table, OR add a column to the bmf_forms
+# table to indicate whether or not a curve exists (which could be
+# because we have not found one, but is normally because there really
+# is no curve).
 
 bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.4.1-34225.7-a',
@@ -78,7 +78,22 @@ bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.43.1-10609.1-a',
                       '2.0.43.1-10609.3-a',
                       '2.0.43.1-11449.1-a',
-                      '2.0.43.1-11449.3-a']
+                      '2.0.43.1-11449.3-a',
+                      '2.0.56.1-127.1-a',
+                      '2.0.56.1-127.1-b',
+                      '2.0.56.1-127.2-a',
+                      '2.0.56.1-127.2-b',
+                      # '2.0.59.1-675.5-b',
+                      # '2.0.59.1-675.8-b',
+                      '2.0.68.1-901.1-a',
+                      '2.0.68.1-901.1-b',
+                      '2.0.68.1-901.2-a',
+                      '2.0.68.1-901.2-b',
+                      '2.0.91.1-784.1-a',
+                      '2.0.91.1-784.1-b',
+                      # '2.0.95.1-624.5-c',
+                      # '2.0.95.1-624.5-d',
+]
 
 def cremona_label_to_lmfdb_label(lab):
     if "." in lab:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -191,7 +191,7 @@ def index():
                             for nf in rqfs)])
 
     # Imaginary quadratics (sample)
-    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 7, 11, 19, 43, 67, 163, 23, 31]]
+    iqfs = ['2.0.{}.1'.format(d) for d in [4, 8, 3, 20, 24, 7, 40, 11, 52]] #, 56, 15, 68, 19, 84, 88, 23, 43, 67, 163]]
     info['fields'].append(['By <a href="{}">imaginary quadratic field</a>'.format(url_for('.statistics_by_signature', d=2, r=0)),
                            ((nf, [url_for('.show_ecnf1', nf=nf), field_pretty(nf)])
                             for nf in iqfs)])

--- a/scripts/ecnf/bmf_check.py
+++ b/scripts/ecnf/bmf_check.py
@@ -22,7 +22,7 @@ fields = ['2.0.{}.1'.format(d) for d in abs_discs]
 
 x = polygen(QQ)
 def poly(d):
-    return x**2+d if d%4 in [1,2] else x**2-x+(d+1)//4
+    return x**2+(d//4) if d%4==0 else x**2-x+(d+1)//4
 
 polys = dict([(field,poly(d)) for field,d in zip(fields, abs_discs)])
 

--- a/scripts/ecnf/bmf_check.py
+++ b/scripts/ecnf/bmf_check.py
@@ -16,14 +16,20 @@ nfcurves = db.ec_nfcurves
 print("setting bmf forms")
 forms = db.bmf_forms
 
-fields = ['2.0.{}.1'.format(d) for d in [4,8,3,7,11]]
+abs_discs = [4,8,3,7,11,18,43,67,163,23,31,47, 59, 71, 79, 83, 20, 24, 15, 35, 52,
+                                         40, 51, 88, 84, 91, 56, 55, 68, 39, 87,95]
+fields = ['2.0.{}.1'.format(d) for d in abs_discs]
+
 x = polygen(QQ)
+def poly(d):
+    return x**2+d if d%4 in [1,2] else x**2-x+(d+1)//4
 
-polys = {'2.0.4.1': x**2+1, '2.0.8.1': x**2+2, '2.0.3.1': x**2-x+1,
-         '2.0.7.1': x**2-x+2, '2.0.11.1': x**2-x+3, }
+polys = dict([(field,poly(d)) for field,d in zip(fields, abs_discs)])
 
-gen_names = {'2.0.4.1': 'i', '2.0.8.1': 't', '2.0.3.1': 'w',
-             '2.0.7.1': 'a', '2.0.11.1': 'a', }
+def gen_name(d):
+    return 'i' if d==4 else 't' if d==8 else 'w' if d==3 else 'a'
+
+gen_names = dict([(field,gen_name(d)) for field,d in zip(fields, abs_discs)])
 
 false_curves = {'2.0.4.1': ['34225.7-a', '34225.7-b', '34225.3-a', '34225.3-b'],
                 
@@ -39,7 +45,10 @@ false_curves = {'2.0.4.1': ['34225.7-a', '34225.7-b', '34225.3-a', '34225.3-b'],
                             '40000.1-b', '40000.7-b'],
 
                 '2.0.11.1': [] }
-                
+
+for fld in fields:
+    if fld not in false_curves:
+        false_curves[fld] = []
 
 def field_from_label(lab):
     r"""


### PR DESCRIPTION
See #5268  for more details.  In this PR we fix a test (necessitated by having extra data), and change the browse/search pages http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/ and http://localhost:37777/EllipticCurve/.  There are now too many IQFs to list them all so we list the first few and add dots to suggest that there are more.  For ECNFs you can se the extra data at http://localhost:37777/EllipticCurve/browse/2/0/ but there is no corresponding page for BMFs.

These knowls have also been updated: 

http://localhost:37777/knowledge/show/rcs.cande.mf.bianchi
http://localhost:37777/knowledge/show/rcs.source.mf.bianchi
http://localhost:37777/knowledge/show/rcs.cande.ec
http://localhost:37777/knowledge/show/rcs.source.ec

so these will need to be reviewed around the same time that the data is copied to prod.  I suggest that this waits a few days to allow more testing on beta (I am running some consistency checks hich will take a while).

Meanwhile I welcome feedback on the revised browse/search pages and knowls.  For the BMF completeness, I extended the complete table of level norms for each field, but for the ECNF completeness knowl (IQF section) I linked back to the BMF completeness instead of copying the table as had been the case.