### PR TITLE
Fix bug in fiber product search

### DIFF
--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -37,6 +37,7 @@ from lmfdb.utils import (
     comma,
     proportioners,
     totaler,
+    key_for_numerically_sort
 )
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import (
@@ -287,7 +288,7 @@ def modcurve_jump(info):
             flash_error("Fiber product decompositions cannot contain repeated terms")
             return redirect(url_for(".index"))
         # Get list of all factors, lexicographically sorted
-        factors = sorted(sum(factors, []), key=lambda x:[int(i) for i in x.split(".")])
+        factors = sorted(sum(factors, []), key=key_for_numerically_sort)
         label = db.gps_gl2zhat_fine.lucky({'factorization': factors}, "label")
         if label is None:
             flash_error("There is no modular curve in the database isomorphic to the fiber product %s", info["jump"])


### PR DESCRIPTION
Try typing `2.3.0.1*7.28.0.1` into the jump box for modular curves.  It fails before this PR with an error message about casting `a` to an int, and works now.