### PR TITLE
Dirichlet characters to modulus 10^6

### DIFF
--- a/lmfdb/backend/searchtable.py
+++ b/lmfdb/backend/searchtable.py
@@ -308,7 +308,7 @@ class PostgresSearchTable(PostgresTable):
             []
             sage: db.lfunc_lfunctions._parse_values({'bad_lfactors':[1,2]})[1][0]
             '[1, 2]'
-            sage: db.char_orbits._parse_values({'modulus':3})
+            sage: db.char_dirichlet._parse_values({'modulus':3})
             [3]
         """
 

--- a/lmfdb/characters/ListCharacters.py
+++ b/lmfdb/characters/ListCharacters.py
@@ -1,8 +1,6 @@
 # ListCharacters.py
 import re
 from sage.all import lcm, factor, Integers
-from sage.databases.cremona import cremona_letter_code
-from lmfdb.characters.web_character import WebDirichlet, parity_string
 from lmfdb.characters.TinyConrey import ConreyCharacter
 from lmfdb.utils import flash_error, integer_divisors
 
@@ -101,37 +99,3 @@ def get_character_modulus(a, b, limit=7):
         entries2[k] = l
     cols = headers
     return headers, entries2, rows, cols
-
-
-def info_from_db_orbit(orbit):
-    mod = orbit['modulus']
-    conductor = orbit['conductor']
-    orbit_index = orbit['orbit_index']
-    orbit_letter = cremona_letter_code(orbit_index - 1)
-    orbit_label = f"{mod}.{orbit_letter}"
-    order = orbit['order']
-    is_odd = parity_string(orbit['parity'])
-    is_prim = _is_primitive(orbit['is_primitive'])
-    return [(mod,
-             num,
-             conductor,
-             orbit_label,
-             order,
-             is_odd,
-             is_prim,
-             WebDirichlet.char2tex(mod, num))
-            for num in orbit['galois_orbit']]
-
-
-def _is_primitive(db_primitive):
-    """
-    Translate db's primitive entry to boolean.
-    """
-    return str(db_primitive) == "True"
-
-
-def _is_odd(db_parity):
-    """
-    Translate db's parity entry to boolean.
-    """
-    return int(db_parity) == -1

--- a/lmfdb/characters/templates/Character.html
+++ b/lmfdb/characters/templates/Character.html
@@ -106,7 +106,7 @@
 function value_handler(evt) {
     evt.preventDefault();
     var val = $("#calc-value-input").val();
-    $("#calc-value-output").load("{{ url_character(type=type, calc='value', number_field = nflabel, modulus = modlabel, number=numlabel) }}" + "?val=" + val,
+    $("#calc-value-output").load("{{ url_character(type=type, calc='value', modulus = modlabel, number=numlabel) }}" + "?val=" + val,
      function() {
         {# render the output #}
         renderMathInElement($("#calc-value-output").get(0), katexOpts);

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -18,7 +18,7 @@ class WebCharacterTest(LmfdbTest):
 class DirichletSearchTest(LmfdbTest):
     def test_nchars(self):
         from lmfdb import db
-        nchars = db.char_orbits.sum('degree')
+        nchars = db.char_dirichlet.sum('degree')
         W = self.tc.get('/Character/Dirichlet/')
         assert comma(nchars) in W.get_data(as_text=True)
 
@@ -248,7 +248,5 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'chi = DirichletCharacter(H, M([1,2]))' in W.get_data(as_text=True), "sage code generator is wrong"
 
     def test_underlying_data(self):
-        W = self.tc.get('/Character/Dirichlet/data/289.j.7').get_data(as_text=True)
-        assert 'is_minimal' in W and 'last_label' in W
         W = self.tc.get('/Character/Dirichlet/data/289.j').get_data(as_text=True)
         assert 'is_minimal' in W

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -248,5 +248,7 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'chi = DirichletCharacter(H, M([1,2]))' in W.get_data(as_text=True), "sage code generator is wrong"
 
     def test_underlying_data(self):
+        W = self.tc.get('/Character/Dirichlet/data/289.j.7').get_data(as_text=True)
+        assert 'is_minimal' in W and 'last_label' in W
         W = self.tc.get('/Character/Dirichlet/data/289.j').get_data(as_text=True)
         assert 'is_minimal' in W

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -249,6 +249,6 @@ class DirichletCharactersTest(LmfdbTest):
 
     def test_underlying_data(self):
         W = self.tc.get('/Character/Dirichlet/data/289.j.7').get_data(as_text=True)
-        assert 'is_minimal' in W and 'last_label' in W
+        assert 'is_minimal' in W and 'last' in W
         W = self.tc.get('/Character/Dirichlet/data/289.j').get_data(as_text=True)
         assert 'is_minimal' in W

--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -8,7 +8,7 @@ Any character object is obtained as a double inheritance of
 2. an object type (list of groups, character group, character)
 
 For Dirichlet characters of modulus up to 100,000, the database holds data for
-character orbits in char_orbits. For these objects, there are the "DB" classes
+character orbits in char_dirichlet. For these objects, there are the "DB" classes
 that replace on-the-fly computation with database lookups.
 
 The code thus defines, from the generic top class WebCharObject
@@ -45,6 +45,7 @@ The design is the following:
 
 from flask import url_for
 from collections import defaultdict
+from sage.databases.cremona import cremona_letter_code
 from sage.all import (gcd, ZZ, Rational, Integers, cached_method,
                       euler_phi, latex)
 from sage.misc.lazy_attribute import lazy_attribute
@@ -60,7 +61,7 @@ from lmfdb.groups.abstract.main import abstract_group_display_knowl
 logger = make_logger("DC")
 
 def parity_string(n):
-    return "odd" if n == -1 else "even"
+    return ("even" if n else "odd") if type(n) == bool else ("odd" if n == -1 else "even")
 
 def bool_string(b):
     return "yes" if b else "no"
@@ -523,16 +524,13 @@ class WebChar(WebCharObject):
     def friends(self):
         from lmfdb.lfunctions.LfunctionDatabase import get_lfunction_by_url
         f = []
-        cglink = url_character(type=self.type,number_field=self.nflabel,modulus=self.modlabel)
-        f.append( ("Character group", cglink) )
-        if self.nflabel:
-            f.append( ('Number field', '/NumberField/' + self.nflabel) )
-        if self.type == 'Dirichlet' and self.chi.is_primitive() and self.conductor < 100000:
-            url = url_character(type=self.type, number_field=self.nflabel, modulus=self.modlabel, number=self.numlabel)
+        if self.type == 'Dirichlet' and self.chi.is_primitive() and self.conductor < 1000000:
+            url = url_character(type=self.type, modulus=self.modlabel, number=self.numlabel)
             lfun_label = get_lfunction_by_url(url[1:], projection='label')
             if lfun_label:
                 f.append(('L-function', url_for('by_full_label', lfun_label)))
         if self.type == 'Dirichlet':
+            f.append( ("Character group", url_character(type=self.type,modulus=self.modlabel)) )
             f.append( ('Sato-Tate group', url_for('st.by_label', label=f'0.1.{self.order}')))
         if len(self.vflabel)>0:
             f.append( ("Value field", url_for("number_fields.by_label", label=self.vflabel)) )
@@ -579,13 +577,10 @@ class WebDBDirichlet(WebDirichlet):
     def _populate_from_db(self):
 
         gal_orbit = self.chi.galois_orbit()
-        min_conrey_conj = gal_orbit[0]
 
-        orbit_data = db.char_orbits.lucky(
-            {'modulus': self.modulus, 'first_label': "{}.{}".format(self.modulus, min_conrey_conj)}
-        )
+        orbit_data = db.char_dirichlet.lucky({'modulus': self.modulus, 'first': gal_orbit[0]})
 
-        self.orbit_index = orbit_data['orbit_index']
+        self.orbit_index = orbit_data['orbit']
         self.orbit_label = orbit_data['label'].split(".")[1]
         self.order = int(orbit_data['order'])
         self.conductor = self.chi.conductor()  # this also sets indlabel
@@ -615,10 +610,6 @@ class WebDBDirichlet(WebDirichlet):
             self.genvalues = self.textuple([self._tex_value(v) for v in vals])
 
     def _set_values_and_groupelts(self):
-        """
-        The char_orbits db collection does not contain `values`,
-        so these are computed on the fly.
-        """
         if self.modulus == 1:
             self.groupelts = [1]
             self.values = [r"\(1\)"]
@@ -673,7 +664,7 @@ class WebDBDirichlet(WebDirichlet):
         self.isminimal = bool_string(orbit_data['is_minimal'])
 
     def _set_parity(self, orbit_data):
-        self.parity = parity_string(int(orbit_data['parity']))
+        self.parity = parity_string(orbit_data['is_even'])
 
     def _set_galoisorbit(self, gal_orbit):
         if self.modulus == 1:
@@ -903,12 +894,8 @@ class WebDBDirichletGroup(WebDirichletGroup, WebDBDirichlet):
         valuepairs = compute_values(chi, self.groupelts)
         min_conrey_conj = chi.min_conrey_conj
 
-        # This next db lookup takes ages, I don't know how to speed it up
-        orbit_label = db.char_orbits.lucky(
-            {'modulus': mod, 'first_label': "{}.{}".format(mod, min_conrey_conj)},
-            projection='label'
-        )
-        logger.debug(f"[DC DB query] modulus = {mod}, first_label = {mod},{min_conrey_conj} -> {orbit_label}")
+        orbit_label = db.char_dirichlet.lucky({'modulus':mod,'first':min_conrey_conj},projection='label')
+        logger.debug(f"[DC DB query] modulus = {mod}, first = {min_conrey_conj} -> {orbit_label}")
 
         return is_prim, order, orbit_label, valuepairs
 
@@ -1138,9 +1125,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
 
     def _populate_from_db(self):
 
-        orbit_data = db.char_orbits.lucky(
-            {'modulus': self.modulus, 'label': self.label}
-        )
+        orbit_data = db.char_dirichlet.lookup(self.label)
         if orbit_data is None:
             raise ValueError
 
@@ -1149,10 +1134,10 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
         self.degree = orbit_data['degree']
         self.isprimitive = bool_string(orbit_data['is_primitive'])
         self.isminimal = bool_string(orbit_data['is_minimal'])
-        self.parity = parity_string(int(orbit_data['parity']))
+        self.parity = parity_string(orbit_data['is_even'])
         self._set_kernel_field_poly(orbit_data)
-        self.orbit_index = orbit_data['orbit_index']
-        self.inducing = orbit_data['primitive_label']
+        self.orbit_index = orbit_data['orbit']
+        self.inducing = "{}.{}".format(orbit_data['conductor'],cremona_letter_code(orbit_data['primitive_orbit']-1))
         self.ind_orbit_label = self.inducing.split(".")[1]
 
         # The rest of the function is setting the Galois orbit
@@ -1170,7 +1155,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
             ]
 
     def _set_kernel_field_poly(self, orbit_data):
-        an_orbit_rep = int(orbit_data['first_label'].split(".")[1])
+        an_orbit_rep = orbit_data['first']
         chi = ConreyCharacter(self.modulus, an_orbit_rep)
         self.first_chi = chi
         if self.order <= 100:

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -704,7 +704,7 @@ def parse_character(inp, query, qfield, prim=False):
             if level > ORBIT_MAX_MOD:
                 raise ValueError("The level is too large.")
             # Check that this character is actually primitive
-            conductor = db.char_orbits.lucky({'modulus':level, 'orbit_index': orbit}, 'conductor')
+            conductor = db.char_dirichlet.lucky({'modulus':level, 'orbit': orbit}, 'conductor')
             if conductor is None:
                 raise ValueError("No character orbit with this label exists.")
             if conductor != level:

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -5,7 +5,7 @@
 from lmfdb import db
 from sage.all import ZZ, prod, gp
 from sage.modular.dims import sturm_bound
-from sage.databases.cremona import cremona_letter_code, class_to_int
+from sage.databases.cremona import cremona_letter_code
 from lmfdb.number_fields.web_number_field import nf_display_knowl, cyclolookup, rcyclolookup
 from lmfdb.characters.TinyConrey import ConreyCharacter
 from lmfdb.utils import (
@@ -268,7 +268,7 @@ def make_newspace_data(level, char_data, k=2):
     data['char_orbit_label'] = char_data['label'].split('.')[-1]
     data['char_order'] = char_data['order']
     data['char_parity'] = char_data['parity']
-    data['conrey_index'] = int(char_data['first_label'].split('.')[-1])
+    data['conrey_index'] = char_data['first']
     data['cusp_dim'] = int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (level, k, data['conrey_index'], level))) * char_data['degree'] # https://pari.math.u-bordeaux.fr/pub/pari/manuals/2.15.4/users.pdf  p.595
     data['dim'] = int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 0)' % (level, k, data['conrey_index'], level))) * char_data['degree'] # mfdim returns the dimension over Q(chi), not over Q
     data['eis_dim'] = int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 3)' % (level, k, data['conrey_index'], level))) * char_data['degree']
@@ -283,10 +283,7 @@ def make_newspace_data(level, char_data, k=2):
     data['level_radical'] = prod(data['level_primes'])
     data['mf_dim'] = data['cusp_dim'] + data['eis_dim']
     data['mf_new_dim'] = data['dim'] + data['eis_new_dim']
-    data['prim_orbit_index'] = class_to_int(char_data['primitive_label'].split('.')[-1]) + 1
-    # To justify the +1 above compare e.g.
-    # https://www.lmfdb.org/ModularForm/GL/Q/holomorphic/data/3333.2.dn 'prim_orbit_index': 50
-    # https://www.lmfdb.org/Character/Dirichlet/data/3333.dn 'primitive_label': '1111.bx' and cremona.class_to_int('bx') == 49
+    data['prim_orbit_index'] = char_data['primitive_orbit']
     data['relative_dim'] = data['dim']/data['char_degree']
     data['sturm_bound'] = sturm_bound(level, k)
     data['weight'] = k
@@ -297,12 +294,8 @@ def make_oldspace_data(newspace_label, char_conductor, prim_orbit_index):
     # This creates enough of data to generate the oldspace decomposition on a newspace page
     level = int(newspace_label.split('.')[0])
     weight = int(newspace_label.split('.')[1])
-    prim_orbit_label = str(char_conductor) + '.' + cremona_letter_code(prim_orbit_index - 1)
-    # To justify the -1 above compare e.g.
-    # https://www.lmfdb.org/ModularForm/GL/Q/holomorphic/data/3333.2.dn 'prim_orbit_index': 50
-    # https://www.lmfdb.org/Character/Dirichlet/data/3333.dn 'primitive_label': '1111.bx' and cremona.class_to_int('bx') == 49
     sub_level_list = [sub_level for sub_level in ZZ(level).divisors() if (sub_level % char_conductor == 0) and sub_level != level]
-    sub_chars = list(db.char_orbits.search({'modulus':{'$in':sub_level_list}, 'primitive_label':prim_orbit_label}))
+    sub_chars = list(db.char_dirichlet.search({'modulus':{'$in':sub_level_list}, 'primitive_orbit':prim_orbit_index}))
     sub_chars = {char['modulus'] : char for char in sub_chars}
 
     oldspaces = []
@@ -310,7 +303,7 @@ def make_oldspace_data(newspace_label, char_conductor, prim_orbit_index):
         entry = {}
         entry['sub_level'] = sub_level
         entry['sub_char_orbit_index'] = sub_chars[sub_level]['orbit_index']
-        entry['sub_conrey_index'] = int(sub_chars[sub_level]['first_label'].split('.')[-1])
+        entry['sub_conrey_index'] = sub_chars[sub_level]['first']
         entry['sub_mult'] = len(ZZ(level/sub_level).divisors())
         if int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
             # only include subspaces with cusp forms
@@ -398,7 +391,8 @@ class WebNewformSpace():
                 raise ValueError("Space %s not found" % label)
             level = int(label.split('.')[0])
             char_label = str(level) + '.' + label.split('.')[-1]
-            char_data = db.char_orbits.lucky({'modulus':level, 'label':char_label})
+            char_data = db.char_dirichlet.lookup(char_label)
+            char_data['parity'] = 1 if char_data['is_even'] else -1
             if not char_data:
                 raise ValueError("Space %s not found" % label)
             data = make_newspace_data(level, char_data)
@@ -502,7 +496,7 @@ class WebGamma1Space():
                 else:
                     self.decomp.append((space, [form for form in newforms if form['space_label'] == space['label']]))
         else:
-            char_orbits = list(db.char_orbits.search({'modulus':level}))
+            char_orbits = list(db.char_dirichlet.search({'modulus':level}))
             newspaces_by_label = {str(level) + '.' + ns['char_orbit_label'] : ns for ns in newspaces} # to match the full character orbit label
             newspace_dims_by_label = {char_orbits[i]['label'] : self.newspace_dims[i] for i in range(len(char_orbits))} # This relies on the fact that newspaces are sorted by char_orbit_index, which is the default at the time of writing.
             for char in char_orbits:
@@ -516,7 +510,7 @@ class WebGamma1Space():
                 elif newspace_dims_by_label[char['label']] != 0:
                     space = {}
                     space['level'] = level
-                    space['conrey_index'] = int(char['first_label'].split('.')[1])
+                    space['conrey_index'] = char['first']
                     space['char_orbit_label'] = char['label'].split('.')[-1]
                     space['char_degree'] = char['degree']
                     space['dim'] = newspace_dims_by_label[char['label']]

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -264,10 +264,10 @@ def make_newspace_data(level, char_data, k=2):
     data['char_conductor'] = char_data['conductor']
     data['char_degree'] = char_data['degree']
     data['char_is_real'] = char_data['is_real']
-    data['char_orbit_index'] = char_data['orbit_index']
+    data['char_orbit_index'] = char_data['orbit']
     data['char_orbit_label'] = char_data['label'].split('.')[-1]
     data['char_order'] = char_data['order']
-    data['char_parity'] = char_data['parity']
+    data['char_parity'] = 1 if char_data['is_even'] else -1
     data['conrey_index'] = char_data['first']
     data['cusp_dim'] = int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (level, k, data['conrey_index'], level))) * char_data['degree'] # https://pari.math.u-bordeaux.fr/pub/pari/manuals/2.15.4/users.pdf  p.595
     data['dim'] = int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 0)' % (level, k, data['conrey_index'], level))) * char_data['degree'] # mfdim returns the dimension over Q(chi), not over Q
@@ -302,7 +302,7 @@ def make_oldspace_data(newspace_label, char_conductor, prim_orbit_index):
     for sub_level in sub_level_list:
         entry = {}
         entry['sub_level'] = sub_level
-        entry['sub_char_orbit_index'] = sub_chars[sub_level]['orbit_index']
+        entry['sub_char_orbit_index'] = sub_chars[sub_level]['orbit']
         entry['sub_conrey_index'] = sub_chars[sub_level]['first']
         entry['sub_mult'] = len(ZZ(level/sub_level).divisors())
         if int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
@@ -392,7 +392,6 @@ class WebNewformSpace():
             level = int(label.split('.')[0])
             char_label = str(level) + '.' + label.split('.')[-1]
             char_data = db.char_dirichlet.lookup(char_label)
-            char_data['parity'] = 1 if char_data['is_even'] else -1
             if not char_data:
                 raise ValueError("Space %s not found" % label)
             data = make_newspace_data(level, char_data)


### PR DESCRIPTION
The new table `char_dirichlet` contains Dirichlet character orbit data up to modulus 10^6, extending `char_orbits` which only covered modulus up to 10^5.  To keep the storage reasonable several columns were changed, necessitating a new table, but the UI should be unchanged (except for a bug fix, computing character values should now work consistently, where as it currently does not, e.g. try evaluating https://www.lmfdb.org/Character/Dirichlet/17/14 (no output is generated because there is a 404 on the request for the value due to a malformed URL).

This PR should not be merged until the table `char_dirichlet` has been copied to prod (in progress now).  Tests pass but I'd appreciate another set of eyes on the code to see if I have missed anything.  In the new schema, the integer `parity` column has been replaced by `is_even` (a boolean), the `first_label` and `last_label` text columns have been replaced by `first` and `last` integers that specify the Conrey index, the `primitive_orbit_label` text column has been replaced by a `primitive_orbit` integer specifying the orbit (as an ordinal starting from 1,  the modulus is the conductor), and the `orbit_index` integer column has been renamed `orbit` for consistency (was and still is an ordinal starting from 1).