### PR TITLE
Style sheet update: no math mode for tables of integers.

### DIFF
--- a/StyleSheet.md
+++ b/StyleSheet.md
@@ -34,7 +34,7 @@ contains other conventions and information for the development process.
 - Search results table should use row striping (ntdata table), headings should all have knowls (or pseudo-knowls).
 - Refine search page headings should have the form "Blah search results", where blah is singular.
 - Refine search pages should have captions above input boxes, no example to right, gray example inside input box.
-- Mathematical values listed in search results, including integers, should be in math mode.
+- Mathematical values listed in search results, including integers, should be in math mode, with the exception of tables whose entries are integers.
 - Search result values that are words (e.g. even/odd, not computed, trivial, etc...) should be lower case in the default html font (not \mathrm).
 - Boolean values in search results that indicate the presence of a property (e.g. IsSolvable) should generally use a checkmark &#x2713; for yes, blank for no, with the checkmark centered.
 - Labels and lists (e.g. Weierstrass coefficients) in search results should be left-aligned.
@@ -50,7 +50,7 @@ contains other conventions and information for the development process.
 - Content captions should be knowls (or contain a knowl) and be followed by colons.
 - Any invariant listed in the properties box should also appear in the body (or header) of the page -- all information should be visible even with the property box closed.
 - Values that are words (e.g yes/no, even/odd, Trivial) should be in lower case using the default (sans serif) font
-- Mathematical values including integers should be displayed in math mode.
+- Mathematical values including integers should be displayed in math mode, with the exception of tables whose entries are integers.
 - Factorizations of negative numbers should include only the sign, not -1 (use web_latex_factored_integer in utilities.py).
 - Mathematical values, including integers, should be in math mode.
 - Values that are words (e.g. yes/no, even/odd, not computed, trivial, etc...) should be lower case in the default html font (not \mathrm).


### PR DESCRIPTION
This PR updates the style sheet to exclude tables of integers from the provision that mathematical data (including integers) should generally be displayed in math mode.  This mostly agrees wtih current practice (e.g. [CMF dimension tables](https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/?search_type=SpaceDimensions) and [p-adic field counts](https://www.lmfdb.org/padicField/) do not use math mode) and is desirable because it reduces page render times, especially when the tables are large.

As noted in the discussion on #5755, the style guide is not always consistently followed  (especially on newer pages).  It would be good to correct instances of this as and when they are noticed, and to review new PRs with the style guide in mind.  If there are cases where conforming to the style guide seems undesirable, please open an issue where it can be discussed (which may lead to changes to the style guide, as in this PR).  The style guide is meant to be used as a tool to help us create a consistent interface but it is not meant to bind us to any particular choice (there are always trade offs).