### PR TITLE
Better character tables for Galois groups

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -14,7 +14,7 @@ from lmfdb.utils import (
     clean_input, prep_ranges, parse_bool, parse_ints, parse_galgrp,
     SearchArray, TextBox, TextBoxNoEg, YesNoBox, ParityBox, CountBox,
     StatsDisplay, totaler, proportioners, prop_int_pretty, Downloader,
-    search_wrap, redirect_no_cache)
+    sparse_cyclotomic_to_mathml, search_wrap, redirect_no_cache)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, LinkCol, MultiProcessedCol, MathCol, CheckCol, SearchCol
 from lmfdb.api import datapage
@@ -323,8 +323,10 @@ def render_group_webpage(args):
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
         data['nilpotency'] = '$%s$' % data['nilpotency']
+        data['have_isom'] = wgg.have_isomorphism
         if data['nilpotency'] == '$-1$':
             data['nilpotency'] = ' not nilpotent'
+        data['dispv'] = sparse_cyclotomic_to_mathml
         downloads = []
         for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("SageMath", "sage")]:
             downloads.append(('Code to {}'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))
@@ -335,6 +337,7 @@ def render_group_webpage(args):
             title=title,
             bread=bread,
             info=data,
+            gp=wgg,
             code=wgg.code,
             properties=prop2,
             friends=friends,

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -24,6 +24,7 @@ from lmfdb.groups.abstract.main import abstract_group_display_knowl
 from .transitive_group import (
     galois_module_knowl_guts, group_display_short,
     subfield_display, resolve_display, chartable,
+    cclasses_display_knowl, character_table_display_knowl,
     group_alias_table, WebGaloisGroup, knowl_cache)
 
 # Test to see if this gap installation knows about transitive groups
@@ -261,10 +262,15 @@ def render_group_webpage(args):
         if ZZ(order).is_prime():
             data['ordermsg'] = "$%s$ (is prime)" % order
         pgroup = len(ZZ(order).prime_factors()) < 2
-        if wgg.num_conjclasses() < 50:
-            data['cclasses'] = wgg.conjclasses()
-        if ZZ(order) < ZZ(10000000) and wgg.num_conjclasses() < 21:
+        if wgg.num_conjclasses() < 51:
+            data['cclasses'] = wgg.conjclasses
+        else:
+            data['cclass_knowl'] = cclasses_display_knowl(n,t)
+        if wgg.num_conjclasses() < 31:
             data['chartable'] = chartable(n, t)
+        else:
+            data['chartable_knowl'] = character_table_display_knowl(n,t, 
+                name="%d x %d character table"%(wgg.num_conjclasses(),wgg.num_conjclasses()))
         data['gens'] = wgg.generator_string()
         if n == 1 and t == 1:
             data['gens'] = 'None needed'

--- a/lmfdb/galois_groups/templates/character-table.html
+++ b/lmfdb/galois_groups/templates/character-table.html
@@ -1,0 +1,48 @@
+{%- include "knowl-defs.html" -%}
+{%- from "knowl-defs.html" import KNOWL with context -%}
+{%- set dummy = gp.conjclasses -%}
+{%- set ccs = gp.conjugacy_classes -%}
+{%- if info.char_highlight -%}
+  <p>The row representing the character {{info.char_highlight}} is highighted below.</p>
+{%- endif -%}
+<table class="nowrap">
+  <tr>
+    <td></td><td></td>
+    {% for c in ccs %}
+      <td class="right">{{ c.display_knowl() | safe }}</td>
+    {% endfor %}
+    <tr>
+    <td></td><td>Size</td>
+    {% for c in ccs %}
+      <td class="right">{{ c.size }}</td>
+    {% endfor %}
+  </tr>
+  {% for p in gp.factors_of_order %}
+    {% set ploop = loop %}
+    <tr>
+      <td></td><td class="right">{{KNOWL('group.conjugacy_class.power_classes',"{} P".format(p))}}</td>
+      {% for c in ccs %}
+        <td class="right">{{ ccs[c['powers'][ploop.index-1]-1].label }}</td>
+      {% endfor %}
+    </tr>
+  {% endfor %}
+  <tr>
+    <td></td><td>{{KNOWL('group.representation.type', 'Type')}}</td>
+  </tr>
+  {% set dispv = info.dispv %}
+
+  {% for chtr in gp.characters %}
+    {% if chtr.label == info.char_highlight %}
+      <tr class="highlighted">
+    {% else %}
+      <tr>
+    {% endif %}
+    <td> {{ chtr.display_knowl() | safe }}</td>
+    <td class="center">{{chtr.type()}}</td>
+    {% set cond = chtr.cyclotomic_n %}
+    {% for val in chtr.values %}
+      <td class="right">{{ dispv(cond, val) | safe }}</td>
+    {% endfor %}
+    </tr>
+  {% endfor %}
+</table>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -64,10 +64,12 @@ table.reptable td, table.reptable th {
 
       {% if info.cclasses is defined %}
    <table class="ntdata">
-      <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
+      <thead><tr><td>Label</td><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
       <tbody>
         {% for c in info.cclasses %}
-           <tr><td> ${{c[3]}}$</td>
+           <tr>
+              <td> {{c[4]}}</td>
+              <td> ${{c[3]}}$</td>
               <td> ${{c[2]}}$</td>
               <td> ${{c[1]}}$</td>
               <td> ${{c[0]}}$</td>
@@ -103,7 +105,9 @@ table.reptable td, table.reptable th {
 
     <table>
       <tr><td>{{KNOWL('group.complex_character_table', 'Character table')}}:
-      {% if info.chartable is defined %}
+      {% if info.have_isom %}
+         {% include 'character_table.html' %}
+      {% elif info.chartable is defined %}
       <td>&nbsp;&nbsp;<td>
       <pre>
 {{info.chartable}}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -21,7 +21,13 @@ table.reptable td, table.reptable th {
       <tr><td>{{KNOWL('gg.simple_name', title='Group')}}:<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
       {% endif %}
       {% if info.n < 16 %}
-      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:<td>&nbsp;&nbsp;<td>${{info.name}}$</tr>
+      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:<td>&nbsp;&nbsp;<td>
+      {% if info.n == 1 %}
+        {{info.name}}
+      {% else %}
+        ${{info.name}}$
+      {% endif %}
+      </tr>
       {% endif %}
       <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}
       <td>{{ place_code('even') }}</td></tr>

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -78,8 +78,7 @@ table.reptable td, table.reptable th {
       </tbody>
       </table>
       {% else %}
-        There are {{ info.num_cc }} conjugacy classes of elements.
-        Data not shown.
+        {{ info.cclass_knowl | safe }}
       {% endif %}
    </p>
    <p>{{ place_code('ccs') }}</p>
@@ -101,21 +100,23 @@ table.reptable td, table.reptable th {
       <tr><td class="nowrap">{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</td>
       <tr><td>{{KNOWL('group.small_group_label','Label')}}:<td>&nbsp;&nbsp;<td>{{info.groupid | safe}}
       <td>{{place_code('id')}}</td></tr>
-    </table>
-
-    <table>
       <tr><td>{{KNOWL('group.complex_character_table', 'Character table')}}:
-      {% if info.have_isom %}
-         {% include 'character_table.html' %}
-      {% elif info.chartable is defined %}
-      <td>&nbsp;&nbsp;<td>
-      <pre>
-{{info.chartable}}
-</pre>
+      {% if not info.wgg.can_chartable %}
+        <td>&nbsp;&nbsp;
+        <td> not computed
+        </table> </div> </p>
+      {% elif info.chartable %}
+        </table>
+        </div>
+        </p>
+        <p>
+         {% include 'character-table.html' %}
       {% else %}
-      not available.
-      {% endif %}
+      <td>&nbsp;&nbsp;
+      <td>
+         {{ info.chartable_knowl | safe }}
     </table> </div> </p>
+      {% endif %}
 
   <p>{{place_code('char_table')}}</p>
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -174,8 +174,7 @@ class WebGaloisGroup:
         wag = self.wag
         imgs = [Permutations(self.n()).unrank(z) for z in self._data['isomorphism']]
         imgs = [gap("PermList(%s)"%str(z)) for z in imgs]
-        iso=wag.G.GroupHomomorphismByImagesNC(self.gapgroupnt(), wag.G_gens(), imgs)
-        return iso
+        return wag.G.GroupHomomorphismByImagesNC(self.gapgroupnt(), wag.G_gens(), imgs)
                        
     @lazy_attribute
     def factors_of_order(self):
@@ -192,34 +191,31 @@ class WebGaloisGroup:
         gap.set('cycletype', 'function(el, n) local ct; ct := CycleLengths(el, [1..n]); ct := ShallowCopy(ct); Sort(ct); ct := Reversed(ct); return(ct); end;')
         wag = self.wag
         self.conjugacy_classes = wag.conjugacy_classes
-        if self.have_isomorphism() and wag.element_repr_type != "Lie":
+        if int(n) == 1:
+            self.conjugacy_classes[0].force_repr('()')
+            return [[self.conjugacy_classes[0], 1, 1, '1', '1A']]
+        elif self.have_isomorphism() and wag.element_repr_type != "Lie":
             isom = self.getisom
             cc = [z.representative for z in self.conjugacy_classes]
             cc1 = [wag.decode(z) for z in cc]
-            ccc = [isom.Image(z) for z in cc1]
+            cc = [isom.Image(z) for z in cc1]
             for j in range(len(self.conjugacy_classes)):
-                self.conjugacy_classes[j].force_repr(str(ccc[j]))
+                self.conjugacy_classes[j].force_repr(str(cc[j]))
             ccn = [z.size for z in self.conjugacy_classes]
-            cc2 = [gap("cycletype("+str(x)+","+str(n)+")") for x in ccc]
+            cc2 = [gap("cycletype("+str(x)+","+str(n)+")") for x in cc]
             cclabels = [z.label for z in self.conjugacy_classes]
         else:
             cc = g.ConjugacyClasses()
             ccn = [x.Size() for x in cc]
-            ccc = [x.Representative() for x in cc]
-            cc2 = [x.cycletype(n) for x in ccc]
             cclabels = ['' for z in cc]
+            cc = [x.Representative() for x in cc]
+            cc2 = [x.cycletype(n) for x in cc]
             for j in range(len(self.conjugacy_classes)):
                 self.conjugacy_classes[j].force_repr(' ')
-        if int(n) == 1:
-            cc2 = [[1]]
-            cc = ['()']
-            cclabels = ['' for z in cc]
-        else:
-            cc = ccc
         cc2 = [str(x) for x in cc2]
         cc2 = [re.sub(r"\[", '', x) for x in cc2]
         cc2 = [re.sub(r"\]", '', x) for x in cc2]
-        ans = [[cc[j], ccc[j].Order(), ccn[j], cc2[j],cclabels[j]] for j in range(len(ccn))]
+        ans = [[cc[j], cc[j].Order(), ccn[j], cc2[j],cclabels[j]] for j in range(len(cc))]
         return ans
 
     @lazy_attribute

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -193,7 +193,7 @@ class WebGaloisGroup:
         self.conjugacy_classes = wag.conjugacy_classes
         if int(n) == 1:
             self.conjugacy_classes[0].force_repr('()')
-            return [[self.conjugacy_classes[0], 1, 1, '1', '1A']]
+            return [['()', 1, 1, '1', '1A']]
         elif self.have_isomorphism() and wag.element_repr_type != "Lie":
             isom = self.getisom
             cc = [z.representative for z in self.conjugacy_classes]

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2473,7 +2473,9 @@ def sub_display_knowl(label, name=None):
         name = f"Subgroup {label}"
     return f'<a title = "{name} [lmfdb.object_information]" knowl="lmfdb.object_information" kwargs="args={label}&func=sub_data">{name}</a>'
 
-def cc_data(gp, label, typ="complex"):
+def cc_data(gp, label, typ="complex", representative=None):
+    # representative allows us to use this mechanism for Galois
+    # group conjugacy classes as well
     if typ == "rational":
         wag = WebAbstractGroup(gp)
         rcc = wag.conjugacy_class_divisions
@@ -2510,7 +2512,9 @@ def cc_data(gp, label, typ="complex"):
             sub_display_knowl(centralizer, "$" + wcent.subgroup_tex + "$")
         )
 
-    if wacc.representative is None:
+    if representative:
+        ans += "<br>Representative: "+representative
+    elif wacc.representative is None:
         ans += "<br>Representative: not computed"
     else:
         if label == '1A':

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2980,11 +2980,9 @@ class WebAbstractConjClass(WebObj):
         WebObj.__init__(self, label, data)
 
     # Allows us to use representative from a Galois group
-    def force_repr(self):
-        self.force_repr = True
-
-    def set_rep(self, newrep):
+    def force_repr(self, newrep):
         self.representative = newrep
+        self.force_repr = True
 
     def display_knowl(self, name=None):
         if not name:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2977,18 +2977,18 @@ class WebAbstractConjClass(WebObj):
         if data is None:
             data = db.gps_groups_cc.lucky({"group": group, "label": label})
         WebObj.__init__(self, label, data)
-        self.force_repr = False
+        self.force_repr_elt = False
 
     # Allows us to use representative from a Galois group
     def force_repr(self, newrep):
         self.representative = newrep
-        self.force_repr = True
+        self.force_repr_elt = True
 
     def display_knowl(self, name=None):
         if not name:
             name = self.label
         force_string = ''
-        if self.force_repr:
+        if self.force_repr_elt:
             force_string = "%7C"+str(self.representative)
         return f'<a title = "{name} [lmfdb.object_information]" knowl="lmfdb.object_information" kwargs="func=cc_data&args={self.group}%7C{self.label}%7Ccomplex{force_string}">{name}</a>'
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2976,8 +2976,8 @@ class WebAbstractConjClass(WebObj):
     def __init__(self, group, label, data=None):
         if data is None:
             data = db.gps_groups_cc.lucky({"group": group, "label": label})
-        force_repr = False
         WebObj.__init__(self, label, data)
+        self.force_repr = False
 
     # Allows us to use representative from a Galois group
     def force_repr(self, newrep):
@@ -2989,7 +2989,7 @@ class WebAbstractConjClass(WebObj):
             name = self.label
         force_string = ''
         if self.force_repr:
-            force_string = "%7C"+self.representative
+            force_string = "%7C"+str(self.representative)
         return f'<a title = "{name} [lmfdb.object_information]" knowl="lmfdb.object_information" kwargs="func=cc_data&args={self.group}%7C{self.label}%7Ccomplex{force_string}">{name}</a>'
 
 class WebAbstractDivision():

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -299,7 +299,6 @@ class WebAbstractGroup(WebObj):
         if self.order == 1:
             gens = []
         elif rep_type == "PC":
-            gpc = G.Pcgs()
             gens = G.GeneratorsOfGroup()
             gens = [gens[z-1] for z in repn['gens']]
         elif rep_type=="Perm":

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -17,8 +17,9 @@ class DynamicKnowlTest(LmfdbTest):
 
     def test_character_table_knowl(self):
         L = self.tc.get('/knowledge/show/gg.character_table.data?n=5&t=5', follow_redirects=True)
-        # character table order can vary, so use trivial character
-        assert '1  1  1  1  1  1  1' in L.get_data(as_text=True)
+        # character values now complicated text in mathml, so look for labels
+        assert '120.34.5a' in L.get_data(as_text=True)
+        assert '5A' in L.get_data(as_text=True)
 
     def test_abstract_group_knowl(self):
         L = self.tc.get('/knowledge/show/lmfdb.object_information?func=group_data&args=16.5', follow_redirects=True)


### PR DESCRIPTION
Addresses issue #525 

This replaces the old GAP character tables with ones computed for abstract groups.

The most typical case is where we have stored an explicit isomorphism to an abstract group in the database, such as

http://127.0.0.1:37777/GaloisGroup/5T4
http://beta.lmfdb.org/GaloisGroup/5T4

This is for almost all groups in degree <=15.  The conjugacy class table now has labels, and the character table is typeset with the conjugacy class labels being knowls with data on the class including a representative.  We still show power class data.  The old tables had the order of the centralizer for a class in a slightly cryptic manner; now the centralizer itself appears in the knowl.

There are some cases where we don't have an explicit isomorphism, or it is suppressed because of data issues with finite groups, such as

http://127.0.0.1:37777/GaloisGroup/5T5
http://beta.lmfdb.org/GaloisGroup/5T5

It now looks like the information above, but the conjugacy classes don't have labels in the main conjugacy class list, and the knowls for the classes in the character table do not list a representative.

Another case is where there are many conjugacy classes.  Before we just didn't give anything on conjugacy classes or the character table.  Now they are in knowls, so they are available if the user really wants to see them.

http://127.0.0.1:37777/GaloisGroup/32T12264
http://beta.lmfdb.org/GaloisGroup/32T12264

In some cases, the abstract group is not in the database or we don't have a character table for it.  

http://127.0.0.1:37777/GaloisGroup/46T12
http://beta.lmfdb.org/GaloisGroup/46T12

Then we give conjugacy class data but no character table.

Finally, the code shows some contortions for the trivial group which for some reason is always a problem here (gap does not have 1T1).