### PR TITLE
Fix friends link from abstract groups to Sato-Tate groups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1131,7 +1131,9 @@ def render_abstract_group(label, data=None):
 
         if db.gps_st.count({"component_group": label}) > 0:
             st_url = (
-                "/SatoTateGroup/?hst=List&component_group=%5B"
+                "/SatoTateGroup/?hst=List&"
+                + 'include_irrational=yes&'
+                + 'component_group=%5B'
                 + str(gap_ints[0])
                 + "%2C"
                 + str(gap_ints[1])


### PR DESCRIPTION
On

http://127.0.0.1:37777/Groups/Abstract/83.1
http://beta.lmfdb.org/Groups/Abstract/83.1

there is a friends link for component group of a Sato-Tate group.  It comes up empty on beta, but not after this change.