### PR TITLE
fix by_url_belyi_search_url

### DIFF
--- a/lmfdb/belyi/main.py
+++ b/lmfdb/belyi/main.py
@@ -160,8 +160,9 @@ def by_url_belyi_search_url(smthorlabel):
         split = split[:-1]
     if len(split) == 1:
         return by_url_belyi_search_group(group=split[0])
-    elif len(split) == 2:  # passport
-        sigma_spl = (split[1]).split('_')
+
+    sigma_spl = (split[1]).split('_')
+    if len(sigma_spl) == 3 and len(split) == 2: # passport
         return redirect(
             url_for(
                 ".by_url_belyi_passport_label",
@@ -172,8 +173,7 @@ def by_url_belyi_search_url(smthorlabel):
             ),
             301,
         )
-    elif len(split) == 3:  # galmap
-        sigma_spl = (split[1]).split('_')
+    elif len(sigma_spl) == 3  and len(split) == 3:  # galmap
         return redirect(
             url_for(
                 ".by_url_belyi_galmap_label",


### PR DESCRIPTION
Prevents errors like:
```
Exception on /Belyi/foo-bar [GET]
Traceback (most recent call last):
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/lmfdb/lmfdb-git-dev/lmfdb/belyi/main.py", line 170, in by_url_belyi_search_url
    sigma1=sigma_spl[1],
IndexError: list index out of range
[2023-10-02 15:42:38 UTC] 500 error on URL https://beta.lmfdb.org/Belyi/foo-bar 