### PR TITLE
Fix allows function to be called from other parts of the LMFDB

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -372,7 +372,7 @@ def render_isogeny_class_webpage(label):
 def url_for_curve_label(label):
     slabel = label.split(".")
     return url_for(
-        ".by_url_curve_label",
+        "g2c.by_url_curve_label",
         cond=slabel[0],
         alpha=slabel[1],
         disc=slabel[2],


### PR DESCRIPTION
Helpful when making a genus 2 curve as a related object from elsewhere, e.g.,

http://beta.lmfdb.org/ModLGaloisRepresentation/Q/2.4.23.2/
http://127.0.0.1:37777/ModLGaloisRepresentation/Q/2.4.23.2/