### PR TITLE
Fix Postgres Example

### DIFF
--- a/Postgres_FAQ.md
+++ b/Postgres_FAQ.md
@@ -248,7 +248,7 @@ Note that you need editor priviledges to add, delete or modify data.
    db.create_table(name='perfect_numbers',
                    search_columns={'numeric': ['N','mersenne_n'],
                                    'int': ['num_factors'],
-                                   'double': ['log_N'],
+                                   'double precision': ['log_N'],
                                    'text': ['label'],
                                    'bool': ['odd'],
                                    },


### PR DESCRIPTION
`double` does not seem to be supported as a number type (see https://github.com/LMFDB/lmfdb/blob/master/lmfdb/backend/base.py#L24), so replace it with `double precision`.