### PR TITLE
hide conductors from property box (ECNF), keeping conductor norm

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -683,7 +683,8 @@ class ECNF():
         self.properties += [('Base field', self.field.field_pretty())]
 
         self.properties += [
-            ('Conductor', self.cond),
+            # hide conductor in Properties box (can be very large)
+            # ('Conductor', self.cond),
             ('Conductor norm', self.cond_norm),
             # See issue #796 for why this is hidden (can be very large)
             # ('j-invariant', self.j),


### PR DESCRIPTION
As suggested in #5287.  For example, compare https://www.lmfdb.org/EllipticCurve/6.6.820125.1/289.1/g/1 with http://localhost:37777/EllipticCurve/6.6.820125.1/289.1/g/1

The compplete conductor, as an ideal, is still displayed on the page.