### PR TITLE
Undo math mode for plain text

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -509,7 +509,7 @@ def render_field_webpage(args):
     # Get rid of python L for big numbers
     #ram_primes = ram_primes.replace('L', '')
     if not ram_primes:
-        ram_primes = r'\(\textrm{None}\)'
+        ram_primes = r'None'
     if nf.is_cm_field():
         # Reflex fields table
         table = ""


### PR DESCRIPTION
Fixes recent change on 

  http://127.0.0.1:37777/NumberField/1.1.1.1

The "None" for ramified primes should be plain text, not roman text in math mode.