### PR TITLE
Fix bug in data page for EC isogeny classes, add link

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -758,7 +758,7 @@ def EC_data(label):
     if match_lmfdb_label(label):
         conductor, iso_class, number = split_lmfdb_label(label)
         if not number: # isogeny class
-            return datapage(label, ["ec_classdata", "ec_padic"], bread=bread, label_col="lmfdb_iso", sorts=[[], ["p"]])
+            return datapage(label, ["ec_classdata", "ec_padic", "ec_curvedata"], title=f"Elliptic curve isogeny class data - {label}", bread=bread, label_cols=["lmfdb_iso", "lmfdb_iso", "lmfdb_iso"], sorts=[[], ["p"], ['conductor', 'iso_nlabel', 'lmfdb_number']])
         iso_label = class_lmfdb_label(conductor, iso_class)
         labels = [label] * 8
         label_cols = ["lmfdb_label"] * 8

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -172,7 +172,8 @@ class ECisog_class():
             self.properties += [('Graph', ''),(None, self.graph_link)]
 
         self.downloads = [('q-expansion to text', url_for(".download_EC_qexp", label=self.lmfdb_iso, limit=1000)),
-                         ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_iso))]
+                          ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_iso)),
+                          ('Underlying data', url_for(".EC_data", label=self.lmfdb_iso))]
 
         self.bread = [('Elliptic curves', url_for("ecnf.index")),
                       (r'$\Q$', url_for(".rational_elliptic_curves")),


### PR DESCRIPTION
To test, visit http://localhost:37777/EllipticCurve/Q/data/14.a.