### PR TITLE
remove dependency on gps_gl2zhat in web_ec.py

### DIFF
--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -63,7 +63,7 @@ CP_LABEL_RE = re.compile(r"\d+[A-Z]+\d+")
 CP_LABEL_GENUS_RE = re.compile(r"\d+[A-Z]+(\d+)")
 SZ_LABEL_RE = re.compile(r"\d+[A-Z]\d+-\d+[a-z]")
 RZB_LABEL_RE = re.compile(r"X\d+")
-S_LABEL_RE = re.compile(r"\d+(G|B|Cs|Cn|Ns|Nn|A4|S4|A5)(\.\d+){0,3}")
+S_LABEL_RE = re.compile(r"(\d+)(G|B|Cs|Cn|Ns|Nn|A4|S4|A5)(\.\d+){0,3}")
 NAME_RE = re.compile(r"X_?(0|1|NS|NS\^?\+|SP|SP\^?\+|S4|SYM)?\(\d+\)")
 
 def learnmore_list():


### PR DESCRIPTION
This PR updates `gl2_subgroup_data` in `web_ec.py` which is used to render subgroup knowls for mod-ell/ell-adic image data on ECQ pages to use the new modular curves table `gps_gl2zhat_fine` for all queries.  Once this is merged and pushed to dev/prod we can delete the table `gps_gl2zhat`.