### PR TITLE
More updates to groups pages

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -34,7 +34,7 @@ function get_all_embeddings(num_embeddings) {
 <table class="ntdata complex-cols">
   <thead>
     <tr>
-      <th class="sticky-head dark" style="min-width: 40px;">&nbsp;&nbsp;{{ KNOWL('cmf.embedding_label', 'Label')}}</th>
+      <th class="sticky-head dark" style="min-width: 40px;">{{ KNOWL('cmf.embedding_label', 'Label')}}&nbsp;&nbsp;</th>
       {% if newform.has_exact_qexp %}
       <th class="sticky-head dark center" style="left: 60px;">\(\iota_m(\nu)\)</th>
       {% endif %}

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -34,7 +34,7 @@ function get_all_embeddings(num_embeddings) {
 <table class="ntdata complex-cols">
   <thead>
     <tr>
-      <th class="sticky-head dark" style="min-width: 40px;">{{ KNOWL('cmf.embedding_label', title='Label')}}</th>
+      <th class="sticky-head dark" style="min-width: 40px;">&nbsp;&nbsp;{{ KNOWL('cmf.embedding_label', 'Label')}}</th>
       {% if newform.has_exact_qexp %}
       <th class="sticky-head dark center" style="left: 60px;">\(\iota_m(\nu)\)</th>
       {% endif %}

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1207,7 +1207,6 @@ def diagram_js_string(gp, only=None):
 def render_abstract_group(label, data=None):
     from lmfdb.app import add_colors #need color for table background color
     even_color = add_colors()["color"]["col_main_ll"]
-    print(even_color)
 
     info = {}
     if data is None:
@@ -2240,7 +2239,6 @@ def cc_data(gp, label, typ="complex"):
             return "Data for conjugacy class {} missing.".format(label)
         classes = div.classes
         wacc = classes[0]
-        print("HERE IS WACC:", wacc)
         mult = len(classes)
         ans = "<h3>Rational conjugacy class {}</h3>".format(label)
         if mult > 1:

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -731,17 +731,15 @@ def by_abelian_label(label):
 def auto_gens(label):
     label = clean_input(label)
     gp = WebAbstractGroup(label)
-#    info['grp_reps_line'] = gp.representative_string(other_page = True) 
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if gp.aut_gens is None:
-        flash_error("The generators for the automorphism group of the group with label  %s have not been computed.", label)
+        flash_error("The generators for the automorphism group of the group with label %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))
     return render_template(
         "auto_gens_page.html",
         gp=gp,
- #       info=info,
         title="Generators of automorphism group for $%s$" % gp.tex_name,
         bread=get_bread([(label, url_for(".by_label", label=label)), ("Automorphism group generators", " ")]),
                         )
@@ -764,7 +762,7 @@ def char_table(label):
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if not gp.complex_characters_known:
-        flash_error("The complex characters for the group with label  %s have not been computed.", label)
+        flash_error("The complex characters for the group with label %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))
     return render_template(
         "character_table_page.html",
@@ -782,7 +780,7 @@ def Qchar_table(label):
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if not gp.rational_characters_known:
-        flash_error("The rational characters for the group with label  %s have not been computed.", label)
+        flash_error("The rational characters for the group with label %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))
     return render_template(
         "rational_character_table_page.html",

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1203,8 +1203,6 @@ def diagram_js_string(gp, only=None):
 
 # Writes individual pages
 def render_abstract_group(label, data=None):
-    from lmfdb.app import add_colors #need color for table background color
-    even_color = add_colors()["color"]["col_main_ll"]
 
     info = {}
     if data is None:
@@ -1219,9 +1217,7 @@ def render_abstract_group(label, data=None):
 
     info["boolean_characteristics_string"] = create_boolean_string(gp)
     info['pos_int_and_factor'] = pos_int_and_factor
-    info['even_color'] = str(even_color)      # "#E3F2FD" in current color
-    info['odd_color'] = "white"
-    
+
     if gp.live():
         title = f"Abstract group {label}"
         friends = []

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -735,7 +735,7 @@ def auto_gens(label):
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
-    if gp.aut_gens == None:
+    if gp.aut_gens is None:
         flash_error("The generators for the automorphism group of the group with label  %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))
     return render_template(

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -204,9 +204,12 @@
 <table class=nowrap>
   {{ gp.stored_representations | safe }}
 </table>
+
+{% if not gp.live() %}
 <p>
 {{ gp.repr_strg() |  safe }}
 </p>
+{% endif %}
 
 {% else %}
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -67,7 +67,6 @@
       </tr>
       <tr>
         <td>{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
-	<!--"#E3F2FD" -->
         {% for c in gp.cc_statistics %}
           <td>{{ c[1] }} </td>
         {% endfor %}
@@ -206,7 +205,7 @@
   {{ gp.stored_representations | safe }}
 </table>
 <p>
-{{ gp.repr_strg() |  safe }}  <!--JP-->
+{{ gp.repr_strg() |  safe }}
 </p>
 
 {% else %}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -47,10 +47,10 @@
 
 <p> {% if gp.order_stats != None %}
   <div class="table-scroll-wrapper">
-   <table class="ntdata" style="margin-left:0;">
+   <table class="ntdata onesticky" style="margin-left:0;">
     <thead>
       <tr>
-        <th class="embedding-wrap sticky-col border-right">{{KNOWL('group.element_order', 'Order')}}</th>
+        <th>{{KNOWL('group.element_order', 'Order')}}</th>
         {% for c in (gp.order_stats | sort) %}
           <th>{{ c[0] }} </th>
         {% endfor %}
@@ -59,14 +59,14 @@
     </thead>
     <tbody>
       <tr>
-        <td class="embedding-wrap sticky-col border-right">Elements</td>
+        <td>Elements</td>
         {% for c in (gp.order_stats | sort) %}
           <td>{{ c[1] }} </td>
         {% endfor %}
         <td class="border-left">{{ gp.order }}</td>
       </tr>
       <tr>
-        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
+        <td>{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
 	<!--"#E3F2FD" -->
         {% for c in gp.cc_statistics %}
           <td>{{ c[1] }} </td>
@@ -75,7 +75,7 @@
       </tr>
       {% if not gp.live() %}
       <tr>
-        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.division', 'Divisions')}}</td>
+        <td>{{KNOWL('group.division', 'Divisions')}}</td>
         {% for c in gp.div_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -83,7 +83,7 @@
       </tr>
       {% if gp.aut_statistics != None %}
       <tr style="border-bottom:none;">
-        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+        <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
         {% for c in gp.aut_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -92,7 +92,7 @@
       {% endif %}
       {% else %}
       <tr>
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.division', 'Divisions')}}</td>
+        <td>{{KNOWL('group.division', 'Divisions')}}</td>
           {% if gp.division_stats %}
             {% for c in gp.division_stats %}
               <td>{{ c[1] }}</td>
@@ -104,9 +104,9 @@
           {% endif %}
       </tr>
       <tr style="border-bottom:none;">
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
-          <td colspan="{{gp.order_stats|length}}">data not computed</td>
-          <td class="border-left"></td>
+        <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+        <td colspan="{{gp.order_stats|length}}">data not computed</td>
+        <td class="border-left"></td>
       </tr>
       {% endif %}
     </tbody>
@@ -119,9 +119,9 @@
 
 <p>
   <div class="table-scroll-wrapper"> 
-  <table class="ntdata" style="margin-left:0;">
+  <table class="ntdata onesticky" style="margin-left:0;">
     <thead>
-      <tr><th class="embedding-wrap sticky-col border-right">Dimension</th>
+      <tr><th>Dimension</th>
         {% for d in (gp.rep_dims) %}
           <th>{{ d }} </th>
         {% endfor %}
@@ -130,7 +130,7 @@
     </thead>
     <tbody>
       <tr>
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.representation.character', 'Irr. complex chars.')}} &nbsp;</td>
+        <td>{{KNOWL('group.representation.character', 'Irr. complex chars.')}} &nbsp;</td>
         {% for n in gp.irrep_statistics %}
           <td>{{ n }} </td>
         {% endfor %}
@@ -138,7 +138,7 @@
       </tr>
       {% if not gp.live() %}
       <tr style="border-bottom:none;">
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.representation.rational_character', 'Irr. rational chars.')}}</td>
+        <td>{{KNOWL('group.representation.rational_character', 'Irr. rational chars.')}}</td>
         {% for n in gp.ratrep_statistics %}
           <td>{{ n }} </td>
         {% endfor %}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -15,6 +15,13 @@
 <script type="text/javascript" src="{{ url_for('static', filename='graphs/graph.js') }}"></script>
 
 
+{% if gp.live() %}
+<p>
+  This group is not stored in the database. However, basic information about the group, computed on the fly, is listed below.
+  </p>
+{% endif %}
+
+
 <h2> Group information</h2>
 <p>
   <table>
@@ -38,13 +45,12 @@
 
 <h2>Group statistics</h2>
 
-<p>
-
-{% if gp.order_stats != None %}
-  <table class="ntdata" style="margin-left:0;">
+<p> {% if gp.order_stats != None %}
+  <div class="table-scroll-wrapper">
+   <table class="ntdata" style="margin-left:0;">
     <thead>
       <tr>
-        <th>{{KNOWL('group.element_order', 'Order')}}</th>
+        <th class="embedding-wrap sticky-col border-right">{{KNOWL('group.element_order', 'Order')}}</th>
         {% for c in (gp.order_stats | sort) %}
           <th>{{ c[0] }} </th>
         {% endfor %}
@@ -53,14 +59,15 @@
     </thead>
     <tbody>
       <tr>
-        <td>Elements</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>Elements</td>
         {% for c in (gp.order_stats | sort) %}
           <td>{{ c[1] }} </td>
         {% endfor %}
         <td class="border-left">{{ gp.order }}</td>
       </tr>
       <tr>
-        <td>{{KNOWL('group.conjugacy_class', 'Conjugacy classes')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
+	<!--"#E3F2FD" -->
         {% for c in gp.cc_statistics %}
           <td>{{ c[1] }} </td>
         {% endfor %}
@@ -68,7 +75,7 @@
       </tr>
       {% if not gp.live() %}
       <tr>
-        <td>{{KNOWL('group.division', 'Divisions')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.division', 'Divisions')}}</td>
         {% for c in gp.div_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -76,7 +83,7 @@
       </tr>
       {% if gp.aut_statistics != None %}
       <tr style="border-bottom:none;">
-        <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
         {% for c in gp.aut_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -85,7 +92,7 @@
       {% endif %}
       {% else %}
       <tr>
-        <td>{{KNOWL('group.division', 'Divisions')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.division', 'Divisions')}}</td>
           {% if gp.division_stats %}
             {% for c in gp.division_stats %}
               <td>{{ c[1] }}</td>
@@ -97,22 +104,24 @@
           {% endif %}
       </tr>
       <tr style="border-bottom:none;">
-        <td>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
           <td colspan="{{gp.order_stats|length}}">data not computed</td>
           <td class="border-left"></td>
       </tr>
       {% endif %}
     </tbody>
   </table>
+  </div> 
   {% endif %}
 </p>
 
 {% if gp.live() or gp.rational_characters %} {# for now, there are a few groups with p>511 dividing the order that do not have rational character tables #}
 
 <p>
+  <div class="table-scroll-wrapper"> 
   <table class="ntdata" style="margin-left:0;">
     <thead>
-      <tr><th>Dimension</th>
+      <tr><th class="embedding-wrap sticky-col border-right">Dimension</th>
         {% for d in (gp.rep_dims) %}
           <th>{{ d }} </th>
         {% endfor %}
@@ -121,7 +130,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>{{KNOWL('group.representation.character', 'Irr. complex chars.')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.representation.character', 'Irr. complex chars.')}} &nbsp;</td>
         {% for n in gp.irrep_statistics %}
           <td>{{ n }} </td>
         {% endfor %}
@@ -129,7 +138,7 @@
       </tr>
       {% if not gp.live() %}
       <tr style="border-bottom:none;">
-        <td>{{KNOWL('group.representation.rational_character', 'Irr. rational chars.')}}</td>
+        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.representation.rational_character', 'Irr. rational chars.')}}</td>
         {% for n in gp.ratrep_statistics %}
           <td>{{ n }} </td>
         {% endfor %}
@@ -138,6 +147,7 @@
       {% endif %}
     </tbody>
   </table>
+  </div>
 </p>
 
 {% endif %}
@@ -146,7 +156,7 @@
 
 
  {% if not gp.live() %}
-<h3>Minimal Presentations</h3>
+<h2>Minimal Presentations</h2>
 
 <p>
   <table>
@@ -195,6 +205,9 @@
 <table class=nowrap>
   {{ gp.stored_representations | safe }}
 </table>
+<p>
+{{ gp.repr_strg() |  safe }}  <!--JP-->
+</p>
 
 {% else %}
 
@@ -214,6 +227,10 @@
   </tr>
   </tr>
 </table>
+
+{% if not gp.live() %}
+{{ gp.repr_strg() |  safe }}
+{% endif %}
 
 {% endif %} {# not live and abelian #}
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -59,14 +59,14 @@
     </thead>
     <tbody>
       <tr>
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>Elements</td>
+        <td class="embedding-wrap sticky-col border-right">Elements</td>
         {% for c in (gp.order_stats | sort) %}
           <td>{{ c[1] }} </td>
         {% endfor %}
         <td class="border-left">{{ gp.order }}</td>
       </tr>
       <tr>
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
+        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.conjugacy_class', 'Conjugacy classes ')}}&nbsp;</td>
 	<!--"#E3F2FD" -->
         {% for c in gp.cc_statistics %}
           <td>{{ c[1] }} </td>
@@ -75,7 +75,7 @@
       </tr>
       {% if not gp.live() %}
       <tr>
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.odd_color}}>{{KNOWL('group.division', 'Divisions')}}</td>
+        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.division', 'Divisions')}}</td>
         {% for c in gp.div_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -83,7 +83,7 @@
       </tr>
       {% if gp.aut_statistics != None %}
       <tr style="border-bottom:none;">
-        <td class="embedding-wrap sticky-col border-right" bgcolor={{info.even_color}}>{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
+        <td class="embedding-wrap sticky-col border-right">{{KNOWL('group.autjugacy_class', 'Autjugacy classes')}}</td>
         {% for c in gp.aut_statistics %}
           <td>{{ c[1] }}</td>
         {% endfor %}
@@ -534,7 +534,7 @@
 
    <p> The character tables for this group have not been computed. </p>
 
-{% else %}  
+{% else %}
 
    <h3>{{KNOWL('group.complex_character_table','Complex character table')}}</h3>
 
@@ -550,14 +550,14 @@
 
 
    {% if gp.number_conjugacy_classes == None %}
-                                                                                                                             
+
        <p> The complex character table for this group is not computed. </p>
-    
+
        {% elif gp.complex_characters_known == False %}
 
       <p> The ${{gp.number_conjugacy_classes}} \times {{gp.number_conjugacy_classes}}$ character table is not available for this group.    </p>
 
-       {% else %} 
+       {% else %}
        {% if gp.number_conjugacy_classes <= 16 %}
 
       {% include 'character_table.html' %}

--- a/lmfdb/groups/abstract/templates/auto_gens_page.html
+++ b/lmfdb/groups/abstract/templates/auto_gens_page.html
@@ -6,9 +6,11 @@
 
 
 <p>
-  &nbsp; Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by its image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
+ Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by its image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
 
-  {% if gp.element_repr_type == 'PC' %} &nbsp; The entries in the table are given as words on the generators in the presentation for this group.   {% endif %}
+{{gp.repr_strg(other_page = True) | safe}}<br>
+  
+<!--  {% if gp.element_repr_type == 'PC' %} &nbsp; The entries in the table are given as words on the generators in the presentation for this group.   {% endif %} -->
 </p>
 
 

--- a/lmfdb/groups/abstract/templates/auto_gens_page.html
+++ b/lmfdb/groups/abstract/templates/auto_gens_page.html
@@ -8,9 +8,7 @@
 <p>
  Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by its image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
 
-{{gp.repr_strg(other_page = True) | safe}}<br>
-  
-<!--  {% if gp.element_repr_type == 'PC' %} &nbsp; The entries in the table are given as words on the generators in the presentation for this group.   {% endif %} -->
+{{gp.repr_strg(other_page=True) | safe}}<br>
 </p>
 
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2347,7 +2347,8 @@ class WebAbstractGroup(WebObj):
             else:
                 return fr"Elements of the group are displayed as matrices in $\{fam}({d},{q})$."
         elif rep_type == "Perm":
-            return "Elements of the group are displayed as permutations"
+            d = data["d"]
+            return f"Elements of the group are displayed as permutations of degree {d}."
         elif rep_type == "PC":
             rep_str =  "Elements of the group are displayed as words in the generators from the presentation given"
             if other_page:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2366,7 +2366,6 @@ class WebAbstractGroup(WebObj):
                 R = fr"\Z/{{{data['q']}}}\Z"
             else:
                 R = r"\Z"
-            d, q = data["d"], data["p"]
             return fr"Elements of the group are displayed as matrices in $\GL_{{{d}}}({R})$."
         else: # if not any of these types
             return ""

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2335,44 +2335,42 @@ class WebAbstractGroup(WebObj):
         else:
             return f"generating {self.rank}-tuples"
 
-        
-    def repr_strg(self,other_page = False):
-        #string to say where elements of group live
-        #other_page is if the description is not on main page for the group (eg. automorphism group generators)
+    def repr_strg(self, other_page=False):
+        # string to say where elements of group live
+        # other_page is if the description is not on main page for the group (eg. automorphism group generators)
         rep_type = self.element_repr_type
-        if rep_type == "Lie":  #same whether from main page or not
-            rep_line = self.representations
-            if rep_line["Lie"][0]["family"][0] == "P":   # note about matrix parentheses
-                return "Elements of the group  are displayed as equivalence classes (represented by square brackets) of matrices  which are elements of the group  $\\" + rep_line["Lie"][0]["family"] + "(" + str(rep_line["Lie"][0]["d"]) +"," +  str(rep_line["Lie"][0]["q"]) +  ")$."
+        data = self.representations.get(rep_type)
+        if rep_type == "Lie":  # same whether from main page or not
+            fam, d, q = data[0]["family"], data[0]["d"], data[0]["q"]
+            if fam[0] == "P":   # note about matrix parentheses
+                return fr"Elements of the group are displayed as equivalence classes (represented by square brackets) of matrices in $\{fam[1:]}({d},{q})$."
             else:
-                return "Elements of the group  are displayed as matrices in the group $\\" + rep_line["Lie"][0]["family"] + "(" + str(rep_line["Lie"][0]["d"]) +"," +  str(rep_line["Lie"][0]["q"]) +  ")$."
+                return fr"Elements of the group are displayed as matrices in $\{fam}({d},{q})$."
         elif rep_type == "Perm":
-            rep_str = "Elements of the group are displayed as permutations from the permutation group construction given"
+            return "Elements of the group are displayed as permutations"
         elif rep_type == "PC":
-            rep_str =  "Elements of the group are displayed as words on the generators listed in the presentation given" 
-        elif rep_type == "GLFp":
-            rep_line = self.representations
-            rep_str =  "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLFp"]["d"]) + "}(\\F_{" + str(rep_line["GLFp"]["p"]) + "})$ defined"
-        elif rep_type == "GLFq":
-            rep_line = self.representations
-            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLFq"]["d"]) + "}(\\F_{" + str(rep_line["GLFq"]["q"]) + "})$ defined"
-        elif rep_type == "GLZN":
-            rep_line = self.representations
-            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZN"]["d"]) + "}(\\Z/{" + str(rep_line["GLZN"]["p"]) + "}\\Z)$ defined"
-        elif rep_type == "GLZq":
-            rep_line = self.representations
-            rep_str =  "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZq"]["d"]) + "}(\\Z/{" + str(rep_line["GLZq"]["q"]) + "}\\Z)$ defined"
-        elif rep_type == "GLZ":
-            rep_line = self.representations
-            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZ"]["d"]) + "}(\\Z)$ defined"
-        else: #if not any of these types 
+            rep_str =  "Elements of the group are displayed as words in the generators from the presentation given"
+            if other_page:
+                return rep_str + " in the Construction section of this group's <a href='%s'>main page</a>." % url_for(".by_label", self.label)
+            else:
+                return rep_str + " above."
+        elif rep_type in ["GLFp", "GLFq", "GLZN", "GLZq", "GLZ"]:
+            d = data["d"]
+            if rep_type == "GLFp":
+                R = fr"\F_{{{data['p']}}}"
+            elif rep_type == "GLFq":
+                R = fr"\F_{{{data['q']}}}"
+            elif rep_type == "GLZN":
+                R = fr"\Z/{{{data['p']}}}\Z"
+            elif rep_type == "GLZq":
+                R = fr"\Z/{{{data['q']}}}\Z"
+            else:
+                R = r"\Z"
+            d, q = data["d"], data["p"]
+            return fr"Elements of the group are displayed as matrices in $\GL_{{{d}}}({R})$."
+        else: # if not any of these types
             return ""
-        if other_page:
-            return rep_str + " in the Construction section of this group's main page."
-        else:
-            return rep_str + " above."
-        return ""    
- 
+
     @lazy_attribute
     def max_sub_cnt(self):
         return db.gps_subgroups.count_distinct(

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2323,6 +2323,44 @@ class WebAbstractGroup(WebObj):
         else:
             return f"generating {self.rank}-tuples"
 
+        
+    def repr_strg(self,other_page = False):
+        #string to say where elements of group live
+        #other_page is if the description is not on main page for the group (eg. automorphism group generators)
+        rep_type = self.element_repr_type
+        if rep_type == "Lie":  #same whether from main page or not
+            rep_line = self.representations
+            if rep_line["Lie"][0]["family"][0] == "P":   # note about matrix parentheses
+                return "Elements of the group  are displayed as equivalence classes (represented by square brackets) of matrices  which are elements of the group  $\\" + rep_line["Lie"][0]["family"] + "(" + str(rep_line["Lie"][0]["d"]) +"," +  str(rep_line["Lie"][0]["q"]) +  ")$."
+            else:
+                return "Elements of the group  are displayed as matrices in the group $\\" + rep_line["Lie"][0]["family"] + "(" + str(rep_line["Lie"][0]["d"]) +"," +  str(rep_line["Lie"][0]["q"]) +  ")$."
+        elif rep_type == "Perm":
+            rep_str = "Elements of the group are displayed as permutations from the permutation group construction given"
+        elif rep_type == "PC":
+            rep_str =  "Elements of the group are displayed as words on the generators listed in the presentation given" 
+        elif rep_type == "GLFp":
+            rep_line = self.representations
+            rep_str =  "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLFp"]["d"]) + "}(\\F_{" + str(rep_line["GLFp"]["p"]) + "})$ defined"
+        elif rep_type == "GLFq":
+            rep_line = self.representations
+            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLFq"]["d"]) + "}(\\F_{" + str(rep_line["GLFq"]["q"]) + "})$ defined"
+        elif rep_type == "GLZN":
+            rep_line = self.representations
+            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZN"]["d"]) + "}(\\Z/{" + str(rep_line["GLZN"]["p"]) + "}\\Z)$ defined"
+        elif rep_type == "GLZq":
+            rep_line = self.representations
+            rep_str =  "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZq"]["d"]) + "}(\\Z/{" + str(rep_line["GLZq"]["q"]) + "}\\Z)$ defined"
+        elif rep_type == "GLZ":
+            rep_line = self.representations
+            rep_str = "Elements of the group are displayed as matrices in the subgroup of $\\GL_{" + str(rep_line["GLZ"]["d"]) + "}(\\Z)$ defined"
+        else: #if not any of these types 
+            return ""
+        if other_page:
+            return rep_str + " in the Construction section of this group's main page."
+        else:
+            return rep_str + " above."
+        return ""    
+ 
     @lazy_attribute
     def max_sub_cnt(self):
         return db.gps_subgroups.count_distinct(

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2144,6 +2144,8 @@ class WebAbstractGroup(WebObj):
             output_strg += show_reps("wreath")
             output_strg += show_reps("nonsplit")
         output_strg += show_reps("aut")
+        if output_strg == "":  #some live groups have no constructions
+            return "data not computed"
         return output_strg
 
     def is_null(self):

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -727,7 +727,7 @@ table.ntdata {
   margin-bottom: 15px;
 }
 table.ntdata thead th {
-  background: {{ color.table_ntdata_background }};
+  background-color: {{ color.table_ntdata_background }};
 }
 table.ntdata > thead {
   border-bottom: 2px solid {{ color.table_ntdata_border }};
@@ -2276,6 +2276,38 @@ div.table-scroll-wrapper thead > tr:last-child > th {
     position: sticky; left: 0; top: 0;
     z-index:3;
 }
+
+/* Automate embedding-wrap, sticky-col and border-right for scrollable tables with one sticky header column */
+div.table-scroll-wrapper table.onesticky :is(th:first-child, td:first-child) {
+    margin: 0;
+    padding: 0;
+    position: -webkit-sticky; left: 0;
+    position: sticky; left: 0;
+    z-index:2;
+    background-clip: padding-box;
+}
+div.table-scroll-wrapper table.onesticky tr:nth-child(even) :is(th:first-child, td:first-child) {
+  background-color: {{color.table_ntdata_background_2}};
+}
+div.table-scroll-wrapper table.onesticky tr:nth-child(odd) :is(th:first-child, td:first-child) {
+  background-color: white;
+}
+div.table-scroll-wrapper table.onesticky thead > tr:last-child > th:first-child {
+  padding-bottom: 2px;
+  border-bottom: 2px solid {{ color.table_ntdata_border}};
+}
+
+/* :is doesn't work for pseudo-elements */
+div.table-scroll-wrapper table.onesticky th:first-child::after, div.table-scroll-wrapper table.onesticky td:first-child::after {
+    content:'';
+    position:absolute;
+    right: 0;
+    top: 0;
+    height:100%;
+    border-right: 2px solid {{ color.table_ntdata_border}};
+}
+
+
 table.nowrap td {
     white-space:nowrap;
 }


### PR DESCRIPTION
This PR should not be merged before my previous PR to avoid any possible conflicts.  

I. Added scroll bar to Group Statistics table.  A good example is a large Sn like 87178291200.a

In messing around with the scrolling, I managed to "fix" the small space issue in the scrolling newform tables by adding two \&nbsp; in front of "Label". There is probably a more elegant solution involving spacing, but this worked. You can check out scrolling on these two pages in beta and local:
http://localhost:37777/ModularForm/GL2/Q/holomorphic/9394/2/a/u/
http://localhost:37777/ModularForm/GL2/Q/holomorphic/4641/2/a/m/


II. Added a line to the Construction section to let users know which construction we use to store elements of the group (permutation, PC group, matrix group, Lie type, etc.).  Also included a line on the auto_gens pages and information about what the "[]" around matrices means for projective groups.  You can just hit random group a few times and see the message for permutation or PC groups.  For matrix groups, here are a few examples. 
GLFp   192.486
GLFq, 58806.d
GLZ, 4608.bt   
GLZN, 384.2000
GLZq 8192.mz


III. Prevent the  character table pages and the automorphism group generators pages from showing up if this data isn't stored in the db.  Beta loads a blank page, while local returns an error message:  localhost:37771/Groups/Abstract/char_table/335544320.bda


IV. Added a banner at top of the page to inform observers when the group is being computed live.  Many groups of order 512 fit this category, eg 512.4251
