### PR TITLE
Remove --restart option

### DIFF
--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -113,7 +113,7 @@ class Configuration(_Configuration):
             "--restart",
             action="store_true",
             dest="core_restart",
-            help="enable restart mode",
+            help="enable restart mode. CAUTION: can cause segfaults on pages using PARI",
         )
 
         parser.add_argument(

--- a/lmfdb/website.py
+++ b/lmfdb/website.py
@@ -8,7 +8,7 @@
 # version 2 of the License, or (at your option) any later version.
 """
 start this via $ sage -python website.py --port <portnumber>
-add --debug if you are developing (auto-restart, full stacktrace in browser, ...)
+add --debug if you are developing (full stacktrace in browser, ...)
 """
 
 # Needs to be done first so that other modules and gunicorn can use logging


### PR DESCRIPTION
This essentially reverts

98001b771 (Add a new option for using the flask reloader that makes --debug work, 2022-06-06)

This is because the current state of pari threading makes running with --restart segfaults immediately on clicking on `random elliptic curve over Q` (throwing a long confusing stacktrace about cypari things). It probably causes crashes on other pages that use pari to dynamically compute data or plots.