### PR TITLE
Quotient group knowls

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1155,7 +1155,6 @@ def render_abstract_group(label, data=None):
             )
             friends += [("As the component group of a Sato-Tate group", st_url)]
 
-    info['display_group_knowl'] = abstract_group_display_knowl
     bread = get_bread([(label, "")])
     learnmore_gp_picture = ('Picture description', url_for(".picture_page"))
 
@@ -1243,7 +1242,7 @@ def shortsubinfo(ambient, short_label):
         ans += "="+latex(factor(wsg.subgroup_order))
     ans += "$</td></tr>"
     if wsg.normal:
-        ans += f"<tr><td>{display_knowl('group.quotient', 'Quotient')}</td><td>${wsg.quotient_tex}$</td></tr>"
+        ans += f"<tr><td>{display_knowl('group.quotient', 'Quotient')}</td><td>{wsg.display_quotient()}</td></tr>"
     else:
         ans += f"<tr><td>Number of conjugates</td><td>{wsg.count}</td></tr>"
     ans += subinfo_getsub("Normalizer", "group.subgroup.normalizer", wsg.normalizer)

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -17,7 +17,6 @@ from flask import (
 #from six import BytesIO
 from string import ascii_lowercase
 from sage.all import ZZ, latex, factor, prod, Permutations, is_prime
-from sage.misc.cachefunc import cached_function
 
 from lmfdb import db
 from lmfdb.app import app
@@ -54,7 +53,8 @@ from .web_groups import (
     WebAbstractRationalCharacter,
     WebAbstractSubgroup,
     group_names_pretty,
-    primary_to_smith
+    primary_to_smith,
+    abstract_group_display_knowl
 )
 from .stats import GroupStats
 
@@ -1155,6 +1155,7 @@ def render_abstract_group(label, data=None):
             )
             friends += [("As the component group of a Sato-Tate group", st_url)]
 
+    info['display_group_knowl'] = abstract_group_display_knowl
     bread = get_bread([(label, "")])
     learnmore_gp_picture = ('Picture description', url_for(".picture_page"))
 
@@ -1910,27 +1911,6 @@ def abstract_group_namecache(labels, cache=None, reverse=None):
                     continue
                 cache[nTj]["pretty"] = f"${tex_name}$" if tex_name else ""
     return cache
-
-@cached_function(key=lambda label,name,pretty,ambient,aut,cache: (label,name,pretty,ambient,aut))
-def abstract_group_display_knowl(label, name=None, pretty=True, ambient=None, aut=False, cache={}):
-    # If you have the group in hand, set the name using gp.tex_name since that will avoid a database call
-    if not name:
-        if pretty:
-            if label in cache and "tex_name" in cache[label]:
-                name = cache[label]["tex_name"]
-            else:
-                name = db.gps_groups.lookup(label, "tex_name")
-            if name is None:
-                name = f"Group {label}"
-            else:
-                name = f"${name}$"
-        else:
-            name = f"Group {label}"
-    if ambient is None:
-        args = label
-    else:
-        args = f"{label}%7C{ambient}%7C{aut}"
-    return f'<a title = "{name} [lmfdb.object_information]" knowl="lmfdb.object_information" kwargs="args={args}&func=group_data">{name}</a>'
 
 
 def sub_display_knowl(label, name=None):

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -339,7 +339,7 @@
   <tr>
     <td>{{KNOWL('group.center',title='Center')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.cent()}}">$Z \simeq {{gp.cent_label()}}$</span></td>
-    <td>$G/Z \simeq {{gp.central_quot()}}$</td>
+    <td>$G/Z \simeq$ {{gp.central_quot()|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.commutator_subgroup',title='Commutator')}}:</td>
@@ -350,22 +350,22 @@
     <tr>
     <td>{{KNOWL('group.frattini_subgroup',title='Frattini')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.fratt()}}">$\Phi \simeq {{gp.fratt_label()}}$</span></td>
-    <td>$G/\Phi \simeq {{gp.frattini_quot()}}$ </td>
+    <td>$G/\Phi \simeq$ {{gp.frattini_quot()|safe}} </td>
   </tr>
  <tr>
     <td>{{KNOWL('group.fitting_subgroup',title='Fitting')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.fitting}}">$\operatorname{Fit} \simeq {{gp.subgroups[gp.fitting].subgroup_tex}}$</td>
-    <td>$G/\operatorname{Fit} \simeq {{gp.subgroups[gp.fitting].quotient_tex}}$</td>
+    <td>$G/\operatorname{Fit} \simeq$ {{info.display_group_knowl(gp.subgroups[gp.fitting].quotient)|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.radical',title='Radical')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.radical}}">$R \simeq {{gp.subgroups[gp.radical].subgroup_tex}}$</td>
-    <td>$G/R \simeq {{gp.subgroups[gp.radical].quotient_tex}}$</td>
+    <td>$G/R \simeq$ {{info.display_group_knowl(gp.subgroups[gp.radical].quotient)|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.socle',title='Socle')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.socle}}">$\operatorname{soc} \simeq {{gp.subgroups[gp.socle].subgroup_tex}}$</td>
-    <td>$G/\operatorname{soc} \simeq {{gp.subgroups[gp.socle].quotient_tex}}$</td>
+    <td>$G/\operatorname{soc} \simeq$ {{info.display_group_knowl(gp.subgroups[gp.socle].quotient)|safe}}</td>
   </tr>
   {% if gp.pgroup == 0 %}
     {% for p, subgp in gp.sylow_subgroups() %}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -339,33 +339,33 @@
   <tr>
     <td>{{KNOWL('group.center',title='Center')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.cent()}}">$Z \simeq {{gp.cent_label()}}$</span></td>
-    <td>$G/Z \simeq$ {{gp.central_quot()|safe}}</td>
+    <td>$G/Z \simeq$ {{gp.subgroups[gp.cent()].display_quotient()|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.commutator_subgroup',title='Commutator')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.comm()}}">$G' \simeq {{gp.comm_label()}}$</span>
  </td>
-    <td> $G/G' \simeq {{gp.abelian_quot()}}$ </td>
+    <td> $G/G' \simeq$ {{gp.subgroups[gp.comm()].display_quotient(ab_invs=gp.smith_abelian_invariants)|safe}}</td>
   </tr>
     <tr>
     <td>{{KNOWL('group.frattini_subgroup',title='Frattini')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.fratt()}}">$\Phi \simeq {{gp.fratt_label()}}$</span></td>
-    <td>$G/\Phi \simeq$ {{gp.frattini_quot()|safe}} </td>
+    <td>$G/\Phi \simeq$ {{gp.subgroups[gp.fratt()].display_quotient()|safe}} </td>
   </tr>
  <tr>
     <td>{{KNOWL('group.fitting_subgroup',title='Fitting')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.fitting}}">$\operatorname{Fit} \simeq {{gp.subgroups[gp.fitting].subgroup_tex}}$</td>
-    <td>$G/\operatorname{Fit} \simeq$ {{info.display_group_knowl(gp.subgroups[gp.fitting].quotient)|safe}}</td>
+    <td>$G/\operatorname{Fit} \simeq$ {{gp.subgroups[gp.fitting].display_quotient()|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.radical',title='Radical')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.radical}}">$R \simeq {{gp.subgroups[gp.radical].subgroup_tex}}$</td>
-    <td>$G/R \simeq$ {{info.display_group_knowl(gp.subgroups[gp.radical].quotient)|safe}}</td>
+    <td>$G/R \simeq$ {{gp.subgroups[gp.radical].display_quotient()|safe}}</td>
   </tr>
   <tr>
     <td>{{KNOWL('group.socle',title='Socle')}}:</td>
     <td><span class="subgp chargp" data-sgid="{{gp.socle}}">$\operatorname{soc} \simeq {{gp.subgroups[gp.socle].subgroup_tex}}$</td>
-    <td>$G/\operatorname{soc} \simeq$ {{info.display_group_knowl(gp.subgroups[gp.socle].quotient)|safe}}</td>
+    <td>$G/\operatorname{soc} \simeq$ {{gp.subgroups[gp.socle].display_quotient()|safe}}</td>
   </tr>
   {% if gp.pgroup == 0 %}
     {% for p, subgp in gp.sylow_subgroups() %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -167,9 +167,9 @@ def abelian_get_elementary(snf):
 
 class WebAbstractGroup(WebObj):
     table = db.gps_groups
-    source = "db" # can be overridden below by either GAP or LiveAbelian
 
     def __init__(self, label, data=None):
+        self.source = "db" # can be overridden below by either GAP or LiveAbelian
         if isinstance(data, WebAbstractGroup):
             # This happens if we're using the _minmax_data in tex_name
             self.G = data.G
@@ -186,11 +186,11 @@ class WebAbstractGroup(WebObj):
                 if dbdata is not None:
                     data = dbdata
                 else:
-                    source = "GAP"
+                    self.source = "GAP"
         elif isinstance(data, LiveAbelianGroup):
             self._data = data.snf
             data = data.snf
-            source = "LiveAbelian"
+            self.source = "LiveAbelian"
         WebObj.__init__(self, label, data)
         if self._data is None:
             # Check if the label is for an order supported by GAP's SmallGroup
@@ -203,7 +203,7 @@ class WebAbstractGroup(WebObj):
                     i = ZZ(m.group(4))
                     if i <= maxi:
                         self._data = (n, i)
-                        source = "GAP"
+                        self.source = "GAP"
         if isinstance(self._data, list):  # live abelian group
             self.snf = primary_to_smith(self._data)  # existence is a marker that we were here
             self.G = LiveAbelianGroup(self.snf)


### PR DESCRIPTION
On the page of a group, various quotient groups appear.  This makes them small group knowls if the group is in the database.  For live groups, they are just links to the group (unless the group is the one we are looking at).  This is done for special subgroups (center, socle, etc.) and in the information about a subgroup when clicked on from the diagram (if it is normal).

Standard page:
http://127.0.0.1:37777/Groups/Abstract/68.4

Live abelian group:
http://127.0.0.1:37777/Groups/Abstract/ab/3.3.9.9.9.9.9.36.72

Live gap group:
http://127.0.0.1:37777/Groups/Abstract/512.1

Notes:
  * there may be other quotient groups which come up in some circumstances.  They can always be handled at a later date.
  * in some cases, a quotient of a live group might be in the database in which case one could make a small group knowl for it.  However, it might not be worth the time to try to look them up.
  * The code also has a start at trying to set a variable inside the web abstract group object to say what type it is.  In the long run, this is would be clearer so we wouldn't have to infer the information by data types of "_data".  However, it wasn't fully working, so isn't actually used yet.


