### PR TITLE
Fix RSZB modular curve label links

### DIFF
--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -128,6 +128,8 @@ def modcurve_link(label):
 
 @modcurve_page.route("/Q/<label>/")
 def by_label(label):
+    if RSZB_LABEL_RE.fullmatch(label):
+        label = db.gps_gl2zhat_fine.lucky({"RSZBlabel":label},projection="label")
     if not LABEL_RE.fullmatch(label):
         flash_error("Invalid label %s", label)
         return redirect(url_for(".index"))

--- a/lmfdb/modular_curves/templates/modcurve.html
+++ b/lmfdb/modular_curves/templates/modcurve.html
@@ -36,7 +36,7 @@
   <tr><td>{{ KNOWL('modcurve.other_labels', 'Rouse and Zureick-Brown (RZB) label') }}:</td><td><a href="http://users.wfu.edu/rouseja/2adic/{{curve.RZBlabel}}.html">{{curve.RZBlabel}}</a></td></tr>
   {% endif %}
   {% if curve.RSZBlabel %}
-  <tr><td>{{ KNOWL('modcurve.other_labels', 'Rouse, Sutherland, and Zureick-Brown (RSZB) label') }}:</td><td><a href="https://blue.lmfdb.xyz/ModularCurve/Q/{{curve.RSZBlabel}}">{{curve.RSZBlabel}}</a></td></tr>
+  <tr><td>{{ KNOWL('modcurve.other_labels', 'Rouse, Sutherland, and Zureick-Brown (RSZB) label') }}:</td><td><a href="/ModularCurve/Q/{{curve.RSZBlabel}}">{{curve.RSZBlabel}}</a></td></tr>
   {% endif %}
   {% if curve.Slabel %}
   <tr><td>{{ KNOWL('ec.galois_rep_modell_image', 'Sutherland (S) label') }}:</td><td>{{curve.Slabel}}</td></tr>

--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -362,7 +362,7 @@ class WebModCurve(WebObj):
             tail.append(
                 (str(D[a]), url_for(".index_Q", **D))
             )
-        tail.append((self.label, " "))
+        tail.append((self.label, url_for(".by_label", label=self.label)))
         return get_bread(tail)
 
     @lazy_attribute


### PR DESCRIPTION
Quick fix to make RSZB label links correctly (they were still hard-wired to blue), and ensure that URLs that use RSZB modular curve labels rather than LMFDB labels work as they should.