### PR TITLE
Proj gp issue

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2259,9 +2259,13 @@ def cc_data(gp, label, typ="complex"):
         if label == '1A':
             ans += "<br>Representative: id"
         else:
-            gp_value = WebAbstractGroup(gp)   #db.gps_groups_test.lucky({'label':gp})
-            repn = gp_value.decode(wacc.representative, as_str=True)
-            ans += "<br>Representative: {}".format("$" + repn + "$")
+            gp_value = WebAbstractGroup(gp)
+            if gp_value.representations.get("Lie"):
+                if gp_value.representations["Lie"][0]["family"][0] == "P":  #Problem with projective lie groups
+                    pass
+                else:    
+                    repn = gp_value.decode(wacc.representative, as_str=True)
+                    ans += "<br>Representative: {}".format("$" + repn + "$")
     return Markup(ans)
 
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -21,7 +21,7 @@
     <tr><td>{{KNOWL('group.name', title='Description:')}}</td><td>${{gp.tex_name}}$  </td></tr>
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(gp.order)}} </td></tr>
     <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(gp.exponent)}} </td></tr>
-    <tr><td>{{KNOWL('group.automorphism', 'Automorphism group')}}:</td><td>{{gp.show_aut_group()|safe}} {% if gp.aut_gens != None   %} (<a href="{{url_for('.auto_gens', label=gp.label)}}">generators</a>){% endif %}</td></tr>
+    <tr><td>{{KNOWL('group.automorphism', 'Automorphism group')}}:</td><td>{{gp.show_aut_group()|safe}} {% if not gp.live() and gp.aut_gens_flag() %} (<a href="{{url_for('.auto_gens', label=gp.label)}}">generators</a>){% endif %}</td></tr>
     <tr><td>{{KNOWL('group.outer_aut', 'Outer automorphisms')}}:</td><td>{{gp.show_outer_group()|safe}}</td></tr>
      {% if not gp.live() %}
     <tr><td>{{KNOWL('group.chief_series', 'Composition factors')}}:</td><td>{{gp.show_composition_factors()|safe}}</td></tr>

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -14,7 +14,7 @@
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(seq.subgroup_order)}} </td></tr>
     <tr><td>{{KNOWL('group.subgroup.index',title='Index:')}}</td><td> {{info.pos_int_and_factor(seq.quotient_order)}} </td></tr>
     <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(seq.sub.exponent)}} </td></tr>
-    <tr><td>{{KNOWL('group.generators', 'Generators:')}}</td><td> ${{seq.amb.show_subgroup_generators(seq)}}$</td></tr>
+    {% if seq.amb.show_subgroup_flag() %}<tr><td>{{KNOWL('group.generators', 'Generators:')}}</td><td> ${{seq.amb.show_subgroup_generators(seq)}}$</td></tr>{% endif %}
   </table>
 </p>
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1736,6 +1736,13 @@ class WebAbstractGroup(WebObj):
             return list(range(1, 1 + len(self.G.GeneratorsOfGroup())))
         return self.representations["PC"]["gens"]
 
+
+    def show_subgroup_flag(self):
+        if self.representations.get("Lie"):
+            if self.representations["Lie"][0]["family"][0] == "P": 	# Issue with projective Lie groups
+                return False
+        return True
+    
     def show_subgroup_generators(self, H):
         if H.subgroup_order == 1:
             return ""
@@ -1895,6 +1902,15 @@ class WebAbstractGroup(WebObj):
     def aut_order_factor(self):
         return latex(factor(self.aut_order))
 
+
+    def aut_gens_flag(self): #issue with Lie type when family is projective
+        if self.aut_gens is None:
+            return False
+        elif self.element_repr_type == "Lie":
+            if self.representations["Lie"][0]["family"][0] == "P":
+                return False
+        return True    
+    
     # outer automorphism group
     def show_outer_group(self):
         try:


### PR DESCRIPTION
This PR is a temporary fix for #5562.  For projective Lie groups, we are suppressing the generators of automorphism groups and subgroups, and the representatives of the conjugacy classes until the data is fixed.

See: https://beta.lmfdb.org/Groups/Abstract/336.208 and click on "generators" of automorphisms or the knowls for conjugacy classes in the complex character table. In the local version, the generators link for automorphisms is gone, and the knowls for conjugacy classes no longer error.

Additionally suppressed generators of automorphism groups for live groups (it was an error that they were ever linked as we do not compute the generators for live groups):
https://beta.lmfdb.org/Groups/Abstract/1920.240463
and click on "generators" of the automorphism group fails. That link is gone in this PR.