### PR TITLE
Fix highlighting of subgroups

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -489,7 +489,7 @@ Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
       {% if not loop.first %}
         ${{symb}}$</td><td>
       {% endif %}
-      <span class="{{sub.spanclass()}} series" data-sgseries="{{spandata}}" data-sgid="{{sub.label}}">${{sub.subgroup_tex}}$</span></td>
+      <span class="{{sub.spanclass()}} series" data-sgseries="{{spandata}}" data-sgid="{{sub.short_label}}">${{sub.subgroup_tex}}$</span></td>
     {% endfor %}
   </tr>
   {% endfor %}


### PR DESCRIPTION
On almost any finite group, such as

http://beta.lmfdb.org/Groups/Abstract/8.3

if your mouse hovers over a subgroup in one of the series (derived, chief, etc.), that series is highlit, maybe other series are highlit (but not all), and that's it.  If you hover over a subgroup such as the center or one from the diagram, that subgroup is highlit everywhere except in the series.

With this change, if you hover over a subgroup in a series, all subgroups in the series are highlit everywhere, and if you hover over a subgroup somewhere else, then it is highlit everywhere.

http://127.0.0.1:37777/Groups/Abstract/8.3

