### PR TITLE
Fix issue #5345

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -665,6 +665,7 @@ def render_field_webpage(args):
         primes = 'prime'
     else:
         primes = 'primes'
+    ram_primes = ','.join([str(z).rstrip('L') for z in nf.ramified_primes()])
     if len(ram_primes) > 30:
         ram_primes = 'see page'
     else:


### PR DESCRIPTION
It was always saying 'see page' for ramified primes in the property box.  This is because the string for ramified primes had javascript code for toggling raw mode.  We just reset the variable.

Fixed page:

http://127.0.0.1:37777/NumberField/2.0.4.1
http://beta.lmfdb.org/NumberField/2.0.4.1

Still says see page:

http://127.0.0.1:37777/NumberField/43.1.11615818670249741926786783635700464005809046848845495205636184619664502520703084303881154330624.1 