### PR TITLE
Handle number field errors in downloads

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1035,17 +1035,24 @@ def unlatex(s):
 @nf_page.route('/<nf>/download/<download_type>')
 def nf_download(**args):
     typ = args['download_type']
-    if typ == 'data':
-        response = make_response(nf_data(**args))
-    else:
-        response = make_response(nf_code(**args))
+    try:
+        if typ == 'data':
+            response = make_response(nf_data(**args))
+        else:
+            response = make_response(nf_code(**args))
+    except Exception as err:
+        return abort(404, str(err))
     response.headers['Content-type'] = 'text/plain'
     return response
 
 
 def nf_data(**args):
     label = args['nf']
+    if not FIELD_LABEL_RE.fullmatch(label):
+        raise ValueError(f"Invalid label {label}")
     nf = WebNumberField(label)
+    if nf.is_null():
+        raise ValueError(f"There is no number field with label {label}")
     data = '/* Data is in the following format\n'
     data += '   Note, if the class group has not been computed, it, the class number, the fundamental units, regulator and whether grh was assumed are all 0.\n'
     data += '[polynomial,\ndegree,\nt-number of Galois group,\nsignature [r,s],\ndiscriminant,\nlist of ramifying primes,\nintegral basis as polynomials in a,\n1 if it is a cm field otherwise 0,\nclass number,\nclass group structure,\n1 if grh was assumed and 0 if not,\nfundamental units,\nregulator,\nlist of subfields each as a pair [polynomial, number of subfields isomorphic to one defined by this polynomial]\n]'
@@ -1112,8 +1119,12 @@ Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\', 'oscar': '#
 
 def nf_code(**args):
     label = args['nf']
+    if not FIELD_LABEL_RE.fullmatch(label):
+        raise ValueError(f"Invalid label {label}")
     lang = args['download_type']
     nf = WebNumberField(label)
+    if nf.is_null():
+        raise ValueError(f"There is no number field with label {label}")
     nf.make_code_snippets()
     code = "{} {} code for working with number field {}\n\n".format(Comment[lang],Fullname[lang],label)
     if lang == 'oscar':

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -91,3 +91,7 @@ class NumberFieldTest(LmfdbTest):
 
     def test_underlying_data(self):
         self.check_args('NumberField/2.2.10069.1', ['Underlying data', 'data/2.2.10069.1'])
+
+    def test_errors(self):
+        self.check_args('NumberField/18.0.10490638424...4432.1/download/sage', 'Invalid label')
+        self.check_args('NumberField/4.3.2.1/download/sage', 'There is no number field with label 4.3.2.1')


### PR DESCRIPTION
Addresses errors like
```
Traceback (most recent call last):
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.8/lib/python3.8/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.8/lib/python3.8/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.8/lib/python3.8/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.8/lib/python3.8/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/number_fields/number_field.py", line 1041, in nf_download
    response = make_response(nf_code(**args))
  File "/home/lmfdb/lmfdb-git-web/lmfdb/number_fields/number_field.py", line 1117, in nf_code
    nf.make_code_snippets()
  File "/home/lmfdb/lmfdb-git-web/lmfdb/number_fields/web_number_field.py", line 973, in make_code_snippets
    self.code['field'][lang] = self.code['field'][lang] % self.poly()
  File "/home/lmfdb/lmfdb-git-web/lmfdb/number_fields/web_number_field.py", line 521, in poly
    return coeff_to_poly(self._data['coeffs'], var=var)
TypeError: 'NoneType' object is not subscriptable
[2023-07-03 14:19:27 UTC] 500 error on URL https://www.lmfdb.org/NumberField/18.0.10490638424...4432.1/download/sage ()
```