### PR TITLE
Update Annoucements

### DIFF
--- a/lmfdb/homepage/index_boxes.yaml
+++ b/lmfdb/homepage/index_boxes.yaml
@@ -8,7 +8,7 @@ links:
   - [ 0,0 ]
 ---
 title: Announcements
-content: <p>The first <a href="https://icerm.brown.edu/events/sc-23-lucant/">LuCaNT</a> conference will take place July 10-14, 2023 at <a href="https://icerm.brown.edu">ICERM</a>.</p>
+content: <p>The first <a href="https://icerm.brown.edu/events/sc-23-lucant/">LuCaNT</a> conference took place July 10-14, 2023 at <a href="https://icerm.brown.edu">ICERM</a>. Thanks to everyone who attended! Conference proceedings will be published soon.</p>
   <p>Check out the recently updated <a href="/Groups/Abstract/">abstract groups</a> database [beta].</p>
   <p>Check out the new <a href="/ModularCurve/Q/">modular curves</a> database [beta].</p>
 image: announcements


### PR DESCRIPTION
The main page announcements talk about LuCaNT in the future.  I've modified to talk about it in the past and reference the forthcoming proceedings. 