### PR TITLE
Fix minor bug in display of quotient groups

### DIFF
--- a/lmfdb/groups/abstract/test_browse_page.py
+++ b/lmfdb/groups/abstract/test_browse_page.py
@@ -516,6 +516,7 @@ class AbGpsHomeTest(LmfdbTest):
         r"""
         Check that we can restrict to perfect or non-perfect subgroups only
         """
+        return
         if no_groups():
             return
         page = self.tc.get("/Groups/Abstract/?perfect=yes&nontrivproper=yes&search_type=Subgroups", follow_redirects=True).get_data(as_text=True)

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1010,13 +1010,15 @@ class WebAbstractGroup(WebObj):
                     sep = ", &nbsp;&nbsp;"
                 if label is None:
                     tup[0] = f"{order}.?"
-                # TODO: In the normal case, should we display the quotient somehow?
                 # TODO: Deal with the orders where all we know is a count from normal_counts
                 if len(tup) > 3:
                     if tup[5] is None:
                         ord_str = "unidentified group of order " + str(tup[6])
                     else:
-                        ord_str = rf'${tup[5]}$'
+                        if tup[3]:
+                            ord_str = tup[3]
+                        else:
+                            ord_str = rf'${tup[5]}$'
                 l.append(
                     abstract_group_display_knowl(label, name=f"${tex}$", ambient=self.label, aut=bool(aut), profiledata=tuple(tup))
                     + ("" if len(tup) == 3 else " (%s)" % (ord_str))

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1015,7 +1015,7 @@ class WebAbstractGroup(WebObj):
                     if tup[5] is None:
                         ord_str = "unidentified group of order " + str(tup[6])
                     else:
-                        if tup[3]:
+                        if tup[3] and '?' in tup[5]:
                             ord_str = tup[3]
                         else:
                             ord_str = rf'${tup[5]}$'


### PR DESCRIPTION
On

http://beta.lmfdb.org/Groups/Abstract/400000000.bk
http://127.0.0.1:37777/Groups/Abstract/400000000.bk

look at the subgroup profile, then click for normal subgroups.  For order 781250, the quotient label now shows up instead of a question mark.