### PR TITLE
Add info the group automorphism generators page

### DIFF
--- a/lmfdb/groups/abstract/templates/auto_gens_page.html
+++ b/lmfdb/groups/abstract/templates/auto_gens_page.html
@@ -8,21 +8,35 @@
 <p>
  Each row represents an {{KNOWL('group.automorphism', 'automorphism')}} given by its image on a set of {{KNOWL('group.generators','generators')}} of the group (listed as the headers of the columns). <br>
 
+<p>
+The column "Inner by" gives an element which gives rise to the automorphism as
+an inner automorphism if it is, in fact, inner.  Otherwise, it is blank. 
+
+<p>
 {{gp.repr_strg(other_page=True) | safe}}<br>
 </p>
 
 
 
 <p>
+  {% set aut_data = gp.auto_gens_data() %}
+  {% set orders = aut_data.orders %}
+  {% set inner = aut_data.inners %}
   <table class="ntdata" style="margin-left:0;">
     <thead>
-      <tr> <th> </th>         {% for c in gp.auto_gens_list()[0] %}
+      <tr> 
+        <th> </th>
+        <th>{{KNOWL('group.element_order','Order')}}</th>
+        <th>{{KNOWL('group.inner_automorphism','Inner by')}}</th>
+        {% for c in gp.auto_gens_list()[0] %}
         <th>${{c}}$</th>
         {% endfor %}
       </tr>
       <tbody>
 	{% for i in range(1,gp.auto_gens_list()|length) %}
       <tr> <td>  </td>
+      <td align="center"> {{ orders[i] }} </td>
+      <td> ${{ inner[i] }}$ </td>
 	{% for j in gp.auto_gens_list()[i] %}
       <td>${{j}}$ </td>
       {% endfor %}
@@ -37,6 +51,7 @@
 
 
 {# Hack to remove the sidebar and move main content over #}
+{#
 {% block sidebar %}
 <style>
 #main {
@@ -46,3 +61,4 @@
 }
 </style>
 {% endblock %}
+#}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1733,7 +1733,7 @@ class WebAbstractGroup(WebObj):
         # take an element of a pcgs in GAP and make our string form
         if elt=='':
             return ''
-        return pcgs_expos_to_str(self, self.pcgs.ExponentsOfPcElement(elt))
+        return self.pcgs_expos_to_str(self.pcgs.ExponentsOfPcElement(elt))
 
     
     def decode_as_pcgs(self, code, as_str=False):
@@ -1747,7 +1747,7 @@ class WebAbstractGroup(WebObj):
             code = code // m
         if as_str:
             # Need to combine some generators
-            return pcgs_expos_to_str(self, vec)
+            return self.pcgs_expos_to_str(vec)
         else:
             return self.pcgs.PcElementByExponents(vec)
 
@@ -2255,10 +2255,10 @@ class WebAbstractGroup(WebObj):
     def aut_gens_flag(self): #issue with Lie type when family is projective, auto stored as permutations often
         if self.aut_gens is None:
             return False
-        elif self.element_repr_type == "Lie":
+        if self.element_repr_type == "Lie":
             if self.representations["Lie"][0]["family"][0] == "P":
                 return False
-        elif self.element_repr_type in ["GLZN", "GLZq", "Lie", "GLFq", "GLFq"]:
+        if self.element_repr_type in ["GLZN", "GLZq", "Lie", "GLFq", "GLFp"]:
             return False
         return True
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1710,6 +1710,32 @@ class WebAbstractGroup(WebObj):
     def pcgs_relative_orders(self):
         return [ZZ(c) for c in self.pcgs.RelativeOrders()]
 
+    def pcgs_expos_to_str(self, vec):
+        w = []
+        e = 0
+        for i, (c, m) in reversed(list(enumerate(zip(vec, reversed(self.pcgs_relative_orders))))):
+            e += c
+            if i + 1 in self.gens_used:
+                w.append(e)
+                e = 0
+            else:
+                e *= m
+        w.reverse()
+        s = ""
+        for i, c in enumerate(w):
+            if c == 1:
+                s += var_name(i)
+            elif c != 0:
+                s += "%s^{%s}" % (var_name(i), c)
+        return s
+        
+    def pcgs_as_str(self, elt):
+        # take an element of a pcgs in GAP and make our string form
+        if elt=='':
+            return ''
+        return pcgs_expos_to_str(self, self.pcgs.ExponentsOfPcElement(elt))
+
+    
     def decode_as_pcgs(self, code, as_str=False):
         # Decode an element
         vec = []
@@ -1721,23 +1747,7 @@ class WebAbstractGroup(WebObj):
             code = code // m
         if as_str:
             # Need to combine some generators
-            w = []
-            e = 0
-            for i, (c, m) in reversed(list(enumerate(zip(vec, reversed(self.pcgs_relative_orders))))):
-                e += c
-                if i + 1 in self.gens_used:
-                    w.append(e)
-                    e = 0
-                else:
-                    e *= m
-            w.reverse()
-            s = ""
-            for i, c in enumerate(w):
-                if c == 1:
-                    s += var_name(i)
-                elif c != 0:
-                    s += "%s^{%s}" % (var_name(i), c)
-            return s
+            return pcgs_expos_to_str(self, vec)
         else:
             return self.pcgs.PcElementByExponents(vec)
 
@@ -1805,7 +1815,6 @@ class WebAbstractGroup(WebObj):
         else:
             R, N, k, d, rep_type = self._matrix_coefficient_data(rep_type)
         L = ZZ(code).digits(N)
-
         def pad(X, m):
             return X + [0] * (m - len(L))
         L = pad(L, k * d**2)
@@ -1996,6 +2005,29 @@ class WebAbstractGroup(WebObj):
     def auto_gens_list(self):
         gens = self.aut_gens
         return [ [ self.decode(gen, as_str=True) for gen in gens[i]] for i in range(len(gens))]
+
+    def auto_gens_data(self):
+        gens = self.aut_gens
+        gens = [ [ self.decode(gen) for gen in z ] for z in gens]
+        auts = [libgap.GroupHomomorphismByImagesNC(self.G,self.G,gens[0],z) for z in gens]
+        orders = [z.Order() for z in auts]
+        def myisinner(a):
+            if a.IsInnerAutomorphism():
+                return a.ConjugatorOfConjugatorIsomorphism()
+            return ''
+        inners = [myisinner(z) for z in auts]
+        rep_type = self.element_repr_type
+        if rep_type == "PC":
+            inners = [self.pcgs_as_str(z) for z in inners]
+        elif rep_type == "Perm":
+            inners = [str(z) for z in inners]
+        else:
+            if self.element_repr_type=="GLFq":
+                R, N, k, d, rep_type = self._matrix_coefficient_data(self.element_repr_type)
+                inners = [matrix(R,d,d,[[z for z in zz] for zz in z3]) if z3 != '' else '' for z3 in inners]
+            inners = [latex(matrix(z)) if z != '' else '' for z in inners]
+        return {'orders': orders, 'inners': inners}
+
 
     def representation_line(self, rep_type, skip_head=False):
         # TODO: Add links to searches for other representations when available
@@ -2226,6 +2258,8 @@ class WebAbstractGroup(WebObj):
         elif self.element_repr_type == "Lie":
             if self.representations["Lie"][0]["family"][0] == "P":
                 return False
+        elif self.element_repr_type in ["GLZN", "GLZq", "Lie", "GLFq", "GLFq"]:
+            return False
         return True
 
     # outer automorphism group


### PR DESCRIPTION
This adds the order of each listed automorphism, and if it is inner, and element which will induce the automorphism.  It also restores the sidebar for these pages so they look more like regular lmfdb pages.  Finally, these pages are turned off for all matrix groups since there seems to be issues with the data.

For a group given by a presentation:
http://beta.lmfdb.org/Groups/Abstract/auto_gens/1440.3334
http://127.0.0.1:37777/Groups/Abstract/auto_gens/1440.3334

Group given by permutations:
http://beta.lmfdb.org/Groups/Abstract/auto_gens/24.12
http://127.0.0.1:37777/Groups/Abstract/auto_gens/24.12

One where the permutations are large, so it doesn't fit on the screen:
http://beta.lmfdb.org/Groups/Abstract/auto_gens/204073344.mo
http://127.0.0.1:37777/Groups/Abstract/auto_gens/204073344.mo

Finallly, a group where we no longer give a like to automorphism generators (near the top is the line for the automorphism group)
http://beta.lmfdb.org/Groups/Abstract/192.486
http://127.0.0.1:37777/Groups/Abstract/192.486