### PR TITLE
Remove spaces from forced representative elements

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -3014,6 +3014,7 @@ class WebAbstractConjClass(WebObj):
 
     # Allows us to use representative from a Galois group
     def force_repr(self, newrep):
+        newrep=newrep.replace(' ','')
         self.representative = newrep
         self.force_repr_elt = True
 


### PR DESCRIPTION
On a page like

http://beta.lmfdb.org/GaloisGroup/15T22
http://127.0.0.1:37777/GaloisGroup/15T22

the knowls for conjugacy classes currently hang (except for the identity).

To get permutations as the representatives, they are being passed in the url.  Before this change, they might contain spaces which this pull request removes.