### PR TITLE
Special subgroup knowls

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1367,13 +1367,16 @@ def shortsubinfo(ambient, short_label):
 
     def subinfo_getsub(title, knowlid, lab):
         full_lab = "%s.%s" % (ambient, lab)
-        h = WebAbstractSubgroup(full_lab)
+        h = WebAbstractSubgroup(full_lab) if lab else None
         prop = display_knowl(knowlid, title)
-        return f"<tr><td>{prop}</td><td>{h.make_span()}</td></tr>\n"
+        if lab:
+            return f"<tr><td>{prop}</td><td>{h.make_span()}</td></tr>\n"
+        else:
+            return f"<tr><td>{prop}</td><td>not computed</td></tr>\n"
 
     ans = (
         'Information on the subgroup <span class="%s" data-sgid="%s">$%s$</span><br>\n'
-        % (wsg.spanclass(), wsg.label, wsg.subgroup_tex)
+        % (wsg.spanclass(), wsg.label, wsg.subgroup_tex if '?' not in wsg.subgroup_tex else '')
     )
     ans += f"<p>{create_boolean_subgroup_string(wsg, type='knowl')}</p>"
     ans += "<table>"
@@ -1398,16 +1401,19 @@ def shortsubinfo(ambient, short_label):
     #    ans += f"<tr><td>{display_knowl('group.generators', 'Generators')}</td><td>${gp.show_subgroup_generators(wsg)}$</td></tr>"
     # if not wsg.characteristic:
     #    ans += f"<tr><td>Number of autjugates</td><td>{wsg.conjugacy_class_count}</td></tr>"
+    alt_tex = wsg.label if '?' in wsg.subgroup_tex else rf'${wsg.subgroup_tex}$'
     ans += (
-        '<tr><td></td><td style="text-align: right"><a href="%s">$%s$ subgroup homepage</a></td>'
-        % (url_for_subgroup_label(wsg.label), wsg.subgroup_tex)
+        '<tr><td></td><td style="text-align: right"><a href="%s">%s subgroup homepage</a></td>'
+        % (url_for_subgroup_label(wsg.label), alt_tex)
     )
-    ans += (
-        '<tr><td></td><td style="text-align: right"><a href="%s">$%s$ abstract group homepage</a></td></tr>'
-        % (url_for_label(wsg.subgroup), wsg.subgroup_tex)
-    )
+    if wsg.subgroup:
+        ans += (
+            '<tr><td></td><td style="text-align: right"><a href="%s">$%s$ abstract group homepage</a></td></tr>'
+            % (url_for_label(wsg.subgroup), wsg.subgroup_tex)
+        )
+        
     # print ""
-    # print ans
+    # print (ans)
     ans += "</table>"
     return ans
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -393,6 +393,7 @@
     <td>{{KNOWL('group.commutator_length', 'Commutator length')}}:</td>
      {% if gp.commutator_count %}
       <td>${{gp.commutator_count}}$</td>
+    {% elif gp.abelian %} <td>$0$</td>
     {% else %} <td>not computed</td> {% endif %}
   </tr>
   {% endif %}
@@ -426,7 +427,7 @@
   <tr>
     <td>{{KNOWL('group.center',title='Center')}}:</td>
     {% if gp.cent() %}
-    <td><span class="subgp chargp" data-sgid="{{gp.cent()}}">$Z \simeq {{gp.cent_label()}}$</span></td>
+    <td><span class="subgp chargp" data-sgid="{{gp.cent()}}">$Z \simeq$ {{gp.cent_label()|safe}}</span></td>
     <td>{{gp.subgroups[gp.cent()].display_quotient("Z")|safe}}</td>
     {% elif gp.center_label %}
     <td>a subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.center_label)}}">${{gp.special_subs_label(gp.center_label)}}$</td>
@@ -437,7 +438,7 @@
   <tr>
     <td>{{KNOWL('group.commutator_subgroup',title='Commutator')}}:</td>
     {% if gp.comm() %}
-    <td><span class="subgp chargp" data-sgid="{{gp.comm()}}">$G' \simeq {{gp.comm_label()}}$</span></td> {# match single quote for code highlighting purposes: ' #}
+    <td><span class="subgp chargp" data-sgid="{{gp.comm()}}">$G' \simeq$ {{gp.subgroups[gp.comm()].knowl()|safe}}</span></td> {# match single quote for code highlighting purposes: ' #}
     <td>{{gp.subgroups[gp.comm()].display_quotient("G'", ab_invs=gp.smith_abelian_invariants)|safe}}</td>
      {% elif gp.commutator_label %}
     <td>a subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.comutator_label)}}">${{gp.special_subs_label(gp.commutator_label)}}$</td>
@@ -448,7 +449,7 @@
   <tr>
     <td>{{KNOWL('group.frattini_subgroup',title='Frattini')}}:</td>
     {% if gp.fratt() %}
-    <td><span class="subgp chargp" data-sgid="{{gp.fratt()}}">$\Phi \simeq {{gp.fratt_label()}}$</span></td>
+    <td><span class="subgp chargp" data-sgid="{{gp.fratt()}}">$\Phi \simeq$ {{gp.subgroups[gp.fratt()].knowl()|safe}}</span></td>
     <td>{{gp.subgroups[gp.fratt()].display_quotient("\\Phi")|safe}} </td>
      {% elif gp.frattini_label %}
     <td>a subgroup isomorphic to <a href="{{url_for('.by_label', label=gp.frattini_label)}}">${{gp.special_subs_label(gp.frattini_label)}}$</td>
@@ -459,7 +460,7 @@
  <tr>
     <td>{{KNOWL('group.fitting_subgroup',title='Fitting')}}:</td>
     {% if gp.fitting %}
-    <td><span class="subgp chargp" data-sgid="{{gp.fitting}}">$\operatorname{Fit} \simeq {{gp.subgroups[gp.fitting].subgroup_tex}}$</td>
+    <td><span class="subgp chargp" data-sgid="{{gp.fitting}}">$\operatorname{Fit} \simeq$ {{gp.subgroups[gp.fitting].knowl()|safe}}</td>
     <td>{{gp.subgroups[gp.fitting].display_quotient("\\operatorname{Fit}")|safe}}</td>
     {% else %}
     <td> not computed</td>
@@ -468,7 +469,7 @@
   <tr>
     <td>{{KNOWL('group.radical',title='Radical')}}:</td>
     {% if gp.radical %}
-    <td><span class="subgp chargp" data-sgid="{{gp.radical}}">$R \simeq {{gp.subgroups[gp.radical].subgroup_tex}}$</td>
+    <td><span class="subgp chargp" data-sgid="{{gp.radical}}">$R \simeq$ {{gp.subgroups[gp.radical].knowl()|safe}}</td>
     <td>{{gp.subgroups[gp.radical].display_quotient("R")|safe}}</td>
     {% else %}
     <td>not computed</td>
@@ -477,20 +478,18 @@
   <tr>
     <td>{{KNOWL('group.socle',title='Socle')}}:</td>
     {% if gp.socle %}
-    <td><span class="subgp chargp" data-sgid="{{gp.socle}}">$\operatorname{soc} \simeq {{gp.subgroups[gp.socle].subgroup_tex}}$</td>
+    <td><span class="subgp chargp" data-sgid="{{gp.socle}}">$\operatorname{soc} \simeq$ {{gp.subgroups[gp.socle].knowl()|safe}}</td>
     <td>{{gp.subgroups[gp.socle].display_quotient("\\operatorname{soc}")|safe}}</td>
     {% else %}
     <td> not computed</td>
     {% endif %}
   </tr>
-  {% if gp.pgroup == 0 %}
     {% for p, subgp in gp.sylow_subgroups() %}
       <tr>
         <td>{{p}}-{{KNOWL('group.sylow_subgroup', 'Sylow subgroup')}}:</td>
-        <td><span class="{{subgp.spanclass()}}" data-sgid="{{subgp.label}}">$P_{ {{p}} } \simeq {{subgp.subgroup_tex}}$</span></td>
+        <td><span class="{{subgp.spanclass()}}" data-sgid="{{subgp.short_label}}">$P_{ {{p}} } \simeq$ {{subgp.knowl()|safe}}</span></td>
       </tr>
     {% endfor %}
-  {% endif %}
 </table>
 
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -96,6 +96,8 @@ def group_pretty_image(label):
 @cached_function(key=lambda label,name,pretty,ambient,aut,profiledata,cache: (label,name,pretty,ambient,aut,profiledata))
 def abstract_group_display_knowl(label, name=None, pretty=True, ambient=None, aut=False, profiledata=None, cache={}):
     # If you have the group in hand, set the name using gp.tex_name since that will avoid a database call
+    if name and '?' in name:
+        name = None
     if not name:
         if pretty:
             if label in cache and "tex_name" in cache[label]:
@@ -1909,7 +1911,7 @@ class WebAbstractGroup(WebObj):
 
     def trans_degree(self):
         if self.transitive_degree is None:
-            return r"$\textrm{not computed}$"
+            return r"not computed"
         else:
             return self.transitive_degree
 
@@ -2233,19 +2235,15 @@ class WebAbstractSubgroup(WebObj):
     def __init__(self, label, data=None):
         WebObj.__init__(self, label, data)
         s = self.subgroup_tex
-        print("$$$$$$$$$$$$$$$ ", self.subgroup)
         if s is None:
             self.subgroup_tex = "?"
-            self.subgroup_tex_parened = "(?)"
+            self.subgroup_tex_parened = "?"
         else:
             self.subgroup_tex_parened = s if is_atomic(s) else "(%s)" % s
         if self._data.get("quotient"):
             q = self.quotient_tex
-            print("++++++++++++++++ ", q)
             if q is None:
                 tryhard = db.gps_groups_test.lookup(self.quotient)
-                print("&&&&&&&&&&&&&&&&&&&& ", self._data['quotient'])
-                print("--------- ", tryhard)
                 if tryhard and tryhard.tex_name:
                     q = tryhard.tex_name
                     self.quotient_tex = q
@@ -2402,13 +2400,16 @@ class WebAbstractSubgroup(WebObj):
 
     def knowl(self, paren=False):
         from lmfdb.groups.abstract.main import sub_display_knowl
+        # jjjjjjjjjjj
         knowlname = self.subgroup_tex_parened if paren else self.subgroup_tex
         return sub_display_knowl(self.label, name=rf'${knowlname}$')
 
     def quotient_knowl(self, paren=False):
         # assumes there is a quotient group
-        print ("********************** ", self.quotient_tex)
-        knowlname = self.quotient_tex_parened if paren else self.quotient_tex
+        if '?' in self.quotient_tex:
+            knowlname = WebAbstractGroup(self.quotient).tex_name
+        else:
+            knowlname = self.quotient_tex_parened if paren else self.quotient_tex
         return abstract_group_display_knowl(self.quotient, name=rf'${knowlname}$')
 
     def display_quotient(self, subname=None, ab_invs=None):

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1976,7 +1976,7 @@ class WebAbstractGroup(WebObj):
     def cent_label(self):
         cent = self.cent()
         if cent:
-            return self.subgroups[self.cent()].subgroup_tex
+            return self.subgroups[self.cent()].knowl()
         return None
 
     def cent_order_factor(self):
@@ -1995,7 +1995,7 @@ class WebAbstractGroup(WebObj):
     def comm_label(self):
         comm = self.comm()
         if comm:
-            return self.subgroups[comm].subgroup_tex
+            return self.subgroups[comm].knowl()
         return nc
 
     def abelian_quot(self):
@@ -2020,7 +2020,7 @@ class WebAbstractGroup(WebObj):
     def fratt_label(self):
         fratt = self.fratt()
         if fratt:
-            return self.subgroups[fratt].subgroup_tex
+            return self.subgroups[fratt].knowl()
         return None
 
     def gen_noun(self):
@@ -2400,7 +2400,6 @@ class WebAbstractSubgroup(WebObj):
 
     def knowl(self, paren=False):
         from lmfdb.groups.abstract.main import sub_display_knowl
-        # jjjjjjjjjjj
         knowlname = self.subgroup_tex_parened if paren else self.subgroup_tex
         return sub_display_knowl(self.label, name=rf'${knowlname}$')
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2233,6 +2233,7 @@ class WebAbstractSubgroup(WebObj):
     def __init__(self, label, data=None):
         WebObj.__init__(self, label, data)
         s = self.subgroup_tex
+        print("$$$$$$$$$$$$$$$ ", self.subgroup)
         if s is None:
             self.subgroup_tex = "?"
             self.subgroup_tex_parened = "(?)"
@@ -2240,9 +2241,18 @@ class WebAbstractSubgroup(WebObj):
             self.subgroup_tex_parened = s if is_atomic(s) else "(%s)" % s
         if self._data.get("quotient"):
             q = self.quotient_tex
+            print("++++++++++++++++ ", q)
             if q is None:
-                self.quotient_tex = "?"
-                self.quotient_tex_parened = "(?)"
+                tryhard = db.gps_groups_test.lookup(self.quotient)
+                print("&&&&&&&&&&&&&&&&&&&& ", self._data['quotient'])
+                print("--------- ", tryhard)
+                if tryhard and tryhard.tex_name:
+                    q = tryhard.tex_name
+                    self.quotient_tex = q
+                    self.quotient_tex_parened = q if is_atomic(q) else "(%s)" % q
+                else:
+                    self.quotient_tex = "?"
+                    self.quotient_tex_parened = "(?)"
             else:
                 self.quotient_tex_parened = q if is_atomic(q) else "(%s)" % q
 
@@ -2397,6 +2407,7 @@ class WebAbstractSubgroup(WebObj):
 
     def quotient_knowl(self, paren=False):
         # assumes there is a quotient group
+        print ("********************** ", self.quotient_tex)
         knowlname = self.quotient_tex_parened if paren else self.quotient_tex
         return abstract_group_display_knowl(self.quotient, name=rf'${knowlname}$')
 


### PR DESCRIPTION
For special subgroups, the subgroups themselves are now subgroup knowls when possible.

Also, commutator length is 0 when the group is abelian.

https://beta.lmfdb.org/Groups/Abstract/132.2
http://127.0.0.1:37777/Groups/Abstract/132.2

Also fixed highlighting for Sylow subgroups.

