### PR TITLE
Fix errors with groups of Lie type

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2255,7 +2255,7 @@ def cc_data(gp, label, typ="complex"):
         else:
             gp_value = WebAbstractGroup(gp)
             if gp_value.representations.get("Lie"):
-                if gp_value.representations["Lie"][0]["family"][0] == "P":  #Problem with projective lie groups
+                if gp_value.representations["Lie"][0]["family"][0] == "P" and  gp_value.order < 2000:  #Problem with projective lie groups of order <2000
                     pass
                 else:
                     repn = gp_value.decode(wacc.representative, as_str=True)

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1717,10 +1717,23 @@ class WebAbstractGroup(WebObj):
 
     def _matrix_coefficient_data(self, rep_type, as_str=False):
         rep_data = self.representations[rep_type]
+        sq_flag = False # used later for certain groups
         if rep_type == "Lie":
-            rep_type = "GLFq"
             rep_data = rep_data[0]
-        d = rep_data["d"]
+            d = rep_data["d"]
+            rep_type = "GLFq"
+            fam = rep_data['family']
+            if fam == "AGL" or fam == "ASL" or fam == "Spin":
+                d += 1 #for AGL and ASL the matrices are in GL(d+1,q)
+            elif fam == "CSU" or fam == "CU" or fam == "GU" or fam == "SU" or fam == "PSU":
+                sq_flag = True #need q^2 instead of q
+            elif fam == "SpinPlus":
+                d = 2**(d//2)  #d should always be even in these cases
+            elif fam == "SpinMinus":
+                d = 2**(d//2)  #d always even
+                sq_flag = True  #also need q^2 instead of q in this case
+        else:
+            d = rep_data["d"]
         k = 1
         if rep_type == "GLZ":
             N = rep_data["b"]
@@ -1736,6 +1749,8 @@ class WebAbstractGroup(WebObj):
             R = rf"\Z/{N}\Z" if as_str else Zmod(N)
         elif rep_type == "GLFq":
             q = ZZ(rep_data["q"])
+            if sq_flag:
+                q = q**2
             R = rf"\F_{{{q}}}" if as_str else GF(q)
             N, k = q.is_prime_power(get_data=True)
             if k == 1:
@@ -1743,7 +1758,7 @@ class WebAbstractGroup(WebObj):
                 rep_type = "GLFp"
         return R, N, k, d, rep_type
 
-    def decode_as_matrix(self, code, rep_type, as_str=False):
+    def decode_as_matrix(self, code, rep_type, as_str=False, LieType = False):
         R, N, k, d, rep_type = self._matrix_coefficient_data(rep_type)
         L = ZZ(code).digits(N)
 
@@ -1757,6 +1772,8 @@ class WebAbstractGroup(WebObj):
             L = [c - shift for c in L]
         x = matrix(R, d, d, L)
         if as_str:
+            if LieType and self.representations["Lie"][0]["family"][0] == "P":
+                return "\left[" + latex(x) + "\\right]"
             return latex(x)
         return x
 
@@ -1767,6 +1784,8 @@ class WebAbstractGroup(WebObj):
             return self.decode_as_perm(code, as_str=as_str)
         elif rep_type == "PC":
             return self.decode_as_pcgs(code, as_str=as_str)
+        elif rep_type == "Lie":  #check for projective families to add "[ ]"
+            return self.decode_as_matrix(code,rep_type=rep_type,as_str=as_str, LieType = True)
         else:
             return self.decode_as_matrix(code, rep_type=rep_type, as_str=as_str)
 
@@ -1780,9 +1799,12 @@ class WebAbstractGroup(WebObj):
             return list(range(1, 1 + len(self.G.GeneratorsOfGroup())))
         return self.representations["PC"]["gens"]
 
+    #JP CHECK HERE
     def show_subgroup_flag(self):
         if self.representations.get("Lie"):
-            if self.representations["Lie"][0]["family"][0] == "P": 	# Issue with projective Lie groups
+#            print("HERE AND order:", self.order < 2000, " and P:",self.representations["Lie"][0]["family"]a)
+            if self.representations["Lie"][0]["family"][0] == "P" and self.order < 2000: # Issue with projective Lie groups
+                print("GOT HERE")
                 return False
         return True
 
@@ -1941,14 +1963,7 @@ class WebAbstractGroup(WebObj):
         if rep_type != "PC":
             rdata = self.representations[rep_type]
         if rep_type == "Lie":
-            if self.element_repr_type == "Lie":
-                # Omit first description since it's used in the latex name
-                desc = "Other groups of " + display_knowl("group.lie_type", "Lie type")
-                rdata = rdata[1:]
-                if not rdata:
-                    return ""
-            else:
-                desc = "Groups of " + display_knowl("group.lie_type", "Lie type")
+            desc = "Groups of " + display_knowl("group.lie_type", "Lie type")
             reps = ", ".join([fr"$\{rep['family']}({rep['d']},{rep['q']})$" for rep in rdata])
             return f'<tr><td>{desc}:</td><td colspan="5">{reps}</td></tr>'
         elif rep_type == "PC":
@@ -2160,11 +2175,12 @@ class WebAbstractGroup(WebObj):
     def aut_order_factor(self):
         return latex(factor(self.aut_order))
 
-    def aut_gens_flag(self): #issue with Lie type when family is projective
+
+    def aut_gens_flag(self): #issue with Lie type when family is projective, auto stored as permutations often
         if self.aut_gens is None:
             return False
         elif self.element_repr_type == "Lie":
-            if self.representations["Lie"][0]["family"][0] == "P":
+            if self.representations["Lie"][0]["family"][0] == "P": 
                 return False
         return True
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1725,7 +1725,7 @@ class WebAbstractGroup(WebObj):
             fam = rep_data['family']
             if fam == "AGL" or fam == "ASL" or fam == "Spin":
                 d += 1 #for AGL and ASL the matrices are in GL(d+1,q)
-            elif fam == "CSU" or fam == "CU" or fam == "GU" or fam == "SU" or fam == "PSU":
+            elif fam == "CSU" or fam == "CU" or fam == "GU" or fam == "SU" or fam == "PSU" or fam == "PGU":
                 sq_flag = True #need q^2 instead of q
             elif fam == "SpinPlus":
                 d = 2**(d//2)  #d should always be even in these cases
@@ -1799,12 +1799,9 @@ class WebAbstractGroup(WebObj):
             return list(range(1, 1 + len(self.G.GeneratorsOfGroup())))
         return self.representations["PC"]["gens"]
 
-    #JP CHECK HERE
     def show_subgroup_flag(self):
         if self.representations.get("Lie"):
-#            print("HERE AND order:", self.order < 2000, " and P:",self.representations["Lie"][0]["family"]a)
             if self.representations["Lie"][0]["family"][0] == "P" and self.order < 2000: # Issue with projective Lie groups
-                print("GOT HERE")
                 return False
         return True
 


### PR DESCRIPTION
This PR fixes some server errors caused by elements of particular groups of Lie type which were not decoding correctly.

Specifically groups of the form *(n,q) where * is CSU, CU, SU, GU, and PSU consist of matrices with entries in the field with q^2 elements, not q elements.  And if * is AGL, ASL, or Spin, the matrices are of dimension n+1, not n.   

When * is Spin+ and Spin-, we have matrices of dimension 2^(n/2), and for Spin- we also have q^2 instead of q for the size of the field the elements are in.

Here are a few group IDs to try (click on "generators" of the automorphism group or if there is a complex character table, click on the knowl for the conjugacy classes to see a representative). These all cause errors on beta (other examples don't necessarily cause errors on beta but are not correctly decoded matrices).

98784.a         AGL(2,7)
151632.a        ASL(3,3)
240.89           CSU(2,5)
20462400.a  CU(2,29)
291456.a        GU(2,23)



I also took this opportunity to show representatives of projective groups in many cases (basically if the order of the group is >2000 then group elements stored in the DB are correct, except for the automorphism group generators which are given as permutations not matrices).  This partially fixes #5562 in many cases. I added "[ ]" around each matrix to indicate that the element we are showing is really the equivalence class of the given matrix.  Suggestions for whether this is appropriate notation, and if we should make this choice of notation more clear, are welcome.

Here are some group IDs, (again, you can see by following the knowl for conjugacy classes in the complex character tables where you will see a representative which doesn't exist in beta). 
6072.a           PSL(2,23)
4680000.a   PSp(4,5)
378000.b      PGU(3,5)
1030200.b    PGL(2,101)

We also now show generators of subgroups for most projective groups
Here are PSL(2,23) subgroups and if you click on any of them you now see generators of the subgroup on the page for each subgroup
http://localhost:37777/Groups/Abstract/?ambient=6072.a&search_type=Subgroups




I also changed the "Construction" section to always show Lie type even if the name of the group matches the particular family.  This fixes an issue that is on the master branch but not yet on production. If you compare the master branch to this and look at 168.42 you'll see that PSL(2,7) is not listed for this group on master but is listed on this branch.