### PR TITLE
multiple cosmetic changes to abstract groups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -880,6 +880,13 @@ def show_factor(n):
         return "$0$"
     return f"${latex(ZZ(n).factor())}$"
 
+#for irrQ_degree and irrC_degree gives negative value as "-"
+def remove_negatives(n):
+    if n < 1:
+        return "-"
+    return n
+
+
 def get_url(label):
     return url_for(".by_label", label=label)
 
@@ -952,8 +959,8 @@ group_columns = SearchColumns([
     ProcessedCol("outer_order", "group.outer_aut", r"$\card{\mathrm{Out}(G)}$", show_factor, align="center", short_title="outer automorphisms", default=False),
     MathCol("transitive_degree", "group.transitive_degree", "Tr. deg", short_title="transitive degree", default=False),
     MathCol("permutation_degree", "group.permutation_degree", "Perm. deg", short_title="permutation degree", default=False),
-    MathCol("irrC_degree", "group.min_complex_irrep_deg", r"$\C$-irrep deg", short_title=r"$\C$-irrep degree", default=False),
-    MathCol("irrQ_degree", "group.min_rational_irrep_deg", r"$\Q$-irrep deg", short_title=r"$\Q$-irrep degree", default=False),
+    ProcessedCol("irrC_degree", "group.min_complex_irrep_deg", r"$\C$-irrep deg", remove_negatives, short_title=r"$\C$-irrep degree", default=False, align="center"),
+    ProcessedCol("irrQ_degree", "group.min_rational_irrep_deg", r"$\Q$-irrep deg", remove_negatives, short_title=r"$\Q$-irrep degree", default=False, align="center"),
     MultiProcessedCol("type", "group.type", "Type - length",
                       ["abelian", "nilpotent", "solvable", "smith_abelian_invariants", "nilpotency_class", "derived_length", "composition_length"],
                       show_type,

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -733,10 +733,9 @@ def auto_gens(label):
     return render_template(
         "auto_gens_page.html",
         gp=gp,
-        title="Generators of automorphism group for %s" % label,
-        bread=get_bread([("Automorphism group generators", " ")]),
-        learnmore=learnmore_list(),
-    )
+        title="Generators of automorphism group for $%s$" % gp.tex_name,
+        bread=get_bread([(label, url_for(".by_label", label=label)), ("Automorphism group generators", " ")]),
+                        )
 
 
 @abstract_page.route("/sub/<label>")

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -584,6 +584,7 @@
 <p>
 
 
+
 {% if not gp.rational_characters and gp.number_conjugacy_classes == None %}
 
    <p> The character tables for this group have not been computed. </p>
@@ -591,6 +592,17 @@
 {% else %}  
 
    <h3>{{KNOWL('group.complex_character_table','Complex character table')}}</h3>
+
+     {% if gp.number_divisions == gp.number_conjugacy_classes %}
+
+        <p>
+           Every character has rational values, so the {{KNOWL('group.complex_character_table','complex character table')}} is the same as the rational character table below.
+        </p>
+
+
+   {% else %}
+
+
 
    {% if gp.number_conjugacy_classes == None %}
                                                                                                                              
@@ -626,16 +638,9 @@
 
 {% endif %}
 
-      {% if gp.number_divisions == gp.number_conjugacy_classes %}
-
-        <p>
-           Every character has rational values, so the {{KNOWL('group.rational_character_table','rational character table')}} is the same as the complex character table.
-        </p>
 
 
-   {% else %}
-  
-
+{% endif %}
 
 <h3>{{KNOWL('group.rational_character_table','Rational character table')}}</h3>
 
@@ -654,7 +659,6 @@
   <p>
     See the <a href="{{url_for('.Qchar_table', label=gp.label)}}">${{gp.number_divisions}} \times {{gp.number_divisions}}$ rational character table</a>.
   </p>
-{% endif %}
 {% endif %}
 {% endif %}
 {% endif %} {# gp.live() #}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -162,7 +162,7 @@
   <tr>
     <td>{{KNOWL('group.rank', 'Rank')}}:</td>
     {% if gp.rank %}
-      <td>${{gp.rank}}$</td>
+      <td>{{gp.rank}}</td>
     {% else %}
       <td>not computed</td>
     {% endif %}
@@ -170,7 +170,7 @@
   <tr>
     <td>{{KNOWL('group.generators', 'Inequivalent ' + gp.gen_noun())}}:</td>
   {% if gp.eulerian_function != None %}
-    <td>${{gp.eulerian_function}}$</td>
+    <td>{{gp.eulerian_function}}</td>
     {% else %} <td>not computed</td> {% endif %}
   </tr>
 </table>
@@ -309,8 +309,8 @@
   <tr>
     <td>{{KNOWL('group.commutator_length', 'Commutator length')}}:</td>
      {% if gp.commutator_count %}
-      <td>${{gp.commutator_count}}$</td>
-    {% elif gp.abelian %} <td>$0$</td>
+      <td>{{gp.commutator_count}}</td>
+    {% elif gp.abelian %} <td>0</td>
     {% else %} <td>not computed</td> {% endif %}
   </tr>
   {% endif %}

--- a/lmfdb/groups/abstract/templates/auto_gens_page.html
+++ b/lmfdb/groups/abstract/templates/auto_gens_page.html
@@ -1,9 +1,9 @@
 
-{% extends "base.html" %}
+{% extends "homepage.html" %}
 
-{% block body %}
+{% block content %}
 
-<br>
+
 
 <p>
   &nbsp; Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by its image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
@@ -33,6 +33,16 @@
     </table>
 </p>
 
+{% endblock %}
 
 
+{# Hack to remove the sidebar and move main content over #}
+{% block sidebar %}
+<style>
+#main {
+  margin:  0px 0px 0px 0px;
+  padding: 0px 0px 0px 10px;
+  min-height:600px;
+}
+</style>
 {% endblock %}

--- a/lmfdb/groups/abstract/templates/character_table_page.html
+++ b/lmfdb/groups/abstract/templates/character_table_page.html
@@ -2,6 +2,9 @@
 
 {% block body %}
 
+Return to the group page:  <a href="{{url_for("abstract.by_label", label=gp.label)}}">{{gp.label}}</a><br><br>
+
+
 {% include 'character_table.html' %}
 
 {% endblock %}

--- a/lmfdb/groups/abstract/templates/rational_character_table.html
+++ b/lmfdb/groups/abstract/templates/rational_character_table.html
@@ -27,7 +27,7 @@
   {% endif %}
   {% for chtr in gp.rational_characters %}
     <tr>
-      <td> {{ chtr.display_knowl() | safe }}</td>{% if gp.has_nontrivial_schur_character %}<td> {% if chtr.schur_index != 1 %} {{chtr.schur_index}} {% endif %} </td> {% endif %}
+      <td> {{ chtr.display_knowl() | safe }}</td>{% if gp.has_nontrivial_schur_character %}<td class="center"> {% if chtr.schur_index != 1 %} {{chtr.schur_index}} {% endif %} </td> {% endif %}
       {% for c in gp.conjugacy_class_divisions %}
         <td class="right">${{ chtr.qvalues[c.classes.0.counter - 1] }}$</td>
       {% endfor %}

--- a/lmfdb/groups/abstract/templates/rational_character_table.html
+++ b/lmfdb/groups/abstract/templates/rational_character_table.html
@@ -22,9 +22,11 @@
     </tr>
   {% endfor %}
 
+<tr><td></td><td>{{KNOWL('group.representation.schur_index', 'Schur index')}}</td></tr>
+    
   {% for chtr in gp.rational_characters %}
     <tr>
-      <td> {{ chtr.display_knowl() | safe }}</td><td></td>
+      <td> {{ chtr.display_knowl() | safe }}</td><td> {{chtr.schur_index}} </td>
       {% for c in gp.conjugacy_class_divisions %}
         <td class="right">${{ chtr.qvalues[c.classes.0.counter - 1] }}$</td>
       {% endfor %}

--- a/lmfdb/groups/abstract/templates/rational_character_table_page.html
+++ b/lmfdb/groups/abstract/templates/rational_character_table_page.html
@@ -2,6 +2,9 @@
 
 {% block body %}
 
+Return to the group page:  <a href="{{url_for("abstract.by_label", label=gp.label)}}">{{gp.label}}</a><br><br>
+
+
 {% include 'rational_character_table.html' %}
 
 {% endblock %}

--- a/lmfdb/groups/abstract/verify.py
+++ b/lmfdb/groups/abstract/verify.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#from lmfdb.groups.abstract import verify
+#TO DO:  subgroups, larger order + 1024
+
+
+from lmfdb import db
+from sage.all import libgap
+
+def test_small_gps(sample_gp):
+    print(sample_gp['label'])
+
+    if sample_gp['order'] != 1024:  #1024 doesn't have standard labels, need to construct another way
+        #create corresponding GAP group
+        id_nums = sample_gp['label'].split(".")
+        G = libgap.SmallGroup(int(id_nums[0]),int(id_nums[1]))
+        #Confirm group order matches
+        print("Group orders match: " + str(sample_gp['order'] == libgap.Order(G)))
+        #Confirm IsAbelian returns same value
+        print("Groups abelian-ness match: " + str((sample_gp['abelian']) == bool(libgap.IsAbelian(G))))
+        #Confirm IsSimple returns same value   
+        print("Groups simple-ness match: " + str((sample_gp['simple']) == bool(libgap.IsSimple(G))))
+        #Confirm IsPerfect returns same value
+        print("Groups perfect-ness match: " + str((sample_gp['perfect']) == bool(libgap.IsPerfect(G))))
+        #Confirm IsMonomial returns same value
+        print("Groups monomial-ness match: " + str((sample_gp['monomial']) == bool(libgap.IsMonomial(G))))
+
+        #Confirm number of non-conjugate subgroups (if known in database)
+        if sample_gp['number_subgroup_classes']:
+            SubLat = libgap.LatticeSubgroups(G)
+            Cons =  libgap.ConjugacyClassesSubgroups(SubLat)
+            print ("Number of subgroup classes match: "  + str(libgap.Size(Cons) == sample_gp['number_subgroup_classes']))
+        if sample_gp['number_normal_subgroups']:
+            NormLat = libgap.NormalSubgroups(G)
+            print ("Number of normal subgroups match: " + str(libgap.Size(NormLat) == sample_gp['number_normal_subgroups']))
+
+
+        # check if minimal permutation  degrees match
+        if sample_gp['permutation_degree']:
+            minpermdeg_gap = libgap.MinimalFaithfulPermutationDegree(G)
+            print("Minimal permutation degrees match: " + str(minpermdeg_gap == sample_gp['permutation_degree']))
+
+            
+        # check order stats
+        stupid_str = 'Set(ConjugacyClasses(SmallGroup(' +  id_nums[0]+ ',' + id_nums[1] + ")), z->Order(Representative(z))) "
+        ords = libgap.eval(stupid_str)
+
+        ordsLMFDB = []
+        ords_list = sample_gp['order_stats']
+        for i in range(len(ords_list)):
+            ordsLMFDB.append(ords_list[i][0])
+        print("Order set matches: " + str(ords == ordsLMFDB))    
+        #print(ords,ordsLMFDB)
+
+        #check degrees
+        irr_stats =  sample_gp['irrep_stats']
+        degLMFDB = []
+        for i in range(len(irr_stats)):
+            for j in range(irr_stats[i][1]):
+                degLMFDB.append(irr_stats[i][0])
+        stupid_str_2 = 'List(Irr(SmallGroup(' + id_nums[0] + ',' + id_nums[1]+    ')), z -> z[1])'
+        degs = libgap.eval(stupid_str_2)
+
+        print("Degrees of characters match: " + str(degs == degLMFDB))
+        #print(degs,degLMFDB)
+
+
+#pick random group of order <= 2000 from DB
+
+for i in range(10):
+    x  = db.gps_groups_test.random({'order': {"$lte" :2000}})
+    sample_gp =db.gps_groups_test.lucky({'label': x})                                                                                    
+    test_small_gps(sample_gp)

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -840,7 +840,7 @@ class WebAbstractGroup(WebObj):
             elif self.number_characteristic_subgroups is None:
                 return """There are <a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, normal='yes')) + """ "> """ +str(self.number_normal_subgroups) + " normal</a> subgroups.  <p>"+normalcolor
             else:
-                ret_str = """ There are  <a href=" """ +str(url_for('.index', search_type='Subgroups', ambient=self.label)) + """ "> """ +str(self.number_normal_subgroups) + """ normal subgroups</a>"""
+                ret_str = """ There are  <a href=" """ +str(url_for('.index', search_type='Subgroups', ambient=self.label, normal='yes')) + """ "> """ +str(self.number_normal_subgroups) + """ normal subgroups</a>"""
                 if self.number_characteristic_subgroups < self.number_normal_subgroups:
                     ret_str = ret_str + """ (<a href=" """ + str(url_for('.index', search_type='Subgroups', ambient=self.label, characteristic='yes')) + """ ">""" + str(self.number_characteristic_subgroups) + " characteristic</a>).<p>"+charcolor+"  "+normalcolor
                 else:


### PR DESCRIPTION
This PR is for a bunch of cosmetic changes to the abstract groups pages.

I. Fixes a bug where we have a link for normal subgroups but the search returned all subgroups, not just normal subgroups. See group 150493593600000000.b and scroll down to "There are 6 normal subgroups" in the Subgroups section to see the difference between beta and local. 

II. Made rank, inequivalent generating pairs, and commutator length NOT LaTeX to match the fonts for other integer values on the pages. Compare for group 8.4 in beta vs local.

III. Added the header and footer in each LMFDB page to complex character table pages, rational character table pages, and pages for generators of the automorphism groups.  This allows for the breadcrumb to the ambient group.  We will need this feature once we create a search page on characters. (The link for the search will be to the character table and a user may want to then go on to the group itself.)
/Groups/Abstract/auto_gens/1728.10278
/Groups/Abstract/char_table/1728.10278
/Groups/Abstract/Qchar_table/1728.10278

IV. Added Schur index as a column in rational character tables if there are any nontrivial Schur indices. I will edit the schur index knowl tomorrow to give an actual definition.
Check out the rational character table for group 63.1 to see an example.

V. After adding Schur index, the rational character table had more information than the complex character table so we also switched which one is displayed when they are the same.  See group 8.4 again.