### PR TITLE
Fix incorrect blurbs on CMF

### DIFF
--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -870,6 +870,8 @@ function switch_basis(btype) {
         # univariate polynomial rings don't support order,
         # we work around it by introducing a dummy variable
         """
+        if self.field_poly_root_of_unity == 4:
+            return PolynomialRing(QQ, 'i')
         m = self.hecke_ring_cyclotomic_generator
         if m is not None and m != 0:
             return PolynomialRing(QQ, [self._zeta_print, 'dummy'], order='negdeglex')


### PR DESCRIPTION
this addresses #5327 

quick explanation of the two-line change: the code for what generators to display is not so straightforward, but it seems that in `web_newform.py`, in the class constructing the object, if `self.field_poly_root_of_unity == 4`, then the blurb will show `i`, but the actual expansion variable, which comes from the private method `_PrintRing`, didn't have such a condition. So I just put this condition into this private method.