### PR TITLE
Add subgroups labels as option for jump box

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -134,8 +134,8 @@ class CmfTest(LmfdbTest):
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+2000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
         assert 'Error: We limit downloads of traces to' in page.get_data(as_text=True)
-        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+30000%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
-        assert '863.2.c' in page.get_data(as_text=True)
+        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?Submit=sage&download=1&query=%7B%27dim%27%3A+%7B%27%24gte%27%3A+83330%7D%2C+%27num_forms%27%3A+%7B%27%24exists%27%3A+True%7D%7D&search_type=SpaceTraces', follow_redirects=True)
+        assert '999983.2.a' in page.get_data(as_text=True)
 
     def test_random(self):
         r"""

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -71,15 +71,6 @@ from .stats import GroupStats
 abstract_group_label_regex = re.compile(r"^(\d+)\.([a-z]+|\d+)$")
 
 
-#abstract_subgroup_label_regex = re.compile(
-#    r"^(\d+)\.([a-z0-9]+)\.(\d+)\.[a-z]+(\d+)(\.[a-z]+\d+)?(\.([N|M]|([N][C](\d+))))?$"
-#)
-
-#abstract_noncanonical_subgroup_label_regex = re.compile(
-#    r"^(\d+)\.([a-z0-9]+)\.(\d+)\.([A-Z]+)(\.([N|M]|([N][C](\d+))))?$"
-#)
-
-
 abstract_subgroup_label_regex = re.compile(
     r"^(\d+)\.([a-z0-9]+)\.(\d+)\.([a-z]+\d+)(?:\.([a-z]+\d+))?(?:\.(N|M|NC\d+))?$"
 )
@@ -882,6 +873,10 @@ def group_jump(info):
     # by abelian label
     if jump.startswith("ab/") and AB_LABEL_RE.fullmatch(jump[3:]):
         return redirect(url_for(".by_abelian_label", label=jump[3:]))
+    # by subgroup label
+    if subgroup_label_is_valid(jump):
+        return redirect(url_for(".by_subgroup_label", label=jump))
+    #transitive group
     from lmfdb.galois_groups.transitive_group import Tfinder
     if Tfinder.fullmatch(jump):
         label = db.gps_transitive.lookup(jump, "abstract_label")
@@ -909,19 +904,8 @@ def group_jump(info):
                 return redirect(url_for(".by_label", label=lab))
             else:
                 flash_error("The group %s has not yet been added to the database." % jump)
-    flash_error("%s is not a valid name for a group; see %s for a list of possible families" % (jump, display_knowl('group.families', 'here')))
+    flash_error("%s is not a valid name for a group or subgroup; see %s for a list of possible families" % (jump, display_knowl('group.families', 'here')))
     return redirect(url_for(".index"))
-
-#def group_download(info):
-#    t = "Stub"
-#    bread = get_bread([("Jump", "")])
-#    return render_template(
-#        "single.html",
-#        kid="rcs.groups.abstract.source",
-#        title=t,
-#        bread=bread,
-#        learnmore=learnmore_list_remove("Source"),
-#    )
 
 def show_factor(n):
     if n is None or n == "":
@@ -1830,7 +1814,7 @@ class GroupsSearchArray(SearchArray):
             ("irrQ_degree", r"$\Q$-irrep degree", ["irrQ_degree", "counter"])
     ]
     jump_example = "8.3"
-    jump_egspan = "e.g. 8.3, GL(2,3), 8T34, C3:C4, C2*A5 or C16.D4"
+    jump_egspan = "e.g. 8.3, GL(2,3), 8T34, C3:C4, C2*A5, C16.D4, or 12.4.2.b1.a1"
     jump_prompt = "Label or name"
     jump_knowl = "group.find_input"
 


### PR DESCRIPTION
Title says it all.  Go to /Groups/Abstract/ and enter a subgroup label in the jump box and it will bring you to subgroup page.

Once this is merged, I will update the knowl group.find_input that describes what the label can be to include subgroup labels.
