### PR TITLE
Remove random link for points on modular curves

### DIFF
--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -1105,6 +1105,10 @@ class RatPointSearchArray(SearchArray):
                              [residue_field, j_field, jinv, j_height, isolated],
                              [family, cusp]]
 
+    def search_types(self, info):
+        # There is no homepage for a point, so we disable the random link
+        return [("List", "Search again")]
+
 class ModCurve_stats(StatsDisplay):
     def __init__(self):
         self.ncurves = comma(db.gps_gl2zhat_fine.count())


### PR DESCRIPTION
This resolves a server error that's currently live on beta if you click on the Random button [here](https://beta.lmfdb.org/ModularCurve/Q/low_degree_points?cusp=no)