### PR TITLE
Fix multiplicity in aut diagram

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -983,12 +983,15 @@ def factor_latex(n):
     return "$%s$" % web_latex(factor(n), False)
 
 def diagram_js(gp, layers, display_opts, aut=False):
+    # Counts are not right for aut diagram if we know up to conj.
+    if aut and not gp.outer_equivalence:
+        autcounts = gp.aut_class_counts
     ll = [
         [
             grp.subgroup,
             grp.short_label,
             grp.subgroup_tex,
-            grp.count,
+            grp.count if (gp.outer_equivalence or not aut) else autcounts[grp.aut_label],
             grp.subgroup_order,
             gp.tex_images.get(grp.subgroup_tex, gp.tex_images["?"]),
             grp.diagramx[0] if aut else (grp.diagramx[2] if grp.normal else grp.diagramx[1]),

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1119,6 +1119,23 @@ class WebAbstractGroup(WebObj):
             edges = [list(edge) for edge in edges]
         return [nodes, edges]
 
+    # Figuring out the subgroup count for an autjugacy class might not be stored
+    # directly.  We do them all at once.  If we only computed up to aut
+    # return {} since we don't need this
+    # output is a dictionary of aut_labels and counts
+    @lazy_attribute
+    def aut_class_counts(self):
+        counts = {}
+        if self.outer_equivalence:
+            return counts
+        subs = self.subgroups
+        for s in subs.values():
+            if s.aut_label in counts:
+                counts[s.aut_label] += s.count
+            else:
+                counts[s.aut_label] = s.count
+        return counts
+
     @lazy_attribute
     def tex_images(self):
         all_tex = list(set(H.subgroup_tex for H in self.subgroups.values())) + ["?"]


### PR DESCRIPTION
In a group like

`http://beta.lmfdb.org/Groups/Abstract/144.111
http://127.0.0.1:37777/Groups/Abstract/144.111

there are 5 conjugacy classes of subgroups of order 2 each containing 3 subgroups, which are all in one class up to automorphism.  In the diagram of subgroups up to automorphism, the count should be 15, and this fixes it.

In the group D_4,

http://beta.lmfdb.org/Groups/Abstract/8.3
http://127.0.0.1:37777/Groups/Abstract/8.3

subgroups of order 2 fall into 2 classes up to automorphism, one class has 2 conjugacy classes with 2 subgroups each, and the other has one conjugacy class with one subgroup.

There should be no changes to the conjugacy class diagram, or diagrams when we only store subgroups up to automorphsim.  An example of the latter is

http://127.0.0.1:37777/Groups/Abstract/32.51
http://beta.lmfdb.org/Groups/Abstract/32.51
