### PR TITLE
Add link to modcurve home page to GL2 subgroup knowls

### DIFF
--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -97,13 +97,14 @@ def gl2_subgroup_data(label):
             raise ValueError
     except ValueError:
         return "Unable to locate data for GL(2,Zhat) subgroup with label: %s" % label
+
     def row_wrap(cap, val): return "<tr><td>%s: </td><td>%s</td></tr>\n" % (cap, val)
     def matrix(m): return r'$\begin{bmatrix}%s&%s\\%s&%s\end{bmatrix}$' % (m[0],m[1],m[2],m[3])
     info = '<table>\n'
     if label != data['label']:
         info += row_wrap('Subgroup <b>%s</b> (%s)' % (label,data['label']), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
     else:
-        info += row_wrap('Subgroup %s' % (label), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
+        info += row_wrap('Subgroup <b>%s</b>' % (label), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
     info += "<tr><td></td><td></td></tr>\n"
     info += row_wrap('Level', data['level'])
     info += row_wrap('Index', data['index'])

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -10,7 +10,6 @@ from lmfdb.utils import web_latex, encode_plot, prop_int_pretty, raw_typeset, di
 from lmfdb.utils.web_display import dispZmat_from_list
 from lmfdb.utils.common_regex import G1_LOOKUP_RE, ZLIST_RE
 from lmfdb.logger import make_logger
-from lmfdb.classical_modular_forms.main import url_for_label as cmf_url_for_label
 
 from sage.all import EllipticCurve, KodairaSymbol, latex, ZZ, QQ, prod, Factorization, PowerSeriesRing, prime_range, RealField, euler_phi, GL, Integers
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -97,14 +97,13 @@ def gl2_subgroup_data(label):
             raise ValueError
     except ValueError:
         return "Unable to locate data for GL(2,Zhat) subgroup with label: %s" % label
-
     def row_wrap(cap, val): return "<tr><td>%s: </td><td>%s</td></tr>\n" % (cap, val)
     def matrix(m): return r'$\begin{bmatrix}%s&%s\\%s&%s\end{bmatrix}$' % (m[0],m[1],m[2],m[3])
     info = '<table>\n'
     if label != data['label']:
         info += row_wrap('Subgroup <b>%s</b> (%s)' % (label,data['label']), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
     else:
-        info += row_wrap('Subgroup <b>%s</b>' % (label), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
+        info += row_wrap('Subgroup %s' % (label), "<small>" + ', '.join(matrix(m) for m in data['generators']) + "</small>")
     info += "<tr><td></td><td></td></tr>\n"
     info += row_wrap('Level', data['level'])
     info += row_wrap('Index', data['index'])
@@ -145,12 +144,8 @@ def gl2_subgroup_data(label):
         degs = [int(s.split('.')[1]) for s in data["reductions"]] + [data['index']]
         degs = [ell*(ell-1)**2*(ell+1)*ell**(4*i) // degs[i] for i in range(e)]
         info += row_wrap("Full %s${}^n$-torsion field degrees" % (ell), ", ".join(["%s"%d for d in degs]))
-    if data['genus'] > 0:
-        info += row_wrap('Newforms', ''.join(['<a href="%s">%s</a>' % (cmf_url_for_label(x), x) for x in data['newforms']]))
-        info += row_wrap('Analytic rank', data['rank'])
-        if data['genus'] == 1 and data['model']:
-            info += row_wrap('Model', '<a href="%s">%s</a>' % (url_for('ec.by_ec_label',label=data['model']), data['model']))
     info += "</table>\n"
+    info += '<div align="right"><a href="%s">%s home page</a></div>' % (str(url_for("modcurve.by_label", label=data['label'])),data['label'])
     return info
 
 def weighted_proj_to_affine_point(P):
@@ -392,7 +387,6 @@ class WebEC():
             data['adelic_level_latex'] = web_latex_factored_integer(M,equals=True)
             P = M.prime_divisors()
             data['adelic_image_size'] = euler_phi(M)*M*(M // prod(P))**2*prod([p**2-1 for p in P]) // self.adelic_index
-            print(data['adelic_image_size'])
         else:
             data['adelic_data'] = {}
 


### PR DESCRIPTION
Adds a link to the modular curve home page for GL2 subgroup data knowls used that are used on elliptic curve pages.  Also fixes a bug in the code attempting to display newforms  and models in the data knowl for groups of genus > 0 by removing that code (I don't think it makes sense to try to put all this into a data knowl, especially the model, the user can now click the modular curve page link to see this information if desired).

Also removes a stray print.