### PR TITLE
Issue with element decoding on gps pages

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1646,30 +1646,24 @@ class WebAbstractGroup(WebObj):
         vec = []
         if code < 0 or code >= self.order:
             raise ValueError
-#        for m in reversed(self.pcgs_relative_orders):
         for m in self.pcgs_relative_orders:
             c = code % m
-#            vec.insert(0, c)
             vec.append(c)
             code = code // m
-        print("vec:", vec)    
         if as_str:
             # Need to combine some generators
             w = []
             e = 0
-            for i, (c, m) in reversed(list(enumerate(zip(vec, self.pcgs_relative_orders)))):
-                print("i:",i," c:",c," m:",m)
+            for i, (c, m) in reversed(list(enumerate(zip(vec, reversed(self.pcgs_relative_orders))))):
                 e += c
                 if i + 1 in self.gens_used:
                     w.append(e)
                     e = 0
                 else:
                     e *= m
-            print("w unreversed:", w)
             w.reverse()
             s = ""
             for i, c in enumerate(w):
-                print("i and c in w:", i, c)
                 if c == 1:
                     s += var_name(i)
                 elif c != 0:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1646,24 +1646,30 @@ class WebAbstractGroup(WebObj):
         vec = []
         if code < 0 or code >= self.order:
             raise ValueError
-        for m in reversed(self.pcgs_relative_orders):
+#        for m in reversed(self.pcgs_relative_orders):
+        for m in self.pcgs_relative_orders:
             c = code % m
-            vec.insert(0, c)
+#            vec.insert(0, c)
+            vec.append(c)
             code = code // m
+        print("vec:", vec)    
         if as_str:
             # Need to combine some generators
             w = []
             e = 0
             for i, (c, m) in reversed(list(enumerate(zip(vec, self.pcgs_relative_orders)))):
+                print("i:",i," c:",c," m:",m)
                 e += c
                 if i + 1 in self.gens_used:
                     w.append(e)
                     e = 0
                 else:
                     e *= m
+            print("w unreversed:", w)
             w.reverse()
             s = ""
             for i, c in enumerate(w):
+                print("i and c in w:", i, c)
                 if c == 1:
                     s += var_name(i)
                 elif c != 0:


### PR DESCRIPTION
This PR fixes an error with decoding elements of groups (just an error with  lists that weren't reversed at the right times).   

I. This code is used to display the generators of subgroups.   Take D4 as an example. On beta we claim that the normal subgroup of order 2 is generated by the generator of order 2. It is instead generated by the square of the generator of order 4:
https://beta.lmfdb.org/Groups/Abstract/sub/8.3.4.a1.a1
vs
http://localhost:37777/Groups/Abstract/sub/8.3.4.a1.a1

Or one of the subgroup of order 4 which on beta the listed generators generate the whole group.  
https://beta.lmfdb.org/Groups/Abstract/sub/8.3.2.a1.a1
vs
http://localhost:37777/Groups/Abstract/sub/8.3.2.a1.a1


II. The code is used to display automorphism group generators.Take C12 where the generators of the automorphisms should send a to a^k where k \in {5,7,11}.  Note that beta has something completely different.

https://beta.lmfdb.org/Groups/Abstract/auto_gens/12.2
vs
http://localhost:37777/Groups/Abstract/auto_gens/12.2 
