### PR TITLE
patch unittest2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pytest-cov
 pytest-xdist
 pyyaml
 timeout_decorator
-unittest2
+git+https://github.com/edgarcosta/unittest2


### PR DESCRIPTION
to avoid 
```
/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/unittest2/compatibility.py:143: in <module>
    class ChainMap(collections.MutableMapping):
E   AttributeError: module 'collections' has no attribute 'MutableMapping'

```