### PR TITLE
Remove restriction on lie groups

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -167,8 +167,8 @@ class WebGaloisGroup:
         return WebAbstractGroup(self.abstract_label())
 
     def have_isomorphism(self):
-        if self.wag.element_repr_type == "Lie":
-            return False
+        #if self.wag.element_repr_type == "Lie":
+        #    return False
         return 'isomorphism' in self._data
 
     @lazy_attribute
@@ -196,7 +196,7 @@ class WebGaloisGroup:
         if int(n) == 1:
             self.conjugacy_classes[0].force_repr('()')
             return [['()', 1, 1, '1', '1A']]
-        elif self.have_isomorphism() and wag.element_repr_type != "Lie":
+        elif self.have_isomorphism():
             isom = self.getisom
             cc = [z.representative for z in self.conjugacy_classes]
             cc1 = [wag.decode(z) for z in cc]


### PR DESCRIPTION
When showing conjugacy classes and character tables on Galois group pages, we added labels to conjugacy classes.  Initially, this was blocked if the abstract group was internally of Lie type because of data issues.  This is no longer needed, so this removes blocking on the level of code.

https://beta.lmfdb.org/GaloisGroup/16T28
http://127.0.0.1:37777/GaloisGroup/16T28
