### PR TITLE
Fix bug in link from ECQ statistics pages

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -205,7 +205,7 @@ class ECstats(StatsDisplay):
     formatters = {'torsion_structure': latex_tor,
                   'sha': latex_sha}
 
-    query_formatters = {'torsion_structure': 'torsion_structure={}'.format,
+    query_formatters = {'torsion_structure': 'torsion={}'.format,
                         'sha': 'sha={}'.format}
 
     stat_list = [


### PR DESCRIPTION
If you go to https://beta.lmfdb.org/EllipticCurve/Q/stats and click on one of the numbers in the "Distribution of torsion subgroups" table (e.g. 6 for Z/2 + Z/8), you'll end up at a search page with no constraints.  This PR fixes the problem.