### PR TITLE
Temp fix for Sylow problems

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2133,10 +2133,10 @@ class SubgroupSearchArray(SearchArray):
         #    name="stem",
         #    label="Stem",
         #    knowl="group.stem_extension")
-        hall = YesNoBox(name="hall", label="Hall subgroup", knowl="group.subgroup.hall")
-        sylow = YesNoBox(
-            name="sylow", label="Sylow subgroup", knowl="group.sylow_subgroup"
-        )
+        #hall = YesNoBox(name="hall", label="Hall subgroup", knowl="group.subgroup.hall")
+        #sylow = YesNoBox(
+        #    name="sylow", label="Sylow subgroup", knowl="group.sylow_subgroup"
+        #)
         subgroup = TextBox(
             name="subgroup",
             label="Subgroup label",

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2179,7 +2179,7 @@ class SubgroupSearchArray(SearchArray):
         self.refine_array = [
             [subgroup, subgroup_order, cyclic, abelian, solvable],
             [normal, characteristic, perfect, maximal, central, nontrivproper],
-            [ambient, ambient_order, direct, split, hall, sylow],
+            [ambient, ambient_order, direct, split],#, hall, sylow],
             [
                 quotient,
                 quotient_order,

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2598,6 +2598,19 @@ class WebAbstractSubgroup(WebObj):
                         self.quotient_tex_parened = q if is_atomic(q) else "(%s)" % q
             else:
                 self.quotient_tex_parened = q if is_atomic(q) else "(%s)" % q
+        # Temp fix for a bug in sylow data
+        p, k = self.subgroup_order.is_prime_power(get_data=True)
+        if self.subgroup_order == 1:
+            self.sylow = self.hall = 1
+        elif self.subgroup_order.gcd(self.quotient_order) == 1:
+            self.hall = self.subgroup_order.radical()
+            if k > 0:
+                self.sylow = p
+            else:
+                self.sylow = p
+        else:
+            self.sylow = self.hall = 0
+
 
     def spanclass(self):
         s = "subgp"


### PR DESCRIPTION
See #5818.

Compare the Sylow subgroups on https://beta.lmfdb.org/Groups/Abstract/12.3 and http://localhost:37777/Groups/Abstract/12.3.  This also removes the search boxes for Sylow and Hall subgroups on the subgroup search page.

Once the underlying data is fixed, this change can be reverted.