### PR TITLE
use ruff to remove superfluous parentheses

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -175,11 +175,11 @@ def validate_label(label):
     elif re.match(r'^\d+\.[a-z]+\.\d+$', label):  # label has both orbit and number
         return True
     else:
-        raise ValueError(("It must be of the form modulus.number, or "
+        raise ValueError("It must be of the form modulus.number, or "
                           "modulus.letter, or modulus.letter.number, "
                           "with modulus and number positive natural numbers "
                           " and letter an alphabetic letter."
-                          ))
+                          )
 
 def jump(info):
     jump_box = info["jump"].strip()  # only called when this present

--- a/lmfdb/lfunctions/Lfunctionutilities.py
+++ b/lmfdb/lfunctions/Lfunctionutilities.py
@@ -272,7 +272,7 @@ def lfuncEPtex(L, fmt):
         fmt could be any of the values: "abstract"
     """
     from .Lfunction import Lfunction_from_db
-    if ((L.Ltype() in ["genus2curveQ"] or isinstance(L, Lfunction_from_db))) and fmt == "arithmetic":
+    if (L.Ltype() in ["genus2curveQ"] or isinstance(L, Lfunction_from_db)) and fmt == "arithmetic":
         try:
             return lfuncEPhtml(L, fmt)
         except Exception:

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -175,7 +175,7 @@ def prime_from_label(K, lab):
     make_keys(K,p)
     d = K.psort_dict[p]
     try:
-        return next((P for P in d if d[P][:2]==(n,j)))
+        return next(P for P in d if d[P][:2]==(n,j))
     except StopIteration:
         return 0
 

--- a/lmfdb/siegel_modular_forms/sample.py
+++ b/lmfdb/siegel_modular_forms/sample.py
@@ -129,10 +129,10 @@ def export(collection, name):
 
     # Fourier coefficients and eigenvalues
     fcs = db.smf_fc.search({'owner_id': id_link}, ['det', 'data'])
-    doc['Fourier_coefficients'] = dict(((fc['det'], fc['data']) for fc in fcs))
+    doc['Fourier_coefficients'] = dict((fc['det'], fc['data']) for fc in fcs)
 
     evs = db.smf_ev.search({'owner_id': id_link}, ['index', 'data'])
-    doc['eigenvalues'] = dict(((ev['index'], ev['data']) for ev in evs))
+    doc['eigenvalues'] = dict((ev['index'], ev['data']) for ev in evs)
 
     label = doc['collection'][0] + '.' + doc['name']
     doc['label']= label

--- a/lmfdb/zeros/zeta/zetazeros.py
+++ b/lmfdb/zeros/zeta/zetazeros.py
@@ -97,7 +97,7 @@ def list_zeros(N=None,
         zeros = zeros_starting_at_t(t, limit)
 
     if fmt == 'plain':
-        response = Response(("%d %s\n" % (n, nstr(z,31+floor(log(z,10))+1,strip_zeros=False,min_fixed=-inf,max_fixed=+inf)) for (n, z) in zeros))
+        response = Response("%d %s\n" % (n, nstr(z,31+floor(log(z,10))+1,strip_zeros=False,min_fixed=-inf,max_fixed=+inf)) for (n, z) in zeros)
         response.headers['content-type'] = 'text/plain'
         if download == "yes":
             response.headers['content-disposition'] = 'attachment; filename=zetazeros'

--- a/scripts/siegel_modular_forms/Yoshida_Lift.py
+++ b/scripts/siegel_modular_forms/Yoshida_Lift.py
@@ -27,7 +27,7 @@ def Yoshida_Lift(F, hhecke_evals, hlevel, hweight=[2, 2], primeprec=100):
                 lam[p] = 0
                 mu[p] = p**(2*(weight -3))*(-p**2 - p*hhecke_evals[F.prime_above(p)] - 1)
             else:
-                lam[p] = p**((weight  - 3))*p*(hhecke_evals[F.primes_above(p)[0]] + hhecke_evals[F.primes_above(p)[1]])
+                lam[p] = p**(weight  - 3)*p*(hhecke_evals[F.primes_above(p)[0]] + hhecke_evals[F.primes_above(p)[1]])
                 mu[p] = p**(2*(weight - 3))*(p**2 + p*hhecke_evals[F.primes_above(p)[0]]*hhecke_evals[F.primes_above(p)[1]] - 1)
         if v == 1:
             if hlevel.valuation(F.primes_above(p)[0]) == 1:
@@ -36,11 +36,11 @@ def Yoshida_Lift(F, hhecke_evals, hlevel, hweight=[2, 2], primeprec=100):
             else:
                 pt = F.primes_above(p)[0]
                 po = F.primes_above(p)[1]
-            lam[p] =  p**((weight  - 3))*(p*hhecke_evals[po] + (p + 1)*hhecke_evals[pt])
+            lam[p] =  p**(weight  - 3)*(p*hhecke_evals[po] + (p + 1)*hhecke_evals[pt])
             mu[p] = p**(2*(weight  - 3))*(p*hhecke_evals[F.primes_above(p)[0]]*hhecke_evals[F.primes_above(p)[1]])
         else:
             if len(F.primes_above(p)) == 2:
-                lam[p] = p**((weight  - 3))*p*(hhecke_evals[F.primes_above(p)[0]] + hhecke_evals[F.primes_above(p)[1]])
+                lam[p] = p**(weight  - 3)*p*(hhecke_evals[F.primes_above(p)[0]] + hhecke_evals[F.primes_above(p)[1]])
                 if hlevel.valuation(F.primes_above(p)[0])*hlevel.valuation(F.primes_above(p)[1]) == 0:
                     mu[p] = 0
                 else:


### PR DESCRIPTION
ruff is a recent and powerful linter

here I used
`
ruff check --fix --select UP034 .
`
to remove superfluous parentheses