### PR TITLE
Small issue with rational char tables

### DIFF
--- a/lmfdb/groups/abstract/templates/rational_character_table.html
+++ b/lmfdb/groups/abstract/templates/rational_character_table.html
@@ -27,7 +27,7 @@
   {% endif %}
   {% for chtr in gp.rational_characters %}
     <tr>
-      <td> {{ chtr.display_knowl() | safe }}</td>{% if gp.has_nontrivial_schur_character %}<td class="center"> {% if chtr.schur_index != 1 %} {{chtr.schur_index}} {% endif %} </td> {% endif %}
+      <td> {{ chtr.display_knowl() | safe }}</td><td class="center"> {% if chtr.schur_index != 1 %} {{chtr.schur_index}} {% endif %} </td> 
       {% for c in gp.conjugacy_class_divisions %}
         <td class="right">${{ chtr.qvalues[c.classes.0.counter - 1] }}$</td>
       {% endfor %}


### PR DESCRIPTION
A recent PR introduced a small bug.  The rational character tables with only trivial schur indices had their  columns shifted by one (the first column of #s didn't match the corresponding header column)

See
http://localhost:37777/Groups/Abstract/465.2
vs
https://beta.lmfdb.org/Groups/Abstract/465.2