### PR TITLE
Use "is None" when testing non_surj

### DIFF
--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -984,7 +984,7 @@ class WebG2C():
             data['split_statement'] = split_statement(data['split_coeffs'], data.get('split_labels'), data['split_condnorms'])
 
         # Nonsurjective primes data
-        if not nonsurj:
+        if nonsurj is None:
             data['exists_nonsurj_data'] = False
         else:
             data['exists_nonsurj_data'] = True


### PR DESCRIPTION
This PR fixes a bug that was causing pages of genus 2 curves with non_maximal_primes = [] and non_maximal_primes = None to be treated the same way, but these values have different meaning (an empty list means there are no nonmaximal primes, while None means the nonmaximal_primes were not computed (currently this has only been done for curves with endomorphism ring Z).