### PR TITLE
Don't set contains -I by default in modular curves

### DIFF
--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -846,7 +846,6 @@ class ModCurveSearchArray(SearchArray):
             knowl="modcurve.contains_negative_one",
             label="Contains $-I$",
             example="yes",
-            example_value=True,
             example_col=True,
             example_span="",
         )


### PR DESCRIPTION
This PR changes the "Contains -I" search option on the modular curves pages to not be set to "yes" by default as it was previously.  Pressing "List results" without specifying any search criteria will now yield 8166335 results rather than 804450.

The decision to set "Contains -I" by default was initially made because most properties of the modular curve $X_H$ (including all those that can be distinguished after applying the forgetful functor from the category of modular curves to curves) depend only on $\langle H,-I\rangle$. But there seems to now be a consensus that this makes it too difficult for users to find familiar curves like $X_1(N)$ that correspond to subgroups $H$ that do not contain $-I$ and outweighs the benefits of restricting the search, one of which was to reduce the number of isomorphic curves returned in the search results.

This change does mean that searches that target properties that depend only on the curve may now include many quadratic refinements (all of which are isomorphic as curves but not as as modular curves).  Of course it was already true that isomorphic curves might be included in search results (e.g. $X_{\mathrm ns}^+(13)$ and $X_{\mathrm s}^+(13)$ ), but it will now be the rule rather than the exception.  The average curve currently has about 10 quadratic refinements/siblings stored in the database, but this number will increase when we extend to level 400.  The current record is [48.768.41.gd.2](https://beta.lmfdb.org/ModularCurve/Q/48.768.41.gd.2/), which has 97 quadratic refinements.

I think this is less of a concern with the new labeling scheme, which clearly distinguishes labels that correspond to $X_H$ for some $H$ containing $-I$ ( "coarse" curves) from those that are quadratic refinements of a coarse curve; the former have 5-part labels while the latter have 7-part labels (from which one can deduce the 5-part label of the coarse curve $X_{\langle H,-I\rangle}$).