### PR TITLE
Removing some math mode

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2383,12 +2383,12 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         profiledata[0] = None
         tex_name = profiledata[2]
         if tex_name is None:
-            ans = "Unknown group<br />"
+            ans = "Unidentified group<br />"
         else:
             ans = f"Group ${tex_name}$<br />"
         ans += f"Order: {order}<br />"
         if profiledata[1] is None:
-            ans += "Isomorphism class unknown<br />"
+            ans += "Isomorphism class has not been identified<br />"
         else:
             # TODO: add hash knowl and search link to groups with this order and hash
             ans += f"Hash: {profiledata[1]}<br />"
@@ -2430,13 +2430,13 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         if quotient_tex in [None, "?"]:
             quotient_tex = profiledata[5]
         if quotient_tex in [None, "?"]:
-            ans += "Unknown quotient<br />"
+            ans += "identified quotient<br />"
         else:
             ans += f"Quotient ${quotient_tex}$<br />"
         ambient_order = int(ambient.split(".")[0])
         ans += f"Quotient order: {ambient_order // order}<br />"
         if profiledata[4] is None:
-            ans += "Quotient isomorphism class unknown<br />"
+            ans += "Quotient isomorphism class has not been identified<br />"
         else:
             # TODO: add hash knowl and search link to groups with this order and hash
             ans += f"Quotient hash: {profiledata[4]}<br />"

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -841,16 +841,16 @@ class WebAbstractGroup(WebObj):
                 if self.number_characteristic_subgroups < self.number_normal_subgroups:
                     ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes')) + """ ">""" + str(self.number_characteristic_subgroups) + " characteristic</a>).<p>"+charcolor+"  "+normalcolor
                 else:
-                    ret_str=ret_str+ " all characteristic.<p>"+charcolor
+                    ret_str=ret_str+ ", and all normal subgroups are characteristic.<p>"+charcolor
                 return ret_str
         elif self.number_normal_subgroups < self.number_subgroups:
             ret_str =  "There are " + str(self.number_subgroups) + """ subgroups in <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ + str(self.number_subgroup_classes) + """ conjugacy classes</a>, <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, normal='yes'))+ """ "> """ +str(self.number_normal_subgroups) + """ normal</a>"""
         else:
             ret_str = """ There are  <a href=" """ +str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ +str(self.number_subgroups) + """ subgroups</a>, all normal"""
         if self.number_characteristic_subgroups < self.number_normal_subgroups:
-            ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes'))+ """ "> """ + str(self.number_characteristic_subgroups) + """ characteristic</a>).<p>"""+charcolor+" "+normalcolor
+            ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes'))+ """ ">""" + str(self.number_characteristic_subgroups) + """ characteristic</a>).<p>"""+charcolor+" "+normalcolor
         else:
-            ret_str = ret_str + ", all characteristic. <p>"+charcolor
+            ret_str = ret_str + ", and all normal subgroups are characteristic. <p>"+charcolor
         return ret_str
 
     @lazy_attribute

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1011,12 +1011,12 @@ class WebAbstractGroup(WebObj):
                 # TODO: Deal with the orders where all we know is a count from normal_counts
                 if len(tup) > 3:
                     if tup[5] is None:
-                        ord_str = "\\text{unknown group of order }" + str(tup[6])
+                        ord_str = "unidentified group of order " + str(tup[6])
                     else:
-                        ord_str = tup[5]
+                        ord_str = rf'${tup[5]}$'
                 l.append(
                     abstract_group_display_knowl(label, name=f"${tex}$", ambient=self.label, aut=bool(aut), profiledata=tuple(tup))
-                    + ("" if len(tup) == 3 else " ( $%s$ )" % (ord_str))
+                    + ("" if len(tup) == 3 else " (%s)" % (ord_str))  
                     + (" x " + str(cnt) if cnt > 1 else "")
                 )
             return sep.join(l)

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -829,26 +829,28 @@ class WebAbstractGroup(WebObj):
 
     @lazy_attribute
     def subgp_paragraph(self):
+        charcolor = r'Characteristic subgroups are shown in <span class="chargp">this color</span>.'
+        normalcolor = r'Normal (but not characteristic) subgroups are shown in <span class="normgp">this color</span>.'
         if self.number_subgroups is None:
             if self.number_normal_subgroups is None:
                 return " "
             elif self.number_characteristic_subgroups is None:
-                return """There are <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, normal='yes')) + """ "> """ +str(self.number_normal_subgroups) + " normal</a> subgroups."
+                return """There are <a href=" """ + str(url_for('.index', search_type='Subgroups', ambiunt=self.label, normal='yes')) + """ "> """ +str(self.number_normal_subgroups) + " normal</a> subgroups.  <p>"+normalcolor
             else:
                 ret_str = """ There are  <a href=" """ +str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ +str(self.number_normal_subgroups) + """ normal subgroups</a>"""
                 if self.number_characteristic_subgroups < self.number_normal_subgroups:
-                    ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes')) + """ ">""" + str(self.number_characteristic_subgroups) + " characteristic</a>)."
+                    ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes')) + """ ">""" + str(self.number_characteristic_subgroups) + " characteristic</a>).<p>"+charcolor+"  "+normalcolor
                 else:
-                    ret_str=ret_str+ " all characteristic. "
+                    ret_str=ret_str+ " all characteristic.<p>"+charcolor
                 return ret_str
         elif self.number_normal_subgroups < self.number_subgroups:
             ret_str =  "There are " + str(self.number_subgroups) + """ subgroups in <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ + str(self.number_subgroup_classes) + """ conjugacy classes</a>, <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, normal='yes'))+ """ "> """ +str(self.number_normal_subgroups) + """ normal</a>"""
         else:
             ret_str = """ There are  <a href=" """ +str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ +str(self.number_subgroups) + """ subgroups</a>, all normal"""
         if self.number_characteristic_subgroups < self.number_normal_subgroups:
-            ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes'))+ """ "> """ + str(self.number_characteristic_subgroups) + """ characteristic</a>). """
+            ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes'))+ """ "> """ + str(self.number_characteristic_subgroups) + """ characteristic</a>).<p>"""+charcolor+" "+normalcolor
         else:
-            ret_str = ret_str + ", all characteristic. "
+            ret_str = ret_str + ", all characteristic. <p>"+charcolor
         return ret_str
 
     @lazy_attribute


### PR DESCRIPTION
When looking at the normal subgroup profile, this changes plain text from being text-inside-latex-math-mode to just text (for a quotient group).

http://127.0.0.1:37777/Groups/Abstract/400000000.bk
http://beta.lmfdb.org/Groups/Abstract/400000000.bk

Note, I am aware of another issue with this the display of quotients in the normal subgroup profile on this page, but am putting that off to another time.