### PR TITLE
Add Galois closure to dynamic number field knowls

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -340,11 +340,12 @@ def nf_knowl_guts(label):
     if wnf.is_galois():
         galstring = r'this field is Galois over $\Q$'
     else:
+        galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
         res = wnf.resolvents()
         if 'gal' in res:
             galstring = formatfield(string2list(res['gal'][0]))
         else:
-            galstring = 'data not computed'
+            galstring = r'degree %d extension of $\Q$ is not in the database'%galord
     out += '<br>Galois closure: ' + galstring
     out += '</div>'
     out += '<div align="right">'

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -340,11 +340,11 @@ def nf_knowl_guts(label):
     if wnf.is_galois():
         galstring = r'this field is Galois over $\Q$'
     else:
-        galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
         res = wnf.resolvents()
         if 'gal' in res:
             galstring = formatfield(string2list(res['gal'][0]))
         else:
+            galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
             galstring = r'degree %d extension of $\Q$ is not in the database'%galord
     out += '<br>Galois closure: ' + galstring
     out += '</div>'

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -337,6 +337,19 @@ def nf_knowl_guts(label):
     out += '<br>Class number: %s ' % str(wnf.class_number_latex())
     if wnf.can_class_number():
         out += wnf.short_grh_string()
+    if wnf.is_galois():
+        galstring = r'this field is Galois over $\Q$'
+    else:
+        galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
+        if galord > 47:
+            galstring = r'degree %d extension over $\Q$, which is too large for this database'%galord
+        else:
+            res = wnf.resolvents()
+            if 'gal' in res:
+                galstring = formatfield(string2list(res['gal'][0]))
+            else:
+                galstring = 'data not computed'
+    out += '<br>Galois closure: ' + galstring
     out += '</div>'
     out += '<div align="right">'
     out += '<a href="%s">%s home page</a>' % (str(url_for("number_fields.by_label", label=label)),label)

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -341,14 +341,11 @@ def nf_knowl_guts(label):
         galstring = r'this field is Galois over $\Q$'
     else:
         galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
-        if galord > 47:
-            galstring = r'degree %d extension over $\Q$, which is too large for this database'%galord
+        res = wnf.resolvents()
+        if 'gal' in res:
+            galstring = formatfield(string2list(res['gal'][0]))
         else:
-            res = wnf.resolvents()
-            if 'gal' in res:
-                galstring = formatfield(string2list(res['gal'][0]))
-            else:
-                galstring = 'data not computed'
+            galstring = 'data not computed'
     out += '<br>Galois closure: ' + galstring
     out += '</div>'
     out += '<div align="right">'

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -340,7 +340,6 @@ def nf_knowl_guts(label):
     if wnf.is_galois():
         galstring = r'this field is Galois over $\Q$'
     else:
-        galord = db.gps_transitive.lookup('%dT%d'%(wnf.degree(), wnf.galois_t()), 'order')
         res = wnf.resolvents()
         if 'gal' in res:
             galstring = formatfield(string2list(res['gal'][0]))


### PR DESCRIPTION
A good place to look for this is on degree six number field pages because the twin sextic algebra and sibling data hit the various options:

 - the field is Galois, as in one of the cubic factors of the twin on http://127.0.0.1:37777/NumberField/6.0.9747.1
 - the field is not Galois, but its Galois closure is in the database (the other cubic in the twin algebra on the same page)
 - the Galois closure has degree <48 so it might be in the database, but we haven't computed it (the degree 9 sibling on the same page)
 - the Galois closure has degree which is too big for our database, as in the degree 10 sibling on http://127.0.0.1:37777/NumberField/6.0.14731.1

If the Galois closure has been computed, there are two options (in the database or not), but this is handled by the number field knowls.

