### PR TITLE
ECQ: better information about twists

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -465,34 +465,114 @@ The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {
 <p>The torsion field $K:=\Q(E[{{data.adelic_level}}])$ is a degree-${{data.data.adelic_image_size}}$ Galois extension of $\Q$ with $\Gal(K/\Q)$ isomorphic to the projection of $H$ to $\GL_2(\Z/{{data.adelic_level}}\Z)$.
 {% endif %}
 
-<h2>$p$-adic regulators</h2>
 
+<h2>{{ KNOWL('ec.isogeny', title='Isogenies') }} </h2>
+{% if data.data.isogeny_degrees != "unknown" %}
+    {{ place_code('isogenies') }}
 <p>
-{% if data.rank==0 %}
-All $p$-adic regulators are identically $1$ since the rank is $0$.
+{% if data.data.isogeny_degrees %}
+This curve has non-trivial cyclic isogenies of degree $d$ for $d=$
+{{ data.data.isogeny_degrees}}.
+<br>
+Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
+consists of {{data.class_size}} curves linked by isogenies of
+{% if data.one_deg %}degree{% else %}degrees dividing{% endif %}
+ {{data.class_deg}}.
 {% else %}
-{% if data.data.p_adic_data_exists %}
-</p><p>
-Note: $p$-adic regulator data only exists for primes $p\ge 5$ of good ordinary
-reduction.
+This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
+    consists of this curve only.
 </p>
-  <select onchange="$('#padic').load('{{url_for('.padic_data', label=data.lmfdb_label, p=0)}}'+this.value, function() { renderMathInElement($('#padic').get(0),katexOpts);}); ">
-  <option value=''>Choose a prime...</option>
-  {% for p in data.data.p_adic_primes %}
-  <option value="{{ p }}">{{ p }}</option>
-  {% endfor %}
-  </select>
-  <div id='padic'></div>
-{% elif data.data.Gamma0optimal %}
-No $p$-adic data exists for this curve.
-{% else %}
-$p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-optimal.
 {% endif %}
 {% endif %}
-    </p>
 
-{% if data.iw %}
+<h2>{{ KNOWL('ec.q.twists', title='Twists') }} </h2>
+<p>
+  {% if data.data.minq_D==1 %}
+  This elliptic curve is its own {{ KNOWL('ec.q.minimal_quadratic_twist', title='minimal quadratic twist') }}.
+  {% else %}
+  The {{ KNOWL('ec.q.minimal_quadratic_twist', title='minimal quadratic twist') }} of this elliptic curve is
+  <a href={{data.data.minq_url}}>{{data.data.minq_label}}</a>, its twist by ${{data.data.minq_D}}$.
+  {% endif %}
+  
+  {% if data.data.CMD==-3 %}
+<p>
+  {% if data.data.min_sextic_twist_disc==1 %}
+  This elliptic curve is its own {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }}.
+  {% else %}
+  The {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }} of this elliptic curve is
+  <a href={{data.data.min_sextic_twist_url}}>{{data.data.min_sextic_twist_label}}</a>,
+  its sextic twist by ${{data.data.min_sextic_twist_disc}}$.
+  {% endif %}
+</p>
+{% endif %}
+{% if data.data.CMD==-4 %}
+<p>
+  {% if data.data.min_quartic_twist_disc==1 %}
+  This elliptic curve is its own {{ KNOWL('ec.q.minimal_twist', title='minimal quartic twist') }}.
+  {% else %}
+  The {{ KNOWL('ec.q.minimal_twist', title='minimal quartic twist') }} of this elliptic curve is
+  <a href={{data.data.min_quartic_twist_url}}>{{data.data.min_quartic_twist_label}}</a>,
+  its quartic twist by ${{data.data.min_quartic_twist_disc}}$.
+  {% endif %}
+  </p>
+{% endif %}
+
+{% if data.torsion_growth_data_exists %}
+
+<h2>{{KNOWL('ec.q.torsion_growth', title='Growth of torsion')}} in number fields</h2>
+<p>
+{% if data.tg==1 %}
+The only number field $K$ of degree less than {{data.tg.maxd}} such that
+$E(K)_{\rm tors}$ is strictly larger than $E(\Q)_{\rm tors}$
+{% if data.mwbsd.tor_order==1 %} (which is trivial)
+{% else %}
+$\cong {{data.mwbsd.tor_struct}}$
+{% endif %}
+is the following:
+{% else %}
+The number fields $K$ of degree less than {{data.tg.maxd}} such that
+$E(K)_{\rm tors}$ is strictly larger than $E(\Q)_{\rm tors}$
+{% if data.mwbsd.torsion==1 %} (which is trivial)
+{% else %}
+$\cong {{data.mwbsd.tor_struct}}$
+{% endif %}
+are as follows:
+{% endif %}
+</p>
+<p>
+<table class="ntdata"><thead>
+<tr>
+<th>$[K:\Q]$</th>
+<td align=center>$K$</td>
+<th>$E(K)_{\rm tors}$</th>
+<th>Base change curve</th>
+</tr>
+</thead><tbody>
+{% for tgd in data.tg.data %}
+<tr>
+<td align=center>${{tgd.d}}$</td>
+<td align=center>{{tgd.f | safe}}</td>
+<td align=center>{{tgd.t}}</td>
+<td align=center>
+{% if tgd.bc_label == 'Not in database' %}Not in database
+{% else %}<a href={{tgd.bc_url}}>{{tgd.bc_label}}</a>
+{% endif %}
+</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</p>
+<p>
+We only show fields where the torsion growth is {{KNOWL('ec.q.torsion_growth', title='primitive')}}.
+{% if data.tg.fields_missing %}
+For fields not in the database, click on the degree shown to reveal the defining polynomial.
+{% endif %}
+</p>
+{% endif %}
+
 <h2>{{ KNOWL('ec.iwasawa_invariants', title='Iwasawa invariants') }} </h2>
+{% if data.iw %}
 <p>
 <table border=1 style="margin-left:5%">
 <tr style="border-bottom: 1px solid #000;">
@@ -556,79 +636,33 @@ No Iwasawa invariant data is available for this curve.
 </p>
 {% endif %}
 
+<h2>$p$-adic regulators</h2>
 
-<h2>{{ KNOWL('ec.isogeny', title='Isogenies') }} </h2>
-{% if data.data.isogeny_degrees != "unknown" %}
-    {{ place_code('isogenies') }}
 <p>
-{% if data.data.isogeny_degrees %}
-This curve has non-trivial cyclic isogenies of degree $d$ for $d=$
-{{ data.data.isogeny_degrees}}.
-<br>
-Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
-consists of {{data.class_size}} curves linked by isogenies of
-{% if data.one_deg %}degree{% else %}degrees dividing{% endif %}
- {{data.class_deg}}.
+{% if data.rank==0 %}
+All $p$-adic regulators are identically $1$ since the rank is $0$.
 {% else %}
-This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_url }}>{{data.class_name}}</a>
-    consists of this curve only.
+{% if data.data.p_adic_data_exists %}
+</p><p>
+Note: $p$-adic regulator data only exists for primes $p\ge 5$ of good ordinary
+reduction.
 </p>
+  <select onchange="$('#padic').load('{{url_for('.padic_data', label=data.lmfdb_label, p=0)}}'+this.value, function() { renderMathInElement($('#padic').get(0),katexOpts);}); ">
+  <option value=''>Choose a prime...</option>
+  {% for p in data.data.p_adic_primes %}
+  <option value="{{ p }}">{{ p }}</option>
+  {% endfor %}
+  </select>
+  <div id='padic'></div>
+{% elif data.data.Gamma0optimal %}
+No $p$-adic data exists for this curve.
+{% else %}
+$p$-adic regulators are not yet computed for curves that are not $\Gamma_0$-optimal.
 {% endif %}
 {% endif %}
+    </p>
 
-{% if data.torsion_growth_data_exists %}
 
-<h2>{{KNOWL('ec.q.torsion_growth', title='Growth of torsion')}} in number fields</h2>
-<p>
-{% if data.tg==1 %}
-The only number field $K$ of degree less than {{data.tg.maxd}} such that
-$E(K)_{\rm tors}$ is strictly larger than $E(\Q)_{\rm tors}$
-{% if data.mwbsd.tor_order==1 %} (which is trivial)
-{% else %}
-$\cong {{data.mwbsd.tor_struct}}$
-{% endif %}
-is the following:
-{% else %}
-The number fields $K$ of degree less than {{data.tg.maxd}} such that
-$E(K)_{\rm tors}$ is strictly larger than $E(\Q)_{\rm tors}$
-{% if data.mwbsd.torsion==1 %} (which is trivial)
-{% else %}
-$\cong {{data.mwbsd.tor_struct}}$
-{% endif %}
-are as follows:
-{% endif %}
-</p>
-<p>
-<table class="ntdata"><thead>
-<tr>
-<th>$[K:\Q]$</th>
-<td align=center>$K$</td>
-<th>$E(K)_{\rm tors}$</th>
-<th>Base change curve</th>
-</tr>
-</thead><tbody>
-{% for tgd in data.tg.data %}
-<tr>
-<td align=center>${{tgd.d}}$</td>
-<td align=center>{{tgd.f | safe}}</td>
-<td align=center>{{tgd.t}}</td>
-<td align=center>
-{% if tgd.bc_label == 'Not in database' %}Not in database
-{% else %}<a href={{tgd.bc_url}}>{{tgd.bc_label}}</a>
-{% endif %}
-</td>
-</tr>
-{% endfor %}
-</tbody>
-</table>
-</p>
-<p>
-We only show fields where the torsion growth is {{KNOWL('ec.q.torsion_growth', title='primitive')}}.
-{% if data.tg.fields_missing %}
-For fields not in the database, click on the degree shown to reveal the defining polynomial.
-{% endif %}
-</p>
-{% endif %}
 
 {#
     <h2> Plot of real points</h2>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -499,7 +499,7 @@ This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_u
   {% if data.data.min_sextic_twist_disc==1 %}
   This elliptic curve is its own {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }}.
   {% else %}
-  The {{ KNOWL('ec.q.minimal_twist', title='minimal quartic twist') }} of this elliptic curve is
+  The {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }} of this elliptic curve is
   <a href={{data.data.min_sextic_twist_url}}>{{data.data.min_sextic_twist_label}}</a>,
   its sextic twist by ${{data.data.min_sextic_twist_disc}}$.
   {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -485,7 +485,7 @@ This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_u
 {% endif %}
 {% endif %}
 
-<h2>{{ KNOWL('ec.q.twists', title='Twists') }} </h2>
+<h2>{{ KNOWL('ec.twists', title='Twists') }} </h2>
 <p>
   {% if data.data.minq_D==1 %}
   This elliptic curve is its own {{ KNOWL('ec.q.minimal_quadratic_twist', title='minimal quadratic twist') }}.
@@ -499,7 +499,7 @@ This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_u
   {% if data.data.min_sextic_twist_disc==1 %}
   This elliptic curve is its own {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }}.
   {% else %}
-  The {{ KNOWL('ec.q.minimal_twist', title='minimal sextic twist') }} of this elliptic curve is
+  The {{ KNOWL('ec.q.minimal_twist', title='minimal quartic twist') }} of this elliptic curve is
   <a href={{data.data.min_sextic_twist_url}}>{{data.data.min_sextic_twist_label}}</a>,
   its sextic twist by ${{data.data.min_sextic_twist_disc}}$.
   {% endif %}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -488,9 +488,9 @@ This curve has no rational isogenies.  Its isogeny class <a href={{ data.class_u
 <h2>{{ KNOWL('ec.twists', title='Twists') }} </h2>
 <p>
   {% if data.data.minq_D==1 %}
-  This elliptic curve is its own {{ KNOWL('ec.q.minimal_quadratic_twist', title='minimal quadratic twist') }}.
+  This elliptic curve is its own {{ KNOWL('ec.q.minimal_twist', title='minimal quadratic twist') }}.
   {% else %}
-  The {{ KNOWL('ec.q.minimal_quadratic_twist', title='minimal quadratic twist') }} of this elliptic curve is
+  The {{ KNOWL('ec.q.minimal_twist', title='minimal quadratic twist') }} of this elliptic curve is
   <a href={{data.data.minq_url}}>{{data.data.minq_label}}</a>, its twist by ${{data.data.minq_D}}$.
   {% endif %}
   

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -526,8 +526,12 @@ class WebEC():
 
         self.friends = [
             ('Isogeny class ' + self.class_name, self.class_url),
-            (f'Minimal quadratic twist {data["minq_info"]} {data["minq_label"]}', data['minq_url']),
-            ('All twists ', url_for(".rational_elliptic_curves", jinv=data['j_invariant']))]
+            (f'Minimal quadratic twist {data["minq_label"]}', data['minq_url'])]
+        if self.cm == -3:
+            self.friends.append((f'Minimal sextic twist {data["min_sextic_twist_label"]}', data['min_sextic_twist_url']))
+        if self.cm == -4:
+            self.friends.append((f'Minimal quartic twist {data["min_quartic_twist_label"]}', data['min_quartic_twist_url']))
+        self.friends.append(('All twists ', url_for(".rational_elliptic_curves", jinv=data['j_invariant'])))
 
         lfun_url = url_for("l_functions.l_function_ec_page", conductor_label=N, isogeny_class_label=iso)
         origin_url = lfun_url.lstrip('/L/').rstrip('/')

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -230,6 +230,32 @@ def short_latex_equation(ainvs):
 def latex_equations(ainvs):
     return [latex_equation(ainvs),homogeneous_latex_equation(ainvs),short_latex_equation(ainvs)]
 
+def sextic_twist_discriminant(ainvs):
+    r""" 
+    Return D such that this is the sextic twist by D of 27.a4 (whose c6=-216) -- only for j=0
+    """
+    a1,a2,a3,a4,a6 = ainvs
+    D = -108 * (a1**6 + 12*a1**4*a2 + 48*a1**2*a2**2 + 64*a2**3 - 432*a3**2 - 1728*a6) # = -216*c6
+
+    # Remove 6th powers and invert: the minus sign in the exponent is
+    # because the text says that 27.a4 is this curve's sextic twist by
+    # D, not the other way round.
+
+    return D.sign() * prod(p ** ((-e)%6) for p,e in D.factor())
+    
+def quartic_twist_discriminant(ainvs):
+    r""" 
+    Return D such that this is the quartic twist by D of 32.a3 (whose c4=48) -- only for j=1728
+    """
+    a1,a2,a3,a4,a6 = ainvs
+    D = 27 * (a1**4 + 8*a1**2*a2 + 16*a2**2 - 24*a1*a3 - 48*a4)
+
+    # Remove 4th powers and invert: the minus sign in the exponent is
+    # because the text says that 32.a3 is this curve's quartic twist
+    # by D, not the other way round.
+
+    return D.sign() * prod(p ** ((-e)%4) for p,e in D.factor())
+
 class WebEC():
     """
     Class for an elliptic curve over Q
@@ -322,7 +348,18 @@ class WebEC():
         data['minq_label'] = db.ec_curvedata.lucky({'ainvs': self.min_quad_twist_ainvs},
                                                    projection='lmfdb_label' if self.label_type == 'LMFDB' else 'Clabel')
         data['minq_info'] = '(itself)' if minqD==1 else '(by {})'.format(minqD)
+        data['minq_url'] = url_for(".by_ec_label", label=data["minq_label"])
 
+        # higher minimal twists:
+        if self.cm == -3:
+            data['min_sextic_twist_disc'] = sextic_twist_discriminant(self.ainvs)
+            data['min_sextic_twist_label'] = '27.a4'
+            data['min_sextic_twist_url'] = url_for(".by_ec_label", label='27.a4')
+        if self.cm == -4:
+            data['min_quartic_twist_disc'] = quartic_twist_discriminant(self.ainvs) 
+            data['min_quartic_twist_label'] = '32.a3'
+            data['min_quartic_twist_url'] = url_for(".by_ec_label", label='32.a3')
+        
         # modular degree:
 
         try:
@@ -489,7 +526,7 @@ class WebEC():
 
         self.friends = [
             ('Isogeny class ' + self.class_name, self.class_url),
-            ('Minimal quadratic twist %s %s' % (data['minq_info'], data['minq_label']), url_for(".by_ec_label", label=data['minq_label'])),
+            (f'Minimal quadratic twist {data["minq_info"]} {data["minq_label"]}', data['minq_url']),
             ('All twists ', url_for(".rational_elliptic_curves", jinv=data['j_invariant']))]
 
         lfun_url = url_for("l_functions.l_function_ec_page", conductor_label=N, isogeny_class_label=iso)


### PR DESCRIPTION
This PR gives home pages of elliptic curves over Q a new small section "Twists", showing the minimal quadratic twists and (where relevant) the minimal quartic/sextic twist.  The Related Object section of the page also has the latter information.

There are two new knowls: https://beta.lmfdb.org/knowledge/show/ec.twists and https://beta.lmfdb.org/knowledge/show/ec.q.minimal_twist and a review of these along with this PR would be appreciated.  The new improved definition for minimal twists was discussed on Zulip (https://lmfdb.zulipchat.com/#narrow/stream/250930-ECQ/topic/minimal.20quadratic.20twists) and the revised data is already on beta and prod.
