### PR TITLE
Save input names in data-name on submit

### DIFF
--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -524,10 +524,18 @@ function cleanSubmit(id)
   var allInputs = myForm.getElementsByTagName('input');
   var allSelects = myForm.getElementsByTagName('select');
   var item, i, n = 0;
+  // We need to reload saved names from their data-name attributes, since pressing the back button would otherwise return us to a broken state.
+  for(i = 0; item = allInputs[i]; i++) {
+    if (typeof(item.dataset.name) != "undefined") {
+      item.setAttribute('name', item.dataset.name);
+    }
+  }
+
   for(i = 0; item = allInputs[i]; i++) {
     if (item.getAttribute('name') ) {
-        // Special case count so that we strip the default value
-        if (!item.value || (item.getAttribute('name') == 'count' && item.value == 50)) {
+      // Special case count so that we strip the default value
+      if (!item.value || (item.getAttribute('name') == 'count' && item.value == 50)) {
+        item.dataset.name = item.getAttribute('name');
         item.setAttribute('name', '');
       } else {
         n++;
@@ -537,6 +545,7 @@ function cleanSubmit(id)
   for(i = 0; item = allSelects[i]; i++) {
     if (item.getAttribute('name') ) {
       if (!item.value) {
+        item.dataset.name = item.getAttribute('name');
         item.setAttribute('name', '');
       } else {
         n++;


### PR DESCRIPTION
Fixes #5346.

To test, on www.lmfdb.org go to any page, enter a search query, click the "back" button to get back to the browse page, and then note that inputs in other search boxes are ignored (whether you're doing a normal search or looking for a random page).

The behavior should be fixed with this PR merged.