### PR TITLE
Fixes links on browse table for hypergeoemtric motives

### DIFF
--- a/lmfdb/hypergm/templates/hgm-index.html
+++ b/lmfdb/hypergm/templates/hgm-index.html
@@ -23,55 +23,55 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 </tr>
 <tr>
 <th>0</th>
-<td><a href="?weight=0&degree=1&family=1">1</a></td>
-<td><a href="?weight=0&degree=3&family=1">3</a></td>
-<td><a href="?weight=0&degree=5&family=1">7</a></td>
-<td><a href="?weight=0&degree=7&family=1">21</a></td>
-<td class="rightline"><a href="?weight=0&degree=9&family=1">13</a></td>
-<td><a href="?weight=0&degree=2&family=1">3</a></td>
-<td><a href="?weight=0&degree=4&family=1">11</a></td>
-<td><a href="?weight=0&degree=6&family=1">23</a></td>
-<td><a href="?weight=0&degree=8&family=1">51</a></td>
-<td><a href="?weight=0&degree=10&family=1">23</a></td>
+<td><a href="?weight=0&degree=1&search_type=Family">1</a></td>
+<td><a href="?weight=0&degree=3&search_type=Family">3</a></td>
+<td><a href="?weight=0&degree=5&search_type=Family">7</a></td>
+<td><a href="?weight=0&degree=7&search_type=Family">21</a></td>
+<td class="rightline"><a href="?weight=0&degree=9&search_type=Family">13</a></td>
+<td><a href="?weight=0&degree=2&search_type=Family">3</a></td>
+<td><a href="?weight=0&degree=4&search_type=Family">11</a></td>
+<td><a href="?weight=0&degree=6&search_type=Family">23</a></td>
+<td><a href="?weight=0&degree=8&search_type=Family">51</a></td>
+<td><a href="?weight=0&degree=10&search_type=Family">23</a></td>
 </tr>
 <tr>
 <th>2</th>
 <td></td>
-<td><a href="?weight=2&degree=3&family=1">10</a></td>
-<td><a href="?weight=2&degree=5&family=1">93</a></td>
-<td><a href="?weight=2&degree=7&family=1">426</a></td>
-<td class="rightline"><a href="?weight=2&degree=9&family=1">1836</a></td>
+<td><a href="?weight=2&degree=3&search_type=Family">10</a></td>
+<td><a href="?weight=2&degree=5&search_type=Family">93</a></td>
+<td><a href="?weight=2&degree=7&search_type=Family">426</a></td>
+<td class="rightline"><a href="?weight=2&degree=9&search_type=Family">1836</a></td>
 <td></td>
-<td><a href="?weight=2&degree=4&family=1">30</a></td>
-<td><a href="?weight=2&degree=6&family=1">234</a></td>
-<td><a href="?weight=2&degree=8&family=1">1234</a></td>
-<td><a href="?weight=2&degree=10&family=1">4475</a></td>
+<td><a href="?weight=2&degree=4&search_type=Family">30</a></td>
+<td><a href="?weight=2&degree=6&search_type=Family">234</a></td>
+<td><a href="?weight=2&degree=8&search_type=Family">1234</a></td>
+<td><a href="?weight=2&degree=10&search_type=Family">4475</a></td>
 </tr>
 <tr>
 <th>4</th>
 <td></td>
 <td></td>
-<td><a href="?weight=4&degree=5&family=1">47</a></td>
-<td><a href="?weight=4&degree=7&family=1">414</a></td>
-<td class="rightline"><a href="?weight=4&degree=9&family=1">2878</a></td>
+<td><a href="?weight=4&degree=5&search_type=Family">47</a></td>
+<td><a href="?weight=4&degree=7&search_type=Family">414</a></td>
+<td class="rightline"><a href="?weight=4&degree=9&search_type=Family">2878</a></td>
 <td></td>
 <td></td>
-<td><a href="?weight=4&degree=6&family=1">84</a></td>
-<td><a href="?weight=4&degree=8&family=1">894</a></td>
-<td><a href="?weight=4&degree=10&family=1">5737</a></td>
+<td><a href="?weight=4&degree=6&search_type=Family">84</a></td>
+<td><a href="?weight=4&degree=8&search_type=Family">894</a></td>
+<td><a href="?weight=4&degree=10&search_type=Family">5737</a></td>
 </tr>
 <tr>
 <th>6</th>
 <td></td>
 <td></td>
 <td></td>
-<td><a href="?weight=6&degree=7&family=1">142</a></td>
-<td class="rightline"><a href="?weight=6&degree=9&family=1">1263</a></td>
+<td><a href="?weight=6&degree=7&search_type=Family">142</a></td>
+<td class="rightline"><a href="?weight=6&degree=9&search_type=Family">1263</a></td>
 <td></td>
 <td></td>
 <td></td>
-<td><a href="?weight=6&degree=8&family=1">204</a></td>
-<td><a href="?weight=6&degree=10&family=1">1936</a></td>
+<td><a href="?weight=6&degree=8&search_type=Family">204</a></td>
+<td><a href="?weight=6&degree=10&search_type=Family">1936</a></td>
 </tr>
 <tr>
 <th>8</th>
@@ -79,12 +79,12 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td></td>
 <td></td>
 <td></td>
-<td class="rightline"><a href="?weight=8&degree=9&family=1">363</a></td>
+<td class="rightline"><a href="?weight=8&degree=9&search_type=Family">363</a></td>
 <td></td>
 <td></td>
 <td></td>
 <td></td>
-<td><a href="?weight=8&degree=10&family=1">426</a></td>
+<td><a href="?weight=8&degree=10&search_type=Family">426</a></td>
 </tr>
 <tr class="topline">
 <th >1</th>
@@ -93,11 +93,11 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td ></td>
 <td ></td>
 <td class="rightline"></td>
-<td ><a href="?weight=1&degree=2&family=1">10</a></td>
-<td ><a href="?weight=1&degree=4&family=1">74</a></td>
-<td ><a href="?weight=1&degree=6&family=1">287</a></td>
-<td ><a href="?weight=1&degree=8&family=1">1001</a></td>
-<td ><a href="?weight=1&degree=10&family=1">2197</a></td>
+<td ><a href="?weight=1&degree=2&search_type=Family">10</a></td>
+<td ><a href="?weight=1&degree=4&search_type=Family">74</a></td>
+<td ><a href="?weight=1&degree=6&search_type=Family">287</a></td>
+<td ><a href="?weight=1&degree=8&search_type=Family">1001</a></td>
+<td ><a href="?weight=1&degree=10&search_type=Family">2197</a></td>
 </tr>
 <tr>
 <th>3</th>
@@ -107,10 +107,10 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td></td>
 <td class="rightline"></td>
 <td></td>
-<td><a href="?weight=3&degree=4&family=1">47</a></td>
-<td><a href="?weight=3&degree=6&family=1">487</a></td>
-<td><a href="?weight=3&degree=8&family=1">3247</a></td>
-<td><a href="?weight=3&degree=10&family=1">14397</a></td>
+<td><a href="?weight=3&degree=4&search_type=Family">47</a></td>
+<td><a href="?weight=3&degree=6&search_type=Family">487</a></td>
+<td><a href="?weight=3&degree=8&search_type=Family">3247</a></td>
+<td><a href="?weight=3&degree=10&search_type=Family">14397</a></td>
 </tr>
 <tr>
 <th>5</th>
@@ -121,9 +121,9 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td class="rightline"></td>
 <td></td>
 <td></td>
-<td><a href="?weight=5&degree=6&family=1">142</a></td>
-<td><a href="?weight=5&degree=8&family=1">1450</a></td>
-<td><a href="?weight=5&degree=10&family=1">10260</a></td>
+<td><a href="?weight=5&degree=6&search_type=Family">142</a></td>
+<td><a href="?weight=5&degree=8&search_type=Family">1450</a></td>
+<td><a href="?weight=5&degree=10&search_type=Family">10260</a></td>
 </tr>
 <tr>
 <th>7</th>
@@ -135,8 +135,8 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td></td>
 <td></td>
 <td></td>
-<td><a href="?weight=7&degree=8&family=1">363</a></td>
-<td><a href="?weight=7&degree=10&family=1">3407</a></td>
+<td><a href="?weight=7&degree=8&search_type=Family">363</a></td>
+<td><a href="?weight=7&degree=10&search_type=Family">3407</a></td>
 </tr>
 <tr>
 <th>9</th>
@@ -149,7 +149,7 @@ the number of corresponding {{KNOWL('hgm.familes', title="hypergeometric familie
 <td></td>
 <td></td>
 <td></td>
-<td><a href="?weight=9&degree=10&family=1">812</a></td>
+<td><a href="?weight=9&degree=10&search_type=Family">812</a></td>
 </tr>
 </table>
 </div>


### PR DESCRIPTION
For example, converting
 https://beta.lmfdb.org/Motive/Hypergeometric/Q/?weight=0&degree=6&family=1
 to
 https://beta.lmfdb.org/Motive/Hypergeometric/Q/?degree=6&weight=0&search_type=Family