### PR TITLE
Move nilpotency on Galois group pages

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -325,7 +325,7 @@ def render_group_webpage(args):
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
         data['nilpotency'] = '$%s$' % data['nilpotency']
         if data['nilpotency'] == '$-1$':
-            data['nilpotency'] += ' (not nilpotent)'
+            data['nilpotency'] = ' not nilpotent'
         downloads = []
         for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("SageMath", "sage")]:
             downloads.append(('Code to {}'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -27,7 +27,6 @@ table.reptable td, table.reptable th {
       <td>{{ place_code('even') }}</td></tr>
       <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</td>
       <td>{{ place_code('primitive') }}</td></tr>
-      <tr><td class="nowrap">{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</td>
       <td>{{ place_code('nilpotent') }}</td></tr>
       <tr><td class="nowrap">{{KNOWL('gg.field_automorphisms', '$\card{\Aut(F/K)}$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</td>
       <td>{{ place_code('auts') }}</td></tr>
@@ -97,6 +96,7 @@ table.reptable td, table.reptable th {
       <td>{{place_code('abelian')}}</td></tr>
       <tr><td>{{KNOWL('group.solvable', 'Solvable')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.solv)}}</td>
       <td>{{place_code('solvable')}}</td></tr>
+      <tr><td class="nowrap">{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</td>
       <tr><td>{{KNOWL('group.small_group_label','Label')}}:<td>&nbsp;&nbsp;<td>{{info.groupid | safe}}
       <td>{{place_code('id')}}</td></tr>
     </table>


### PR DESCRIPTION
Nilpotency class is an invariant of the group, not of the group action.  This moves it to the right section.

When the group is not nilpotent, we now just say that instead of saying the class is -1 (an internal convention) as well.

Example which is nilpotent

http://127.0.0.1:37777/GaloisGroup/8T22
http://beta.lmfdb.org/GaloisGroup/8T22

and one where it is not

http://127.0.0.1:37777/GaloisGroup/8T14
http://beta.lmfdb.org/GaloisGroup/8T14