### PR TITLE
Fix buggy subgroup page 

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -260,12 +260,12 @@ def get_group_prop_display(gp):
     elif hasattr(gp, 'hyperelementary') and gp.hyperelementary:  # Now hyperelementary is a top level implication
         hyperelementaryp = f" for $p = {hyperelementaryp}$"
     nilp_class = getattr(gp, 'nilpotency_class', None)
-    if nilp_class:
+    if nilp_class is not None:
         nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of class {nilp_class}"
     else:
         nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of uncomputed class"
     solv_length = getattr(gp, 'derived_length', None)
-    if solv_length:
+    if solv_length is not None:
         solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {solv_length}"
     else:
         solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of uncomputed length"

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -313,8 +313,8 @@ def get_group_impl_display(gp):
     else:
         solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of uncomputed length"
     return {
-        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} (nil_phrase)",
-        "solvable": f"{display_knowl('group.solvable', 'solvable')} (solv_phrase)",
+        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} ({nilp_phrase})",
+        "solvable": f"{display_knowl('group.solvable', 'solvable')} ({solv_phrase})",
     }
 
 

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -182,7 +182,7 @@ def find_props(
     props = []
     noted = set()
     for prop in overall_order:
-        if not getattr(gp, prop) or prop in noted or prop not in show:
+        if not getattr(gp, prop, None) or prop in noted or prop not in show:
             continue
         noted.add(prop)
         impl = [B for B in implications.get(prop, []) if B not in noted]
@@ -229,18 +229,21 @@ group_prop_implications = {
 
 def get_group_prop_display(gp):
     # We want elementary and hyperelementary to display which primes, but only once
-    elementaryp = ",".join(str(p) for (p, e) in ZZ(gp.elementary).factor())
-    hyperelementaryp = ",".join(
-        str(p)
-        for (p, e) in ZZ(gp.hyperelementary).factor()
-        if not p.divides(gp.elementary)
-    )
+    elementaryp = ''
+    hyperelementaryp = ''
+    if hasattr(gp, 'elementary'):
+        elementaryp = ",".join(str(p) for (p, e) in ZZ(gp.elementary).factor())
+        hyperelementaryp = ",".join(
+            str(p)
+            for (p, e) in ZZ(gp.hyperelementary).factor()
+            if not p.divides(gp.elementary)
+        )
     if (
         gp.order == 1
     ):  # here it will be implied from cyclic, so both are in the implication list
         elementaryp = " (for every $p$)"
         hyperelementaryp = ""
-    elif gp.pgroup:  # We don't display p since there's only one in play
+    elif hasattr(gp, 'pgroup') and gp.pgroup:  # We don't display p since there's only one in play
         elementaryp = hyperelementaryp = ""
     elif gp.cyclic:  # both are in the implication list
         elementaryp = f" ($p = {elementaryp}$)"
@@ -248,22 +251,22 @@ def get_group_prop_display(gp):
             hyperelementaryp = ""
         else:
             hyperelementaryp = f" (also for $p = {hyperelementaryp}$)"
-    elif gp.is_elementary:  # Now elementary is a top level implication
+    elif hasattr(gp, 'is_elementary') and gp.is_elementary:  # Now elementary is a top level implication
         elementaryp = f" for $p = {elementaryp}$"
-        if gp.elementary == gp.hyperelementary:
+        if hasattr(gp, 'hyperelementary') and gp.elementary == gp.hyperelementary:
             hyperelementaryp = ""
         else:
             hyperelementaryp = f" (also for $p = {hyperelementaryp}$)"
-    elif gp.hyperelementary:  # Now hyperelementary is a top level implication
+    elif hasattr(gp, 'hyperelementary') and gp.hyperelementary:  # Now hyperelementary is a top level implication
         hyperelementaryp = f" for $p = {hyperelementaryp}$"
     overall_display = {
         "cyclic": display_knowl("group.cyclic", "cyclic"),
         "abelian": display_knowl("group.abelian", "abelian"),
         "nonabelian": display_knowl("group.abelian", "nonabelian"),
-        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} of class {gp.nilpotency_class}",
+        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} of class {getattr(gp, 'nilpotency_class', 'not computed')}",
         "supersolvable": display_knowl("group.supersolvable", "supersolvable"),
         "monomial": display_knowl("group.monomial", "monomial"),
-        "solvable": f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {gp.derived_length}",
+        "solvable": f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {getattr(gp, 'derived_length', 'not computed')}",
         "nonsolvable": display_knowl("group.solvable", "nonsolvable"),
         "Zgroup": f"a {display_knowl('group.z_group', 'Z-group')}",
         "Agroup": f"an {display_knowl('group.a_group', 'A-group')}",
@@ -290,8 +293,8 @@ def get_group_prop_display(gp):
 def get_group_impl_display(gp):
     # Mostly we display things the same in implication lists, but there are a few extra parentheses
     return {
-        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} (of class {gp.nilpotency_class})",
-        "solvable": f"{display_knowl('group.solvable', 'solvable')} (of {display_knowl('group.derived_series', 'length')} {gp.derived_length})",
+        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} (of class {getattr(gp, 'nilpotency_class', 'not computed')})",
+        "solvable": f"{display_knowl('group.solvable', 'solvable')} (of {display_knowl('group.derived_series', 'length')} {getattr(gp, 'derived_length', 'not computed')})",
     }
 
 
@@ -468,7 +471,11 @@ def create_boolean_subgroup_string(sgp, type="normal"):
         main = f"The subgroup is {display_props(props)}."
     else:
         main = f"This subgroup is {display_props(props)}."
-    unknown = [overall_display[prop] for prop in overall_order if getattr(sgp, prop) is None]
+    unknown = [prop for prop in overall_order if getattr(sgp, prop, None) is None]
+    if {'ab_simple', 'nab_simple'} <= set(unknown):
+        unknown.remove('ab_simple')
+        
+    unknown = [overall_display[prop] for prop in unknown]
     if unknown:
         main += f"  Whether it is {display_props(unknown, 'or')} has not been computed."
     return main
@@ -478,6 +485,8 @@ def create_boolean_string(gp, type="normal"):
     # We totally order the properties in two ways: by the order that they should be listed overall,
     # and by the order they should be listed in implications
     # For the first order, it's important that A come before B whenever A => B
+    if not gp:
+        return "Properties have not been computed"
     overall_order = [
         "cyclic",
         "abelian",
@@ -563,7 +572,11 @@ def create_boolean_string(gp, type="normal"):
         main = f"{display_props(props)}."
     else:
         main = f"This group is {display_props(props)}."
-    unknown = [overall_display[prop] for prop in overall_order if getattr(gp, prop) is None]
+    unknown = [prop for prop in overall_order if getattr(gp, prop, None) is None]
+    if {'ab_simple', 'nab_simple'} <= set(unknown):
+        unknown.remove('ab_simple')
+        
+    unknown = [overall_display[prop] for prop in unknown]
     if unknown and type != "knowl":
         main += f"  Whether it is {display_props(unknown, 'or')} has not been computed."
     return main

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -303,12 +303,12 @@ def get_group_prop_display(gp):
 def get_group_impl_display(gp):
     # Mostly we display things the same in implication lists, but there are a few extra parentheses
     nilp_class = getattr(gp, 'nilpotency_class', None)
-    if nilp_class:
+    if nilp_class is not None:
         nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of class {nilp_class}"
     else:
         nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of uncomputed class"
     solv_length = getattr(gp, 'derived_length', None)
-    if solv_length:
+    if solv_length is not None:
         solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {solv_length}"
     else:
         solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of uncomputed length"

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -259,14 +259,24 @@ def get_group_prop_display(gp):
             hyperelementaryp = f" (also for $p = {hyperelementaryp}$)"
     elif hasattr(gp, 'hyperelementary') and gp.hyperelementary:  # Now hyperelementary is a top level implication
         hyperelementaryp = f" for $p = {hyperelementaryp}$"
+    nilp_class = getattr(gp, 'nilpotency_class', None)
+    if nilp_class:
+        nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of class {nilp_class}"
+    else:
+        nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of uncomputed class"
+    solv_length = getattr(gp, 'derived_length', None)
+    if solv_length:
+        solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {solv_length}"
+    else:
+        solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of uncomputed length"
     overall_display = {
         "cyclic": display_knowl("group.cyclic", "cyclic"),
         "abelian": display_knowl("group.abelian", "abelian"),
         "nonabelian": display_knowl("group.abelian", "nonabelian"),
-        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} of class {getattr(gp, 'nilpotency_class', 'not computed')}",
+        "nilpotent": nilp_phrase,
         "supersolvable": display_knowl("group.supersolvable", "supersolvable"),
         "monomial": display_knowl("group.monomial", "monomial"),
-        "solvable": f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {getattr(gp, 'derived_length', 'not computed')}",
+        "solvable": solv_phrase,
         "nonsolvable": display_knowl("group.solvable", "nonsolvable"),
         "Zgroup": f"a {display_knowl('group.z_group', 'Z-group')}",
         "Agroup": f"an {display_knowl('group.a_group', 'A-group')}",
@@ -292,9 +302,19 @@ def get_group_prop_display(gp):
 
 def get_group_impl_display(gp):
     # Mostly we display things the same in implication lists, but there are a few extra parentheses
+    nilp_class = getattr(gp, 'nilpotency_class', None)
+    if nilp_class:
+        nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of class {nilp_class}"
+    else:
+        nilp_phrase = f"{display_knowl('group.nilpotent', 'nilpotent')} of uncomputed class"
+    solv_length = getattr(gp, 'derived_length', None)
+    if solv_length:
+        solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of {display_knowl('group.derived_series', 'length')} {solv_length}"
+    else:
+        solv_phrase = f"{display_knowl('group.solvable', 'solvable')} of uncomputed length"
     return {
-        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} (of class {getattr(gp, 'nilpotency_class', 'not computed')})",
-        "solvable": f"{display_knowl('group.solvable', 'solvable')} (of {display_knowl('group.derived_series', 'length')} {getattr(gp, 'derived_length', 'not computed')})",
+        "nilpotent": f"{display_knowl('group.nilpotent', 'nilpotent')} (nil_phrase)",
+        "solvable": f"{display_knowl('group.solvable', 'solvable')} (solv_phrase)",
     }
 
 

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -13,7 +13,13 @@
     {% endif %}
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(seq.subgroup_order)}} </td></tr>
     <tr><td>{{KNOWL('group.subgroup.index',title='Index:')}}</td><td> {{info.pos_int_and_factor(seq.quotient_order)}} </td></tr>
-    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(seq.sub.exponent)}} </td></tr>
+    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> 
+    {% if seq.sub|attr('exponent')  %}
+        {{info.pos_int_and_factor(seq.sub.exponent)}} 
+    {% else %}
+        not computed
+    {% endif %}
+    </td></tr>
     {% if seq.amb.show_subgroup_flag() %}<tr><td>{{KNOWL('group.generators', 'Generators:')}}</td><td> ${{seq.amb.show_subgroup_generators(seq)}}$</td></tr>{% endif %}
   </table>
 </p>
@@ -60,9 +66,27 @@
   {% if seq.quotient is not none %}    <tr><td>{{KNOWL('group.name', title='Description:')}}</td>
       <td><a href="{{url_for('.by_label', label=seq.quotient)}}">${{seq.quotient_tex}}$</a></td></tr> {% endif %}
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(seq.quotient_order)}} </td></tr>
-    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> {{info.pos_int_and_factor(seq.quo.exponent)}} </td></tr>
-    <tr><td>Automorphism Group:</td><td>{{seq.quo.show_aut_group()|safe}}</td></tr>
-    <tr><td>Outer Automorphisms:</td><td>{{seq.quo.show_outer_group()|safe}}</td></tr>
+    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> 
+    {% if seq.sub|attr('exponent')  %}
+      {{info.pos_int_and_factor(seq.quo.exponent)}} 
+    {% else %}
+      not computed
+    {% endif %}
+    </td></tr>
+    <tr><td>Automorphism Group:</td><td>
+    {% if seq.quo|attr('show_aut_group')%}
+      {{seq.quo.show_aut_group()|safe}}
+    {% else %}
+      not computed
+    {% endif %}
+    </td></tr>
+    <tr><td>Outer Automorphisms:</td><td>
+    {% if seq.quo|attr('show_outer_group')%}
+      {{seq.quo.show_outer_group()|safe}}
+    {% else %}
+      not computed
+    {% endif %}
+    </td></tr>
   </table>
 </p>
 
@@ -88,7 +112,13 @@
   {% endif %}
   <table>
     <tr><td>$\operatorname{Aut}(G)$</td><td>{{seq.amb.show_aut_group()|safe}}</td></tr>
-    <tr><td>$\operatorname{Aut}(H)$</td><td>{{seq.sub.show_aut_group()|safe}}</td></tr>
+    <tr><td>$\operatorname{Aut}(H)$</td><td>
+    {% if seq.sub|attr('show_aut_group') %}
+      {{seq.sub.show_aut_group()|safe}}
+    {% else %}
+      not computed
+    {% endif %}
+      </td></tr>
     {% if seq.aut_weyl_group is not none %}
       <tr><td>$\operatorname{res}({{S}})$</td><td><a href="{{url_for('.by_label', label=seq.aut_weyl_group)}}">${{seq.aut_weyl.tex_name}}$</a>, of order {{info.pos_int_and_factor(seq.aut_weyl.order)}}</td></tr>
     {% elif seq.aut_weyl_index is not none %}

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -14,7 +14,7 @@
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(seq.subgroup_order)}} </td></tr>
     <tr><td>{{KNOWL('group.subgroup.index',title='Index:')}}</td><td> {{info.pos_int_and_factor(seq.quotient_order)}} </td></tr>
     <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td>
-    {% if seq.sub|attr('exponent')  %}
+    {% if seq.sub.exponent  %}
         {{info.pos_int_and_factor(seq.sub.exponent)}} 
     {% else %}
         not computed

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -13,7 +13,7 @@
     {% endif %}
     <tr><td>{{KNOWL('group.order',title='Order:')}}</td><td> {{info.pos_int_and_factor(seq.subgroup_order)}} </td></tr>
     <tr><td>{{KNOWL('group.subgroup.index',title='Index:')}}</td><td> {{info.pos_int_and_factor(seq.quotient_order)}} </td></tr>
-    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td> 
+    <tr><td>{{KNOWL('group.exponent',title='Exponent:')}}</td><td>
     {% if seq.sub|attr('exponent')  %}
         {{info.pos_int_and_factor(seq.sub.exponent)}} 
     {% else %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1892,7 +1892,7 @@ class WebAbstractGroup(WebObj):
         try:
             if self.aut_group is None:
                 if self.aut_order is None:
-                    return r"$\textrm{not computed}$"
+                    return r"not computed"
                 else:
                     return f"Group of order {pos_int_and_factor(self.aut_order)}"
             else:
@@ -2355,11 +2355,14 @@ class WebAbstractSubgroup(WebObj):
         return ", ".join(specials)
 
     def _lookup(self, label, data, Wtype):
+        if not label:
+            return None
         for rec in data:
-            if rec["label"] == label:
-                return Wtype(label, rec)
-            elif rec.get("short_label") == label:
-                return Wtype(rec["label"], rec)
+            if rec:
+                if rec["label"] == label:
+                    return Wtype(label, rec)
+                elif 'short_label' in rec and rec.get("short_label") == label:
+                    return Wtype(rec["label"], rec)
         # It's possible that the label refers to a small group that is not in the database
         # but that we can create dynamically
         return Wtype(label)
@@ -2386,6 +2389,11 @@ class WebAbstractSubgroup(WebObj):
     def sub(self):
         S = self._lookup(self.subgroup, self._full, WebAbstractGroup)
         # We set various properties from S for create_boolean_subgroup_string
+        if not S:
+            order = self.subgroup_order
+            self.order = order
+            self.pgroup = len(ZZ(order).abs().factor())==1
+            return self
         for prop in [
             "pgroup",
             "is_elementary",

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -278,7 +278,9 @@ class WebAbstractGroup(WebObj):
         return ZZ(self.G.Order())
     @lazy_attribute
     def exponent(self):
-        return ZZ(self.G.Exponent())
+        if self.G:
+            return ZZ(self.G.Exponent())
+        return None
 
     @lazy_attribute
     def cyclic(self):
@@ -2391,9 +2393,14 @@ class WebAbstractSubgroup(WebObj):
         # We set various properties from S for create_boolean_subgroup_string
         if not S:
             order = self.subgroup_order
-            self.order = order
-            self.pgroup = len(ZZ(order).abs().factor())==1
-            return self
+            #newgroup.order = order
+            #newgroup.pgroup = len(ZZ(order).abs().factor())==1
+            newgroup = WebAbstractGroup('nolabel',
+                data={'order': order, 'G': None, 'abelian': self.abelian,
+                      # What if aut_label is set?
+                      'aut_group': self.aut_label, 'aut_order': None,
+                      'pgroup':len(ZZ(order).abs().factor())==1})
+            return newgroup
         for prop in [
             "pgroup",
             "is_elementary",


### PR DESCRIPTION
On beta

http://127.0.0.1:37777/Groups/Abstract/sub/167772160.bng.40960.CP
https://beta.lmfdb.org/Groups/Abstract/sub/167772160.bng.40960.CP

it says that the subgroup is nilpotent, but that the nilpotency class is -1 which is inconsistent.  The subgroup is in the database, but only minimal information was computed about it.  The code was substituting information about the ambient group for it and the subgroup.  Fixing that led to various places missing data caused an error.

Also, fixing that uncovered that if it is not computed whether or not the group is simple, that fact that it was not computed was being reported twice (internally, there are flags for abelian-non-solvable and nonabelian-non-solvable).

Also fixed a place where plain text was put in textrm inside math mode.