### PR TITLE
Update formatting for download options

### DIFF
--- a/lmfdb/lattice/test_lattice.py
+++ b/lmfdb/lattice/test_lattice.py
@@ -82,7 +82,7 @@ class HomePageTest(LmfdbTest):
 
     def test_downloadstring_search(self):
         L = self.tc.get("/Lattice/?class_number=8").get_data(as_text=True)
-        assert 'Download displayed columns' in L
+        assert 'displayed columns' in L
 
     def test_download_shortest(self):
         L = self.tc.get("/Lattice/13.14.28.8.1/download/magma/shortest_vectors").get_data(as_text=True)

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -590,9 +590,11 @@ function update_download_url(link) {
   }
   newval = $("input[name=download_row_count]").val();
   console.log("newval", newval);
-  if (newval.length > 0) {
+  if (newval.length > 0 && newval != "all") {
     params.set("download_row_count", newval);
   }
+  newval = $('#downlang-select').find(":selected").val();
+  params.set("Submit", newval);
   url.search = params.toString();
   link.href = url.href;
   console.log(link.href);

--- a/lmfdb/templates/download_search_results.html
+++ b/lmfdb/templates/download_search_results.html
@@ -1,6 +1,6 @@
-{% set lang_text = {'text': 'Text', 'gp': 'Pari/GP', 'gap' : 'GAP', 'sage': 'SageMath', 'magma': 'Magma', 'oscar': 'Oscar'} %}
+{% set lang_text = {'text': 'Text', 'gp': 'Pari/GP', 'gap' : 'GAP', 'sage': 'SageMath', 'magma': 'Magma', 'oscar': 'Oscar', 'csv': 'CSV'} %}
 {% if not languages %}
-{% set languages = ['text', 'gp', 'sage', 'magma', 'oscar'] %}
+{% set languages = ['text', 'gp', 'sage', 'magma', 'oscar', 'csv'] %}
 {% endif %}
 
 &nbsp;
@@ -14,7 +14,7 @@
 {% endif %}
 <a class="like-button" href="{{modify_url(query_add='download=1&query='+(info.query|string))}}" onclick="return update_download_url(this);">Download</a>
 {{KNOWL('doc.search_columns', 'displayed columns')}} for
-<input id="download_row_count_input" name="download_row_count" type="text" value="all" /> rows
+<input id="download_row_count_input" name="download_row_count" type="text" value="{% if info.start == 0%}all{% else %}{{info.start+1}}-{{upper_count}}{% endif %}" /> results
 <label for="downlang-select">to</label>
 <select name="downlang" id="downlang-select">
   {% for lang in languages %}

--- a/lmfdb/templates/download_search_results.html
+++ b/lmfdb/templates/download_search_results.html
@@ -1,6 +1,6 @@
-{% set lang_text = {'gp': 'Pari/GP', 'gap' : 'GAP', 'sage': 'SageMath', 'magma': 'Magma', 'oscar': 'Oscar'} %}
+{% set lang_text = {'text': 'Text', 'gp': 'Pari/GP', 'gap' : 'GAP', 'sage': 'SageMath', 'magma': 'Magma', 'oscar': 'Oscar'} %}
 {% if not languages %}
-{% set languages = ['gp', 'sage', 'magma', 'oscar'] %}
+{% set languages = ['text', 'gp', 'sage', 'magma', 'oscar'] %}
 {% endif %}
 
 &nbsp;
@@ -12,8 +12,13 @@
   </span>
   <span id="download-form" style="display:none;">
 {% endif %}
-Download displayed columns for <span id="row_selector_hidden"><a onclick="return show_row_selector();" href="#">all rows</a></span><span id="row_selector_shown"><input id="download_row_count_input" name="download_row_count" type="text" /> rows</span> to &nbsp;
-{% for lang in languages %}
-  <a class="like-button" href="{{modify_url(query_add='Submit='+lang+'&download=1&query='+(info.query|string))}}" onclick="return update_download_url(this);">{{lang_text[lang]}}</a>&nbsp;
-{% endfor %}
+<a class="like-button" href="{{modify_url(query_add='download=1&query='+(info.query|string))}}" onclick="return update_download_url(this);">Download</a>
+{{KNOWL('doc.search_columns', 'displayed columns')}} for
+<input id="download_row_count_input" name="download_row_count" type="text" value="all" /> rows
+<label for="downlang-select">to</label>
+<select name="downlang" id="downlang-select">
+  {% for lang in languages %}
+    <option value="{{lang}}"{% if lang=='text' %} selected{% endif %}>{{lang_text[lang]}}</option>
+  {% endfor %}
+</select>
 </span>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1421,15 +1421,14 @@ a.navlink {
   font-weight: bold;
   font-size: 11px;
   text-align: center;
-  padding: 5px;
-  padding-top: 3px;
-  padding-bottom: 4px;
+  padding: 4px;
   border: 1px solid {{color.a_nav_border}};
   outline: 1px solid {{color.a_nav_background}};
   text-decoration: none;
   margin-left: 1px;
   margin-top: 10px;
-  vertical-align: top;
+  vertical-align: middle;
+  border-radius: 4px;
 }
 
 hr {

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -16,16 +16,18 @@ import time
 import datetime
 import re
 import itertools
+import csv
+import io
 
-from flask import abort, send_file, stream_with_context, Response, request
+from flask import abort, send_file, stream_with_context, Response, request, redirect, url_for
 from urllib.parse import urlparse, urlunparse
 
 from werkzeug.datastructures import Headers
 from ast import literal_eval
 from io import BytesIO
-from sage.all import Integer, Rational
+from sage.all import Integer, Rational, lazy_attribute
 
-from lmfdb.utils import plural_form, pluralize
+from lmfdb.utils import plural_form, pluralize, flash_error
 
 class DownloadLanguage():
     # We choose the most common values; override these if needed in each subclass
@@ -93,6 +95,17 @@ class DownloadLanguage():
         """
         return ", "
 
+    def comment(self, inp):
+        return "\n".join(self.comment_prefix + line if line else "" for line in inp.split("\n"))
+
+    def string_to_lang(self, inp):
+        """
+        Override this function to remove quotes change backslash parsing.
+        Used for languages like CSV where someone else has already dealt with escaping.
+        """
+        inp = inp.replace("\\", "\\\\").replace('"', '\\"')
+        return '"{0}"'.format(inp)
+
     def to_lang(self, inp, level=1):
         """
         Converts a python object into a string for use in the given language.  At a minimum,
@@ -105,8 +118,7 @@ class DownloadLanguage():
         elif inp is False:
             return self.false
         if isinstance(inp, str):
-            inp = inp.replace("\\", "\\\\").replace('"', '\\"')
-            return '"{0}"'.format(inp)
+            return self.string_to_lang(inp)
         if isinstance(inp, (int, Integer, Rational)):
             return str(inp)
         try:
@@ -152,6 +164,10 @@ class DownloadLanguage():
         if not isinstance(inp, str):
             inp = self.to_lang(inp)
         return name + " " + self.assignment_defn + " " + inp + self.line_end + "\n"
+
+    def assign_columns(self, columns, column_names):
+        # We have a special function for assigning columns, to support adding hyperlinks to knowls in CSV files
+        return self.assign("columns", column_names)
 
     def assign_iter(self, name, inp):
         """
@@ -300,6 +316,10 @@ class TextLanguage(DownloadLanguage):
     start_and_end = ["", "\n\n"]
     iter_sep = "\n"
 
+    def assign(self, name, inp):
+        # We don't want to include the column definition here, since it's already in comments
+        return ""
+
     def assign_iter(self, name, inp):
         # For text downloads, we just give the data
         yield from inp
@@ -315,6 +335,57 @@ class TextLanguage(DownloadLanguage):
             return "\t"
         else:
             return ", "
+
+class CSVLanguage(DownloadLanguage):
+    name = "csv"
+    file_suffix = ".csv"
+    start_and_end = ["", ""]
+    iter_sep = "\n"
+    buff = io.StringIO()
+
+    def comment(self, inp):
+        # CSV does not support comments
+        return ""
+
+    def string_to_lang(self, inp):
+        # The csv module deals with escaping backslashes, and we don't want extra quotes
+        return inp
+
+    @lazy_attribute
+    def writer(self):
+        return csv.writer(self.buff)
+
+    def write(self, inp):
+        t = self.buff.tell()
+        self.writer.writerow(inp)
+        self.buff.seek(t)
+        return self.buff.readline()
+
+    def assign(self, name, inp):
+        # Column assignments are handled separately below
+        return ""
+
+    def assign_columns(self, columns, column_names):
+        urlparts = urlparse(request.url)
+        urls = [urlunparse(urlparts._replace(
+            path=url_for("knowledge.show", ID=col.knowl),
+            params="",
+            query="",
+            fragment="")) for col in columns]
+        return self.write([f'=HYPERLINK("{url}", "{name}")'
+                           for (url, name) in zip(urls, column_names)])
+
+    def assign_iter(self, name, inp):
+        # For CSV downloads, we only output data rows since CSV does not support comments
+        yield from inp
+
+    def to_lang_iter(self, inp):
+        """
+        We use the csv module to generate the output
+        """
+        for row in inp:
+            yield self.write(row)
+
 
 class Downloader():
     """
@@ -343,6 +414,7 @@ class Downloader():
         'gap': GAPLanguage(),
         'text': TextLanguage(),
         'oscar': OscarLanguage(),
+        'csv': CSVLanguage(),
     }
 
     # To automatically add data to the create_record function, you can modify the following dictionary,
@@ -433,10 +505,9 @@ class Downloader():
         if isinstance(lang, str):
             lang = self.languages.get(lang, TextLanguage())
         filename = filebase + lang.file_suffix
-        c = lang.comment_prefix
         mydate = time.strftime("%d %B %Y")
         s = '\n'
-        s += c + ' %s downloaded from the LMFDB on %s.\n' % (title, mydate)
+        s += lang.comment(' %s downloaded from the LMFDB on %s.\n' % (title, mydate))
         s += result
         bIO = BytesIO()
         bIO.write(s.encode('utf-8'))
@@ -466,12 +537,11 @@ class Downloader():
         filename = filebase
         if add_ext:
             filename += lang.file_suffix
-        c = lang.comment_prefix
         mydate = time.strftime("%d %B %Y")
 
         @stream_with_context
         def _generator():
-            yield '\n' + c + ' %s downloaded from the LMFDB on %s.\n' % (title, mydate)
+            yield lang.comment('\n %s downloaded from the LMFDB on %s.\n' % (title, mydate))
             # Rather than just doing `yield from generator`, we need to buffer
             # since otherwise the response is inefficiently broken up into tiny chunks
             # causing the download to slow.
@@ -633,9 +703,24 @@ class Downloader():
         sort, sort_desc = self.get_sort(info, query)
 
         # The user can limit the number of results
-        try:
-            limit = int(info.get("download_row_count"))
-        except Exception:
+        if "download_row_count" in info:
+            limit = info["download_row_count"]
+            match = re.match(r"\s*(\d+)\s*-\s*(\d+)\s*", limit)
+            if match:
+                offset = int(match.group(1)) - 1
+                limit = int(match.group(2)) - offset
+                if limit < 0:
+                    limit = 0
+            else:
+                match = re.match(r"\s*(\d+)\s*", limit)
+                if match:
+                    offset = 0
+                    limit = int(match.group(1))
+                else:
+                    flash_error('Row constraint (%s) must be "all", an integer, or a range of integers', limit)
+                    return redirect(url)
+        else:
+            offset = 0
             limit = None
 
         # The number of results is needed in advance since we want to show it at the top
@@ -643,7 +728,7 @@ class Downloader():
         num_results = table.count(query)
 
         # Actually issue the query, and store the result in an iterator
-        data = iter(table.search(query, projection=proj, sort=sort, one_per=one_per, limit=limit))
+        data = iter(table.search(query, projection=proj, sort=sort, one_per=one_per, limit=limit, offset=offset))
 
         # We get the first 50 results, in order to accommodate sections (like modular forms) where default and contingent columns rely on having access to info["results"]
         # We don't get all the results, since we want to support downloading millions of records, where this would time out.
@@ -675,30 +760,27 @@ class Downloader():
         #print("FIRST FIFTY", first50)
 
         # Create a generator that produces the lines of the download file
-        c = lang.comment_prefix
-
         def make_download():
             # We start with a string describing the query, the number of results and the sort order
-            yield c + ' Search link: %s\n' % url
+            yield lang.comment(' Search link: %s\n' % url)
             if limit is None:
                 num_res_disp = pluralize(num_results, self.short_name)
             else:
-                num_res_disp = pluralize(limit, self.short_name, denom=num_results)
-            yield c + ' Query "%s" %s %s%s.\n\n' %(
+                num_res_disp = pluralize(limit, self.short_name, denom=num_results, offset=offset)
+            yield lang.comment(' Query "%s" %s %s%s.\n\n' %(
                 str(info.get('query')),
                 "returned" if limit is None else "was limited to",
                 num_res_disp,
-                "" if sort_desc is None else f", sorted by {sort_desc}")
+                "" if sort_desc is None else f", sorted by {sort_desc}"))
 
             # We then describe the columns included, both in a comment and as a variable
-            yield c + ' Each entry in the following data list has the form:\n'
-            yield c + '    [' + ', '.join(data_format) + ']\n'
-            yield c + ' For more details, see the definitions at the bottom of the file.\n'
+            yield lang.comment(' Each entry in the following data list has the form:\n')
+            yield lang.comment('    [' + ', '.join(data_format) + ']\n')
+            yield lang.comment(' For more details, see the definitions at the bottom of the file.\n')
             if make_data_comment:
-                yield '\n' + c + ' ' + make_data_comment  + '\n'
-            yield '\n\n'
-            if lang.name != "text":
-                yield lang.assign("columns", column_names)
+                yield lang.comment(f'\n {make_data_comment}\n')
+            yield lang.comment('\n\n')
+            yield lang.assign_columns(cols, column_names)
 
             # This is where the actual contents are included, applying postprocess and col.download to each
             yield from lang.assign_iter("data", lang.to_lang_iter(
@@ -741,14 +823,14 @@ class Downloader():
                     knowl = col.download_desc
                 if knowl:
                     if name.lower() == col.title.lower():
-                        yield c + f" {col.title} --\n"
+                        yield lang.comment(f" {col.title} --\n")
                     else:
-                        yield c + f"{col.title} ({name}) --\n"
+                        yield lang.comment(f"{col.title} ({name}) --\n")
                     for line in knowl.split("\n"):
                         if line.strip():
-                            yield c + "    " + line.rstrip() + "\n"
+                            yield lang.comment("    " + line.rstrip() + "\n")
                         else:
-                            yield "\n"
-                    yield "\n\n"
+                            yield lang.comment("\n")
+                    yield lang.comment("\n\n")
 
         return self._wrap_generator(make_download(), filename, lang=lang)

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -978,8 +978,10 @@ def plural_form(noun):
         noun += "s"
     return noun
 
-def pluralize(n, noun, omit_n=False, denom=None):
+def pluralize(n, noun, omit_n=False, denom=None, offset=0):
     if denom is not None:
+        if offset != 0:
+            return f"{n}/{denom} {plural_form(noun)} (starting at row {offset+1})"
         return f"{n}/{denom} {plural_form(noun)}"
     if n == 1:
         if omit_n:


### PR DESCRIPTION
First page of results:
<img width="886" alt="Screenshot 2024-01-29 at 14 08 50" src="https://github.com/LMFDB/lmfdb/assets/22795/3db7e851-ad8e-43d4-96b5-229826f2dbce">

Second page of results:
<img width="944" alt="Screenshot 2024-01-29 at 14 09 04" src="https://github.com/LMFDB/lmfdb/assets/22795/f46c0bfb-3018-40c9-a0ac-f62e200f5d63">


Text download is now the default, and has been updated to make it easier to parse.  Besides the data lines, every non-empty line starts with a # symbol, and the data lines are now just tab-delimited for easier copy-pasting into a spreadsheet.

I also added an option to download search results as a CSV file for loading into a spreadsheet, since I think that's how a lot of people work (the comments are all deleted, but the first row is the column labels, with hyperlinks to the corresponding knowls).