### PR TITLE
AL_dims -> ALdims

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -5,9 +5,7 @@ import os
 import yaml
 
 from flask import render_template, url_for, redirect, abort, request, make_response
-from sage.all import (
-    ZZ, next_prime, cartesian_product_iterator,
-    cached_function, prime_range, prod, gcd, nth_prime)
+from sage.all import ZZ, next_prime, cached_function, prime_range, prod, gcd, nth_prime
 from sage.databases.cremona import class_to_int, cremona_letter_code
 
 from lmfdb import db
@@ -94,11 +92,7 @@ def level_bound(nontriv=None):
 #############################################################################
 
 def ALdims_knowl(al_dims, level, weight):
-    dim_dict = {}
-    for vec, dim, cnt in al_dims:
-        dim_dict[tuple(ev for (p, ev) in vec)] = dim
-    short = "+".join(r'\(%s\)'%dim_dict.get(vec,0) for vec in cartesian_product_iterator([[1,-1] for _ in range(len(al_dims[0][0]))]))
-    # We erase plus_dim and minus_dim if they're obvious
+    short = "+".join(["$%s$"%(d) for d in al_dims])
     AL_table = ALdim_table(al_dims, level, weight)
     return r'<a title="[ALdims]" knowl="dynamic_show" kwargs="%s">%s</a>'%(AL_table, short)
 
@@ -150,7 +144,7 @@ def display_decomp(level, weight, char_orbit_label, hecke_orbit_dims):
     return r'+'.join(terms)
 
 def show_ALdims_col(info):
-    return any(space.get('AL_dims') for space in info["results"])
+    return any(space.get('ALdims') for space in info["results"])
 
 def display_ALdims(level, weight, al_dims):
     if al_dims:
@@ -1163,7 +1157,7 @@ def dimension_form_search(info, query):
              title='Dimension search results',
              err_title='Dimension search input error',
              per_page=None,
-             projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_index', 'dim', 'hecke_orbit_dims', 'AL_dims', 'char_conductor','eis_dim','eis_new_dim','cusp_dim', 'mf_dim', 'mf_new_dim', 'plus_dim', 'num_forms'],
+             projection=['label', 'analytic_conductor', 'level', 'weight', 'conrey_index', 'dim', 'hecke_orbit_dims', 'ALdims', 'char_conductor','eis_dim','eis_new_dim','cusp_dim', 'mf_dim', 'mf_new_dim', 'plus_dim', 'num_forms'],
              postprocess=dimension_space_postprocess,
              bread=get_dim_bread,
              learnmore=learnmore_list)
@@ -1186,7 +1180,7 @@ space_columns = SearchColumns([
     MathCol("char_order", "character.dirichlet.order", r"$\operatorname{ord}(\chi)$", short_title="character order", default=True),
     MathCol("dim", "cmf.display_dim", "Dim.", short_title="dimension", default=True),
     MultiProcessedCol("decomp", "cmf.dim_decomposition", "Decomp.", ["level", "weight", "char_orbit_label", "hecke_orbit_dims"], display_decomp, default=True, align="center", short_title="decomposition", td_class=" nowrap"),
-    MultiProcessedCol("al_dims", "cmf.atkin_lehner_dims", "AL-dims.", ["level", "weight", "AL_dims"], display_ALdims, contingent=show_ALdims_col, default=True, short_title="Atkin-Lehner dimensions", align="center", td_class=" nowrap")])
+    MultiProcessedCol("al_dims", "cmf.atkin_lehner_dims", "AL-dims.", ["level", "weight", "ALdims"], display_ALdims, contingent=show_ALdims_col, default=True, short_title="Atkin-Lehner dimensions", align="center", td_class=" nowrap")])
 
 @search_wrap(table=db.mf_newspaces,
              title='Newspace search results',

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -65,7 +65,7 @@ class CmfTest(LmfdbTest):
         assert r"""["20.5.b.a", "20.5.d.a", "20.5.d.b", "20.5.d.c", "20.5.f.a"]""" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newspace/244.4.w')
-        assert "[1456, -16, 0, -14, -28, 64, 0, -16, -3156, 168, 0, 36, -108]" in page.get_data(as_text=True)
+        assert "[1456, -16, 0, -14, -28, 64, 0, -16, -3156, 168, 0, 36, -108" in page.get_data(as_text=True)
         assert "244.4.w" in page.get_data(as_text=True)
 
     def test_download_magma(self):

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -329,7 +329,7 @@ class CmfTest(LmfdbTest):
         assert 'A-L signs' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15&search_type=Spaces', follow_redirects=True)
         assert 'AL-dims.' in page.get_data(as_text=True)
-        assert r'\(0\)+\(1\)+\(0\)+\(0\)' in page.get_data(as_text=True)
+        assert r'$0$+$1$+$0$+$0$' in page.get_data(as_text=True)
 
     def test_Fricke_signs_search(self):
         r"""

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -65,7 +65,7 @@ class CmfTest(LmfdbTest):
         assert r"""["20.5.b.a", "20.5.d.a", "20.5.d.b", "20.5.d.c", "20.5.f.a"]""" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_newspace/244.4.w')
-        assert "[7, 31, 35, 43, 51, 55, 59, 63, 67, 71, 79, 87, 91, 115, 139, 227]" in page.get_data(as_text=True)
+        assert "[1456, -16, 0, -14, -28, 64, 0, -16, -3156, 168, 0, 36, -108]" in page.get_data(as_text=True)
         assert "244.4.w" in page.get_data(as_text=True)
 
     def test_download_magma(self):

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -3,6 +3,7 @@
 # See templates/space.html for how functions are called
 
 from lmfdb import db
+from sage.all import ZZ
 from sage.databases.cremona import cremona_letter_code
 from lmfdb.number_fields.web_number_field import nf_display_knowl, cyclolookup, rcyclolookup
 from lmfdb.characters.TinyConrey import ConreyCharacter
@@ -82,50 +83,42 @@ def cyc_display(m, d, real_sub):
         return name
 
 def ALdim_table(al_dims, level, weight):
-    # Assume that the primes always appear in the same order
-    al_dims = sorted(al_dims, key=lambda x:tuple(-ev for (p,ev) in x[0]))
-    header = []
-    first_row = al_dims[0][0]
-    primes = [p for (p,ev) in first_row]
+    sign_char = lambda x: "-" if x else "+"
+    url_sign_char = lambda x: "-" if x else "%2B"
+    primes = ZZ(level).prime_divisors()
     num_primes = len(primes)
-    for p, ev in first_row:
-        header.append(r'<th>\(%s\)</th>'%p)
-    if len(first_row) > 1:
+    header = [r'<th>\(%s\)</th>'%p for p in primes]
+    if num_primes > 1:
         header.append(r"<th class='right'>%s</th>"%(display_knowl('cmf.fricke', title='Fricke').replace('"',"'")))
-    header.append('<th>Dim.</th>')
+    header.append('<th>Dim</th>')
     rows = []
-    fricke = {1:0,-1:0}
-    for i, (vec, dim, cnt) in enumerate(al_dims):
-        row = []
-        sign = 1
-        s = ''
-        for p, ev in vec:
-            if ev == 1:
-                s += '%2B'
-                symb = '+'
-            else:
-                sign = -sign
-                s += '-'
-                symb = '-'
-            row.append(r'<td>\(%s\)</td>'%(symb))
-        if len(vec) > 1:
-            row.append(r"<td class='right'>\(%s\)</td>"%('+' if sign == 1 else '-'))
-        query = {'level':level, 'weight':weight, 'char_order':1, 'atkin_lehner_string':s}
-        if cnt == 1:
-            query['jump'] = 'yes'
+    fricke = [0,0]
+    for i, dim in enumerate(al_dims):
+        if dim == 0:
+            continue
+        print(i)
+        b = list(reversed(ZZ(i).bits()))
+        print(b)
+        b = [0 for j in range(num_primes-len(b))] + b
+        print(b)
+        row = list(map(lambda x:r'<td>\(%s\)</td>'%sign_char(x),b))
+        sign = sum(b) % 2
+        if num_primes > 1:
+            row.append(r"<td class='right'>$%s$</td>"%sign_char(sign))
+        query = {'level':level, 'weight':weight, 'char_order':1, 'atkin_lehner_string':"".join(map(url_sign_char,b))}
         link = newform_search_link(r'\(%s\)'%dim, **query)
         row.append(r'<td>%s</td>'%(link))
         fricke[sign] += dim
-        if i == len(al_dims) - 1 and len(vec) > 1:
+        if i == len(al_dims) - 1 and num_primes > 1:
             tr = "<tr class='endsection'>"
         else:
             tr = "<tr>"
         rows.append(tr + ''.join(row) + '</tr>')
     if num_primes > 1:
         plus_knowl = display_knowl('cmf.plus_space',title='Plus space').replace('"',"'")
-        plus_link = newform_search_link(r'\(%s\)'%fricke[1], level=level, weight=weight, char_order=1, fricke_eigenval=1)
+        plus_link = newform_search_link(r'\(%s\)'%fricke[0], level=level, weight=weight, char_order=1, fricke_eigenval=1)
         minus_knowl = display_knowl('cmf.minus_space',title='Minus space').replace('"',"'")
-        minus_link = newform_search_link(r'\(%s\)'%fricke[-1], level=level, weight=weight, char_order=1, fricke_eigenval=-1)
+        minus_link = newform_search_link(r'\(%s\)'%fricke[1], level=level, weight=weight, char_order=1, fricke_eigenval=-1)
         rows.append(r"<tr><td colspan='%s'>%s</td><td class='right'>\(+\)</td><td>%s</td></tr>"%(num_primes, plus_knowl, plus_link))
         rows.append(r"<tr><td colspan='%s'>%s</td><td class='right'>\(-\)</td><td>%s</td></tr>"%(num_primes, minus_knowl, minus_link))
     return ("<table class='ntdata'><thead><tr>%s</tr></thead><tbody>%s</tbody></table>" %
@@ -355,7 +348,7 @@ class WebNewformSpace():
                                   for N, i, conrey, mult in self.oldspaces)
 
     def ALdim_table(self):
-        return ALdim_table(self.AL_dims, self.level, self.weight)
+        return ALdim_table(self.ALdims, self.level, self.weight)
 
     def trace_expansion(self, prec_max=10):
         return trace_expansion_generic(self, prec_max)

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -96,11 +96,8 @@ def ALdim_table(al_dims, level, weight):
     for i, dim in enumerate(al_dims):
         if dim == 0:
             continue
-        print(i)
         b = list(reversed(ZZ(i).bits()))
-        print(b)
         b = [0 for j in range(num_primes-len(b))] + b
-        print(b)
         row = list(map(lambda x:r'<td>\(%s\)</td>'%sign_char(x),b))
         sign = sum(b) % 2
         if num_primes > 1:

--- a/lmfdb/verify/mf_newspaces.py
+++ b/lmfdb/verify/mf_newspaces.py
@@ -130,12 +130,12 @@ class mf_newspaces(MfChecker):
         return self._run_query(SQL("hecke_orbit_dims IS NOT NULL AND hecke_orbit_dims = ARRAY(SELECT DISTINCT UNNEST(hecke_orbit_dims) ORDER BY 1) AND num_forms > 1 AND trace_bound != 1"))
 
     @overall
-    def check_AL_dims_plus_dim(self):
+    def check_ALdims_plus_dim(self):
         """
-        check that AL_dims and plus_dim is set whenever char_orbit_index=1 and dim > 0
+        check that ALdims and plus_dim is set whenever char_orbit_index=1 and dim > 0
         """
         # TIME about 20s
-        return self.check_non_null(['AL_dims', 'plus_dim'], {'char_orbit_index':1, 'dim':{'$gt':0}})
+        return self.check_non_null(['ALdims', 'plus_dim'], {'char_orbit_index':1, 'dim':{'$gt':0}})
 
     @overall
     def check_dim0_num_forms(self):
@@ -194,12 +194,12 @@ class mf_newspaces(MfChecker):
         return self.check_array_sum('hecke_orbit_dims', 'dim', {'hecke_orbit_dims':{'$exists':True}})
 
     @overall
-    def check_sum_AL_dims(self):
+    def check_sum_ALdims(self):
         """
         If AL_dims is set, check that AL_dims sum to dim
         """
         # TIME 0.3 s
-        query = SQL(r'SELECT label FROM mf_newspaces t1  WHERE t1.dim !=( SELECT  SUM(s.d) FROM (SELECT ((jsonb_array_elements("AL_dims"))->>1)::int d FROM mf_newspaces t2 WHERE t2.label = t1.label) s ) AND  "AL_dims" is not NULL')
+        query = SQL(r'SELECT label FROM mf_newspaces t1  WHERE t1.dim != (SELECT SUM(s) FROM UNNEST(t1."ALdims") s) AND  "ALdims" is not NULL')
         return self._run_query(query=query)
 
     @overall


### PR DESCRIPTION
To simplify the addition of more newspaces and to save space, the jsonb column `AL_dims` of  `mf_newspaces` is being replaced by an integer[] column `ALdims` which just lists the dimension of the Atkin-Lehner subspaces (for newspaces with trivial character) where the order is implicit (same order we use on the web pages).

Data needs to be tweaked and copied to prod before this is merged, but the code won't change, so submitting this now to get tests going (the prod tests will fail, I'll rerun them once the data is there).