### PR TITLE
Search for adelic image labels

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -383,7 +383,7 @@ def url_for_label(label):
 
 elladic_image_label_regex = re.compile(r'(\d+)\.(\d+)\.(\d+)\.(\d+)')
 modell_image_label_regex = re.compile(r'(\d+)(G|B|Cs|Cn|Ns|Nn|A4|S4|A5)(\.\d+)*')
-modm_image_label_regex = re.compile(r'(\d+)\.(\d+)\.(\d+)\.([a-z]+)\.(\d+)(-(\d+).(\d+))?')
+modm_image_label_regex = re.compile(r'(\d+)\.(\d+)\.(\d+)\.([a-z]+|\?)(\.(\d+)-(\d+).(\d+))?')
 
 class EC_download(Downloader):
     table = db.ec_curvedata

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -113,6 +113,16 @@ class EllCurveTest(LmfdbTest):
         # Test that we correctly fixed issue 4678
         self.check_args('EllipticCurve/Q/?jinv=-4096%2F11&optimal=on', '156 matches')
 
+    def test_galois_image_search(self):
+        # This searches for an adelic image label '550.1200.37.?' which exists in ec_curvedata
+        L = self.tc.get('/EllipticCurve/Q/?galois_image=550.1200.37.%3F&search_type=List')
+        assert '121.d1' in L.get_data(as_text=True)
+
+        # This searches for both adelic image label '550.1200.37.?' and ell-adic image
+        # label 5.60.0.1, which exists in ec_curvedata
+        L = self.tc.get('/EllipticCurve/Q/?hst=List&cm=noCM&galois_image=550.1200.37.%3F%2C5.60.0.1&search_type=List')
+        assert '3025.a2' in L.get_data(as_text=True)
+
     def test_isogeny_class(self):
         L = self.tc.get('/EllipticCurve/Q/11/a/')
         assert '[0, -1, 1, 0, 0]' in L.get_data(as_text=True)


### PR DESCRIPTION
The alpha branch currently allows to search for a list of galois images on the elliptic curve search page; these galois images could be mod-ell, ell-adic, or mod-m. This in principle allows to search for adelic image labels, since the adelic image will be the mod-m image with the largest level. However, many of these labels have not been fully computed, and are of the form '550.1200.37.?'.

This PR allows the user to search for such incomplete labels. The content is a one-line change in the regex handling mod-m images, which means that labels of the form '550.1200.37.?' are considered mod-m image labels, and the search gets executed. (Currently the above will throw an error because that string is not recognised as a valid galois image label of any flavour.)