### PR TITLE
evidently none isn't always none

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -879,7 +879,7 @@ def show_factor(n):
 
 #for irrQ_degree and irrC_degree gives negative value as "-"
 def remove_negatives(n):
-    if n is None:
+    if n is None or  n == "":
         return "?"
     elif int(n) < 1:
         return "-"


### PR DESCRIPTION
Some group searches are failing on beta because I forgot to add an option for the empty string instead of None.

For example, search groups in the range below and you get  a server error because irrQ_degree or irrC_degree is None but being passed to a function as "".:

https://beta.lmfdb.org/Groups/Abstract/?order=190000-200000