### PR TITLE
Subgroup error fix

### DIFF
--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -6,7 +6,9 @@
 <h2> Subgroup ($H$) information</h2>
 <p>
   <table>
-    {% if seq.subgroup is not none %}
+    {% if seq.sub.sub_missing %}
+    <tr><td>{{KNOWL('group.name', title='Description:')}}</td><td> ${{seq.subgroup_tex}}$</td></tr>
+    {% elif seq.subgroup is not none %}
     <tr><td>{{KNOWL('group.name', title='Description:')}}</td><td><a href="{{url_for('.by_label', label=seq.subgroup)}}">${{seq.subgroup_tex}}$</a></td></tr>
     {% else %}
     <tr><td>{{KNOWL('group.name', title='Description:')}}</td><td>not computed</td></tr>

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2815,6 +2815,16 @@ class WebAbstractSubgroup(WebObj):
                       'aut_group': self.aut_label, 'aut_order': None,
                       'pgroup':len(ZZ(order).abs().factor())==1})
             return newgroup
+        if self.subgroup_order == 6561: 
+            gp = WebAbstractGroup(self.subgroup, None)
+            if gp.source == "Missing":
+                order = self.subgroup_order
+                newgroup = WebAbstractGroup('nolabel',
+                      data={'order': order, 'G': None, 'abelian': self.abelian,'cyclic': self.cyclic,
+                      # What if aut_label is set?
+                      'aut_group': self.aut_label, 'aut_order': None, 'sub_missing' : True,
+                      'pgroup':len(ZZ(order).abs().factor())==1})
+                return newgroup
         for prop in [
             "pgroup",
             "is_elementary",


### PR DESCRIPTION
We were getting error pages on subgroups of order 6561 which are not in the database.  This pr should fix it.  

You can compare subgroup pages of this order whose isomorphism type is not in the database (these pages error on beta):
1049760.t.160.a1
1679616.zd.256.a1

with those whose isomorphism type IS in the database:
52488.bg.8.A
39366.cz.6.c1.a1