### PR TITLE
With subgroups show order

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -16,7 +16,7 @@ from flask import (
 )
 #from six import BytesIO
 from string import ascii_lowercase
-from sage.all import ZZ, latex, factor, prod, Permutations
+from sage.all import ZZ, latex, factor, prod, Permutations, is_prime
 from sage.misc.cachefunc import cached_function
 
 from lmfdb import db
@@ -1237,6 +1237,10 @@ def shortsubinfo(ambient, short_label):
     )
     ans += f"<p>{create_boolean_subgroup_string(wsg, type='knowl')}</p>"
     ans += "<table>"
+    ans += f"<tr><td>{display_knowl('group.order', 'Order')}</td><td>${wsg.subgroup_order}"
+    if wsg.subgroup_order > 1 and not is_prime(wsg.subgroup_order):
+        ans += "="+latex(factor(wsg.subgroup_order))
+    ans += "$</td></tr>"
     if wsg.normal:
         ans += f"<tr><td>{display_knowl('group.quotient', 'Quotient')}</td><td>${wsg.quotient_tex}$</td></tr>"
     else:


### PR DESCRIPTION
On the page of an abstract group, if you click on a subgroup in the diagram you get some information about the subgroup.  This adds the order of the subgroup to the list of information.  If the order is not one and not a prime, it also shows it in factored form.

http://127.0.0.1:37777/Groups/Abstract/12.1
http://beta.lmfdb.org/Groups/Abstract/12.1