### PR TITLE
inexact gonality search, ui-tweaks

### DIFF
--- a/lmfdb/modular_curves/isog_class.py
+++ b/lmfdb/modular_curves/isog_class.py
@@ -106,7 +106,7 @@ class ModCurveIsog_class():
         if self.conductor is not None:
             self.properties.append(('Conductor', '$' + self.web_curve.factored_conductor + '$'))
         if self.rank is not None:
-            self.properties.append(('Analytic rank', str(self.rank)))
+            self.properties.append(('Analytic rank', prop_int_pretty(self.rank)))
 
         self.friends = self.web_curve.friends[1:]
 

--- a/lmfdb/modular_curves/main.py
+++ b/lmfdb/modular_curves/main.py
@@ -816,8 +816,10 @@ class ModCurveSearchArray(SearchArray):
                      ('possibly', 'possibly'),
                      ('atleast', 'at least'),
                      ('atmost', 'at most'),
+                     ('inexactly', 'inexactly'),
                      ],
-            min_width=85)
+            min_width=86,
+        )
         gonality = TextBoxWithSelect(
             name="q_gonality",
             knowl="modcurve.gonality",
@@ -891,14 +893,15 @@ class ModCurveSearchArray(SearchArray):
         points_type = SelectBox(
             name="points_type",
             options=[('', 'non-cusp'),
-                     ('noncm', 'non-CM, non-cusp'),
+                     ('noncm', 'non-CM/cusp'),
                      ('all', 'all'),
                      ],
-            min_width=105)
+            min_width=114,
+        )
         points = TextBoxWithSelect(
             name="points",
             knowl="modcurve.known_points",
-            label="$j$-points",
+            label="Points",
             example="0, 3-5",
             select_box=points_type,
         )

--- a/lmfdb/modular_curves/templates/modcurve_isoclass.html
+++ b/lmfdb/modular_curves/templates/modcurve_isoclass.html
@@ -36,10 +36,10 @@ text-align: center;
     {% endif %}
     {# <th>{{KNOWL('modcurve.cusp_widths', title = 'Cusp widths') }}</th> #}
     <th>{{KNOWL('modcurve.cusp_orbits', title = 'Cusp orbits') }}</th>
-    <th>{{KNOWL('modcurve.cusps', title='Rational cusps') }}</th>
+    <th>{{KNOWL('modcurve.cusps', title='$\Q$-cusps') }}</th>
     <th>{{ KNOWL("modcurve.gonality", "$\Q$-gonality")}}</th>
     <th>{{ KNOWL("modcurve.gonality", "$\overline{\Q}$-gonality")}}</th>
-    <th>{{ KNOWL("modcurve.cm_discriminants", "Rational CM points") }}</th>
+    <th>{{ KNOWL("modcurve.cm_discriminants", "CM points") }}</th>
   </tr>
   
   {% for curve in iso_class.curves %}
@@ -88,7 +88,7 @@ text-align: center;
   {% endif %}
   {# <td class="center">{{ curve.web_curve.cusp_widths_display }}</td> #}
   <td class="center">{{ curve.web_curve.cusp_orbits_display }}</td>
-  <td class="center">{{ curve.rational_cusps }}</td>
+  <td class="center">${{ curve.rational_cusps }}$</td>
   <td class="center">${{ curve.q_gonality if curve.q_gonality else "%s \\le \\gamma \\le %s"%(curve.q_gonality_bounds[0],curve.q_gonality_bounds[1]) }}$</td>
   <td class="center">${{ curve.qbar_gonality if curve.qbar_gonality else "%s \\le \\gamma \\le %s"%(curve.qbar_gonality_bounds[0],curve.qbar_gonality_bounds[1]) }}$</td>
   <td class="center"> {{ "yes $\quad(D =$ $%s$)"%(curve.web_curve.cm_discriminant_list) if curve.cm_discriminants else "none" }}</td>
@@ -99,10 +99,10 @@ text-align: center;
 
 <h2> {{ KNOWL('modcurve.invariants', 'Invariants') }} of this Gassmann class</h2>
 <table>
-  <tr><td>{{ KNOWL("modcurve.level", "Level") }}:</td><td> ${{ iso_class.level }}$ </td><td style="width:20px;"></td><td>{{ KNOWL("modcurve.sl2level", "$\SL_2$-level") }}:</td><td>${{ iso_class.sl2level }}$</td><td style="width:60px;"></td>{% if iso_class.genus > 0 %}<td>{{ KNOWL("modcurve.newform_level", "Newform level:") }}</td><td>${{ iso_class.web_curve.newform_level }}$</td>{% endif %}</tr>
+  <tr><td style="width:105px;">{{ KNOWL("modcurve.level", "Level") }}:</td><td> ${{ iso_class.level }}$ </td><td style="width:20px;"></td><td>{{ KNOWL("modcurve.sl2level", "$\SL_2$-level") }}:</td><td>${{ iso_class.sl2level }}$</td><td style="width:60px;"></td>{% if iso_class.genus > 0 %}<td>{{ KNOWL("modcurve.newform_level", "Newform level:") }}</td><td>${{ iso_class.web_curve.newform_level }}$</td>{% endif %}</tr>
   <tr><td>{{ KNOWL("modcurve.index", "Index") }}:</td><td> ${{ iso_class.index }}$ </td><td style="width:20px;"></td><td>{{ KNOWL("modcurve.psl2index", "$\PSL_2$-index") }}:<td>${{ iso_class.psl2index }}$</td></tr>
   <tr><td>{{ KNOWL("modcurve.genus", "Genus") }}:</td><td> ${{ iso_class.genus }} = 1 + \frac{ {{iso_class.psl2index}} }{12} - \frac{ {{iso_class.nu2}} }{4} - \frac{ {{iso_class.nu3}} }{3} - \frac{ {{iso_class.cusps}} }{2}$</td></tr>
-  <tr><td>{{ KNOWL("modcurve.cusps", "Cusps") }}:</td><td> {{ iso_class.cusps }}</td><td style="width:20px;"></td>
+  <tr><td>{{ KNOWL("modcurve.cusps", "Cusps") }}:</td><td> ${{ iso_class.cusps }}$</td><td style="width:20px;"></td>
   <tr><td>{{ KNOWL("modcurve.elliptic_points", "Elliptic points") }}:</td> <td> ${{iso_class.nu2}}$ of order $2$ and ${{iso_class.nu3}}$ of order $3$ </td></tr>
 </table>
 {% if iso_class.genus > 0 and iso_class.dims is not none %}

--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -5,7 +5,7 @@ from collections import Counter
 from flask import url_for
 
 from sage.all import lazy_attribute, prod, euler_phi, ZZ, QQ, latex, PolynomialRing, lcm, NumberField
-from lmfdb.utils import WebObj, integer_prime_divisors, teXify_pol, web_latex, pluralize, display_knowl, raw_typeset
+from lmfdb.utils import WebObj, integer_prime_divisors, teXify_pol, web_latex, pluralize, display_knowl, raw_typeset, prop_int_pretty
 from lmfdb.utils.web_display import compress_multipolynomial
 from lmfdb import db
 from lmfdb.classical_modular_forms.main import url_for_label as url_for_mf_label
@@ -420,16 +420,16 @@ class WebModCurve(WebObj):
     def properties(self):
         props = [
             ("Label", self.label),
-            ("Level", str(self.level)),
-            ("Index", str(self.index)),
-            ("Genus", str(self.genus)),
+            ("Level", prop_int_pretty(self.level)),
+            ("Index", prop_int_pretty(self.index)),
+            ("Genus", prop_int_pretty(self.genus)),
         ]
         if self.image is not None:
             props.append((None, self.image))
         if hasattr(self,"rank") and self.rank is not None:
-            props.append(("Analytic rank", str(self.rank)))
-        props.extend([("Cusps", str(self.cusps)),
-                      (r"$\Q$-cusps", str(self.rational_cusps))])
+            props.append(("Analytic rank", prop_int_pretty(self.rank)))
+        props.extend([("Cusps", prop_int_pretty(self.cusps)),
+                      (r"$\Q$-cusps", prop_int_pretty(self.rational_cusps))])
         return props
 
     @lazy_attribute

--- a/lmfdb/utils/search_parsing.py
+++ b/lmfdb/utils/search_parsing.py
@@ -1766,6 +1766,10 @@ def parse_interval(inp, query, qfield, quantifier_type, bounds_field=None, split
         query[bounds_field + ".2"] = {"$lte": parse_singleton(inp)}
     elif quantifier_type == "atleast":
         query[bounds_field + ".1"] = {"$gte": parse_singleton(inp)}
+    elif quantifier_type == "inexactly":
+        x = parse_singleton(inp)
+        collapse_ors(["$or", [{bounds_field + ".1": {"$lte":x}, bounds_field + ".2": {"$gt":x}},
+                              {bounds_field + ".1": {"$lt":x}, bounds_field + ".2": {"$gte":x}}]], query)
     else:
         X = str_to_intervals(inp, split_minus, parse_singleton)
         if quantifier_type == "exactly":


### PR DESCRIPTION
This PR adds an "inexactly" search option to interval queries that will match only intervals that properly contain the specified value and uses it to provide an option to search for curves whose gonality bounds permit a specified gonality but for which the exact gonality is not known, for example

http://127.0.0.1:37777/ModularCurve/Q/?level=1-70&genus=3-&gonality_type=inexactly&q_gonality=2&contains_negative_one=yes

returns the 1293 curves of level up to 70 of genus >= 3 for which the gonality could be 2 but is not known to be 2 (as noted in the Zulip thread for the modular curves workshop, this includes cases where we really should know that the gonality has to be greater than 2).

The PR also cleans up a few tiny ui issues (number in property box not in math mode, option box, table alignment, etc..)