### PR TITLE
Add subgroup search link

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1,4 +1,3 @@
-
 import re
 
 import time
@@ -2751,6 +2750,10 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
                     url_for("abstract.by_subgroup_label", label=H.label), H.label
                 )
             ans += "</div><br />"
+    else:
+        ans += '<a href="{}">{}</a>&nbsp;'.format(
+            f"/Groups/Abstract/?subgroup_order={order}&ambient={ambient}&search_type=Subgroups",
+            "Subgroups with this order")
     if label != "None":
         ans += f'<div align="right"><a href="{url}">{label} home page</a></div>'
     if quotient_label != "None":


### PR DESCRIPTION
On a page such as

  http://beta.lmfdb.org/Groups/Abstract/7434971050829414400.a
  http://127.0.0.1:37777/Groups/Abstract/7434971050829414400.a

some of the subgroups in the profile are not identified as abstract groups.  They are represented as question marks, and the knowls for them only give their order.  This adds a link to that knowl to search for subgroups with that order and ambient group.