### PR TITLE
Two quick fixes

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -734,7 +734,7 @@ def auto_gens(label):
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
-    if gp.aut_gens is None:
+    if gp.live() or gp.aut_gens is None:
         flash_error("The generators for the automorphism group of the group with label %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))
     return render_template(
@@ -761,6 +761,9 @@ def char_table(label):
     if gp.is_null():
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
+    if gp.live():
+        flash_error("The complex characters for the group with label %s have not been computed.", label)
+        return redirect(url_for(".by_label", label=label))
     if not gp.complex_characters_known:
         flash_error("The complex characters for the group with label %s have not been computed.", label)
         return redirect(url_for(".by_label", label=label))

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2363,7 +2363,7 @@ class WebAbstractGroup(WebObj):
         elif rep_type == "PC":
             rep_str =  "Elements of the group are displayed as words in the generators from the presentation given"
             if other_page:
-                return rep_str + " in the Construction section of this group's <a href='%s'>main page</a>." % url_for(".by_label", self.label)
+                return rep_str + " in the Construction section of this group's <a href='%s'>main page</a>." % url_for(".by_label", label=self.label)
             else:
                 return rep_str + " above."
         elif rep_type in ["GLFp", "GLFq", "GLZN", "GLZq", "GLZ"]:


### PR DESCRIPTION
Latest PRs had a small error which shows up for auto_gens pages of any group represented by a presentation.   Try 12.4  or 1344.3988  (click on "generators").

Took opportunity of making this PR to also make it so that live groups gave useful error message if you try to directly navigate to the auto_gens or char_table pages.