### PR TITLE
Add minimal siblings

### DIFF
--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -131,6 +131,8 @@ table.ntdata a {
             {{ info.cclasses | safe }}</tr>
             <tr><td>
             {{ info.character_table | safe }}</tr>
+            <tr><td>
+            {{KNOWL('nf.minimal_sibling', title='Minimal sibling')}}: {{ nf.minimal_sibling() | safe }}</tr>
           </table>
 
         <h2> {{ KNOWL('nf.intermediate_fields', title='Intermediate fields') }}</h2>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -131,8 +131,6 @@ table.ntdata a {
             {{ info.cclasses | safe }}</tr>
             <tr><td>
             {{ info.character_table | safe }}</tr>
-            <tr><td>
-            {{KNOWL('nf.minimal_sibling', title='Minimal sibling')}}: {{ nf.minimal_sibling() | safe }}</tr>
           </table>
 
         <h2> {{ KNOWL('nf.intermediate_fields', title='Intermediate fields') }}</h2>
@@ -196,6 +194,8 @@ table.ntdata a {
                 {% endfor %}
             {% endif %}
         {% endfor %}
+            <tr><td>
+            {{KNOWL('nf.minimal_sibling', title='Minimal sibling')}}: <td>{{ nf.minimal_sibling() | safe }}</tr>
         </table>
         </div>
         {% endif %}

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -451,6 +451,13 @@ class WebNumberField:
     def knowl(self):
         return nf_display_knowl(self.get_label(), self.field_pretty())
 
+    def minimal_sibling(self):
+        if 'is_minimal_sibling' in self._data:
+            if self._data['is_minimal_sibling']:
+                return 'This field is its own minimal sibling'
+            return formatfield(self._data['minimal_sibling'])
+        return na_text()
+
     # Is the polynomial polredabs'ed
     def is_reduced(self):
         if not self.haskey('reduced'):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -455,7 +455,7 @@ class WebNumberField:
         if 'is_minimal_sibling' in self._data:
             if self._data['is_minimal_sibling']:
                 return 'This field is its own minimal sibling'
-            return formatfield(self._data['minimal_sibling'])
+            return formatfield(self._data['minimal_sibling'], show_poly=True)
         return na_text()
 
     # Is the polynomial polredabs'ed


### PR DESCRIPTION
On number field pages, this displays the minimal sibling of the field.  The possibilities are

it is a different field: http://127.0.0.1:37777/NumberField/4.2.4107.1

it is the same field: http://127.0.0.1:37777/NumberField/4.0.117.1

we computed it, but it is not in the database (yet): http://127.0.0.1:37777/NumberField/6.0.932501808.1

not computed yet: http://127.0.0.1:37777/NumberField/20.0.287532152115567788032.1

I put it with the section on the Galois group since the idea is that there is only one per Galois closure, but an argument could be made to put it in the sibling section.