### PR TITLE
When running locally in debug mode, raise errors

### DIFF
--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -5,7 +5,7 @@ from psycopg2.errors import NumericValueOutOfRange
 from sage.misc.decorators import decorator_keywords
 from sage.misc.cachefunc import cached_function
 
-from lmfdb.app import ctx_proc_userdata
+from lmfdb.app import ctx_proc_userdata, is_debug_mode
 from lmfdb.utils.search_parsing import parse_start, parse_count, SearchParsingError
 from lmfdb.utils.utilities import flash_error, flash_info, to_dict
 
@@ -65,6 +65,8 @@ class Wrapper():
             errpage = self.f(info, query)
         except Exception as err:
             # Errors raised in parsing; these should mostly be SearchParsingErrors
+            if is_debug_mode():
+                raise
             info['err'] = str(err)
             err_title = query.pop('__err_title__', self.err_title)
             return render_template(self.template, info=info, title=err_title, **template_kwds)
@@ -165,6 +167,8 @@ class SearchWrapper(Wrapper):
                     # Errors raised in jump box, for example
                     # Using the search results is an okay default, though some
                     # jump boxes will use their own error processing
+                    if is_debug_mode():
+                        raise
                     if "%s" in str(err):
                         flash_error(str(err), info[key])
                     else:


### PR DESCRIPTION
This change makes it easier to find errors that arise when editing code, which are caught and hidden in production to prevent server errors.