### PR TITLE
Fix a few group server errors

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1360,14 +1360,11 @@ def render_abstract_group(label, data=None):
     if data is None:
         label = clean_input(label)
         gp = WebAbstractGroup(label)
-    if gp.is_null() or gp.source == "Missing": #groups of order 6561 are not in GAP but are labeled in Magma
-            flash_error("No group with label %s was found in the database.", label)
-            return redirect(url_for(".index"))
     elif isinstance(data, list): # abelian group
         gp = WebAbstractGroup(label, data=data)
-#    if gp.is_null():
-#        flash_error("No group with label %s was found in the database.", label)
-#        return redirect(url_for(".index"))
+    if gp.is_null() or gp.source == "Missing": #groups of order 6561 are not in GAP but are labeled in Magma
+        flash_error("No group with label %s was found in the database.", label)
+        return redirect(url_for(".index"))
     # check if it fails to be a potential label even
 
     info["boolean_characteristics_string"] = create_boolean_string(gp)

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -745,7 +745,7 @@ def by_abelian_label(label):
 def auto_gens(label):
     label = clean_input(label)
     gp = WebAbstractGroup(label)
-    if gp.is_null():
+    if gp.is_null() or gp.source == "Missing":  # latter is for groups in Magma but not GAP db
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if gp.live() or gp.aut_gens is None:
@@ -774,7 +774,7 @@ def char_table(label):
     info = to_dict(request.args,
                    dispv=sparse_cyclotomic_to_mathml)
     gp = WebAbstractGroup(label)
-    if gp.is_null():
+    if gp.is_null() or gp.source == "Missing":  # latter is for groups not in GAP but in Magma db
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if gp.live():
@@ -800,7 +800,7 @@ def Qchar_table(label):
     label = clean_input(label)
     info = to_dict(request.args, conv=integer_to_mathml)
     gp = WebAbstractGroup(label)
-    if gp.is_null():
+    if gp.is_null() or gp.source == "Missing": # latter is for groups not in GAP but in Magma db
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     if not gp.rational_characters_known:
@@ -821,7 +821,7 @@ def Qchar_table(label):
 def _subgroup_diagram(label, title, only, style):
     label = clean_input(label)
     gp = WebAbstractGroup(label)
-    if gp.is_null():
+    if gp.is_null() or gp.source == "Missing":  # latter is for groups in Magma but not in GAP db
         flash_error("No group with label %s was found in the database.", label)
         return redirect(url_for(".index"))
     dojs, display_opts = diagram_js_string(gp, only=only)
@@ -1360,11 +1360,14 @@ def render_abstract_group(label, data=None):
     if data is None:
         label = clean_input(label)
         gp = WebAbstractGroup(label)
+    if gp.is_null() or gp.source == "Missing": #groups of order 6561 are not in GAP but are labeled in Magma
+            flash_error("No group with label %s was found in the database.", label)
+            return redirect(url_for(".index"))
     elif isinstance(data, list): # abelian group
         gp = WebAbstractGroup(label, data=data)
-    if gp.is_null():
-        flash_error("No group with label %s was found in the database.", label)
-        return redirect(url_for(".index"))
+#    if gp.is_null():
+#        flash_error("No group with label %s was found in the database.", label)
+#        return redirect(url_for(".index"))
     # check if it fails to be a potential label even
 
     info["boolean_characteristics_string"] = create_boolean_string(gp)
@@ -1640,7 +1643,7 @@ def picture(label):
     if label_is_valid(label):
         label = clean_input(label)
         gp = WebAbstractGroup(label)
-        if gp.is_null():
+        if gp.is_null() or gp.source == "Missing": # latter is for groups in Magma but not GAP db
             flash_error("No group with label %s was found in the database.", label)
             return redirect(url_for(".index"))
         # The user specifically requested the image, so we don't impose a limit on the number of conjugacy classes

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -257,8 +257,7 @@ class WebAbstractGroup(WebObj):
 
     # We support some basic information for groups not in the database using GAP
     def live(self):
-        # return not self.source == "db"
-        return self._data is not None and not isinstance(self._data, dict)
+        return self._data is not None and not isinstance(self._data, dict)  
 
     @lazy_attribute
     def G(self):
@@ -286,7 +285,10 @@ class WebAbstractGroup(WebObj):
         if self.order == 1 or self.element_repr_type == "PC":  # trvial
             return self.PCG
         else:
-            gens = [self.decode(g) for g in self.representations[self.element_repr_type]["gens"]]
+            if self.element_repr_type == "Lie":   #need to take first entry of Lie type
+                gens = [self.decode(g) for g in self.representations[self.element_repr_type][0]["gens"]]
+            else:
+                gens = [self.decode(g) for g in self.representations[self.element_repr_type]["gens"]]
             return libgap.Group(gens)
 
     @lazy_attribute
@@ -2199,6 +2201,7 @@ class WebAbstractGroup(WebObj):
 
     # automorphism group
     def show_aut_group(self):
+        print("HERE!!!", self.aut_group, self.aut_order)
         try:
             if self.aut_group is None:
                 if self.aut_order is None:
@@ -2206,8 +2209,11 @@ class WebAbstractGroup(WebObj):
                 else:
                     return f"Group of order {pos_int_and_factor(self.aut_order)}"
             else:
-                url = url_for(".by_label", label=self.aut_group)
-                return f'<a href="{url}">${group_names_pretty(self.aut_group)}$</a>, of order {pos_int_and_factor(self.aut_order)}'
+                if self.aut_order is None:
+                    return r"not computed"
+                else:
+                    url = url_for(".by_label", label=self.aut_group)
+                    return f'<a href="{url}">${group_names_pretty(self.aut_group)}$</a>, of order {pos_int_and_factor(self.aut_order)}'
         except AssertionError:  # timed out
             return r"$\textrm{Computation timed out}$"
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2201,7 +2201,6 @@ class WebAbstractGroup(WebObj):
 
     # automorphism group
     def show_aut_group(self):
-        print("HERE!!!", self.aut_group, self.aut_order)
         try:
             if self.aut_group is None:
                 if self.aut_order is None:


### PR DESCRIPTION
1. Fixed a server error when the element_repr_type was of Lie type.  See 
http://localhost:37771/Groups/Abstract/sub/64.102.2.d1.a1
https://beta.lmfdb.org/Groups/Abstract/sub/64.102.2.d1.a1

or 
http://localhost:37771/Groups/Abstract/sub/95040.a.220.a1.b1
https://beta.lmfdb.org/Groups/Abstract/sub/95040.a.220.a1.b1


2. Fixed a server error when order of auto group of subgroup is not known and we were trying to factor 0. This fixes #5857 
Compare
https://beta.lmfdb.org/Groups/Abstract/sub/1024.ec.2.i1 
http://localhost:37771/Groups/Abstract/sub/1024.ec.2.i1


3. Fixed a lingering issue with groups of order 6561 (we have Magma id # but not GAP id #).   In a past PR I had fixed it if these groups showed up as subgroups, but didn't fix it from the jump box or if someone directly entered a group of that order in the url.   I hopefully have fixed everywhere this is an issue (automorphisms page, character tables pages, etc.).
If you go to the groups page and put "6561.3" in the find box on beta and locally, you'll see that in the latter case we get a reasonable error message while in the former it's just a server error.  Just for completeness, the group 6561.286346
 IS in the db and so that should direct to a valid page even after this PR.
