### PR TITLE
fix for #5478

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -171,8 +171,8 @@ class ECisog_class():
         if ncurves>1:
             self.properties += [('Graph', ''),(None, self.graph_link)]
 
-        self.downloads = [('q-expansion to text', url_for(".download_EC_qexp", label=self.iso_label, limit=1000)),
-                         ('All stored data to text', url_for(".download_EC_all", label=self.iso_label))]
+        self.downloads = [('q-expansion to text', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=1000)),
+                         ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_iso))]
 
         self.bread = [('Elliptic curves', url_for("ecnf.index")),
                       (r'$\Q$', url_for(".rational_elliptic_curves")),


### PR DESCRIPTION
This fixes #5478 .  It's trivial.

To test, go to http://localhost:37777/EllipticCurve/Q/256a/ or http://localhost:37777/EllipticCurve/Q/256/a/ and click on the two Download links on the right.  You'll see the data, not an error message.