### PR TITLE
Restore conjugacy class reps in knowls

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2522,7 +2522,7 @@ def cc_data(gp, label, typ="complex", representative=None):
         else:
             gp_value = WebAbstractGroup(gp)
             if gp_value.representations.get("Lie") and gp_value.representations["Lie"][0]["family"][0] == "P" and gp_value.order < 2000:  #Problem with projective lie groups of order <2000
-                    pass
+                pass
             else:
                 repn = gp_value.decode(wacc.representative, as_str=True)
                 ans += "<br>Representative: {}".format("$" + repn + "$")

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2521,12 +2521,11 @@ def cc_data(gp, label, typ="complex", representative=None):
             ans += "<br>Representative: id"
         else:
             gp_value = WebAbstractGroup(gp)
-            if gp_value.representations.get("Lie"):
-                if gp_value.representations["Lie"][0]["family"][0] == "P" and gp_value.order < 2000:  #Problem with projective lie groups of order <2000
+            if gp_value.representations.get("Lie") and gp_value.representations["Lie"][0]["family"][0] == "P" and gp_value.order < 2000:  #Problem with projective lie groups of order <2000
                     pass
-                else:
-                    repn = gp_value.decode(wacc.representative, as_str=True)
-                    ans += "<br>Representative: {}".format("$" + repn + "$")
+            else:
+                repn = gp_value.decode(wacc.representative, as_str=True)
+                ans += "<br>Representative: {}".format("$" + repn + "$")
     return Markup(ans)
 
 


### PR DESCRIPTION
In a group like

http://beta.lmfdb.org/Groups/Abstract/32.7
http://127.0.0.1:37777/Groups/Abstract/32.7

go down to the character tables, click on a conjugacy class or division.  This restores the representative