### PR TITLE
CMF changes to remove depency on conrey_indexes

### DIFF
--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -357,7 +357,7 @@ class CMF_download(Downloader):
     def download_spaces(self, info):
         lang = info.get(self.lang_key,'text').strip()
         query = literal_eval(info.get('query', '{}'))
-        proj = ['label', 'analytic_conductor', 'conrey_indexes', 'char_order']
+        proj = ['label', 'analytic_conductor', 'conrey_index', 'char_order']
         spaces = list(db.mf_newspaces.search(query, projection=proj))
         s = ""
         c = self.comment_prefix[lang]

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -36,6 +36,7 @@ from lmfdb.classical_modular_forms.web_space import (
     ALdim_table, NEWLABEL_RE as NEWSPACE_RE, OLDLABEL_RE as OLD_SPACE_LABEL_RE)
 from lmfdb.classical_modular_forms.download import CMF_download
 from lmfdb.sato_tate_groups.main import st_display_knowl
+from lmfdb.characters.TinyConrey import ConreyCharacter
 from lmfdb.characters.main import ORBIT_MAX_MOD
 
 POSINT_RE = re.compile("^[1-9][0-9]*$")
@@ -712,7 +713,7 @@ def parse_character(inp, query, qfield, prim=False):
     else:
         if prim:
             raise ValueError("You must use the orbit label when searching by primitive character")
-        query['conrey_indexes'] = {'$contains': int(orbit)}
+        query['conrey_index'] = ConreyCharacter(modulus=level,number=orbit).min_conrey_conj
 
 newform_only_fields = {
     'nf_label': 'Coefficient field',
@@ -1162,7 +1163,7 @@ def dimension_form_search(info, query):
              title='Dimension search results',
              err_title='Dimension search input error',
              per_page=None,
-             projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_indexes', 'dim', 'hecke_orbit_dims', 'AL_dims', 'char_conductor','eis_dim','eis_new_dim','cusp_dim', 'mf_dim', 'mf_new_dim', 'plus_dim', 'num_forms'],
+             projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_index', 'dim', 'hecke_orbit_dims', 'AL_dims', 'char_conductor','eis_dim','eis_new_dim','cusp_dim', 'mf_dim', 'mf_new_dim', 'plus_dim', 'num_forms'],
              postprocess=dimension_space_postprocess,
              bread=get_dim_bread,
              learnmore=learnmore_list)
@@ -1179,8 +1180,8 @@ def dimension_space_search(info, query):
 space_columns = SearchColumns([
     LinkCol("label", "cmf.label", "Label", url_for_label, default=True),
     FloatCol("analytic_conductor", "cmf.analytic_conductor", r"$A$", default=True, short_title="analytic conductor", align="left"),
-    MultiProcessedCol("character", "cmf.character", r"$\chi$", ["level", "conrey_indexes"],
-                      lambda level,indexes: r'<a href="%s">\( \chi_{%s}(%s, \cdot) \)</a>' % (url_for("characters.render_Dirichletwebpage", modulus=level, number=indexes[0]), level, indexes[0]),
+    MultiProcessedCol("character", "cmf.character", r"$\chi$", ["level", "conrey_index"],
+                      lambda level,number: r'<a href="%s">\( \chi_{%s}(%s, \cdot) \)</a>' % (url_for("characters.render_Dirichletwebpage", modulus=level, number=number), level, indexes[0]),
                       short_title="character", default=True),
     MathCol("char_order", "character.dirichlet.order", r"$\operatorname{ord}(\chi)$", short_title="character order", default=True),
     MathCol("dim", "cmf.display_dim", "Dim.", short_title="dimension", default=True),

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1181,7 +1181,7 @@ space_columns = SearchColumns([
     LinkCol("label", "cmf.label", "Label", url_for_label, default=True),
     FloatCol("analytic_conductor", "cmf.analytic_conductor", r"$A$", default=True, short_title="analytic conductor", align="left"),
     MultiProcessedCol("character", "cmf.character", r"$\chi$", ["level", "conrey_index"],
-                      lambda level,number: r'<a href="%s">\( \chi_{%s}(%s, \cdot) \)</a>' % (url_for("characters.render_Dirichletwebpage", modulus=level, number=number), level, indexes[0]),
+                      lambda level,number: r'<a href="%s">\( \chi_{%s}(%s, \cdot) \)</a>' % (url_for("characters.render_Dirichletwebpage", modulus=level, number=number), level, number),
                       short_title="character", default=True),
     MathCol("char_order", "character.dirichlet.order", r"$\operatorname{ord}(\chi)$", short_title="character order", default=True),
     MathCol("dim", "cmf.display_dim", "Dim.", short_title="dimension", default=True),

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -164,7 +164,7 @@ function get_all_embeddings(num_embeddings) {
     <tr>
       <td>{{ KNOWL('cmf.embedding',title='Embeddings') }}: </td>
       <td><input type='text' name='m' style="width: 160px" value="{{info.m}}" placeholder="1-{{newform.dim}}"></td>
-      <td><span class="formexample"> e.g. 1-3 or {{newform.conrey_indexes[-1]}}.{{newform.relative_dim}}</span></td>
+      <td><span class="formexample"> e.g. 1-3 or {{newform.conrey_index}}.{{newform.relative_dim}}</span></td>
     </tr>
     {% endif %}
     <tr>

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -8,6 +8,7 @@ from sage.all import prod
 from sage.arith.srange import srange
 from lmfdb.utils import signtocolour
 from sage.databases.cremona import cremona_letter_code
+from lmfdb.characters.TinyConrey import ConreyCharacter
 
 
 def svgBegin():
@@ -488,7 +489,7 @@ def paintSvgHoloNew(condmax):
     max_k = 0  # the largest weight we see
 
     for nf in db.mf_newforms.search({'analytic_conductor': {'$lte': condmax}},
-                                    projection=['analytic_conductor', 'label', 'weight', 'conrey_indexes', 'dim', 'char_degree'],
+                                    projection=['analytic_conductor', 'label', 'level', 'weight', 'conrey_index', 'dim', 'char_degree'],
                                     sort=[('analytic_conductor', 1)]):
         _, k, _, hecke_letter = nf['label'].split('.')
         if int(k) > max_k:
@@ -501,7 +502,8 @@ def paintSvgHoloNew(condmax):
             if z1 is not None:
                 values[nf['weight']].append([nf['label'].split('.'), z1, lfun_url, nf["analytic_conductor"]])
         else:
-            for character in nf['conrey_indexes']:
+            conrey_orbit = ConreyCharacter(modulus=nf['level'],number=nf['conrey_index']).galois_orbit
+            for character in conrey_orbit:
                 for j in range(nf['dim'] // nf['char_degree']):
                     label = nf['label'].split('.') + [str(character), str(j + 1)]
                     lfun_url = 'ModularForm/GL2/Q/holomorphic/' + '/'.join(label)

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -966,7 +966,8 @@ def l_function_cmf_page(level, weight, char_orbit_label, hecke_orbit, character,
 
 @l_function_page.route("/ModularForm/GL2/Q/holomorphic/<int:level>/<int:weight>/<int:character>/<hecke_orbit>/<int:number>/")
 def l_function_cmf_old(level, weight, character, hecke_orbit, number):
-    char_orbit_label = db.mf_newspaces.lucky({'conrey_indexes': {'$contains': character}, 'level': level, 'weight': weight}, projection='char_orbit_label')
+    min_character = ConreyCharacter(modulus=level,number=character).min_conrey_conj
+    char_orbit_label = db.mf_newspaces.lucky({'conrey_index': min_character, 'level': level, 'weight': weight}, projection='char_orbit_label')
     if char_orbit_label is None:
         return abort(404, 'Invalid character label')
     number += 1 # There was a shift from 0-based to 1-based in the new label scheme
@@ -982,7 +983,8 @@ def l_function_cmf_old(level, weight, character, hecke_orbit, number):
 
 @l_function_page.route("/ModularForm/GL2/Q/holomorphic/<int:level>/<int:weight>/<int:character>/<hecke_orbit>/")
 def l_function_cmf_redirect_1(level, weight, character, hecke_orbit):
-    char_orbit_label = db.mf_newspaces.lucky({'conrey_indexes': {'$contains': character}, 'level': level, 'weight': weight}, projection='char_orbit_label')
+    min_character = ConreyCharacter(modulus=level,number=character).min_conrey_conj
+    char_orbit_label = db.mf_newspaces.lucky({'conrey_index': min_character, 'level': level, 'weight': weight}, projection='char_orbit_label')
     if char_orbit_label is None:
         return abort(404, 'Invalid character label')
     return redirect(url_for('.l_function_cmf_page',
@@ -1004,7 +1006,8 @@ def l_function_cmf_orbit(level, weight, char_orbit_label, hecke_orbit):
 
 @l_function_page.route("/ModularForm/GL2/Q/holomorphic/<int:level>/<int:weight>/<int:character>/")
 def l_function_cmf_redirect_a1(level, weight, character):
-    char_orbit_label = db.mf_newspaces.lucky({'conrey_indexes': {'$contains': character}, 'level': level, 'weight': weight}, projection='char_orbit_label')
+    min_character = ConreyCharacter(modulus=level,number=character).min_conrey_conj
+    char_orbit_label = db.mf_newspaces.lucky({'conrey_index': min_character, 'level': level, 'weight': weight}, projection='char_orbit_label')
     return redirect(url_for('.l_function_cmf_page',
                                     level=level,
                                     weight=weight,

--- a/lmfdb/lfunctions/main.py
+++ b/lmfdb/lfunctions/main.py
@@ -38,6 +38,7 @@ from .Lfunctionutilities import (
     getConductorIsogenyFromLabel)
 
 from lmfdb.characters.web_character import WebDirichlet
+from lmfdb.characters.TinyConrey import ConreyCharacter
 from lmfdb.lfunctions import l_function_page
 from lmfdb.maass_forms.plot import paintSvgMaass
 from lmfdb.classical_modular_forms.web_newform import convert_newformlabel_from_conrey

--- a/lmfdb/verify/mf_hecke_cc.py
+++ b/lmfdb/verify/mf_hecke_cc.py
@@ -55,18 +55,6 @@ class mf_hecke_cc(MfChecker):
         return self._run_query(query=query)
 
     @overall_long
-    def check_conrey_indexes(self):
-        """
-        when grouped by hecke_orbit_code, check that conrey_indexs
-        match conrey_indexes, embedding_index ranges from 1 to
-        relative_dim (when grouped by conrey_index), and embedding_m
-        ranges from 1 to dim
-        """
-        # ps: In check_embedding_m and check_embedding_index, we already checked that embedding_m and  check_embedding_index are in an increasing sequence
-        query = SQL("WITH foo as (SELECT hecke_orbit_code, sort(array_agg(DISTINCT conrey_index)) conrey_indexes, count(DISTINCT embedding_index) relative_dim, count(embedding_m) dim FROM mf_hecke_cc GROUP BY hecke_orbit_code) SELECT t1.label FROM mf_newforms t1, foo WHERE t1.hecke_orbit_code = foo.hecke_orbit_code AND (t1.conrey_indexes != foo.conrey_indexes OR t1.relative_dim != foo.relative_dim OR t1.dim != foo.dim)")
-        return self._run_query(query=query)
-
-    @overall_long
     def check_an_length(self):
         """
         check that an_normalized is a list of pairs of doubles of length at least 1000

--- a/lmfdb/verify/mf_newforms.py
+++ b/lmfdb/verify/mf_newforms.py
@@ -70,7 +70,7 @@ class mf_newforms(MfChecker):
         bad_labels = []
         labels = self.check_crosstable_count('mf_newspaces', 1, 'space_label', 'label')
         bad_labels.extend([label + " (count)" for label in labels])
-        for col in ['Nk2', 'analytic_conductor', 'char_conductor', 'char_degree', 'char_is_real', 'char_orbit_index', 'char_orbit_label', 'char_order', 'char_parity', 'char_values', 'conrey_indexes', 'level', 'level_is_prime', 'level_is_prime_power', 'level_is_square', 'level_is_squarefree', 'level_primes', 'level_radical', 'prim_orbit_index', 'weight', 'weight_parity']:
+        for col in ['Nk2', 'analytic_conductor', 'char_conductor', 'char_degree', 'char_is_real', 'char_orbit_index', 'char_orbit_label', 'char_order', 'char_parity', 'char_values', 'conrey_index', 'level', 'level_is_prime', 'level_is_prime_power', 'level_is_square', 'level_is_squarefree', 'level_primes', 'level_radical', 'prim_orbit_index', 'weight', 'weight_parity']:
             labels = self.check_crosstable('mf_newspaces', col, 'space_label', col, 'label')
             bad_labels.extend([label + " (%s)"%col for label in labels])
         return bad_labels

--- a/lmfdb/verify/mf_newspaces.py
+++ b/lmfdb/verify/mf_newspaces.py
@@ -308,7 +308,7 @@ class mf_newspaces(MfChecker):
         # TIME about 70s
         return self._test_equality(rec['sturm_bound'], sturm_bound0(rec['level'], rec['weight']), verbose, "Sturm bound failure: {0} != {1}")
 
-    @slow(ratio=0.001, report_slow=60, max_slow=10000, constraint={'weight':{'$gt':1}}, projection=['level', 'weight', 'relative_dim', 'conrey_indexes', 'char_order'])
+    @slow(ratio=0.001, report_slow=60, max_slow=10000, constraint={'weight':{'$gt':1}}, projection=['level', 'weight', 'relative_dim', 'conrey_index', 'char_order'])
     def check_Skchi_dim_formula(self, rec, verbose=False):
         """
         for k > 1 check that dim is the Q-dimension of S_k^new(N,chi) (using sage dimension formula)
@@ -318,10 +318,10 @@ class mf_newspaces(MfChecker):
         if rec['level'] < 3:
             dirchar = rec['level']
         else:
-            dirchar = get_dirchar(rec['level'], rec['conrey_indexes'][0])
+            dirchar = get_dirchar(rec['level'], rec['conrey_index'])
         return self._test_equality(rec['relative_dim'], dimension_new_cusp_forms(dirchar, rec['weight']), verbose)
 
-    @slow(ratio=0.01, report_slow=10, constraint={'weight':{'$gt':1}}, projection=['level', 'weight', 'char_degree', 'char_order', 'eis_dim', 'cusp_dim', 'mf_dim', 'conrey_indexes'])
+    @slow(ratio=0.01, report_slow=10, constraint={'weight':{'$gt':1}}, projection=['level', 'weight', 'char_degree', 'char_order', 'eis_dim', 'cusp_dim', 'mf_dim', 'conrey_index'])
     def check_dims(self, rec, verbose=False):
         """
         for k > 1 check each of eis_dim, eis_new_dim, cusp_dim, mf_dim, mf_new_dim using Sage dimension formulas (when applicable)
@@ -330,7 +330,7 @@ class mf_newspaces(MfChecker):
         if rec['level'] < 3:
             dirchar = rec['level']
         else:
-            dirchar = get_dirchar(rec['level'], rec['conrey_indexes'][0])
+            dirchar = get_dirchar(rec['level'], rec['conrey_index'])
         k = rec['weight']
         m = rec['char_degree']
         for func, key in [(dimension_eis, 'eis_dim'), (dimension_cusp_forms, 'cusp_dim'), (dimension_modular_forms, 'mf_dim')]:


### PR DESCRIPTION
As a prelude to extending the range of the CMF database to higher levels, this PR removes all code dependency on the `conrey_indexes` column in the tables: `mf_newforms`, `mf_newspaces`, and `mf_subspaces`, as this data is no longer stored in the Dirichlet character database (only the min and max elements of the list of Conrey indexes in a character orbit are now stored -- this ensures that the space required grows quasi-linearly with the modulus rather than quasi-quadratically).

A new column `conrey_index` has been added to each of these tables that contains the first element of `conrey_indexes` (the minimal Conrey index in the character orbit).  In most situations only the first element of the list was being used, and in cases where the entire list is needed it is now  computed on the fly using the TinyConrey interface to Pari/GP implemented by @BarinderBanwait (this is only used when listing embedded newforms or L-functions).  This code is fast enough to easily compute all the character orbits that we currently use on the fly (the largest is https://alpha.lmfdb.org/Character/Dirichlet/3997/cz, which has 144 elements) and I have tested it with the modulus ranging up to a million (character orbits with hundreds of thousands of elements take about 5 seconds but I don't expect we will ever add any of these).

None of these changes should be visible to the user.

The updated tables with the new `conrey_index` column have already been copied to proddb.  Once this change has been merged and pushed to production I will drop the `conrey_indexes` column.