### PR TITLE
Lookup ec plot

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -677,7 +677,9 @@ class ECNF():
 
         # Plot
         if K.signature()[0]:
-            self.plot = encode_plot(EC_nf_plot(K,self.ainvs, self.field.generator_name()), transparent=True)
+            self.plot = db.ec_nfportraits.lookup(self.label, "portrait")
+            if self.plot is None:
+                self.plot = encode_plot(EC_nf_plot(K,self.ainvs, self.field.generator_name()), transparent=True)
             self.plot_link = '<a href="{0}"><img src="{0}" width="200" height="150"/></a>'.format(self.plot)
             self.properties += [(None, self.plot_link)]
         self.properties += [('Base field', self.field.field_pretty())]

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -677,7 +677,9 @@ class ECNF():
 
         # Plot
         if K.signature()[0]:
-            self.plot = db.ec_nfportraits.lookup(self.label, "portrait")
+            self.plot = None
+            if self.degree > 2:
+                self.plot = db.ec_nfportraits.lookup(self.label, "portrait")
             if self.plot is None:
                 self.plot = encode_plot(EC_nf_plot(K,self.ainvs, self.field.generator_name()), transparent=True)
             self.plot_link = '<a href="{0}"><img src="{0}" width="200" height="150"/></a>'.format(self.plot)


### PR DESCRIPTION
Using a newly created table of precomputed ecnf plots, this cuts page load times for elliptic curves over cubic, quartic, quintic and sextic fields dramatically.  Compare http://localhost:37777/EllipticCurve/6.6.1075648.1/197.2/b/1 and https://beta.lmfdb.org/EllipticCurve/6.6.1075648.1/197.2/b/1