### PR TITLE
Remove duplicate friend

### DIFF
--- a/lmfdb/modl_galois_representations/web_modlgal.py
+++ b/lmfdb/modl_galois_representations/web_modlgal.py
@@ -94,9 +94,9 @@ class WebModLGalRep(WebObj):
         kerfield = WebNumberField.from_coeffs(self.kernel_polynomial)
         if kerfield and kerfield._data:
             friends.append(("Number field "+kerfield.field_pretty(), url_for("number_fields.by_label", label=kerfield.label)))
-        kerfield = WebNumberField.from_coeffs(self.projective_kernel_polynomial)
-        if kerfield and kerfield._data:
-            friends.append(("Number field "+kerfield.field_pretty(), url_for("number_fields.by_label", label=kerfield.label)))
+        projkerfield = WebNumberField.from_coeffs(self.projective_kernel_polynomial)
+        if projkerfield and projkerfield._data and projkerfield.label != kerfield.label:
+            friends.append(("Number field "+projkerfield.field_pretty(), url_for("number_fields.by_label", label=projkerfield.label)))
 
         if self.dimension > 1 and hasattr(self, "determinant_label"):
             friends.append(("Determinant " + self.determinant_label, url_for_modlgal_label(label=self.determinant_label)))


### PR DESCRIPTION
With a mod ell representation, the number field for the (minimal sibling) of the representation and of the projective representation are listed as friends.  If they are the same (e.g., any mod 2 representation), then we only want to list it once.

http://beta.lmfdb.org/ModLGaloisRepresentation/Q/2.2.43.1/
http://127.0.0.1:37777/ModLGaloisRepresentation/Q/2.2.43.1/