### PR TITLE
fix some details found by ruff

### DIFF
--- a/lmfdb/characters/HeckeCharacters.py
+++ b/lmfdb/characters/HeckeCharacters.py
@@ -76,8 +76,7 @@ class RayClassGroup(AbelianGroup_class):
         return self.exp(x.exponents())
 
     def iter_exponents(self):
-        for e in xmrange(self.invariants(), tuple):
-            yield e
+        yield from xmrange(self.invariants(), tuple)
 
     def iter_ideals(self):
         for e in self.iter_exponents():

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -379,5 +379,4 @@ def ideals_iterator(K,minnorm=1,maxnorm=Infinity):
     r""" Return an iterator over all ideals of norm n up to maxnorm (sorted).
     """
     for n in srange(minnorm,maxnorm+1):
-        for I in ideals_of_norm(K,n):
-            yield I
+        yield from ideals_of_norm(K,n)

--- a/lmfdb/typed_data/type_generation.py
+++ b/lmfdb/typed_data/type_generation.py
@@ -35,7 +35,7 @@ def ImmutableExtensionFactory(t, t_name):
     class ImmutableExtensionClass(t):
         @staticmethod
         def __new__(cls, x):
-            return super(ImmutableExtensionClass, cls).__new__(cls, x)
+            return super().__new__(cls, x)
 
     return ImmutableExtensionClass
 

--- a/lmfdb/utils/color.py
+++ b/lmfdb/utils/color.py
@@ -284,8 +284,7 @@ class ColorScheme():
             if hasattr(subcls, 'code'):
                 yield subcls
             else:
-                for subsub in subcls.__allsubclasses__():
-                    yield subsub
+                yield from subcls.__allsubclasses__()
 
 
 class YellowKnowls(ColorScheme):

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -170,8 +170,7 @@ class Downloader():
         @stream_with_context
         def _generator():
             yield '\n' + c + ' %s downloaded from the LMFDB on %s.\n' % (title, mydate)
-            for line in generator:
-                yield line
+            yield from generator
 
         headers = Headers()
         headers.add('Content-Disposition', 'attachment', filename=filename)

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -967,7 +967,7 @@ def datetime_to_timestamp_in_ms(dt):
 def timestamp_in_ms_to_datetime(ts):
     return datetime.datetime.utcfromtimestamp(float(int(ts)/1000000.0))
 
-class WebObj(object):
+class WebObj:
     def __init__(self, label, data=None):
         self.label = label
         if data is None:


### PR DESCRIPTION
ruff is a fast linter, with many available useful checks, and the capacity to fix some of its issued warnings.

The changes here were done using

`ruff check --fix --select UP008,UP028,UP004 lmfdb/`