### PR TITLE
Fix regex in parsing Galois group codes

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -611,7 +611,7 @@ def complete_group_code(code):
         t = int(rematch.group(2))
         return [(n, t)]
     # convert small group label to GAP code
-    if re.match(r'^\d+\.\d+',code):
+    if re.match(r'^\d+\.\d+$',code):
         code = "[%s,%s]"%tuple(code.split("."))
     # Try GAP code
     rematch = re.match(r'^\[\d+,\d+\]$', code)


### PR DESCRIPTION
Fixes issue #5451 

To test, put something like 5.1.442.1 in the jump box for Galois groups.  It should be rejected, but not give a server error.