### PR TITLE
CMF tweaks to accommodate recently added data

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -840,7 +840,7 @@ newform_columns = SearchColumns([
                  align="center", short_title="projective image"),
     MultiProcessedCol("cm", "cmf.self_twist", "CM",
                       ["is_cm", "cm_discs"],
-                      lambda is_cm, cm_discs: ", ".join(map(quad_field_knowl, cm_discs)) if is_cm else "None",
+                      lambda is_cm, cm_discs: ", ".join(map(quad_field_knowl, cm_discs)) if is_cm else ("None" if is_cm == False else "not computed"),
                       short_title="CM",
                       download_col="cm_discs"),
     MultiProcessedCol("rm", "cmf.self_twist", "RM",

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -186,7 +186,7 @@ def index():
             flash_error("Invalid search type; if you did not enter it in the URL please report")
     info["stats"] = CMF_stats()
     info["weight_list"] = ('1', '2', '3', '4', '5-8', '9-16', '17-32', '33-64', '65-%d' % weight_bound() )
-    info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-2000', '2001-4000', '4001-6000', '6001-8000', '8001-%d' % level_bound() )
+    info["level_list"] = ('1', '2-10', '11-100', '101-1000', '1001-5000', '5001-10000', '10001-50000', '50001-100000', '100001-1000000')
     return render_template("cmf_browse.html",
                            info=info,
                            title="Classical modular forms",
@@ -1172,8 +1172,9 @@ space_columns = SearchColumns([
                       short_title="character"),
     MathCol("char_order", "character.dirichlet.order", r"$\operatorname{ord}(\chi)$", short_title="character order"),
     MathCol("dim", "cmf.display_dim", "Dim.", short_title="dimension"),
-    MultiProcessedCol("decomp", "cmf.dim_decomposition", "Decomp.", ["level", "weight", "char_orbit_label", "hecke_orbit_dims"], display_decomp, align="center", short_title="decomposition", td_class=" nowrap"),
-    MultiProcessedCol("al_dims", "cmf.atkin_lehner_dims", "AL-dims.", ["level", "weight", "ALdims"], display_ALdims, contingent=show_ALdims_col, short_title="Atkin-Lehner dimensions", align="center", td_class=" nowrap")])
+    MathCol("num_forms", "cmf.galois_oribit", "Orbits", short_title="Galois orbits"),
+    MultiProcessedCol("decomp", "cmf.dim_decomposition", "Decomposition", ["level", "weight", "char_orbit_label", "hecke_orbit_dims"], display_decomp, align="center", short_title="decomposition", td_class=" nowrap"),
+    MultiProcessedCol("al_dims", "cmf.atkin_lehner_dims", "AL-decomposition.", ["level", "weight", "ALdims"], display_ALdims, contingent=show_ALdims_col, short_title="AL-decomposition", align="center", td_class=" nowrap")])
 
 @search_wrap(table=db.mf_newspaces,
              title='Newspace search results',
@@ -1218,7 +1219,6 @@ def reliability_page():
                            bread=get_bread(other='Reliability'),
                            learnmore=learnmore_list_remove('Reliability'))
 
-
 @cmf.route("/FormPictures")
 def picture_page():
     t = "Pictures for classical modular forms"
@@ -1229,7 +1229,6 @@ def picture_page():
         bread=get_bread(other="Form Pictures"),
         learnmore=learnmore_list(),
     )
-
 
 def projective_image_sort_key(im_type):
     if im_type == 'A4':
@@ -1305,15 +1304,15 @@ class CMF_stats(StatsDisplay):
 
     @lazy_attribute
     def short_summary(self):
-        return r'The database currently contains %s (%s of) %s, corresponding to %s modular forms over the complex numbers.  You can <a href="%s">browse further statistics</a> or <a href="%s">create your own</a>.' % (self.nforms, self.galois_orbit_knowl, self.newform_knowl, self.ndim, url_for(".statistics"), url_for(".dynamic_statistics"))
+        return r'The database currently contains %s (%s of) %s, and %s of their embeddings into the complex numbers. You can <a href="%s">browse further statistics</a> or <a href="%s">create your own</a>.' % (self.nforms, self.galois_orbit_knowl, self.newform_knowl, self.ndim, url_for(".statistics"), url_for(".dynamic_statistics"))
 
     @lazy_attribute
     def summary(self):
-        return r"The database currently contains %s (%s of) %s and %s nonzero %s, corresponding to %s modular forms over the complex numbers.  In addition to the statistics below, you can also <a href='%s'>create your own</a>." % (self.nforms, self.galois_orbit_knowl, self.newform_knowl, self.nspaces, self.newspace_knowl, self.ndim, url_for(".dynamic_statistics"))
+        return r"The database currently contains %s (%s of) %s in %s %s, and %s of their embeddings into the complex numbers.  In addition to the statistics below, you can also <a href='%s'>create your own</a>." % (self.nforms, self.galois_orbit_knowl, self.newform_knowl, self.nspaces, self.newspace_knowl, self.ndim, url_for(".dynamic_statistics"))
 
     @lazy_attribute
     def buckets(self):
-        return {'level':['1','2-10','11-100','101-1000','1001-2000', '2001-4000','4001-6000','6001-8000','8001-%d'%level_bound()],
+        return {'level':['1','2-10','11-100','101-1000','1001-5000', '5001-10000','10001-50000','50001-100000','100001-1000000'],
                 'weight':['1','2','3','4','5-8','9-16','17-32','33-64','65-%d'%weight_bound()],
                 'dim':['1','2','3','4','5','6-10','11-20','21-100','101-1000','1001-10000','10001-100000'],
                 'relative_dim':['1','2','3','4','5','6-10','11-20','21-100','101-1000'],

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -199,7 +199,7 @@ function get_all_embeddings(num_embeddings) {
     {% for p, ev in newform.atkin_lehner_eigenvals %}
     <tr>
       <td class="center"> \({{ p }}\) </td>
-      <td class="center"> \({{ ev }}\)</td>
+      <td class="center"> \({% if ev==1 %} +1 {%else%} {{ev}} {% endif %}\)</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -76,10 +76,12 @@
   	<td> {{ KNOWL('cmf.defining_polynomial',title='Defining polynomial') }}: </td>
   	<td>{{ newform.field_poly_display | safe }}</td>
   </tr>
-  <tr>
-    <td> {{ KNOWL('cmf.coefficient_ring',title='Coefficient ring') }}: </td>
-    <td> {{ newform.ring_display() | safe }}</td>
-  </tr>
+    {% if newform.hecke_ring_generator_nbound %}
+    <tr>
+      <td> {{ KNOWL('cmf.coefficient_ring',title='Coefficient ring') }}: </td>
+      <td> {{ newform.ring_display() | safe }}</td>
+    </tr>
+    {% endif %}
   {% elif newform.dim == 1 %}
   <tr>
     <td> {{ KNOWL('cmf.coefficient_field',title='Coefficient field') }}: </td>
@@ -103,7 +105,7 @@
   {% if newform.char_order == 1 %}
   <tr>
     <td> {{ KNOWL('cmf.fricke', title='Fricke sign') }}: </td>
-    <td>\({{ newform.fricke_eigenval }}\)</td>
+    <td>{{ newform.fricke_eigenval_display() | safe }}</td>
   </tr>
   {% endif %}
   {% if newform.projective_image %}
@@ -239,7 +241,7 @@ function show_qexp(qstyle) {
 </div>
 {% else %}
 <h2> {{ KNOWL('cmf.q-expansion',title='$q$-expansion')}}</h2>
-<p>The dimension is sufficiently large that we do not compute an algebraic \(q\)-expansion, but we have computed the {{ KNOWL('cmf.trace_form', title='trace expansion') }}.</p>
+<p>The algebraic \(q\)-expansion of this newform has not been computed, but we have computed the {{ KNOWL('cmf.trace_form', title='trace expansion') }}.</p>
 
 <form id="qexp">
   <table><tr><td>

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -324,7 +324,7 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15&char_order=1', follow_redirects=True)
         assert 'A-L signs' in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/?level=15&search_type=Spaces', follow_redirects=True)
-        assert 'AL-dims.' in page.get_data(as_text=True)
+        assert 'AL-decomposition.' in page.get_data(as_text=True)
         assert r'$0$+$1$+$0$+$0$' in page.get_data(as_text=True)
 
     def test_Fricke_signs_search(self):

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -88,9 +88,9 @@ def ALdim_table(al_dims, level, weight):
     def url_sign_char(x): return "-" if x else "%2B"
     primes = ZZ(level).prime_divisors()
     num_primes = len(primes)
-    header = [r'<th>\(%s\)</th>'%p for p in primes]
+    header = [r"<th class='center'>\(%s\)</th>"%p for p in primes]
     if num_primes > 1:
-        header.append(r"<th class='right'>%s</th>"%(display_knowl('cmf.fricke', title='Fricke').replace('"',"'")))
+        header.append(r"<th class='center'>%s</th>"%(display_knowl('cmf.fricke', title='Fricke').replace('"',"'")))
     header.append('<th>Dim</th>')
     rows = []
     fricke = [0,0]
@@ -99,10 +99,10 @@ def ALdim_table(al_dims, level, weight):
             continue
         b = list(reversed(ZZ(i).bits()))
         b = [0 for j in range(num_primes-len(b))] + b
-        row = [r'<td>\(%s\)</td>'%sign_char(x) for x in b]
+        row = [r"<td class='center'>\(%s\)</td>"%sign_char(x) for x in b]
         sign = sum(b) % 2
         if num_primes > 1:
-            row.append(r"<td class='right'>$%s$</td>"%sign_char(sign))
+            row.append(r"<td class='center'>\(%s\)</td>"%sign_char(sign))
         query = {'level':level, 'weight':weight, 'char_order':1, 'atkin_lehner_string':"".join(map(url_sign_char,b))}
         link = newform_search_link(r'\(%s\)'%dim, **query)
         row.append(r'<td>%s</td>'%(link))
@@ -117,8 +117,8 @@ def ALdim_table(al_dims, level, weight):
         plus_link = newform_search_link(r'\(%s\)'%fricke[0], level=level, weight=weight, char_order=1, fricke_eigenval=1)
         minus_knowl = display_knowl('cmf.minus_space',title='Minus space').replace('"',"'")
         minus_link = newform_search_link(r'\(%s\)'%fricke[1], level=level, weight=weight, char_order=1, fricke_eigenval=-1)
-        rows.append(r"<tr><td colspan='%s'>%s</td><td class='right'>\(+\)</td><td>%s</td></tr>"%(num_primes, plus_knowl, plus_link))
-        rows.append(r"<tr><td colspan='%s'>%s</td><td class='right'>\(-\)</td><td>%s</td></tr>"%(num_primes, minus_knowl, minus_link))
+        rows.append(r"<tr><td colspan='%s'>%s</td><td class='center'>\(+\)</td><td>%s</td></tr>"%(num_primes, plus_knowl, plus_link))
+        rows.append(r"<tr><td colspan='%s'>%s</td><td class='center'>\(-\)</td><td>%s</td></tr>"%(num_primes, minus_knowl, minus_link))
     return ("<table class='ntdata'><thead><tr>%s</tr></thead><tbody>%s</tbody></table>" %
             (''.join(header), ''.join(rows)))
 


### PR DESCRIPTION
This PR contains a bunch of minor tweaks to handle the recent addition of about 700,000 newforms to the LMFDB (including all weight 2 newforms for Gamm0(N) for N up to 50000).  For most of these we do not have algebraic eigenvalues, just the trace form, and for dim <= 20, the Hecke field.  This PR prevents server errors in cases where the old code was expecting certain columns to always be defined (e.g. inner twists, self twists, hecke_ring info for dim <= 20, etc...).

It also updates the browse ranges and stats to better reflect the new data set (which has more than twice as many newforms as it did before).  This data has not been copied to proddb yet, but none of these code changes depend on any of the data changes, they just make the code more flexible.