### PR TITLE
Lots of minor changes

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -143,8 +143,15 @@
       {% else %}
       <tr>
         <td>{{KNOWL('group.division', 'Divisions')}}</td>
-          <td  colspan="{{gp.order_stats|length}}">data not computed</td>
-          <td class="border-left"></td>
+          {% if gp.division_stats %}
+            {% for c in gp.division_stats %}
+              <td>{{ c[1] }}</td>
+            {% endfor %}
+        <td class="border-left">{{ gp.number_divisions }}</td>
+          {% else %}
+            <td  colspan="{{gp.order_stats|length}}">data not computed</td>
+            <td class="border-left"></td>
+          {% endif %}
       </tr>
       <tr style="border-bottom:none;">
         <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -87,12 +87,8 @@
     <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{gp.exponent}} </td></tr>
     <tr><td>{{KNOWL('group.automorphism', 'Automorphism group')}}:</td><td>{{gp.show_aut_group()|safe}}</td></tr>
     <tr><td>{{KNOWL('group.outer_aut', 'Outer automorphisms')}}:</td><td>{{gp.show_outer_group()|safe}}</td></tr>
-    {% if not gp.live() %}
     <tr><td>{{KNOWL('group.permutation_degree', 'Permutation degree')}}:</td><td>{{gp.transitive_degree}}</td></tr>
-    {% if not (gp.solvable or gp.simple) %}
     <tr><td>{{KNOWL('group.chief_series', 'Composition factors')}}:</td><td>{{gp.show_composition_factors()|safe}}</td></tr>
-    {% endif %}
-    {% endif %}
   </table>
 </p>
 
@@ -143,6 +139,17 @@
           <td>{{ c[1] }}</td>
         {% endfor %}
         <td class="border-left">{{ gp.number_autjugacy_classes }}</td>
+      </tr>
+      {% else %}
+      <tr>
+        <td>{{KNOWL('group.division', 'Divisions')}}</td>
+          <td  colspan="{{gp.order_stats|length}}">data not computed</td>
+          <td class="border-left"></td>
+      </tr>
+      <tr style="border-bottom:none;">
+        <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+          <td colspan="{{gp.order_stats|length}}">data not computed</td>
+          <td class="border-left"></td>
       </tr>
       {% endif %}
     </tbody>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -246,18 +246,40 @@
       {% endif %}
     </tr>
   {% endif %}
-  {% if not gp.live() or gp.pgroup > 1 %}
   <tr>
     <td>{{KNOWL('group.rank', 'Rank')}}:</td>
-    <td>${{gp.rank}}$</td>
+    {% if gp.rank %}
+      <td>${{gp.rank}}$</td>
+    {% else %}
+      <td>not computed</td>
+    {% endif %}
   </tr>
-  {% endif %}
-  {% if not gp.live() and gp.order > 1 and gp.eulerian_function is defined %}
   <tr>
     <td>{{KNOWL('group.generators', 'Inequivalent ' + gp.gen_noun())}}:</td>
+  {% if gp.eulerian_function is defined %}
     <td>${{gp.eulerian_function}}$</td>
+    {% else %} <td>not computed</td> {% endif %}
+  
   </tr>
-  {% endif %}
+</table>
+
+{% else %}
+
+<h2>Constructions</h2>
+
+<table class=nowrap>
+  <tr>
+    <td>{{KNOWL('group.rank', 'Rank')}}:</td>
+    {% if gp.rank %}
+      <td>${{gp.rank}}$</td>
+    {% else %} <td>not computed</td> {% endif %}
+  <tr>
+    <td>{{KNOWL('group.generators', 'Inequivalent ' + gp.gen_noun())}}:</td>
+    {% if gp.eulerian_function %}
+      <td>${{gp.eulerian_function}}$</td>
+    {% else %} <td>not computed</td> {% endif %}
+  </tr>
+  </tr>
 </table>
 
 {% endif %} {# not live and abelian #}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -335,6 +335,12 @@ class WebAbstractGroup(WebObj):
         return None
 
     @lazy_attribute
+    def transitive_degree(self):
+        if isinstance(self.G, LiveAbelianGroup):
+            return self.order
+        return "not computed"
+
+    @lazy_attribute
     def pgroup(self):
         if self.order == 1:
             return 1
@@ -759,14 +765,19 @@ class WebAbstractGroup(WebObj):
                 ])
             except AssertionError:  # timed out
                 pass
+        if "not" in str(self.transitive_degree):
+            props.extend([("Perm deg.", "not computed")])
+        else:
+            props.extend([("Perm deg.", f"${self.transitive_degree}$")])
         if not self.live():
             props.extend([
-                ("Rank", f"${self.rank}$"),
-                ("Perm deg.", f"${self.transitive_degree}$"),
+                ("Rank", f"${self.rank}$")
                 # ("Faith. dim.", str(self.faithful_reps[0][0])),
             ])
         elif self.pgroup > 1:
             props.append(("Rank", f"${self.rank}$"))
+        else:
+            props.extend([("Rank", "not computed")])
         return props
 
     @lazy_attribute
@@ -1226,7 +1237,7 @@ class WebAbstractGroup(WebObj):
     @lazy_attribute
     def cc_stats(self):
         if self.abelian:
-            return self.order_stats
+            return sorted(self.order_stats)
         return sorted(Counter([cc.order for cc in self.conjugacy_classes]).items())
 
     @lazy_attribute
@@ -1437,7 +1448,37 @@ class WebAbstractGroup(WebObj):
     def out_order_factor(self):
         return latex(factor(self.outer_order))
 
+    def live_composition_factors(self):
+        from .main import by_abelian_label
+        from .main import url_for_label
+        basiclist = []
+        if isinstance(self.G, LiveAbelianGroup) or self.solvable:
+            theorder = ZZ(self.G.Order()).factor()
+            # We could work harder here to get small group labels for
+            # these cyclic groups, but why bother?  This way, the lookup
+            # is only done for one of them, and only if the user clicks
+            # on the link
+            basiclist = [(url_for(".by_abelian_label", label=z[0]),
+                "C_{%d}"%z[0], 
+                "" if z[1] == 1 else "<span style='font-size: small'> x %d</span>"% z[1]
+                )
+                for z in theorder]
+
+        # The only non-solvable option with order a multiple of 128
+        # below 2000 is ...
+        if ZZ(self.G.Order()) == 1920:
+            basiclist = [
+                (url_for(".by_abelian_label", label=2), "C_2", "<span style='font-size: small'> x 5</span>"),
+                (url_for_label("60.5"), "A_5", "")]
+        if not basiclist:
+            return "data not computed"
+        return ", ".join('<a href="%s">$%s$</a>%s' % z for z in basiclist)
+
     def show_composition_factors(self):
+        if self.live():
+            return self.live_composition_factors()
+        if self.order == 1:
+            return "none"
         CF = Counter(self.composition_factors)
         display = {
             rec["label"]: rec["tex_name"]
@@ -1448,7 +1489,8 @@ class WebAbstractGroup(WebObj):
         from .main import url_for_label
 
         def exp(n):
-            return "" if n == 1 else f" ({n})"
+            #return "" if n == 1 else f" ({n})"
+            return "" if n == 1 else f"<span style='font-size: small'> x {n}</span>"
 
         return ", ".join(
             f'<a href="{url_for_label(label)}">${display[label]}$</a>{exp(e)}'
@@ -1665,6 +1707,9 @@ class LiveAbelianGroup():
 
     def Exponent(self):
         return self.snf[-1] if self.snf else 1
+
+    def CharacterDegrees(self):
+        return [(1,self.Order())]
 
     def Sylows(self):
         if not self.snf:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -504,6 +504,9 @@ class WebAbstractGroup(WebObj):
     def rank(self):
         if self.pgroup > 1:
             return ZZ(self.G.RankPGroup())
+        if isinstance(self.G, LiveAbelianGroup):
+            return len(self.snf)
+        return None
 
     @lazy_attribute
     def primary_abelian_invariants(self):
@@ -769,15 +772,13 @@ class WebAbstractGroup(WebObj):
             props.extend([("Perm deg.", "not computed")])
         else:
             props.extend([("Perm deg.", f"${self.transitive_degree}$")])
-        if not self.live():
-            props.extend([
-                ("Rank", f"${self.rank}$")
                 # ("Faith. dim.", str(self.faithful_reps[0][0])),
-            ])
-        elif self.pgroup > 1:
-            props.append(("Rank", f"${self.rank}$"))
-        else:
-            props.extend([("Rank", "not computed")])
+        props.extend([
+            ("Rank", f"${self.rank}$" if self.rank else "not computed") ])
+        #elif self.pgroup > 1:
+        #    props.append(("Rank", f"${self.rank}$"))
+        #else:
+        #    props.extend([("Rank", "not computed")])
         return props
 
     @lazy_attribute
@@ -1553,6 +1554,8 @@ class WebAbstractGroup(WebObj):
             return "generating triples"
         elif self.rank == 4:
             return "generating quadruples"
+        elif not self.rank:
+            return "generating tuples"
         else:
             return f"generating {self.rank}-tuples"
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1449,7 +1449,6 @@ class WebAbstractGroup(WebObj):
         return latex(factor(self.outer_order))
 
     def live_composition_factors(self):
-        from .main import by_abelian_label
         from .main import url_for_label
         basiclist = []
         if isinstance(self.G, LiveAbelianGroup) or self.solvable:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1469,7 +1469,7 @@ class WebAbstractGroup(WebObj):
 
         # The only non-solvable option with order a multiple of 128
         # below 2000 is ...
-        if ZZ(self.G.Order()) == 1920:
+        elif ZZ(self.G.Order()) == 1920:
             basiclist = [
                 (url_for(".by_abelian_label", label=2), "C_2", "<span style='font-size: small'> x 5</span>"),
                 (url_for_label("60.5"), "A_5", "")]

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -774,12 +774,8 @@ class WebAbstractGroup(WebObj):
         else:
             props.extend([("Perm deg.", f"${self.transitive_degree}$")])
                 # ("Faith. dim.", str(self.faithful_reps[0][0])),
-        props.extend([
-            ("Rank", f"${self.rank}$" if self.rank else "not computed") ])
-        #elif self.pgroup > 1:
-        #    props.append(("Rank", f"${self.rank}$"))
-        #else:
-        #    props.extend([("Rank", "not computed")])
+        props.append(
+            ("Rank", f"${self.rank}$" if self.rank else "not computed"))
         return props
 
     @lazy_attribute
@@ -1247,7 +1243,7 @@ class WebAbstractGroup(WebObj):
         if isinstance(self.G, LiveAbelianGroup):
             divcnts = [(z[0], z[1]/euler_phi(z[0])) for z in self.cc_stats]
             self.number_divisions = sum([z[1] for z in divcnts])
-            return [(z[0], z[1]/euler_phi(z[0])) for z in self.cc_stats]
+            return divcnts
         if self.live():
             return None
         return sorted(

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -18,6 +18,7 @@ from sage.all import (
     prod,
     lcm,
     is_prime,
+    euler_phi,
     cartesian_product_iterator,
 )
 from sage.libs.gap.libgap import libgap
@@ -1243,6 +1244,12 @@ class WebAbstractGroup(WebObj):
 
     @lazy_attribute
     def division_stats(self):
+        if isinstance(self.G, LiveAbelianGroup):
+            divcnts = [(z[0], z[1]/euler_phi(z[0])) for z in self.cc_stats]
+            self.number_divisions = sum([z[1] for z in divcnts])
+            return [(z[0], z[1]/euler_phi(z[0])) for z in self.cc_stats]
+        if self.live():
+            return None
         return sorted(
             Counter([div.order for div in self.conjugacy_class_divisions]).items()
         )


### PR DESCRIPTION
This contains a bug fix: the number of conjugacy classes for

http://beta.lmfdb.org/Groups/Abstract/27.1
http://127.0.0.1:37777/Groups/Abstract/27.1

had some numbers in the wrong position.

It also starts to uniformize pages.  It lists composition factors for all groups:

http://127.0.0.1:37777/Groups/Abstract/ab/9.9.9.9.9.9  (on-the-fly abelian group)
http://127.0.0.1:37777/Groups/Abstract/1920.240418 (on-the-fly non-solvable group)
http://127.0.0.1:37777/Groups/Abstract/512.402873  (on-the-fly solvable nonabelian group)

 lists the correct number of irreducible complex representations for on-the-fly abelian groups (see the 9.9.9.9.9.9 example above), says data not computed for on-the-fly groups for numbers of divisions and autjugacy classes, and lists the transitive permutation degree for on-the-fly abelian groups (now says data not computed for on-the-fly nonabelian groups), always lists permutation degree in the properties box, always includes rank in the properties box (says not computed when that's the case).

There will be more uniformization changes, but I don't want bundle too many together.