### PR TITLE
ecnf base_change part 1

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -610,11 +610,15 @@ class ECNF():
             # ('j-invariant', self.j),
             ('CM', self.cm_bool)]
 
+        if not self.base_change:
+            self.base_change = []  # in case it was False or None instead of []
+        # (temporary) delete labels of curves over intermediate fields (not Q)
+        self.base_change = [lab for lab in self.base_change if '-' not in lab]
         if self.base_change:
+            # delete incomplete labels
             self.base_change = [lab for lab in self.base_change if '?' not in lab]
             self.properties += [('Base change', 'yes: %s' % ','.join(str(lab) for lab in self.base_change))]
         else:
-            self.base_change = []  # in case it was False instead of []
             self.properties += [('Base change', 'no')]
         self.properties += [('Q-curve', self.qc)]
 


### PR DESCRIPTION
See #5279 

The only effect of this is that if the base_change column of ec_nfcurves contains labels of curves over number fields (not Q), they are ignored when displaying the curve's home page.  I tested this by manually changing this column entry for a couple of curves, but then I changed them back (as without this code change the display was confusing -- though whether anyone would have noticed that for a couple f curves over one sexstic field is unlikely!).

The test for a label begin for a curve over a number field is simply that those labe;s contain "-".  The code which ignores labels containing '?' was there already.