### PR TITLE
correct typo on congruent number page

### DIFF
--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -252,7 +252,7 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
 
 <h3>Distribution of &#1064;</h3>
 <p>
-  Over half the curves ($574,290$) have trivial &#1064;.  The largest value seen is $719057$, for $n=7396$.
+  Over half the curves ($574,290$) have trivial &#1064;.  The largest value seen is $7396 = 86^2$, for $n=719057$.
 </p>
 
 <h2>Credit and acknowledgements</h2> 


### PR DESCRIPTION
As reported by Harvey Rose: on https://www.lmfdb.org/EllipticCurve/Q/CongruentNumbers in the section about Sha values it switches the value of n for which $E_n$ has largest analytic Sha and the Sha value itself.  (HR queried the fact that 719057 is not a square!)

This PR just swaps the two numbers over, also showing that 7396 is 86^2.