### PR TITLE
Small changes to subgroups html

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -338,7 +338,7 @@
 
 <p>{{gp.subgp_paragraph|safe}}</p>
 
-
+<h3>Special subgroups</h3>
 
 <table>
   <tr>
@@ -433,7 +433,7 @@
       <button class='sub_ sub_active' onclick="select_subgroup_mode(''); return false">up to conjugacy</button>
       <button class='sub_aut sub_inactive' onclick="select_subgroup_mode('aut'); return false">up to automorphism</button>
     </div>
-</div>
+  </div>
 
 {# Just header information for the diagrams #}
 
@@ -468,7 +468,7 @@
   </div>
 {% endif %}
 
-</div>
+</p>
 
 {# This is the setup string for the subgroup lattices #}
 <script type="text/javascript">
@@ -482,9 +482,11 @@
       <h4>{{sub_desc}}</h4>
       {{ sub_summary | safe }}
       {% if sub_profile %}
+      <table>
         {% for ordline in sub_profile %}
-          Order {{ordline[0]}}: {{ordline[1] | safe}} <br />
+	<tr><td>Order {{ordline[0]}}: {{ordline[1] | safe}}</td></tr>
         {% endfor %}
+      </table>
       {% endif %}
     </div>
   {% endfor %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -832,8 +832,8 @@ class WebAbstractGroup(WebObj):
 
     @lazy_attribute
     def subgp_paragraph(self):
-        charcolor = r'Characteristic subgroups are shown in <span class="chargp">this color</span>.'
-        normalcolor = r'Normal (but not characteristic) subgroups are shown in <span class="normgp">this color</span>.'
+        charcolor = display_knowl('group.characteristic_subgroup', "Characteristic") + r' subgroups are shown in <span class="chargp">this color</span>.'
+        normalcolor = display_knowl('group.subgroup.normal', "Normal") + r' (but not characteristic) subgroups are shown in <span class="normgp">this color</span>.'
         if self.number_subgroups is None:
             if self.number_normal_subgroups is None:
                 return " "


### PR DESCRIPTION
1. Added a "special subgroups" subheader to clarify that it's not a list of all subgroups.
2. Fixed malformed html that caused styling issues. (p previously closed by div.)
3. Turned group profile into a table so knowls show up in the right place.
4. Linked to knowls for characteristic and normal subgroups.

Compare
https://beta.lmfdb.org/Groups/Abstract/1176.217
to
http://localhost:37777/Groups/Abstract/1176.217