### PR TITLE
Dirchar timeout issue

### DIFF
--- a/lmfdb/backend/searchtable.py
+++ b/lmfdb/backend/searchtable.py
@@ -1493,5 +1493,13 @@ class PostgresSearchTable(PostgresTable):
         """
         return self.stats.count_distinct(col, query, record=record)
 
-    def sum(self, col):
-        return self.stats.sum(col)
+    def sum(self, col, constraint={}):
+        """
+        The sum of a given column.
+
+        INPUT:
+
+        - ``col`` -- the name of the column
+        - ``constraint`` -- a query dictionary constraining which rows are considered
+        """
+        return self.stats.sum(col, constraint)

--- a/lmfdb/backend/searchtable.py
+++ b/lmfdb/backend/searchtable.py
@@ -1492,3 +1492,7 @@ class PostgresSearchTable(PostgresTable):
         - ``record`` -- (default True) whether to record the number of results in the stats table.
         """
         return self.stats.count_distinct(col, query, record=record)
+
+    def sum(self, col):
+        print("wakka wakka")
+        return self.stats.sum(col)

--- a/lmfdb/backend/searchtable.py
+++ b/lmfdb/backend/searchtable.py
@@ -1494,5 +1494,4 @@ class PostgresSearchTable(PostgresTable):
         return self.stats.count_distinct(col, query, record=record)
 
     def sum(self, col):
-        print("wakka wakka")
         return self.stats.sum(col)

--- a/lmfdb/backend/statstable.py
+++ b/lmfdb/backend/statstable.py
@@ -611,7 +611,7 @@ class PostgresStatsTable(PostgresBase):
                 if satisfies_constraint(rec[0])
             }
 
-    def _quick_extreme(self, col, ccols, cvals, kind="max"):
+    def _quick_statistic(self, col, ccols, cvals, kind="max"):
         """
         Return the min or max value achieved by the column, or None if not cached.
 
@@ -621,7 +621,7 @@ class PostgresStatsTable(PostgresBase):
         - ``ccols`` -- constraint columns
         - ``cvals`` -- constraint values.  The max will be taken over rows where
           the constraint columns take on these values.
-        - ``kind`` -- either "min" or "max"
+        - ``kind`` -- either "min" or "max" or "sum"
         """
         constraint = SQL("constraint_cols = %s AND constraint_values = %s")
         values = [kind, Json([col]), ccols, cvals]
@@ -632,7 +632,7 @@ class PostgresStatsTable(PostgresBase):
         if cur.rowcount:
             return cur.fetchone()[0]
 
-    def _slow_extreme(self, col, constraint, kind="max"):
+    def _slow_statistic(self, col, constraint, kind="max"):
         """
         Compute the minimum/maximum value achieved by the column.
 
@@ -648,10 +648,13 @@ class PostgresStatsTable(PostgresBase):
             values = []
         else:
             where = SQL(" WHERE {0}").format(qstr)
+
         if kind == "min":
             base_selecter = SQL("SELECT {0} FROM {1}{2} ORDER BY {0}")
         elif kind == "max":
             base_selecter = SQL("SELECT {0} FROM {1}{2} ORDER BY {0} DESC ")
+        elif kind == "sum":
+            base_selecter = SQL("SELECT SUM({0}) FROM {1}{2} ")
         else:
             raise ValueError("Invalid kind")
         base_selecter = base_selecter.format(
@@ -668,9 +671,9 @@ class PostgresStatsTable(PostgresBase):
             m = cur.fetchone()[0]
         return m
 
-    def _record_extreme(self, col, ccols, cvals, m, kind="max"):
+    def _record_statistic(self, col, ccols, cvals, m, kind="max"):
         """
-        Store a computed maximum value in the stats table.
+        Store a computed statistic (referenced by `kind`) in the stats table.
 
         INPUT:
 
@@ -678,6 +681,7 @@ class PostgresStatsTable(PostgresBase):
         - ``ccols`` -- the constraint columns
         - ``cvals`` -- the constraint values
         - ``m`` -- the maximum value to be stored
+        - ``kind`` -- the kind of statistic. Usually `min` or `max` or `sum`
         """
         try:
             inserter = SQL(
@@ -717,11 +721,11 @@ class PostgresStatsTable(PostgresBase):
         if col not in self.table.search_cols:
             raise ValueError("%s not a column of %s" % (col, self.search_table))
         ccols, cvals = self._split_dict(constraint)
-        m = self._quick_extreme(col, ccols, cvals, kind="max")
+        m = self._quick_statistic(col, ccols, cvals, kind="max")
         if m is None:
-            m = self._slow_extreme(col, constraint, kind="max")
+            m = self._slow_statistic(col, constraint, kind="max")
             if record and self.saving:
-                self._record_extreme(col, ccols, cvals, m, kind="max")
+                self._record_statistic(col, ccols, cvals, m, kind="max")
         return m
 
     def min(self, col, constraint={}, record=True):
@@ -746,67 +750,23 @@ class PostgresStatsTable(PostgresBase):
         if col not in self.table.search_cols:
             raise ValueError("%s not a column of %s" % (col, self.search_table))
         ccols, cvals = self._split_dict(constraint)
-        m = self._quick_extreme(col, ccols, cvals, kind="min")
+        m = self._quick_statistic(col, ccols, cvals, kind="min")
         if m is None:
-            m = self._slow_extreme(col, constraint, kind="min")
+            m = self._slow_statistic(col, constraint, kind="min")
             if record and self.saving:
-                self._record_extreme(col, ccols, cvals, m, kind="min")
+                self._record_statistic(col, ccols, cvals, m, kind="min")
         return m
 
-    def _slow_sum(self, col):
-        """
-        Compute the sum of a column
-
-        INPUT:
-
-        - ``col`` -- the column
-        """
-        inserter = SQL("SELECT SUM({0}) FROM {1}")
-        inserter = inserter.format(Identifier(col), Identifier(self.search_table))
-        cur = self._execute(inserter)
-        if cur.rowcount:
-            return cur.fetchone()[0]
-
-    def _record_sum(self, col, m):
-        """
-        Cache the sum
-
-        INPUT:
-
-        - ``col`` -- the column
-        - ``m``   -- the value to store as sum
-        """
-        inserter = SQL(
-                "INSERT INTO {0} "
-                "(cols, value) "
-                "VALUES (%s, %s)"
-            )
-        self._execute(
-            inserter.format(Identifier(self.stats)),
-            [Json([col]), m],
-        )
-
-    def _quick_sum(self, col):
-        """
-        This just looks up the sum; returns None if it hasn't been computed
-        """
-        values = [Json([col])]
-        selecter = SQL(
-            "SELECT value FROM {0} WHERE cols = %s AND threshold IS NULL"
-        ).format(Identifier(self.stats))
-        cur = self._execute(selecter, values)
-        if cur.rowcount:
-            return cur.fetchone()[0]        
-
-    def sum(self, col, record=True):
+    def sum(self, col, constraint={}, record=True):
         """
         Look up sum; if it exists return it, otherwise compute it, store it, and return
         """
-        m = self._quick_sum(col)
+        ccols, cvals = self._split_dict(constraint)
+        m = self._quick_statistic(col, ccols, cvals, kind="sum")
         if m is None:
-            m = self._slow_sum(col)
+            m = self._slow_statistic(col, constraint, kind="sum")
             if record:
-                self._record_sum(col, m)
+                self._record_statistic(col, ccols, cvals, m, kind="sum")
         return m
 
     def _bucket_iterator(self, buckets, constraint):

--- a/lmfdb/backend/statstable.py
+++ b/lmfdb/backend/statstable.py
@@ -754,6 +754,13 @@ class PostgresStatsTable(PostgresBase):
         return m
 
     def _slow_sum(self, col):
+        """
+        Compute the sum of a column
+
+        INPUT:
+
+        - ``col`` -- the column
+        """
         inserter = SQL("SELECT SUM({0}) FROM {1}")
         inserter = inserter.format(Identifier(col), Identifier(self.search_table))
         cur = self._execute(inserter)
@@ -761,6 +768,14 @@ class PostgresStatsTable(PostgresBase):
             return cur.fetchone()[0]
 
     def _record_sum(self, col, m):
+        """
+        Cache the sum
+
+        INPUT:
+
+        - ``col`` -- the column
+        - ``m``   -- the value to store as sum
+        """
         inserter = SQL(
                 "INSERT INTO {0} "
                 "(cols, value) "
@@ -772,6 +787,9 @@ class PostgresStatsTable(PostgresBase):
         )
 
     def _quick_sum(self, col):
+        """
+        This just looks up the sum; returns None if it hasn't been computed
+        """
         values = [Json([col])]
         selecter = SQL(
             "SELECT value FROM {0} WHERE cols = %s AND threshold IS NULL"
@@ -781,6 +799,9 @@ class PostgresStatsTable(PostgresBase):
             return cur.fetchone()[0]        
 
     def sum(self, col, record=True):
+        """
+        Look up sum; if it exists return it, otherwise compute it, store it, and return
+        """
         m = self._quick_sum(col)
         if m is None:
             m = self._slow_sum(col)

--- a/lmfdb/backend/table.py
+++ b/lmfdb/backend/table.py
@@ -2564,7 +2564,3 @@ class PostgresTable(PostgresBase):
         updater = SQL("UPDATE meta_tables SET important = %s WHERE name = %s")
         self._execute(updater, [importance, self.search_table])
 
-    def sum_column(self, col):
-        summer = SQL("SELECT SUM({0}) FROM {1}")
-        summer = summer.format(Identifier(col), Identifier(self.search_table))
-        return self._execute(summer).fetchone()[0]

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -734,7 +734,7 @@ class DirichStats(StatsDisplay):
                   "is_real": yesno}
 
     def __init__(self):
-        self.nchars = db.char_orbits.sum('degree') # 3039650754
+        self.nchars = db.char_orbits.sum('degree')
         self.norbits = db.char_orbits.count()
         self.maxmod = db.char_orbits.max("modulus")
 

--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -734,7 +734,7 @@ class DirichStats(StatsDisplay):
                   "is_real": yesno}
 
     def __init__(self):
-        self.nchars = 3039650754 # db.char_orbits.sum_column('degree')
+        self.nchars = db.char_orbits.sum('degree') # 3039650754
         self.norbits = db.char_orbits.count()
         self.maxmod = db.char_orbits.max("modulus")
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -19,7 +19,6 @@ class DirichletSearchTest(LmfdbTest):
     def test_nchars(self):
         from lmfdb import db
         nchars = db.char_orbits.sum('degree')
-        # assert nchars == 3039650754 # if this fails, one also needs to update DirichStats.__init__
         W = self.tc.get('/Character/Dirichlet/')
         assert comma(nchars) in W.get_data(as_text=True)
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -18,8 +18,8 @@ class WebCharacterTest(LmfdbTest):
 class DirichletSearchTest(LmfdbTest):
     def test_nchars(self):
         from lmfdb import db
-        nchars = db.char_orbits.sum_column('degree')
-        assert nchars == 3039650754 # if this fails, one also needs to update DirichStats.__init__
+        nchars = db.char_orbits.sum('degree')
+        # assert nchars == 3039650754 # if this fails, one also needs to update DirichStats.__init__
         W = self.tc.get('/Character/Dirichlet/')
         assert comma(nchars) in W.get_data(as_text=True)
 


### PR DESCRIPTION
addresses #5800 

Previously, going to the Dirchars homepage would recompute the number of dirichlet characters every time via a time-consuiming SQL query. This led to some timeouts.

Now, this is done as for min and max: this number is computed once and cached with the statstable of `char_orbits`; it is then looked up whenever the page is loaded. This should speed up loading that page.