### PR TITLE
Base change2

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -11,7 +11,7 @@ from lmfdb.number_fields.web_number_field import WebNumberField, field_pretty
 from lmfdb.lfunctions.LfunctionDatabase import (get_lfunction_by_url,
                                         get_instances_by_Lhash_and_trace_hash)
 from lmfdb.sato_tate_groups.main import st_display_knowl
-from lmfdb.elliptic_curves.web_ec import conductor_from_label
+from lmfdb.elliptic_curves.web_ec import conductor_from_label, cremona_label_to_lmfdb_label
 
 # The conductor label seems to only have three parts for the trivial ideal (1.0.1)
 # field 3.1.23.1 uses upper case letters for isogeny class
@@ -691,6 +691,7 @@ class ECNF():
 
         if not self.base_change:
             self.base_change = []  # in case it was False or None instead of []
+        self.nbc = len(self.base_change)
 
         # add base_change yes/no to Properties box
         if self.base_change:
@@ -707,9 +708,11 @@ class ECNF():
             ('Rank', r),
         ]
 
-        # add links to base curves if base-change - first separate labels over Q from others:
+        # add links to base curves if base-change - first separate
+        # labels over Q from others, and convert any Cremona labels to
+        # LMFDB labels:
+        self.base_change_Q = [cremona_label_to_lmfdb_label(lab) for lab in self.base_change if '-' not in lab]
 
-        self.base_change_Q = [lab for lab in self.base_change if '-' not in lab]
         # sort by conductor (so also unkown curves come last)
         self.base_change_Q.sort(key=lambda lab:ZZ(conductor_from_label(lab)))
         self.bcQtext = [] # for the Base change section of the home page
@@ -731,10 +734,10 @@ class ECNF():
             field_knowl = FIELD(nf).knowl()
             if '?' in lab:
                 cond_norm = cond.split(".")[0]
-                self.bcNFtext.append("a curve over {} with conductor norm {} (not in the database)".format(field_knowl,cond_norm))
+                self.bcNFtext.append(["{}".format(field_knowl), "a curve with conductor norm {} (not in the database)".format(cond_norm)])
             else:
                 url = url_for(".show_ecnf", nf=nf, conductor_label=cond, class_label=cl, number=num)
-                self.bcNFtext.append('<a href="{}">{}</a> (defined over {})'.format(url,lab,field_knowl))
+                self.bcNFtext.append(["{}".format(field_knowl), '<a href="{}">{}</a>'.format(url,lab)])
                 self.friends += [(r'Base change of %s' % lab, url)]
         self._code = None # will be set if needed by get_code()
 

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -1,14 +1,93 @@
+import re
 from flask import url_for
 from urllib.parse import quote
+from markupsafe import Markup, escape
 from sage.all import (Infinity, PolynomialRing, QQ, RDF, ZZ, KodairaSymbol,
                       implicit_plot, plot, prod, rainbow, sqrt, text, var)
 from lmfdb import db
 from lmfdb.utils import (encode_plot, names_and_urls, web_latex, display_knowl,
-                         web_latex_split_on, integer_squarefree_part)
-from lmfdb.number_fields.web_number_field import WebNumberField
+                         web_latex_split_on, integer_squarefree_part, nf_string_to_label)
+from lmfdb.number_fields.web_number_field import WebNumberField, field_pretty
 from lmfdb.lfunctions.LfunctionDatabase import (get_lfunction_by_url,
                                         get_instances_by_Lhash_and_trace_hash)
 from lmfdb.sato_tate_groups.main import st_display_knowl
+from lmfdb.elliptic_curves.web_ec import conductor_from_label
+
+# The conductor label seems to only have three parts for the trivial ideal (1.0.1)
+# field 3.1.23.1 uses upper case letters for isogeny class
+LABEL_RE = re.compile(r"\d+\.\d+\.\d+\.\d+-\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+\d+")
+SHORT_LABEL_RE = re.compile(r"\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+\d+")
+CLASS_LABEL_RE = re.compile(r"\d+\.\d+\.\d+\.\d+-\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+")
+SHORT_CLASS_LABEL_RE = re.compile(r"\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+")
+FIELD_RE = re.compile(r"\d+\.\d+\.\d+\.\d+")
+
+def split_full_label(lab):
+    r""" Split a full curve label into 4 components
+    (field_label,conductor_label,isoclass_label,curve_number)
+    """
+    if not LABEL_RE.fullmatch(lab):
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid elliptic curve label." % escape(lab)))
+    data = lab.split("-")
+    field_label = data[0]
+    conductor_label = data[1]
+    isoclass_label = re.search("(CM)?[a-zA-Z]+", data[2]).group()
+    curve_number = re.search(r"\d+", data[2]).group()  # (a string)
+    return (field_label, conductor_label, isoclass_label, curve_number)
+
+
+def split_short_label(lab):
+    r""" Split a short curve label into 3 components
+    (conductor_label,isoclass_label,curve_number)
+    """
+    if not SHORT_LABEL_RE.fullmatch(lab):
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid short elliptic curve label." % escape(lab)))
+    data = lab.split("-")
+    conductor_label = data[0]
+    isoclass_label = re.search("[a-zA-Z]+", data[1]).group()
+    curve_number = re.search(r"\d+", data[1]).group()  # (a string)
+    return (conductor_label, isoclass_label, curve_number)
+
+
+def split_class_label(lab):
+    r""" Split a class label into 3 components
+    (field_label, conductor_label,isoclass_label)
+    """
+    if not CLASS_LABEL_RE.fullmatch(lab):
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid elliptic curve isogeny class label." % escape(lab)))
+    data = lab.split("-")
+    field_label = data[0]
+    conductor_label = data[1]
+    isoclass_label = data[2]
+    return (field_label, conductor_label, isoclass_label)
+
+
+def split_short_class_label(lab):
+    r""" Split a short class label into 2 components
+    (conductor_label,isoclass_label)
+    """
+    if not SHORT_CLASS_LABEL_RE.fullmatch(lab):
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid short elliptic curve isogeny class label." % escape(lab)))
+    data = lab.split("-")
+    conductor_label = data[0]
+    isoclass_label = data[1]
+    return (conductor_label, isoclass_label)
+
+def conductor_label_norm(lab):
+    r""" extract norm from conductor label (as a string)"""
+    s = lab.replace(' ','')
+    if re.match(r'\d+.\d+',s):
+        return s.split('.')[0]
+    else:
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid conductor label. It must be of the form N.m or [N,c,d]" % escape(lab)))
+
+def get_nf_info(lab):
+    r""" extract number field label from string and pretty"""
+    try:
+        label = nf_string_to_label(lab)
+        pretty = field_pretty (label)
+    except ValueError as err:
+        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid number field label. %s" % (escape(lab),err)))
+    return label, pretty
 
 special_names = {'2.0.4.1': 'i',
                  '2.2.5.1': 'phi',
@@ -612,12 +691,10 @@ class ECNF():
 
         if not self.base_change:
             self.base_change = []  # in case it was False or None instead of []
-        # (temporary) delete labels of curves over intermediate fields (not Q)
-        self.base_change = [lab for lab in self.base_change if '-' not in lab]
+
+        # add base_change yes/no to Properties box
         if self.base_change:
-            # delete incomplete labels
-            self.base_change = [lab for lab in self.base_change if '?' not in lab]
-            self.properties += [('Base change', 'yes: %s' % ','.join(str(lab) for lab in self.base_change))]
+            self.properties += [('Base change', 'yes')]
         else:
             self.properties += [('Base change', 'no')]
         self.properties += [('Q-curve', self.qc)]
@@ -630,9 +707,35 @@ class ECNF():
             ('Rank', r),
         ]
 
-        for E0 in self.base_change:
-            self.friends += [(r'Base change of %s /\(\Q\)' % E0, url_for("ec.by_ec_label", label=E0))]
+        # add links to base curves if base-change - first separate labels over Q from others:
 
+        self.base_change_Q = [lab for lab in self.base_change if '-' not in lab]
+        # sort by conductor (so also unkown curves come last)
+        self.base_change_Q.sort(key=lambda lab:ZZ(conductor_from_label(lab)))
+        self.bcQtext = [] # for the Base change section of the home page
+        for lab in self.base_change_Q:
+            if '?' in lab:
+                cond = conductor_from_label(lab)
+                self.bcQtext.append('a curve of conductor {} (not in the database)'.format(cond))
+                # but omit from friends
+            else:
+                url = url_for("ec.by_ec_label", label=lab)
+                self.bcQtext.append('<a href="{}">{}</a>'.format(url,lab))
+                self.friends += [(r'Base change of {} /\(\Q\)'.format(lab), url)]
+
+        self.base_change_NF = [lab for lab in self.base_change if '-' in lab]
+        # we want to use split_full_label but that will fail if the class code + number are '?'
+        self.base_change_NFsplit = [(lab,)+split_full_label(lab.replace('?','a1')) for lab in self.base_change_NF]
+        self.bcNFtext = [] # for the Base change section of the home page
+        for (lab,nf,cond,cl,num) in self.base_change_NFsplit:
+            field_knowl = FIELD(nf).knowl()
+            if '?' in lab:
+                cond_norm = cond.split(".")[0]
+                self.bcNFtext.append("a curve over {} with conductor norm {} (not in the database)".format(field_knowl,cond_norm))
+            else:
+                url = url_for(".show_ecnf", nf=nf, conductor_label=cond, class_label=cl, number=num)
+                self.bcNFtext.append('<a href="{}">{}</a> (defined over {})'.format(url,lab,field_knowl))
+                self.friends += [(r'Base change of %s' % lab, url)]
         self._code = None # will be set if needed by get_code()
 
         self.downloads = [('All stored data to text', url_for(".download_ECNF_all", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number))]

--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -11,6 +11,12 @@ from lmfdb.lfunctions.LfunctionDatabase import (get_lfunction_by_url,
 
 logger = make_logger("ecnf")
 
+def curve_url(c):
+    return url_for(".show_ecnf",
+                   nf=c['field_label'],
+                   conductor_label=c['conductor_label'],
+                   class_label=c['iso_label'],
+                   number=c['number'])
 
 class ECNF_isoclass():
 
@@ -88,13 +94,6 @@ class ECNF_isoclass():
         self.field = FIELD(self.field_label)
         self.field_name = field_pretty(self.field_label)
         self.field_knowl = nf_display_knowl(self.field_label, self.field_name)
-
-        def curve_url(c):
-            return url_for(".show_ecnf",
-                           nf=c['field_label'],
-                           conductor_label=c['conductor_label'],
-                           class_label=c['iso_label'],
-                           number=c['number'])
 
         self.curves = [[c['short_label'], curve_url(c), web_ainvs(self.field_label,c['ainvs'])] for c in self.db_curves]
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -9,7 +9,6 @@ import time
 from urllib.parse import quote, unquote
 
 from flask import render_template, request, url_for, redirect, send_file, make_response, abort
-from markupsafe import Markup, escape
 from sage.all import factor, is_prime, QQ, ZZ, PolynomialRing
 
 from lmfdb import db
@@ -31,85 +30,15 @@ from lmfdb.number_fields.web_number_field import nf_display_knowl, WebNumberFiel
 from lmfdb.sato_tate_groups.main import st_display_knowl
 from lmfdb.ecnf import ecnf_page
 from lmfdb.ecnf.ecnf_stats import ECNF_stats
-from lmfdb.ecnf.WebEllipticCurve import ECNF, web_ainvs
+
+from lmfdb.ecnf.WebEllipticCurve import (ECNF, web_ainvs, LABEL_RE,
+                                         CLASS_LABEL_RE,
+                                         FIELD_RE, split_full_label,
+                                         split_class_label,
+                                         conductor_label_norm,
+                                         get_nf_info)
+
 from lmfdb.ecnf.isog_class import ECNF_isoclass
-
-# The conductor label seems to only have three parts for the trivial ideal (1.0.1)
-# field 3.1.23.1 uses upper case letters for isogeny class
-LABEL_RE = re.compile(r"\d+\.\d+\.\d+\.\d+-\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+\d+")
-SHORT_LABEL_RE = re.compile(r"\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+\d+")
-CLASS_LABEL_RE = re.compile(r"\d+\.\d+\.\d+\.\d+-\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+")
-SHORT_CLASS_LABEL_RE = re.compile(r"\d+\.\d+(\.\d+)?-(CM)?[a-zA-Z]+")
-FIELD_RE = re.compile(r"\d+\.\d+\.\d+\.\d+")
-
-def split_full_label(lab):
-    r""" Split a full curve label into 4 components
-    (field_label,conductor_label,isoclass_label,curve_number)
-    """
-    if not LABEL_RE.fullmatch(lab):
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid elliptic curve label." % escape(lab)))
-    data = lab.split("-")
-    field_label = data[0]
-    conductor_label = data[1]
-    isoclass_label = re.search("(CM)?[a-zA-Z]+", data[2]).group()
-    curve_number = re.search(r"\d+", data[2]).group()  # (a string)
-    return (field_label, conductor_label, isoclass_label, curve_number)
-
-
-def split_short_label(lab):
-    r""" Split a short curve label into 3 components
-    (conductor_label,isoclass_label,curve_number)
-    """
-    if not SHORT_LABEL_RE.fullmatch(lab):
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid short elliptic curve label." % escape(lab)))
-    data = lab.split("-")
-    conductor_label = data[0]
-    isoclass_label = re.search("[a-zA-Z]+", data[1]).group()
-    curve_number = re.search(r"\d+", data[1]).group()  # (a string)
-    return (conductor_label, isoclass_label, curve_number)
-
-
-def split_class_label(lab):
-    r""" Split a class label into 3 components
-    (field_label, conductor_label,isoclass_label)
-    """
-    if not CLASS_LABEL_RE.fullmatch(lab):
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid elliptic curve isogeny class label." % escape(lab)))
-    data = lab.split("-")
-    field_label = data[0]
-    conductor_label = data[1]
-    isoclass_label = data[2]
-    return (field_label, conductor_label, isoclass_label)
-
-
-def split_short_class_label(lab):
-    r""" Split a short class label into 2 components
-    (conductor_label,isoclass_label)
-    """
-    if not SHORT_CLASS_LABEL_RE.fullmatch(lab):
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid short elliptic curve isogeny class label." % escape(lab)))
-    data = lab.split("-")
-    conductor_label = data[0]
-    isoclass_label = data[1]
-    return (conductor_label, isoclass_label)
-
-def conductor_label_norm(lab):
-    r""" extract norm from conductor label (as a string)"""
-    s = lab.replace(' ','')
-    if re.match(r'\d+.\d+',s):
-        return s.split('.')[0]
-    else:
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid conductor label. It must be of the form N.m or [N,c,d]" % escape(lab)))
-
-def get_nf_info(lab):
-    r""" extract number field label from string and pretty"""
-    try:
-        label = nf_string_to_label(lab)
-        pretty = field_pretty (label)
-    except ValueError as err:
-        raise ValueError(Markup("<span style='color:black'>%s</span> is not a valid number field label. %s" % (escape(lab),err)))
-    return label, pretty
-
 
 def get_bread(*breads):
     bc = [("Elliptic curves", url_for(".index"))]

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -502,41 +502,52 @@ Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>   con
 
 <h2> {{KNOWL('ec.base_change','Base change')}} </h2>
 <div>
+
 <p>
-This curve {% if ec.base_change_Q %} is the
-{{KNOWL('ec.base_change','base change')}} from \(\Q\) of
-<ul>
-{% for E0 in ec.bcQtext%}
-  <li>
-{{E0 | safe}}
-</li>
-  {% endfor %}
-</ul>
-It is hence also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+  {% if ec.qc=="yes" %}
+  This elliptic curve is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+  {% elif ec.qc=="no" %}
+  This elliptic curve is not a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+  {% else %}
+  It has not yet been determined whether or not this elliptic curve is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+  {% endif %}
+
+  {% if ec.base_change %}
+It is the {{KNOWL('ec.base_change','base change')}} of the following
+{% if ec.nbc == 1 %}
+elliptic curve:
 {% else %}
-is not the {{KNOWL('ec.base_change','base change')}} of an elliptic curve defined over \(\Q\).
-{% if ec.qc=="yes" %}
-It is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
-{% elif ec.qc=="no" %}
-It is not a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
-{% else %}
-It has not yet been determined whether or not it is a  {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+{{ ec.nbc }} elliptic curves:
 {% endif %}
-{% endif %}
-</p>
-{% if ec.base_change_NF %}
-<p>
-{% if ec.base_change_Q %} It is also {% else %} This curve is {% endif %} the
-{{KNOWL('ec.base_change','base change')}} of
-<ul>
-{% for E0 in ec.bcNFtext%}
-<li>
-  {{E0 | safe}}
-  </li>
+<table class="ntdata"><thead>
+<tr>
+<th>Base field</th>
+<th>Curve</th>
+</tr>
+</thead><tbody>
+{% for e in ec.bcQtext %}
+<tr>
+<td align=center> \(\Q\)</td>
+<td align=center>{{e | safe}}</td>
+</tr>
 {% endfor %}
-</ul>
+{% for e in ec.bcNFtext %}
+<tr>
+<td align=center>{{e[0] | safe}}</td>
+<td align=center>{{e[1] | safe}}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</p>
+
+{% else %}
+
+<p>
+  It is not the {{KNOWL('ec.base_change','base change')}} of an elliptic curve defined over any subfield.
 </p>
 {% endif %}
+
 </div>
 
 {% if DEBUG %}

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -503,12 +503,16 @@ Its isogeny class <a href={{ ec.urls.class }}>{{ec.short_class_label}}</a>   con
 <h2> {{KNOWL('ec.base_change','Base change')}} </h2>
 <div>
 <p>
-This curve {% if ec.base_change %} is the
-{{KNOWL('ec.base_change','base change')}} of
-{% for E0 in ec.base_change%}
-<a href={{url_for("ec.by_ec_label",label=E0)}}>{{E0}}</a>,
-{% endfor %}
-defined over \(\Q\), so it is also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
+This curve {% if ec.base_change_Q %} is the
+{{KNOWL('ec.base_change','base change')}} from \(\Q\) of
+<ul>
+{% for E0 in ec.bcQtext%}
+  <li>
+{{E0 | safe}}
+</li>
+  {% endfor %}
+</ul>
+It is hence also a {{KNOWL('ec.q_curve', '\(\Q\)-curve')}}.
 {% else %}
 is not the {{KNOWL('ec.base_change','base change')}} of an elliptic curve defined over \(\Q\).
 {% if ec.qc=="yes" %}
@@ -520,6 +524,19 @@ It has not yet been determined whether or not it is a  {{KNOWL('ec.q_curve', '\(
 {% endif %}
 {% endif %}
 </p>
+{% if ec.base_change_NF %}
+<p>
+{% if ec.base_change_Q %} It is also {% else %} This curve is {% endif %} the
+{{KNOWL('ec.base_change','base change')}} of
+<ul>
+{% for E0 in ec.bcNFtext%}
+<li>
+  {{E0 | safe}}
+  </li>
+{% endfor %}
+</ul>
+</p>
+{% endif %}
 </div>
 
 {% if DEBUG %}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -64,6 +64,9 @@ def class_lmfdb_label(conductor, iso_class):
 def class_cremona_label(conductor, iso_class):
     return "%s%s" % (conductor, iso_class)
 
+def cremona_label_to_lmfdb_label(clab):
+    return clab if "." in clab else next(db.ec_curvedata.search({"Clabel": clab}, projection='lmfdb_label'))
+
 logger = make_logger("ec")
 
 def gl2_subgroup_data(label):

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -47,6 +47,11 @@ def split_lmfdb_label(lab):
 def split_cremona_label(lab):
     return cremona_label_regex.match(lab).groups()
 
+def conductor_from_label(lab):
+    if "?" in lab: 
+        return lab.split(".")[0]
+    return split_lmfdb_label(lab)[0] if '.' in lab else  split_cremona_label(lab)[0]
+
 def curve_lmfdb_label(conductor, iso_class, number):
     return "%s.%s%s" % (conductor, iso_class, number)
 


### PR DESCRIPTION
This displays the newly uploaded data about base change of elliptic curves from base fields other than Q (as well as base change from Q as before).

The properties box now only says "yes" or "no" for base change.  The Base change section at the bottom of a curve's home page now display base change information as a table, with links when the downstairs curve is in the database and a suitable message otherwise (so even then those curves are over Q there is more informatin than before).

Examples:

http://localhost:37777/EllipticCurve/6.6.453789.1/189.1/b/1 : cyclic sextic base field, curve is b.c. from Q so also of curves over the quadratic and cubic subfields

http://localhost:37777/EllipticCurve/6.6.820125.1/289.1/g/1 : sextic base field, curve is b.c. from a cubic subfield (but not Q)

http://localhost:37777/EllipticCurve/6.6.820125.1/64.1/b/1 : sextic base field, b.c. from quadratic subfield

http://localhost:37777/EllipticCurve/4.4.13824.1/24.1/b/6 : quartic base field with one quadratic subfield, base change from that and from Q

http://localhost:37777/EllipticCurve/4.4.1600.1/400.1/a/5 : biquadratic base field, b.c. from Q(x4) and from three quadratic fields (x2 each)

Use the random faility for more examples.  Note that with the current data without this patch, you might ask for base-change curves only but see curves which say that they are not base change.  The knowl for base change suggests that "base change" is short for "base change from Q" because that matched the old data;  I think it should be changed (after this) to being short for "base change from a proper subfield".

I also think that the search box labelled "Q-curves" should be changed to something like "Q-curves / base change", as I suggested recently (but have not put into this PR).  I still find myself looking for a search box called "base change" for several seconds before I remember that it is hidden behind "Q-curves".