### PR TITLE
Escape percent signs when printing error

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -283,7 +283,7 @@ def api_query(table, id=None):
         except KeyError as err:
             return apierror("No key %s in table %s", [err, table])
         except Exception as err:
-            return apierror(str(err))
+            return apierror(str(err).replace("%", "%%"))
 
     if single_object and not data:
         return apierror("no document with id %s found in table %s.", [id, table])


### PR DESCRIPTION
With bad input to the api, it tries to catch the error and print it, but if there are percent signs then printing the error fails.

See https://beta.lmfdb.org/api/gps_groups/?permutation_degree=12&abelian=no%&_format=json for an example.