### PR TITLE
Fix CMF downloads (resolves #6080)

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf2.py
+++ b/lmfdb/classical_modular_forms/test_cmf2.py
@@ -28,7 +28,7 @@ class CmfTest(LmfdbTest):
             assert str(out) == exp
         for label in ['212.2.k.a', '887.2.a.b']:
             page = self.tc.get('/ModularForm/GL2/Q/holomorphic/download_qexp/{}'.format(label), follow_redirects=True)
-            assert 'No q-expansion found for {}'.format(label) in page.get_data(as_text=True)
+            assert 'q-expansion not available for newform {}'.format(label) in page.get_data(as_text=True)
 
     def test_download(self):
         r"""


### PR DESCRIPTION
This PR addresses #6080 and also addresses a longstanding bug in the magma download which was appending an extra 0 at the end of the q-expansion.