### PR TITLE
Add picture description pages

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -53,6 +53,7 @@ def learnmore_list():
     return [('Source and acknowledgments', url_for(".how_computed_page")),
             ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
+            ('Picture description', url_for(".picture_page")),
             ('Classical modular form labels', url_for(".labels_page"))]
 
 
@@ -1207,6 +1208,18 @@ def reliability_page():
     return render_template("single.html", kid='rcs.rigor.cmf', title=t,
                            bread=get_bread(other='Reliability'),
                            learnmore=learnmore_list_remove('Reliability'))
+
+
+@cmf.route("/Pictures")
+def picture_page():
+    t = "Pictures for classical modular forms"
+    return render_template(
+        "single.html",
+        kid='cmf.picture_description',
+        title=t,
+        bread=get_bread(other="Pictures"),
+        learnmore=learnmore_list_remove('Picture')
+    )
 
 
 def projective_image_sort_key(im_type):

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -67,6 +67,7 @@ def learnmore_list():
             ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
             ('Elliptic curve labels', url_for(".labels_page")),
+            ('Picture description', url_for(".picture_page")),
             ('Congruent number curves', url_for(".render_congruent_number_data"))]
 
 # Return the learnmore list with the matchstring entry removed
@@ -831,6 +832,15 @@ def reliability_page():
     bread = get_bread('Reliability')
     return render_template("single.html", kid='rcs.rigor.ec.q',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
+
+@ec_page.route("/Pictures")
+def picture_page():
+    t = r'Pictures for elliptic curves over $\Q$'
+    bread = get_bread('Pictures')
+    return render_template(
+        "single.html", kid='ec.q.picture_description',
+        title=t, bread=bread, learnmore=learnmore_list_remove('Picture')
+    )
 
 @ec_page.route("/Labels")
 def labels_page():

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -92,6 +92,7 @@ def learnmore_list():
         ("Source and acknowledgements", url_for(".how_computed_page")),
         ("Completeness of the data", url_for(".completeness_page")),
         ("Reliability of the data", url_for(".reliability_page")),
+        ('Picture description', url_for(".picture_page")),
         ("Abstract  group labeling", url_for(".labels_page")),
     ]
 
@@ -1289,6 +1290,19 @@ def reliability_page():
         title=t,
         bread=bread,
         learnmore=learnmore_list_remove("Reliability"),
+    )
+
+
+@abstract_page.route("/Pictures")
+def picture_page():
+    t = "Pictures for abstract groups"
+    bread = get_bread("Pictures")
+    return render_template(
+        "single.html",
+        kid="group.picture_description",
+        title=t,
+        bread=bread,
+        learnmore=learnmore_list_remove("Picture")
     )
 
 


### PR DESCRIPTION
This pull request adds picture description pages and sets the model to add further picture description pages. In short, in the "Learn more" section of the sidebar, this adds a picture description link. Clicking on it takes one to a page populated by a picture description knowl.

I also wrote these knowls for abstract groups (as requested by Alina Bucur) and for modular forms. Tomorrow I'll write the knowl for modular curves, and possibly for any other areas of the LMFDB that have or will soon receive portraits.