### PR TITLE
Shorten subgroup generators

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -22,7 +22,7 @@
     </td></tr>
     {% if seq.amb.show_subgroup_flag() %}
 	<tr><td>{{KNOWL('group.generators', 'Generators:')}}</td><td>
-		${{seq.amb.show_subgroup_generators(seq)}}$</td></tr>
+		{{seq.amb.show_subgroup_generators(seq)|safe}}</td></tr>
 	{% endif %}
 	{% if seq.nilpotent %}
     <tr><td>{{KNOWL('group.nilpotent', title='Nilpotency

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1881,7 +1881,11 @@ class WebAbstractGroup(WebObj):
     def show_subgroup_generators(self, H):
         if H.subgroup_order == 1:
             return ""
-        return ", ".join(self.decode(g, as_str=True) for g in H.generators)
+        gens = ", ".join(self.decode(g, as_str=True) for g in H.generators)
+        if self.element_repr_type == "Perm":
+            gens=raw_typeset(gens,compress_perm(gens))
+            return gens
+        return raw_typeset(gens,"$" + gens + "$")
 
     # @lazy_attribute
     # def fp_isom(self):

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1883,8 +1883,7 @@ class WebAbstractGroup(WebObj):
             return ""
         gens = ", ".join(self.decode(g, as_str=True) for g in H.generators)
         if self.element_repr_type == "Perm":
-            gens=raw_typeset(gens,compress_perm(gens))
-            return gens
+            return raw_typeset(gens,compress_perm(gens))
         return raw_typeset(gens,"$" + gens + "$")
 
     # @lazy_attribute


### PR DESCRIPTION
Quick fix on subgroup pages to only show parts of the generators if they are long.

Compare beta and local for:
/Groups/Abstract/sub/6400000000.gpl.16.EI
or
/Groups/Abstract/sub/819200000000.bj.512.S

Note it allows for copying of generators if the group is PC:
/sub/12.4.2.b1.b1