### PR TITLE
Also catch other kinds of exceptions in search

### DIFF
--- a/lmfdb/elliptic_curves/test_browse_page.py
+++ b/lmfdb/elliptic_curves/test_browse_page.py
@@ -96,3 +96,7 @@ class HomePageTest(LmfdbTest):
         L = self.tc.get("EllipticCurve/Q/?isogeny_degrees=13&search_type=List")
         assert '[0, 0, 1, -849658625, 9532675710156]' in L.get_data(as_text=True)
         assert '[0, -1, 1, -10, -20]' not in L.get_data(as_text=True)
+
+        # Test error handling
+        L = self.tc.get("EllipticCurve/Q/?conductor=162&jinv=-1159088625%2F097152")
+        assert ' is not a valid input' in L.get_data(as_text=True)

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -62,7 +62,7 @@ class Wrapper():
         template_kwds = {key: info.get(key, val()) for key, val in self.kwds.items()}
         try:
             errpage = self.f(info, query)
-        except ValueError as err:
+        except Exception as err:
             # Errors raised in parsing; these should mostly be SearchParsingErrors
             info['err'] = str(err)
             err_title = query.pop('__err_title__', self.err_title)


### PR DESCRIPTION
Fixes a bug observed in the flasklog, where https://beta.lmfdb.org/EllipticCurve/Q/?hst=List&conductor=162&jinv=-1159088625%2F097152&search_type=List caused a server error.