### PR TITLE
Fixed latex rendering typo: none ramified primes for QQ

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -509,7 +509,7 @@ def render_field_webpage(args):
     # Get rid of python L for big numbers
     #ram_primes = ram_primes.replace('L', '')
     if not ram_primes:
-        ram_primes = r'\textrm{None}'
+        ram_primes = r'\(\textrm{None}\)'
     if nf.is_cm_field():
         # Reflex fields table
         table = ""


### PR DESCRIPTION
Fixed issue raised here: https://github.com/LMFDB/lmfdb/issues/5571