### PR TITLE
Add discriminant root field for number fields

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -604,7 +604,6 @@ def render_field_webpage(args):
         # note that the first degree 4 number field missed the zero of the zeta function
         if abs(D**n) < 50000000:
             info['friends'].append(('L-function', url_for('l_functions.l_function_nf_page', label=label)))
-            #info['friends'].append(('L-function', "/L/NumberField/%s" % label))
     info['friends'].append(('Galois group', url_for("galois_groups.by_label", label="%dT%d" % (n, t))))
     discrootfieldcoeffs = nf.discrootfieldcoeffs()[0]
     rf_label = db.nf_fields.lucky({'coeffs': discrootfieldcoeffs}, 'label')

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -504,7 +504,7 @@ def render_field_webpage(args):
         loc_alg += '</tbody></table>\n'
 
     ram_primes_raw = str(ram_primes).replace('L', '')[1:-1]
-    ram_primes = [rf'\({compress_int(z,cutoff=30)[0]}\)' for z in ram_primes]
+    ram_primes = [rf'\({compress_int(z,cutoff=30,sides=5)[0]}\)' for z in ram_primes]
     ram_primes = (', ').join(ram_primes)
     # Get rid of python L for big numbers
     #ram_primes = ram_primes.replace('L', '')
@@ -603,8 +603,13 @@ def render_field_webpage(args):
         # hide ones that take a long time to compute on the fly
         # note that the first degree 4 number field missed the zero of the zeta function
         if abs(D**n) < 50000000:
-            info['friends'].append(('L-function', "/L/NumberField/%s" % label))
-    info['friends'].append(('Galois group', "/GaloisGroup/%dT%d" % (n, t)))
+            info['friends'].append(('L-function', url_for('l_functions.l_function_nf_page', label=label)))
+            #info['friends'].append(('L-function', "/L/NumberField/%s" % label))
+    info['friends'].append(('Galois group', url_for("galois_groups.by_label", label="%dT%d" % (n, t))))
+    discrootfieldcoeffs = nf.discrootfieldcoeffs()[0]
+    rf_label = db.nf_fields.lucky({'coeffs': discrootfieldcoeffs}, 'label')
+    if rf_label:
+        info['friends'].append(('Discriminant root field', url_for("number_fields.by_label", label=rf_label)))
     if 'dirichlet_group' in info:
         info['friends'].append(('Dirichlet character group',
                                 url_for("characters.dirichlet_group_table",

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -29,6 +29,7 @@ table.ntdata a {
        <tr><td>{{ KNOWL('nf.discriminant', title="Discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.discriminant|safe}}<td>{{ place_code('discriminant') }}
        <tr><td>{{ KNOWL('nf.root_discriminant', title="Root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.rd}}<td>{{ place_code('rd') }}
       <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>{{info.ram_primes|safe}}<td>{{ place_code('ramified_primes') }}
+      <tr><td>{{ KNOWL('nf.discriminant_root_field', title="Discriminant root field") }}:<td>&nbsp;&nbsp;<td>{{nf.discrootfield()|safe}}
       <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q) }$:<td>&nbsp;&nbsp;<td>${{info.auts}}$<td>{{ place_code('automorphisms') }}
 {% if info.is_abelian %}
     <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>


### PR DESCRIPTION
There was a request for adding some classical resolvents (as opposed to all resolvents) for number fields.  This adds the discriminant root field since it can be done without adding to the database.  It is something which is already on pages for p-adic fields.  It adds it as a number field knowl near the top of the page, and as a friend if it is in the database.  The main cases are:

It is a quadratic field in the database:
http://127.0.0.1:37777/NumberField/6.0.10571.1
It is a quadratic field not in the database:
http://127.0.0.1:37777/NumberField/47.1.31280045577397422652719953713309913701940250885770507510815871257152976174188094627629760512.1
It is Q:
http://127.0.0.1:37777/NumberField/4.0.23104.1

While adding the friend, I updated the friend links for L-function and Galois group to use url_for.