### PR TITLE
Remove space messing up knowl id

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -151,7 +151,7 @@
 
 <p>
   {% if seq.characteristic %}
-  Since the subgroup $H$ is {{KNOWL('group.characteristic_subgroup', 'characteristic')}}, the {{KNOWL('group.automorphism', 'automorphism group')}} $\operatorname{Aut}(G)$ of the ambient group acts on $H$, yielding a homomorphism $\operatorname{res} : \operatorname{Aut}(G) \to \operatorname{Aut}(H)$.  The image of $\operatorname{res}$ on the {{KNOWL('group.automorphism', 'inner automorphism group')}} $\operatorname{Inn}(G)$ is the {{KNOWL(' group.weyl_group','Weyl group')}} $W = G / Z_G(H)$.
+  Since the subgroup $H$ is {{KNOWL('group.characteristic_subgroup', 'characteristic')}}, the {{KNOWL('group.automorphism', 'automorphism group')}} $\operatorname{Aut}(G)$ of the ambient group acts on $H$, yielding a homomorphism $\operatorname{res} : \operatorname{Aut}(G) \to \operatorname{Aut}(H)$.  The image of $\operatorname{res}$ on the {{KNOWL('group.automorphism', 'inner automorphism group')}} $\operatorname{Inn}(G)$ is the {{KNOWL('group.weyl_group','Weyl group')}} $W = G / Z_G(H)$.
   {% set S = "\operatorname{Aut}(G)" %}
   {% else %}
   While the subgroup $H$ is not {{KNOWL('group.characteristic_subgroup', 'characteristic')}}, the stabilizer $S$ of $H$ in the {{KNOWL('group.automorphism', 'automorphism group')}} $\operatorname{Aut}(G)$ of the ambient group acts on $H$, yielding a homomorphism $\operatorname{res} : S \to \operatorname{Aut}(H)$.  The image of $\operatorname{res}$ on the {{KNOWL('group.automorphism', 'inner automorphisms')}} $\operatorname{Inn}(G) \cap S$ is the {{KNOWL('group.weyl_group','Weyl group')}} $W = N_G(H) / Z_G(H)$.


### PR DESCRIPTION
On a subgroup page, it looks like Weyl group knowl is not written, and if you click on it, you get a warning about there being an extraneous space.  This removes the space.

First line of the section on Automorphism information:

https://beta.lmfdb.org/Groups/Abstract/sub/32.11.4.a1.a1
http://127.0.0.1:37777/Groups/Abstract/sub/32.11.4.a1.a1
