### PR TITLE
Use 'minimal sibling of splitting field' on mod-l galrep pages

### DIFF
--- a/lmfdb/modl_galois_representations/templates/modlgal_rep.html
+++ b/lmfdb/modl_galois_representations/templates/modlgal_rep.html
@@ -31,9 +31,9 @@
 <h2>Associated number fields</h2>
 
 <table>
-  <tr><td>{{ KNOWL('modlgal.splitting_field','Splitting field') }} of $\rho$:</td><td>{{ rep.kernel_sibling | safe }}</td></tr>
+  <tr><td>{{ KNOWL('nf.minimal_sibling','Minimal sibling')}} of the {{ KNOWL('modlgal.splitting_field','splitting field') }} of $\rho$:</td><td>{{ rep.kernel_sibling | safe }}</td></tr>
   {% if rep.base_ring_characteristic != 2 %}
-  <tr><td>{{ KNOWL('modlgal.splitting_field','Splitting field') }} of $\mathbb{P}\rho$:</td><td>{{ rep.projective_kernel_sibling | safe }}</td></tr>
+  <tr><td>{{ KNOWL('nf.minimal_sibling','Minimal sibling')}} of the {{ KNOWL('modlgal.splitting_field','splitting field') }} of $\mathbb{P}\rho$:</td><td>{{ rep.projective_kernel_sibling | safe }}</td></tr>
   {% endif %}
 </table>
 


### PR DESCRIPTION
Minor tweak to mod-l galrep pages to clarify that the number field used to represent the splitting field is the minimal sibling.