### PR TITLE
Compress polynomials in the search results display

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -21,7 +21,7 @@ from lmfdb.utils import (
     parse_signed_ints, parse_primes, parse_bracketed_posints, parse_nf_string,
     parse_floats, parse_subfield, search_wrap, parse_padicfields,
     raw_typeset, raw_typeset_poly, flash_info, input_string_to_poly,
-    raw_typeset_int, compress_poly_Q)
+    raw_typeset_int, compress_poly_Q, compress_polynomial)
 from lmfdb.utils.web_display import compress_int
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, SearchCol, CheckCol, MathCol, ProcessedCol, MultiProcessedCol, CheckMaybeCol
@@ -894,7 +894,7 @@ def nf_postprocess(res, info, query):
     cache = knowl_cache(list(set(galois_labels)))
     for rec in res:
         wnf = WebNumberField.from_data(rec)
-        rec["poly"] = wnf.web_poly()
+        rec["poly"] = '$'+compress_polynomial(wnf.poly(),30)+'$'
         rec["disc"] = wnf.disc_factored_latex()
         rec["galois"] = wnf.galois_string(cache=cache)
         rec["class_group_desc"] = wnf.class_group_invariants()

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -49,7 +49,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'raw_typeset', 'raw_typeset_poly', 'raw_typeset_poly_factor',
            'raw_typeset_qexp', 'raw_typeset_int', 'compress_poly_Q',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat',
-           'pos_int_and_factor']
+           'pos_int_and_factor', 'compress_polynomial']
 
 from flask import (request, make_response, flash, url_for,
                    render_template, send_file)
@@ -114,6 +114,7 @@ from .web_display import (
     raw_typeset,
     raw_typeset_poly,
     compress_poly_Q,
+    compress_polynomial,
     pos_int_and_factor,
     raw_typeset_poly_factor,
     raw_typeset_qexp,


### PR DESCRIPTION
In number field search results, interesting information is sometimes way off the screen because polynomials are large.  This limits the space used for those polynomials.

http://127.0.0.1:37777/NumberField/?hst=List&degree=37&search_type=List
http://beta.lmfdb.org/NumberField/?hst=List&degree=37&search_type=List