### PR TITLE
more honest reporting of analytic Sha status for ECQ

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -195,7 +195,7 @@ class ECstats(StatsDisplay):
     baseurl_func = ".rational_elliptic_curves"
 
     knowls = {'rank': 'ec.rank',
-              'sha': 'ec.q.analytic_sha_order',
+              'sha': 'ec.analytic_sha_order',
               'torsion_structure': 'ec.torsion_order'}
 
     top_titles = {'rank': 'rank',

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -271,10 +271,10 @@ white-space: pre in order to keep line breaks! #}
         	  {% if data.mwbsd.sha > 1 %}
           	  = {{data.mwbsd.sha2}}
             {% endif %}
-            {% if data.rank > 1 %}
-              ({{ KNOWL('ec.q.analytic_sha_value',title="rounded") }})
-            {% else %}
+            {% if data.mwbsd.sha_is_exact %}
               ({{ KNOWL('ec.q.analytic_sha_value',title="exact") }})
+            {% else %}
+              ({{ KNOWL('ec.q.analytic_sha_value',title="rounded") }})
             {% endif %}
           {% endif %}
         </td>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -272,9 +272,9 @@ white-space: pre in order to keep line breaks! #}
           	  = {{data.mwbsd.sha2}}
             {% endif %}
             {% if data.mwbsd.sha_is_exact %}
-              ({{ KNOWL('ec.q.analytic_sha_value',title="exact") }})
+              ({{ KNOWL('ec.analytic_sha_value',title="exact") }})
             {% else %}
-              ({{ KNOWL('ec.q.analytic_sha_value',title="rounded") }})
+              ({{ KNOWL('ec.analytic_sha_value',title="rounded") }})
             {% endif %}
           {% endif %}
         </td>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -620,7 +620,7 @@ class WebEC():
             mwbsd['reg']  = self.regulator
             mwbsd['sha']  = self.sha
             mwbsd['sha2'] = latex_sha(self.sha)
-            mwbsd['sha_is_exact'] = self.rank==0 and self.conductor<500000
+            mwbsd['sha_is_exact'] = self.rank==0 # see Issue #5872
             for num in ['reg', 'special_value', 'real_period', 'area']:
                 mwbsd[num]  = RR(mwbsd[num])
         except AttributeError:

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -620,6 +620,7 @@ class WebEC():
             mwbsd['reg']  = self.regulator
             mwbsd['sha']  = self.sha
             mwbsd['sha2'] = latex_sha(self.sha)
+            mwbsd['sha_is_exact'] = self.rank==0 and self.conductor<500000
             for num in ['reg', 'special_value', 'real_period', 'area']:
                 mwbsd[num]  = RR(mwbsd[num])
         except AttributeError:


### PR DESCRIPTION
See #5872 .

The choice of whether to display "exact" or "rounded" against the analytic Sha value (for elliptic curves over Q) has been moved to python code from the template, and now only shows "exact" if N<500000 and r==0 (instead of whenever r<=1 and all N).

Compare 

 - http://localhost:37777/EllipticCurve/Q/600689/a/1 (rank 0, large conductor, now says "rounded" not "exact")
 - http://localhost:37777/EllipticCurve/Q/37/a/1 (rank 1, small conductor, ditto)