### PR TITLE
A bunch of small fixes to abstract groups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2412,9 +2412,15 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         ans += f"Order: {order}<br />"
         ans += f"Exponent: {gp.exponent}<br />"
         if quotient_label == "None":
-            isomorphism_label = "Subgroups with this isomorphism type: "
+            if aut:
+                isomorphism_label = "Representatives of classes of subgroups up to automorphism with this isomorphism type: "
+            else:
+                isomorphism_label = "Representatives of classes of subgroups up to conjugacy with this isomorphism type: "
         else:
-            isomorphism_label = "Subgroups with this isomorphism type and quotient: "
+            if aut:  #JP FIX BELOW
+                isomorphism_label = "Subgroups with this isomorphism type and quotient: "
+            else:
+                isomorphism_label = "Subgroups with this isomorphism type and quotient: "
     if quotient_label != "None":
         if quotient_label.startswith("ab/"):
             data = canonify_abelian_label(quotient_label[3:])

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2372,7 +2372,7 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         for i, c in enumerate(profiledata):
             if c in ["None", "?"]:
                 profiledata[i] = None
-        if len(profiledata) == 6 and profiledata[3] is not None:
+        if len(profiledata) == 7 and profiledata[3] is not None: 
             quotient_label = profiledata[3]
             quotient_tex = profiledata[5]
         else:
@@ -2412,15 +2412,15 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         ans += f"Order: {order}<br />"
         ans += f"Exponent: {gp.exponent}<br />"
         if quotient_label == "None":
-            if aut:
+            if aut == "True":
                 isomorphism_label = "Representatives of classes of subgroups up to automorphism with this isomorphism type: "
             else:
-                isomorphism_label = "Representatives of classes of subgroups up to conjugacy with this isomorphism type: "
+                isomorphism_label = "Representatives of classes of subgroups up to conjugation with this isomorphism type: "
         else:
-            if aut:  #JP FIX BELOW
-                isomorphism_label = "Subgroups with this isomorphism type and quotient: "
+            if aut == "True": 
+                isomorphism_label = "Representatives of classes of subgroups up to automorphism with this isomorphism type and quotient: "
             else:
-                isomorphism_label = "Subgroups with this isomorphism type and quotient: "
+                isomorphism_label = "Representatives  of classes of subgroups up to conjugation with this isomorphism type and quotient: "
     if quotient_label != "None":
         if quotient_label.startswith("ab/"):
             data = canonify_abelian_label(quotient_label[3:])
@@ -2480,12 +2480,12 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
                     return H.subgroup == label
                 if len(profiledata) == 3 and label != "None":
                     return H.subgroup == label
-                if len(profiledata) == 6 and label != "None" and quotient_label != "None":
+                if len(profiledata) == 7 and label != "None" and quotient_label != "None":  
                     return H.subgroup == label and H.quotient == quotient_label
                 return all(a == b for (a, b) in zip(profiledata, (H.subgroup, H.subgroup_hash, H.subgroup_tex, H.quotient, H.quotient_hash, H.quotient_tex)))
 
             subs = [H for H in ambient.subgroups.values() if sub_matches(H)]
-            if aut and not ambient.outer_equivalence:
+            if aut == "True" and not ambient.outer_equivalence:
                 # TODO: need to deal with non-canonical labels
                 subs = [H for H in subs if H.label.split(".")[-1] == "a1"]
             subs.sort(key=lambda H: label_sortkey(H.label))

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -594,8 +594,12 @@
                                                                                                                              
        <p> The complex character table for this group is not computed. </p>
     
-   {% else %}      
-      {% if gp.number_conjugacy_classes <= 16 %}
+       {% elif gp.complex_characters_known == False %}
+
+      <p> The ${{gp.number_conjugacy_classes}} \times {{gp.number_conjugacy_classes}}$ character table is not available for this group.    </p>
+
+       {% else %} 
+       {% if gp.number_conjugacy_classes <= 16 %}
 
       {% include 'character_table.html' %}
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -20,7 +20,7 @@
   <table>
     <tr><td>{{KNOWL('group.name', title='Description:')}}</td><td>${{gp.tex_name}}$  </td></tr>
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(gp.order)|safe}} </td></tr>
-    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(gp.exponent|safe)}} </td></tr>
+    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(gp.exponent)|safe}} </td></tr>
     <tr><td>{{KNOWL('group.automorphism', 'Automorphism group')}}:</td><td>{{gp.show_aut_group()|safe}} {% if not gp.live() and gp.aut_gens_flag() %} (<a href="{{url_for('.auto_gens', label=gp.label)}}">generators</a>){% endif %}</td></tr>
     <tr><td>{{KNOWL('group.outer_aut', 'Outer automorphisms')}}:</td><td>{{gp.show_outer_group()|safe}}</td></tr>
      {% if not gp.live() %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -358,7 +358,7 @@ class WebAbstractGroup(WebObj):
     def transitive_degree(self):
         if isinstance(self.G, LiveAbelianGroup):
             return self.order
-        return "not computed"
+        return None # "not computed"
 
     @lazy_attribute
     def pgroup(self):


### PR DESCRIPTION
This PR fixes a number of small issues.

- A wrong closed parenthesis messed up the exponent for very large groups. See S47 exponent:  https://beta.lmfdb.org/Groups/Abstract/258623241511168180642964355153611979969197632389120000000000.a  
versus locally:
http://localhost:37777/Groups/Abstract/258623241511168180642964355153611979969197632389120000000000.a

- Sometimes we know how many conjugacy classes there are but we don't compute the actual character table (or don't save it if it is too large). There was an error where we were attempting to show character tables that didn't  exist.  You can see this in S47 again, where we claimed a character table existed that just did not:
https://beta.lmfdb.org/Groups/Abstract/258623241511168180642964355153611979969197632389120000000000.a
vs
https://localhost:37777/Groups/Abstract/258623241511168180642964355153611979969197632389120000000000.a
or sometimes when we printed the header for a character table but not the table itself
https://beta.lmfdb.org/Groups/Abstract/12096.a
vs
https://localhost:37777/Groups/Abstract/12096.a


- A "not computed" for transitive degree needed to have the  latex formatting removed in the property box  for live groups
https://beta.lmfdb.org/Groups/Abstract/1920.240463
vs
https://localhost:37777/Groups/Abstract/1920.240463

-  The knowls in the  "Profile" option for subgroups were returning some errors.  First, up to conjugacy for all subgroups they were not displaying enough representatives.  Then up to both conjugacy and automorphism for normal subgroups they were not displaying any representatives.  The issue was two fold: a variable that was not actually a boolean, and the wrong length for a list. To see one example, go to group **24.6** in beta  or local  and click on "Profile" under "Subgroup diagram and profile". There are 3 non conjugate subgroups isomorphic to C2 but in beta when you click on the "C2"  in the profile, it would only show 2  representatives instead of 3 inside the knowl.  I also changed the wording a little  to make it more clear what those subgroups listed in the knowl represented. Similarly if you click on "normal subgroups" and click on any knowl for the subgroups, you will actually see representatives locally that are not showing up  in  beta.  
