### PR TITLE
Pinning down the curve, when as a curve over Q (e.g. an elliptic or genus 2 curve), if it is present in the LMFDB.

### DIFF
--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -350,16 +350,22 @@ class WebModCurve(WebObj):
         friends = []
         if self.simple and self.newforms:
             friends.append(("Modular form " + self.newforms[0], url_for_mf_label(self.newforms[0])))
-            if self.genus == 1:
-                s = self.newforms[0].split(".")
-                label = s[0] + "." + s[3]
-                friends.append(("Isogeny class " + label, url_for("ec.by_ec_label", label=label)))
-            if self.genus == 2:
-                g2c_url = db.lfunc_instances.lucky({'Lhash':str(self.trace_hash), 'type' : 'G2Q'}, 'url')
-                if g2c_url:
-                    s = g2c_url.split("/")
-                    label = s[2] + "." + s[3]
-                    friends.append(("Isogeny class " + label, url_for("g2c.by_label", label=label)))
+            if self.curve_label:
+                assert self.genus in [1,2]
+                route = "ec.by_ec_label" if self.genus == 1 else "g2c.by_label"
+                name = ("Elliptic" if self.genus ==1 else "Genus 2") + " curve " + self.curve_label
+                friends.append((name, url_for(route, label=self.curve_label)))
+            else: # the best we can do is to point to the isogeny class
+                if self.genus == 1:
+                    s = self.newforms[0].split(".")
+                    label = s[0] + "." + s[3]
+                    friends.append(("Isogeny class " + label, url_for("ec.by_ec_label", label=label)))
+                if self.genus == 2:
+                    g2c_url = db.lfunc_instances.lucky({'Lhash':str(self.trace_hash), 'type' : 'G2Q'}, 'url')
+                    if g2c_url:
+                        s = g2c_url.split("/")
+                        label = s[2] + "." + s[3]
+                        friends.append(("Isogeny class " + label, url_for("g2c.by_label", label=label)))
             friends.append(("L-function", "/L" + url_for_mf_label(self.newforms[0])))
         else:
             friends.append(("L-function not available",""))


### PR DESCRIPTION
https://beta.lmfdb.org/ModularCurve/Q/6.6.1.a.1/
vs
http://localhost:37777/ModularCurve/Q/6.6.1.a.1/

There are no examples of this for genus 2, even though, we know a couple
https://beta.lmfdb.org/Genus2Curve/Q/interesting