### PR TITLE
Fix CMF Gamma1 pages

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_full_gamma1_space.html
@@ -101,7 +101,7 @@
 
 {% endif %}
 
-{% if space.new_dim > 0 %}
+{% if space.dim > 0 %}
 {% if space.has_trace_form %}
 <script>
 function show_qexp(qstyle) {
@@ -131,6 +131,8 @@ function show_qexp(qstyle) {
   </form>
 </div>
 {% endif %}
+
+{% if space.decomp %}
 
 <h2> {{ KNOWL('cmf.decomposition.new.gamma1', title='Decomposition') }} of \({{ space.new_latex() }}\)</h2>
 
@@ -169,9 +171,11 @@ function show_qexp(qstyle) {
 {% endif %}
 {% endif %}
 
+{% endif %}
+
 <!-- Definitions for coefficient fields -->
 
-{% if space.old_dim > 0 %}
+{% if space.dim_grid.S.old > 0 %}
 <h2> {{ KNOWL('cmf.decomposition.old.gamma1', title='Decomposition') }} of \({{ space.old_latex() }}\) into {{ KNOWL('cmf.oldspace',title='lower level spaces')}}</h2>
 
 <div class="center">

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -216,7 +216,6 @@ class DimGrid():
 
 class WebNewformSpace():
     def __init__(self, data):
-        # Need to set mf_dim, eis_dim, cusp_dim, new_dim, old_dim
         self.__dict__.update(data)
         self.factored_level = web_latex_factored_integer(self.level, equals=True)
         self.has_projective_image_types = all(typ+'_dim' in data for typ in ('dihedral','a4','s4','a5'))
@@ -377,14 +376,7 @@ class WebGamma1Space():
         newspaces = list(db.mf_newspaces.search({'level':level, 'weight':weight, 'char_parity': self.weight_parity}))
         oldspaces = db.mf_gamma1_subspaces.search({'level':level, 'sub_level':{'$ne':level}, 'weight':weight}, ['sub_level','sub_mult'])
         self.oldspaces = [(old['sub_level'],old['sub_mult']) for old in oldspaces]
-        self.dim_grid = sum(DimGrid.from_db(space) for space in newspaces) if newspaces else DimGrid()
-        #self.mf_dim = sum(space['mf_dim'] for space in newspaces)
-        #self.eis_dim = sum(space['eis_dim'] for space in newspaces)
-        #self.eis_new_dim = sum(space['eis_new_dim'] for space in newspaces)
-        #self.eis_old_dim = self.eis_dim - self.eis_new_dim
-        #self.cusp_dim = sum(space['cusp_dim'] for space in newspaces)
-        self.new_dim = sum(space['dim'] for space in newspaces)
-        self.old_dim = sum((space['cusp_dim']-space['dim']) for space in newspaces)
+        self.dim_grid = DimGrid.from_db(data)
         self.decomp = []
         newforms = list(db.mf_newforms.search({'level':level, 'weight':weight}, ['label', 'space_label', 'dim', 'level', 'char_orbit_label', 'hecke_orbit', 'char_degree']))
         self.has_uncomputed_char = False
@@ -396,12 +388,12 @@ class WebGamma1Space():
                 self.decomp.append((space, [form for form in newforms if form['space_label'] == space['label']]))
         self.plot = db.mf_gamma1_portraits.lookup(self.label, projection="portrait")
         self.properties = [('Label',self.label),]
-        if self.plot is not None and self.new_dim > 0:
+        if self.plot is not None and self.dim > 0:
             self.properties += [(None, '<a href="{0}"><img src="{0}" width="200" height="200"/></a>'.format(self.plot))]
         self.properties +=[
             ('Level',str(self.level)),
             ('Weight',str(self.weight)),
-            ('Dimension',str(self.new_dim))
+            ('Dimension',str(self.dim))
         ]
         if self.num_spaces is not None:
             self.properties.append(('Nonzero newspaces',str(self.num_spaces)))


### PR DESCRIPTION
In cases where there is data in `mf_gamma1` that doesn't have corresponding rows in `mf_newspaces` the dimension grid and decomposition to old spaces are currently missing or broken, e.g.

https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/9999/4/
https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/99999/2/

This PR fixes this problem.

