### PR TITLE
modcurve changes to handle missing decompositions

### DIFF
--- a/lmfdb/modular_curves/templates/modcurve.html
+++ b/lmfdb/modular_curves/templates/modcurve.html
@@ -14,7 +14,7 @@
   <tr><td>{{ KNOWL("modcurve.cusps", "Cusps") }}:</td><td> {{ curve.cusps_display }}</td><td style="width:20px;"></td><td>{{ KNOWL("modcurve.cusp_widths", "Cusp widths") }}</td><td>{{ curve.cusp_widths_display }}</td><td style="width:60px;"></td><td>{{ KNOWL("modcurve.cusp_orbits", "Cusp orbits") }}</td><td>{{ curve.cusp_orbits_display }}</td></tr>
   <tr><td>{{ KNOWL("modcurve.elliptic_points", "Elliptic points") }}:</td> <td> ${{curve.nu2}}$ of order $2$ and ${{curve.nu3}}$ of order $3$ </td></tr>
   {% if curve.genus > 0 %}
-  <tr><td>{{ KNOWL('modcurve.rank', 'Analytic rank') }}:</td><td> ${{ curve.rank }}$ </td></tr>
+  <tr><td>{{ KNOWL('modcurve.rank', 'Analytic rank') }}:</td><td> {% if curve.rank is not none %} ${{ curve.rank }}$ {% else %} not computed {% endif %} </td></tr>
   {% endif %}
   <tr><td>{{ KNOWL("modcurve.gonality", "$\Q$-gonality")}}:</td><td> ${{ curve.q_gonality if curve.q_gonality else "%s \\le \\gamma \\le %s"%(curve.q_gonality_bounds[0],curve.q_gonality_bounds[1]) }}$ </td></tr>
   <tr><td>{{ KNOWL("modcurve.gonality", "$\overline{\Q}$-gonality")}}:</td><td> ${{ curve.qbar_gonality if curve.qbar_gonality else "%s \\le \\gamma \\le %s"%(curve.qbar_gonality_bounds[0],curve.qbar_gonality_bounds[1]) }}$ </td></tr>
@@ -62,11 +62,25 @@
 </table>
 {% endif %}
 
-{% if curve.genus > 0 %}
+{% if curve.genus > 0 and curve.dims is not none %}
 <h2> {{ KNOWL('ag.jacobian', 'Jacobian') }} </h2>
 
 <table>
   <tr><td>{{ KNOWL('ag.conductor', 'Conductor') }}:</td><td> ${{ curve.factored_conductor }}$ </td></tr>
+  <tr>
+    <td>
+      {{ KNOWL('av.simple', 'Simple') }}:
+    </td>
+    <td>
+      {% if curve.simple %}
+        yes
+      {% elif curve.simple is not none %}
+        no
+      {% else %}
+        not computed
+      {% endif %}
+    </td>
+  </tr>
   <tr>
     <td>
       {{ KNOWL('av.squarefree', 'Squarefree') }}:
@@ -74,8 +88,10 @@
     <td>
       {% if curve.squarefree %}
         yes
-      {% else %}
+      {% elif curve.squarefree is not none %}
         no
+      {% else %}
+        not computed
       {% endif %}
     </td>
   </tr>
@@ -365,7 +381,7 @@ We are removing this section until we have more sources of non-rational points. 
       <th>{{ KNOWL('modcurve.modular_cover','Degree') }}</th>
       <th>{{ KNOWL('modcurve.genus','Genus') }}</th>
       <th>{{ KNOWL('modcurve.rank','Rank') }}</th>
-      {% if curve.genus > 0 %}
+      {% if curve.dims %}
       <th>{{ KNOWL('modcurve.modular_cover','Kernel decomposition') }}</th>
       {% endif %}
     </tr>
@@ -379,10 +395,12 @@ We are removing this section until we have more sources of non-rational points. 
     <td align="center">${{ degree }}$</td>
     <td align="center">${{ genus }}$</td>
     <td align="center">${{ rank }}$</td>
+    {% if curve.dims %}
     {% if genus > 0 %}
     <td><span>{{ kernel if kernel else "dimension zero" | safe }}</span></td>
     {% elif curve.genus > 0 %}
     <td>full Jacobian</td>
+    {% endif %}
     {% endif %}
   </tr>
   {% endfor %}
@@ -401,7 +419,7 @@ We are removing this section until we have more sources of non-rational points. 
       <th>{{ KNOWL('modcurve.modular_cover','Degree') }}</th>
       <th>{{ KNOWL('modcurve.genus','Genus') }}</th>
       <th>{{ KNOWL('modcurve.rank','Rank') }}</th>
-      {% if curve.genus > 0 %}
+      {% if curve.dims %}
       <th>{{ KNOWL('modcurve.modular_cover','Kernel decomposition') }}</th>
       {% endif %}
     </tr>
@@ -415,10 +433,12 @@ We are removing this section until we have more sources of non-rational points. 
     <td align="center">${{ degree }}$</td>
     <td align="center">${{ genus }}$</td>
     <td align="center">${{ rank }}$</td>
+    {% if curve.dims %}
     {% if genus > 0 %}
     <td><span>{{ kernel if kernel else "dimension zero" | safe }}</span></td>
     {% elif curve.genus > 0 %}
     <td>full Jacobian</td>
+    {% endif %}
     {% endif %}
   </tr>
   {% endfor %}
@@ -436,8 +456,8 @@ We are removing this section until we have more sources of non-rational points. 
       <th>{{ KNOWL('modcurve.relative_index', 'Index') }}</th>
       <th>{{ KNOWL('modcurve.modular_cover','Degree') }}</th>
       <th>{{ KNOWL('modcurve.genus','Genus') }}</th>
+      {% if curve.dims %}
       <th>{{ KNOWL('modcurve.rank','Rank') }}</th>
-      {% if curve.genus > 0 %}
       <th>{{ KNOWL('modcurve.modular_cover','Kernel decomposition') }}</th>
       {% endif %}
     </tr>
@@ -450,8 +470,8 @@ We are removing this section until we have more sources of non-rational points. 
     <td align="center">${{ index }}$</td>
     <td align="center">${{ degree }}$</td>
     <td align="center">${{ genus }}$</td>
+    {% if curve.dims %}
     <td align="center">${{ rank }}$</td>
-    {% if curve.genus > 0 %}
     <td><span>{{ kernel if kernel else "dimension zero" | safe }}</span></td>
     {% endif %}
   </tr>

--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -350,7 +350,7 @@ class WebModCurve(WebObj):
             friends.append(("L-function", "/L" + url_for_mf_label(self.newforms[0])))
         else:
             friends.append(("L-function not available",""))
-        if self.genus > 0:
+        if self.genus > 0 and self.trace_hash is not None:
             for r in self.table.search({'trace_hash':self.trace_hash},['label','name','newforms']):
                 if r['newforms'] == self.newforms and r['label'] != self.label:
                     friends.append(("Modular curve " + (r['name'] if r['name'] else r['label']),url_for("modcurve.by_label", label=r['label'])))

--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -133,7 +133,7 @@ def name_to_latex(name):
     return f"${name}$"
 
 def factored_conductor(conductor):
-    return "\\cdot".join(f"{p}{showexp(e, wrap=False)}" for (p, e) in conductor) if conductor else "1"
+    return "\\cdot".join(f"{p}{showexp(e, wrap=False)}" for (p, e) in conductor) if conductor else ("1" if conductor == [] else r"?")
 
 def remove_leading_coeff(jfac):
     if "(%s)" % jfac.unit() == (str(jfac).split("*")[0]).replace(' ',''):
@@ -142,6 +142,8 @@ def remove_leading_coeff(jfac):
         return str(jfac)
 
 def formatted_dims(dims, mults):
+    if dims is None:
+        return "not computed"
     if not dims:
         return ""
     # Collapse newforms with the same dimension
@@ -152,6 +154,8 @@ def formatted_dims(dims, mults):
     return "$" + r"\cdot".join(f"{d}{showexp(c, wrap=False)}" for (d, c) in zip(dims, mults)) + "$"
 
 def formatted_newforms(newforms, mults):
+    if newforms is None:
+        return "not computed"
     if not newforms:
         return ""
     return ", ".join(f'<a href="{url_for_mf_label(label)}">{label}</a>{showexp(c)}' for (label, c) in zip(newforms, mults))
@@ -316,7 +320,7 @@ class WebModCurve(WebObj):
         ]
         if self.image is not None:
             props.append((None, self.image))
-        if hasattr(self,"rank"):
+        if hasattr(self,"rank") and self.rank is not None:
             props.append(("Analytic rank", str(self.rank)))
         props.extend([("Cusps", str(self.cusps)),
                       (r"$\Q$-cusps", str(self.rational_cusps))])
@@ -637,7 +641,8 @@ class WebModCurve(WebObj):
             C["index"] // self.index if flip else self.index // C["index"], # relative index
             C["psl2index"] // self.psl2index if flip else self.psl2index // C["psl2index"], # relative degree
             C["genus"],
-            "" if C["rank"] is None else C["rank"],
+            "?" if C["rank"] is None else C["rank"],
+            "not computed" if C["dims"] is None or self.dims is None else
             (formatted_dims(*difference(C["dims"], self.dims,
                                         C["mults"], self.mults)) if flip else
              formatted_dims(*difference(self.dims, C["dims"],


### PR DESCRIPTION
Now that we have started adding data past level 70, there are curves for which we have not computed the decomposition of the Jacobian, which means that some changes are needed to make things display reasonably when information that was previously known for every modular curve in the database is no longer always known (this includes not just the decomposition, but also things like the analytic rank, whether the Jacobian is simple/squarefree, etc..)