### PR TITLE
Modular Curves Verification: checking ratpts map to ratpts

### DIFF
--- a/lmfdb/verify/modcurve/modcurve_modelmaps.py
+++ b/lmfdb/verify/modcurve/modcurve_modelmaps.py
@@ -1,0 +1,76 @@
+
+from sage.all import ProjectiveSpace, PolynomialRing, QQ
+
+from lmfdb.lmfdb_database import db
+from lmfdb.modular_curves.upload import VARORDER
+from ..verification import TableChecker, slow
+
+
+def apply_map_to_pt(a_map, a_pt):
+    how_many_vars = a_pt.count(':') + 1
+    my_vars = VARORDER[:how_many_vars]
+    P = ProjectiveSpace(QQ, how_many_vars - 1, names=my_vars)
+    my_pt = P(a_pt.split(':'))
+    Pol = PolynomialRing(QQ, how_many_vars, names=my_vars)
+    output = []
+    my_pt_tuple = tuple(my_pt)
+    for a_pol in a_map:
+        output.append(Pol(a_pol)(my_pt_tuple))
+    return output
+
+
+class modcurve_modelmaps(TableChecker):
+    table = db.modcurve_modelmaps
+    label_col = 'domain_label'
+
+    @slow(projection=['domain_label', 'codomain_label', 'coordinates', 'domain_model_type', 'codomain_model_type'])
+    def check_rat_pts_map_to_rat_pts(self, rec):
+        """
+        given a rational point on a modular curve, and a map from this modular curve
+        to another one, check that the image is a rational point on the latter curve
+        """
+
+        # First look up ratpts on the domain
+
+        for point in db.modcurve_points.search({'curve_label':rec['domain_label'],
+                                                'coordinates':{'$exists':True}}):
+            try:
+                relevant_pts = point['coordinates'][rec['domain_model_type']]  # these are the pts that can be hit with the map
+            except KeyError:
+                # means there are no points on the model required by the map
+                continue
+            
+            jinv_this_pt = point['jinv']  # needed for the third test below
+            for rel_pt in relevant_pts:
+                pt_on_codomain_as_list = apply_map_to_pt(rec['coordinates'], rel_pt)
+                
+                # TEST 1: check this pt is rational
+                if not all([t in QQ for t in pt_on_codomain_as_list]):
+                    return False
+
+                # TEST 2: check this is actually a point on the codomain
+                codomain_info = db.modcurve_models.lookup({'modcurve':rec['codomain_label'],
+                                                       'model_type':rec['codomain_model_type']},
+                                                       projection=['equation', 'number_variables'])
+                codomain_info = list(codomain_info)
+                assert len(codomain_info) == 1  # multiple entries is bad
+                codomain_info = codomain_info[0]
+                Pol = PolynomialRing(QQ, codomain_info['number_variables'], names=VARORDER[:codomain_info['number_variables']])
+                for f_str in codomain_info['equation']:
+                    assert Pol(f_str)(pt_on_codomain_as_list) == 0, "point not on codomain"
+                
+                ### TEST 3: check this pt is accounted for in modcurve_points
+
+                # 3a. first get the points on the codomain
+                points_on_codomain_with_this_j = db.modcurve_points.lookup({'curve_label':rec['codomain_label'],
+                                                'jinv':jinv_this_pt})
+                points_on_codomain_with_this_j = list(points_on_codomain_with_this_j)
+                assert len(points_on_codomain_with_this_j) == 1
+
+                # 3b. now check the point is among them
+                pts_on_codomain_as_str = points_on_codomain_with_this_j['coordinates'][rec['codomain_model_type']]  # a list of strings
+                P = ProjectiveSpace(QQ, codomain_info['number_variables'] - 1, names=VARORDER[:codomain_info['number_variables']])
+                assert P(pt_on_codomain_as_list) in [P(pt_str.split(':')) for pt_str in pts_on_codomain_as_str], "missing point"
+        
+        return True
+

--- a/lmfdb/verify/modcurve/modcurve_modelmaps.py
+++ b/lmfdb/verify/modcurve/modcurve_modelmaps.py
@@ -1,5 +1,6 @@
 
-from sage.all import ProjectiveSpace, PolynomialRing, QQ
+from sage.all import ProjectiveSpace, PolynomialRing, QQ, lazy_attribute
+from collections import defaultdict
 
 from lmfdb.lmfdb_database import db
 from lmfdb.modular_curves.upload import VARORDER
@@ -23,6 +24,20 @@ class modcurve_modelmaps(TableChecker):
     table = db.modcurve_modelmaps
     label_col = 'domain_label'
 
+    @lazy_attribute
+    def modcurve_points(self):
+        ans = defaultdict(list)
+        for rec in db.modcurve_points.search({}, ["curve_label", "coordinates", "jinv"]):
+            ans[rec["curve_label"]].append(rec)
+        return ans
+
+    @lazy_attribute
+    def modcurve_models(self):
+        ans = defaultdict(list)
+        for rec in db.modcurve_models.search({}, ["modcurve", "model_type", "equation", "number_variables"]):
+            ans[rec["modcurve"], rec["model_type"]] = (rec["equation"], rec["number_variables"])
+        return ans
+
     @slow(projection=['domain_label', 'codomain_label', 'coordinates', 'domain_model_type', 'codomain_model_type'])
     def check_rat_pts_map_to_rat_pts(self, rec):
         """
@@ -31,9 +46,9 @@ class modcurve_modelmaps(TableChecker):
         """
 
         # First look up ratpts on the domain
-
-        for point in db.modcurve_points.search({'curve_label':rec['domain_label'],
-                                                'coordinates':{'$exists':True}}):
+        for point in self.modcurve_points[rec["domain_label"]]:
+            if not point.get("coordinates"):
+                continue
             try:
                 relevant_pts = point['coordinates'][rec['domain_model_type']]  # these are the pts that can be hit with the map
             except KeyError:
@@ -49,27 +64,20 @@ class modcurve_modelmaps(TableChecker):
                     return False
 
                 # TEST 2: check this is actually a point on the codomain
-                codomain_info = db.modcurve_models.lookup({'modcurve':rec['codomain_label'],
-                                                       'model_type':rec['codomain_model_type']},
-                                                       projection=['equation', 'number_variables'])
-                codomain_info = list(codomain_info)
-                assert len(codomain_info) == 1  # multiple entries is bad
-                codomain_info = codomain_info[0]
-                Pol = PolynomialRing(QQ, codomain_info['number_variables'], names=VARORDER[:codomain_info['number_variables']])
-                for f_str in codomain_info['equation']:
+                equation, number_variables = self.modcurve_models[rec["codomain_label"], rec["codomain_model_type"]]
+                Pol = PolynomialRing(QQ, number_variables, names=VARORDER[:number_variables])
+                for f_str in equation:
                     assert Pol(f_str)(pt_on_codomain_as_list) == 0, "point not on codomain"
                 
                 ### TEST 3: check this pt is accounted for in modcurve_points
 
                 # 3a. first get the points on the codomain
-                points_on_codomain_with_this_j = db.modcurve_points.lookup({'curve_label':rec['codomain_label'],
-                                                'jinv':jinv_this_pt})
-                points_on_codomain_with_this_j = list(points_on_codomain_with_this_j)
+                points_on_codomain_with_this_j = [rec for rec in self.modcurve_points[rec["codomain_label"]] if rec["jinv"] == jinv_this_pt]
                 assert len(points_on_codomain_with_this_j) == 1
 
                 # 3b. now check the point is among them
-                pts_on_codomain_as_str = points_on_codomain_with_this_j['coordinates'][rec['codomain_model_type']]  # a list of strings
-                P = ProjectiveSpace(QQ, codomain_info['number_variables'] - 1, names=VARORDER[:codomain_info['number_variables']])
+                pts_on_codomain_as_str = points_on_codomain_with_this_j[0]['coordinates'][rec['codomain_model_type']]  # a list of strings
+                P = ProjectiveSpace(QQ, number_variables - 1, names=VARORDER[:number_variables])
                 assert P(pt_on_codomain_as_list) in [P(pt_str.split(':')) for pt_str in pts_on_codomain_as_str], "missing point"
         
         return True

--- a/lmfdb/verify/modcurve/modcurve_modelmaps.py
+++ b/lmfdb/verify/modcurve/modcurve_modelmaps.py
@@ -45,18 +45,15 @@ class modcurve_modelmaps(TableChecker):
         given a rational point on a modular curve, and a map from this modular curve
         to another one, check that the image is a rational point on the latter curve
         """
-
         # First look up ratpts on the domain
         for point in self.modcurve_points[rec["domain_label"]]:
             if not point.get("coordinates"):
                 continue
             try:
                 relevant_pts = point['coordinates'][str(rec['domain_model_type'])]  # these are the pts that can be hit with the map
-                print(f"Found point on {rec['domain_label']}")
             except KeyError:
                 # means there are no points on the model required by the map
                 continue
-            jinv_this_pt = point['jinv']  # needed for the third test below
             for rel_pt in relevant_pts:
                 pt_on_codomain_as_list = apply_map_to_pt(rec['coordinates'], rel_pt)
 
@@ -67,22 +64,9 @@ class modcurve_modelmaps(TableChecker):
                 # TEST 2: check this is actually a point on the codomain
                 equation, number_variables = self.modcurve_models[rec["codomain_label"], rec["codomain_model_type"]]
                 Pol = PolynomialRing(QQ, number_variables, names=VARORDER[:number_variables])
-                for f_str in equation:
-                    assert Pol(f_str)(pt_on_codomain_as_list) == 0, "point not on codomain"
 
-                ### TEST 3: check this pt is accounted for in modcurve_points
+                if not all([Pol(f_str)(pt_on_codomain_as_list) == 0 for f_str in equation]):
+                    return False
 
-                # 3a. first get the points on the codomain
-                points_on_codomain_with_this_j = [rec for rec in self.modcurve_points[rec["codomain_label"]] if rec["jinv"] == jinv_this_pt]
-                assert len(points_on_codomain_with_this_j) == 1
-
-                # 3b. now check the point is among them
-                if str(rec['codomain_model_type']) in points_on_codomain_with_this_j[0]['coordinates']:
-                    pts_on_codomain_as_str = points_on_codomain_with_this_j[0]['coordinates'][str(rec['codomain_model_type'])]
-                else:
-                    # Means we don't have coordinates on the model we're dealing with, so can't do anything
-                    continue
-                P = ProjectiveSpace(QQ, number_variables - 1, names=VARORDER[:number_variables])
-                assert P(pt_on_codomain_as_list) in [P(pt_str.split(':')) for pt_str in pts_on_codomain_as_str], "missing point"
         return True
 


### PR DESCRIPTION
This addresses #5918 

Specifically: this PR consists of a verification test on `modcurve_modelmaps` and `modcurve_points`. Here's what it does:

1. for each map in `modcurve_modelmaps`:
2. get the rational points on the domain of the map with a search on `modcurve_points`;
3. send these rational points to the codomain;
4. ASSERT the image point is rational ("Test 1");
5. ASSERT the image point actually lies on the codomain ("Test 2");
6. ASSERT the image point is already accounted for in `modcurve_points` (on the codomain curve) ("Test 3")

This combined test passes on legendre in about 80 seconds.

@roed314 we have discussed this PR in person, if you could review before it gets merged, that'd be great