### PR TITLE
Make download links more consistent

### DIFF
--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -406,9 +406,9 @@ class WebNewform():
         downloads.append(
                 ('Code to Magma', url_for(".cmf_code_download", label=self.label, download_type='magma')))
         downloads.append(
-                ('Code to Pari', url_for(".cmf_code_download", label=self.label, download_type='pari')))
+                ('Code to PariGP', url_for(".cmf_code_download", label=self.label, download_type='pari')))
         downloads.append(
-                ('Code to Sage', url_for(".cmf_code_download", label=self.label, download_type='sage')))
+                ('Code to SageMath', url_for(".cmf_code_download", label=self.label, download_type='sage')))
 
         downloads.append(('Underlying data', url_for('.mf_data', label=label)))
         return downloads

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -747,7 +747,7 @@ class ECNF():
         self._code = None # will be set if needed by get_code()
 
         self.downloads = [('All stored data to text', url_for(".download_ECNF_all", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number))]
-        for lang in [["Magma","magma"], ["GP", "gp"], ["SageMath","sage"]]:
+        for lang in [["Magma","magma"], ["PariGP", "gp"], ["SageMath","sage"]]:
             self.downloads.append(('Code to {}'.format(lang[0]),
                                    url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
                                            class_label=self.iso_label, number=self.number, download_type=lang[1])))

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -70,7 +70,7 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
         assert 'Code to Magma' in L.get_data(as_text=True)
         assert 'Code to SageMath' in L.get_data(as_text=True)
-        assert 'Code to GP' in L.get_data(as_text=True)
+        assert 'Code to PariGP' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/magma')
         assert 'Magma code for working with elliptic curve 2.2.89.1-81.1-a1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/sage')

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -558,9 +558,9 @@ class WebEC():
         self.downloads = [('q-expansion to text', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=1000)),
                           ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_label)),
                           ('Code to Magma', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
-                          ('Code to SageMath', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
-                          ('Code to Pari/GP', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp')),
                           ('Code to Oscar', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='oscar')),
+                          ('Code to PariGP', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp')),
+                          ('Code to SageMath', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
                           ('Underlying data', url_for(".EC_data", label=self.lmfdb_label)),
         ]
 

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -321,7 +321,7 @@ def render_group_webpage(args):
         if data['nilpotency'] == '$-1$':
             data['nilpotency'] += ' (not nilpotent)'
         downloads = []
-        for lang in [["Magma","magma"], ["SageMath","sage"], ["Oscar", "oscar"]]:
+        for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("SageMath", "sage")]:
             downloads.append(('Code to {}'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))
         downloads.append(('Underlying data', url_for(".gg_data", label=label)))
         bread = get_bread([(label, ' ')])

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1219,9 +1219,9 @@ def render_abstract_group(label, data=None):
         title = f"Abstract group ${gp.tex_name}$"
 
         downloads = [
+            ("Group to Gap", url_for(".download_group", label=label, download_type="gap")),
             ("Group to Magma", url_for(".download_group", label=label, download_type="magma")),
             ("Group to Oscar", url_for(".download_group", label=label, download_type="oscar")),
-            ("Group to Gap", url_for(".download_group", label=label, download_type="gap")),
             ("Underlying data", url_for(".gp_data", label=label)),
         ]
 

--- a/lmfdb/higher_genus_w_automorphisms/main.py
+++ b/lmfdb/higher_genus_w_automorphisms/main.py
@@ -736,15 +736,19 @@ def render_family(args):
                            (bread_sign,' ')])
 
         if len(Ltopo_rep) == 0 or len(dataz) == 1:
-            downloads = [('Code to Magma', url_for(".hgcwa_code_download", label=label, download_type='magma')),
-                         ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
+            downloads = [
+                ('Code to GAP', url_for(".hgcwa_code_download", label=label, download_type='gap')),
+                ('Code to Magma', url_for(".hgcwa_code_download", label=label, download_type='magma')),
+            ]
         else:
-            downloads = [('Code to Magma', None),
-                         (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='magma')),
-                         (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_magma')),
-                         ('Code to Gap', None),
-                         (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
-                         (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_gap'))]
+            downloads = [
+                ('Code to GAP', None),
+                (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
+                (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_gap')),
+                ('Code to Magma', None),
+                (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='magma')),
+                (u'\u2003 Up to topological equivalence', url_for(".hgcwa_code_download", label=label, download_type='topo_magma')),
+            ]
         downloads.append(('Underlying data', url_for(".hgcwa_data", label=label)))
         return render_template("hgcwa-show-family.html",
                                title=title, bread=bread, info=info,
@@ -940,16 +944,20 @@ def render_passport(args):
             (data['cc'][0], ' ')])
 
         if numb == 1 or braid_length == 0:
-            downloads = [('Code to Magma', url_for(".hgcwa_code_download", label=label, download_type='magma')),
-                     ('Code to Gap', url_for(".hgcwa_code_download", label=label, download_type='gap'))]
+            downloads = [
+                ('Code to GAP', url_for(".hgcwa_code_download", label=label, download_type='gap')),
+                ('Code to Magma', url_for(".hgcwa_code_download", label=label, download_type='magma')),
+            ]
 
         else:
-            downloads = [('Code to Magma', None),
-                             (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='magma')),
-                             (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_magma')),
-                             ('Code to Gap', None),
-                             (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
-                             (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_gap'))]
+            downloads = [
+                ('Code to GAP', None),
+                (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='gap')),
+                (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_gap')),
+                ('Code to Magma', None),
+                (u'\u2003 All vectors', url_for(".hgcwa_code_download", label=label, download_type='magma')),
+                (u'\u2003 Up to braid equivalence', url_for(".hgcwa_code_download", label=label, download_type='braid_magma')),
+            ]
         downloads.append(('Underlying data', url_for(".hgcwa_data", label=label)))
 
         return render_template("hgcwa-show-passport.html",

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -687,7 +687,7 @@ def render_field_webpage(args):
                   ('Galois group', group_pretty_and_nTj(data['degree'], t))]
     downloads = [('Stored data to gp',
                   url_for('.nf_download', nf=label, download_type='data'))]
-    for lang in [["Magma","magma"], ["SageMath","sage"], ["Pari/GP", "gp"], ["Oscar", "oscar"]]:
+    for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("PariGP", "gp"), ("SageMath", "sage")]:
         downloads.append(('Code to {}'.format(lang[0]),
                           url_for(".nf_download", nf=label, download_type=lang[1])))
     downloads.append(('Underlying data', url_for(".nf_datapage", label=label)))


### PR DESCRIPTION
* In code links for the download section, always use alphabetical order (GMOPS)
* Use SageMath rather than Sage, PariGP rather than Pari, GP or Pari/GP, and GAP rather than Gap.