### PR TITLE
Add p tags to embedded newform page

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
@@ -4,9 +4,9 @@
 <a name="coefficient_data"></a>
 <h2>Coefficient data</h2>
 
-For each \(n\) we display the coefficients of the \(q\)-expansion \(a_n\), the
+<p>For each \(n\) we display the coefficients of the \(q\)-expansion \(a_n\), the
 {{ KNOWL('cmf.satake_parameters',title='Satake parameters') }} \(\alpha_p\),
-and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).
+and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).</p>
 
 
 <script>


### PR DESCRIPTION
The missing <p> tags mean that the "Satake parameter" knowl currently opens at the bottom of the page.  Compare https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/3069/1/hs/b/1748/1/ and http://localhost:37777/ModularForm/GL2/Q/holomorphic/3069/1/hs/b/1748/1/