### PR TITLE
Add maximal/largest CMF search option and two small tweaks

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -14,9 +14,9 @@ from lmfdb.utils import (
     parse_noop, parse_equality_constraints, integer_options, parse_subset,
     search_wrap, display_float, factor_base_factorization_latex,
     flash_error, to_dict, comma, display_knowl, bigint_knowl, num2letters,
-    SearchArray, TextBox, SelectBox, TextBoxWithSelect, YesNoBox,
+    SearchArray, TextBox, TextBoxNoEg, SelectBox, TextBoxWithSelect, YesNoBox,
     DoubleSelectBox, RowSpacer, HiddenBox, SearchButtonWithSelect,
-    SubsetBox, ParityMod, CountBox, SelectBoxNoEg,
+    SubsetBox, ParityMod, CountBox,
     StatsDisplay, proportioners, totaler, integer_divisors,
     redirect_no_cache)
 from psycodict.utils import range_formatter

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -14,7 +14,7 @@ from lmfdb.utils import (
     parse_noop, parse_equality_constraints, integer_options, parse_subset,
     search_wrap, display_float, factor_base_factorization_latex,
     flash_error, to_dict, comma, display_knowl, bigint_knowl, num2letters,
-    SearchArray, TextBox, TextBoxNoEg, SelectBox, TextBoxWithSelect, YesNoBox,
+    SearchArray, TextBox, SelectBox, TextBoxWithSelect, YesNoBox,
     DoubleSelectBox, RowSpacer, HiddenBox, SearchButtonWithSelect,
     SubsetBox, ParityMod, CountBox, SelectBoxNoEg,
     StatsDisplay, proportioners, totaler, integer_divisors,

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -787,7 +787,6 @@ def newform_parse(info, query):
             query['is_largest'] = True
         elif info['is_maximal_largest'] == 'notlargest':
             query['is_largest'] = False
-    parse_bool(info, query, 'is_maximal')
     parse_ints(info, query, 'hecke_ring_index')
     parse_ints(info, query, 'hecke_ring_generator_nbound')
     if 'projective_image_type' in info and not 'projective_image' in info:

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -790,7 +790,9 @@ def newform_parse(info, query):
     parse_bool(info, query, 'is_maximal')
     parse_ints(info, query, 'hecke_ring_index')
     parse_ints(info, query, 'hecke_ring_generator_nbound')
-    if info.get('projective_image','').lower() in ["dn","dihedral"]:
+    if 'projective_image_type' in info and not 'projective_image' in info:
+        query['projective_image_type'] = info['projective_image_type']
+    elif info.get('projective_image','').lower() in ["dn","dihedral"]:
         query["projective_image_type"] = "Dn"
     else:
         parse_noop(info, query, 'projective_image', func=str.upper)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -274,6 +274,29 @@ class CmfTest(LmfdbTest):
                 page = self.tc.get('/ModularForm/GL2/Q/holomorphic/38/9/d/a/%d/%d/' % (c, e),follow_redirects=True)
                 assert "Newform orbit 38.9.d.a" in page.get_data(as_text=True)
 
+    def test_maximal(self):
+        page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=1234&weight=2")
+        assert '15 matches' in page.get_data(as_text=True)
+        assert '1234.2.a.h' in page.get_data(as_text=True)
+        assert '1234.2.a.i' in page.get_data(as_text=True)
+        assert '1234.2.b.c' in page.get_data(as_text=True)
+        page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=1234&weight=2&is_maximal_largest=maximal")
+        assert 'unique match' in page.get_data(as_text=True)
+        assert not '1234.2.a.h' in page.get_data(as_text=True)
+        assert '1234.2.a.i' in page.get_data(as_text=True)
+        assert not '1234.2.b.c' in page.get_data(as_text=True)
+        page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=1234&weight=2&is_maximal_largest=largest")
+        assert '5 matches' in page.get_data(as_text=True)
+        assert '1234.2.a.h' in page.get_data(as_text=True)
+        assert '1234.2.a.i' in page.get_data(as_text=True)
+        assert not '1234.2.b.c' in page.get_data(as_text=True)
+        page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?level=1234&weight=2&is_maximal_largest=notlargest")
+        assert '10 matches' in page.get_data(as_text=True)
+        assert not '1234.2.a.h' in page.get_data(as_text=True)
+        assert not '1234.2.a.i' in page.get_data(as_text=True)
+        assert '1234.2.b.c' in page.get_data(as_text=True)
+
+
     def test_dim_table(self):
         page = self.tc.get("/ModularForm/GL2/Q/holomorphic/?weight=12&level=23&search_type=Dimensions", follow_redirects=True)
         assert 'Dimension search results' in page.get_data(as_text=True)

--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -201,7 +201,7 @@ class CmfTest(LmfdbTest):
                 ('level=900-1000&weight=1-&projective_image=D2',
                     ['Results (26 matches)', r"\sqrt{-1}", r"\sqrt{-995}", r"\sqrt{137}"]
                     )]:
-            for s in Subsets(['has_self_twist=yes', 'has_self_twist=cm', 'has_self_twist=rm', 'projective_image_type=Dn','dim=1-4']):
+            for s in Subsets(['has_self_twist=yes', 'has_self_twist=cm', 'has_self_twist=rm', 'projective_image=Dn','dim=1-4']):
                 s = '&'.join(['/ModularForm/GL2/Q/holomorphic/?search_type=List', begin[0]] + list(s))
                 page = self.tc.get(s, follow_redirects=True)
                 for elt in begin[1]:

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -8,7 +8,7 @@ import yaml
 
 from flask import url_for
 from lmfdb.characters.TinyConrey import get_sage_genvalues, ConreyCharacter
-from sage.all import (prime_range, latex, QQ, PolynomialRing, prime_pi, gcd,
+from sage.all import (prime_range, latex, QQ, PolynomialRing, prime_pi, gcd, previous_prime,
                       CDF, ZZ, CBF, cached_method, vector, lcm, RR, lazy_attribute)
 from sage.databases.cremona import cremona_letter_code, class_to_int
 
@@ -183,7 +183,12 @@ class WebNewform():
         self.hecke_ring_cyclotomic_generator = None # in case there is no data in mf_hecke_nf
         if self.embedding_label is None:
             hecke_cols = ['hecke_ring_numerators', 'hecke_ring_denominators', 'hecke_ring_inverse_numerators', 'hecke_ring_inverse_denominators', 'hecke_ring_cyclotomic_generator', 'hecke_ring_character_values', 'hecke_ring_power_basis', 'maxp']
-            eigenvals = db.mf_hecke_nf.lucky({'hecke_orbit_code': self.hecke_orbit_code}, ['an'] + hecke_cols)
+            if self.dim == 1:
+                # avoid using mf_hecke_nf when the dimension is 1
+                vals = ConreyCharacter(self.level, db.char_dirichlet.lookup("%s.%s"%(self.level,self.char_orbit_label),projection="first")).values_gens
+                eigenvals = { 'hecke_ring_cyclotomic_generator': 0, 'hecke_ring_character_values': vals, 'hecke_ring_power_basis': True, 'maxp': previous_prime(len(self.traces)+1), 'an': self.traces }
+            else:
+                eigenvals = db.mf_hecke_nf.lucky({'hecke_orbit_code': self.hecke_orbit_code}, ['an'] + hecke_cols)
             if eigenvals and eigenvals.get('an'):
                 self.has_exact_qexp = True
                 for attr in hecke_cols:
@@ -1203,7 +1208,7 @@ function switch_basis(btype) {
                         return []
                     out = [0]*(max(e for _, e in data) + 1)
                     for c, e in data:
-                        out[e] = c
+                        out[e] += c
                     return out
                 coeffs = [to_list(data) for data in self.qexp[:prec]]
                 return raw_typeset_qexp(coeffs, superscript=True, var=self._zeta_print, final_rawvar='z')


### PR DESCRIPTION
This PR adds a new search option (supported by two new boolean columns on `mf_newforms`) to each for newforms that are
- maximal (only newform in its ambient subspace)
- largest (newform is strictly larger than any other newform in it ambient subspace)
- not largest (not largest)
where the ambient subspace is either the newspace (for nontrivial character) or the relevant Atkin-Lehner subspace (for trivial character).

So, for example, getting zero results on http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/?level=1&is_maximal_largest=notlargest is consistent with Maeda's conjecture, and http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/?level_type=prime&weight=2&dim=8&char_order=1&is_maximal_largest=notlargest is consistent with Cowan-Martin's conjecture, but http://127.0.0.1:37777/ModularForm/GL2/Q/holomorphic/?level_type=squarefree&weight=2&dim=8&char_order=1&is_maximal_largest=notlargest while not inconsistent with this conjecture, perhaps gives one pause (and a desire to compute more data, which is in progress).

This PR also includes a hack to void using `mf_hecke_nf` for forms of dimension 1 (the traceform in `mf_newforms` suffices in this case), which will save a non-trivial amount of space, and a one character fix for #6074.

The updated version of `mf_newforms` with the new columns has been copied to proddb.