### PR TITLE
Add minimal sibling to search

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1178,7 +1178,7 @@ class NFSearchArray(SearchArray):
             example_span="[8,3], 8.3, C5 or 7T2")
         is_galois = YesNoBox(
             name="is_galois",
-            label="Is Galois",
+            label="Galois",
             knowl="nf.galois_group")
         regulator = TextBox(
             name="regulator",

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -917,6 +917,7 @@ def number_field_search(info, query):
     parse_posints(info,query,'index')
     parse_primes(info,query,'inessentialp',name='Inessential primes',
                  qfield='inessentialp', mode=info.get('inessential_quantifier'))
+    parse_bool(info,query,'is_minimal_sibling')
     info['wnf'] = WebNumberField.from_data
     info['gg_display'] = group_pretty_and_nTj
 
@@ -1165,6 +1166,10 @@ class NFSearchArray(SearchArray):
             name="cm_field",
             label="CM field",
             knowl="nf.cm_field")
+        is_minimal_sibling = YesNoBox(
+            name="is_minimal_sibling",
+            label="Minimal sibling",
+            knowl="nf.minimal_sibling")
         gal = TextBox(
             name="galois_group",
             label="Galois group",
@@ -1255,10 +1260,10 @@ class NFSearchArray(SearchArray):
             [regulator, subfield],
             [completion, monogenic],
             [index, inessentialprimes],
-            [count]]
+            [count, is_minimal_sibling]]
 
         self.refine_array = [
             [degree, signature, class_number, class_group, cm_field],
             [num_ram, ram_primes, ur_primes, gal, is_galois],
             [discriminant, rd, regulator, subfield, completion],
-            [monogenic, index, inessentialprimes]]
+            [is_minimal_sibling, monogenic, index, inessentialprimes]]


### PR DESCRIPTION
Now that we have minimal sibling information for more than 99% of the number field database, this adds it as a search option.  You can compare the counts for

D_4 quartic which is not a minimal sibling:
http://127.0.0.1:37777/NumberField/?degree=4&galois_group=d4&is_minimal_sibling=no
D_4 quartic which is a minimal sibling:
http://127.0.0.1:37777/NumberField/?degree=4&galois_group=d4&is_minimal_sibling=yes
D_4 quartic, both cases:
http://127.0.0.1:37777/NumberField/?degree=4&galois_group=d4