### PR TITLE
better threshold for Artin L-functions

### DIFF
--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -38,9 +38,12 @@ OLD_LABEL_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+c\d+$
 OLD_ORBIT_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+$')
 Dn_RE = re.compile(r'^d\d+$')
 
-artin_Lfunction_threshold = {2: 10000,
-                             3: 10000,
-                             4: 4000}
+# degree -> bound on conductor
+artin_Lfunction_threshold = {
+    2: 10000,
+    3: 10000,
+    4: 4000,
+}
 
 
 # Utility for permutations

--- a/lmfdb/artin_representations/main.py
+++ b/lmfdb/artin_representations/main.py
@@ -9,6 +9,7 @@ from flask import render_template, request, url_for, redirect, abort
 from sage.all import ZZ, cached_function
 
 from lmfdb import db
+from lmfdb.app import is_debug_mode
 from lmfdb.utils import (
     parse_primes, parse_restricted, parse_galgrp,
     parse_ints, parse_container, parse_bool, clean_input, flash_error,
@@ -36,6 +37,10 @@ ORBIT_RE = re.compile(r'^\d+\.\d+\.\d+(t\d+)?\.[a-z]+$')
 OLD_LABEL_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+c\d+$')
 OLD_ORBIT_RE = re.compile(r'^\d+\.\d+(e\d+)?(_\d+(e\d+)?)*\.\d+(t\d+)?\.\d+$')
 Dn_RE = re.compile(r'^d\d+$')
+
+artin_Lfunction_threshold = {2: 10000,
+                             3: 10000,
+                             4: 4000}
 
 
 # Utility for permutations
@@ -387,7 +392,7 @@ def render_artin_representation_webpage(label):
                     friends.append(("L-function", url_for("l_functions.l_function_dirichlet_page", modulus=cc.modulus, number=cc.number)))
 
         # Dimension > 1
-        elif int(the_rep.conductor())**the_rep.dimension() <= 729000000000000:
+        elif the_rep.conductor() <= artin_Lfunction_threshold.get(int(the_rep.dimension()), 0) or is_debug_mode():
             friends.append(("L-function", url_for("l_functions.l_function_artin_page",
                                               label=the_rep.label())))
         orblabel = re.sub(r'\.[a-z]+$', '', label)

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -63,6 +63,7 @@ from lmfdb.maass_forms.web_maassform import WebMaassForm
 from lmfdb.sato_tate_groups.main import st_link_by_name
 from lmfdb.siegel_modular_forms.sample import Sample
 from lmfdb.artin_representations.math_classes import ArtinRepresentation
+from lmfdb.artin_representations.main import artin_Lfunction_threshold
 import lmfdb.hypergm.hodge
 from .Lfunction_base import Lfunction
 from lmfdb.lfunctions import logger
@@ -1259,7 +1260,7 @@ class ArtinLfunction(Lfunction):
 
         # disable expensive L-functions, these should not be linked anywhere regardless
         # this threshold comes from lmfdb/artin_representations/main.py
-        if not is_debug_mode() and self.level**self.degree > 729000000000000:
+        if not (self.level <= artin_Lfunction_threshold.get(int(self.degree), 0) or is_debug_mode()):
             raise ValueError(f'Error constructing L-function for the Artin representation {self.origin_label}, as the conductor/degree is too large.')
 
         self.level_factored = factor(self.level)


### PR DESCRIPTION
Lowering the threshold on the conductor from
```
> N := 729000000000000; [RealField(8) | N^(1/d) : d in [2..4]];
[ 27000000., 90000.000, 5196.1524 ]
```
to
```
# degree -> bound on conductor
artin_Lfunction_threshold = {
    2: 10000,
    3: 10000,
    4: 4000,
}
```

I also have tested some of the L-functions at the edge of the threshold, and they seem to be computed in about 5s