### PR TITLE
Fix issue of deprication warning on zulip

### DIFF
--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -119,8 +119,7 @@ def list_factored_to_factored_poly_otherorder(sfacts_fc_list, galois=False, vari
             this_poly = ZZT(list(reversed(g)))
             this_degree = this_poly.degree()
             this_number_field = NumberField(this_poly, "a")
-            this_gal = this_number_field.galois_group(type='pari')
-            this_t_number = this_gal.group().__pari__()[2].sage()
+            this_t_number = this_number_field.galois_group().group().transitive_number()
             gal_list.append([this_degree, this_t_number])
 
         # casting from ZZT -> ZZpT


### PR DESCRIPTION
Updates computation of t-number of Galois groups of factors of an L-function

Should be no visible change to the user, but removes the deprication warnings mentioned by Edgar on zulip (e.g., see an L-function page of a genus 2 curve).