### PR TITLE
Fix server error on links that are both old and broken

### DIFF
--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -151,7 +151,7 @@ def convert_spacelabel_from_conrey(spacelabel_conrey):
     N, k, n = map(int, spacelabel_conrey.split('.'))
     try:
         return db.mf_newspaces.lucky({'conrey_index': ConreyCharacter(N,n).min_conrey_conj, 'level': N, 'weight': k}, projection='label')
-    except AssertionError: # N and n not relatively prime
+    except ValueError: # N and n not relatively prime
         pass
 
 


### PR DESCRIPTION
Followup fix to #5982: now need to catch a `ValueError` on urls like https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/20/8/0/