### PR TITLE
Fix placement of subgroups in the diagram

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1289,14 +1289,16 @@ def diagram_js(gp, layers, display_opts, aut=False, normal=False):
     # Counts are not right for aut diagram if we know up to conj.
     if aut and not gp.outer_equivalence:
         autcounts = gp.aut_class_counts
-    ilayer = 2
+    ilayer = 4
     iorder = 0
     if normal:
         ilayer += 1
         iorder += 1
-    if aut and not gp.outer_equivalence:
-        ilayer += 4
-        iorder += 4
+    if not aut and not gp.outer_equivalence:
+        ilayer += 2
+        iorder += 2
+    if gp.outer_equivalence and ilayer>3:
+       ilayer -= 2 
     ll = [
         [
             grp.subgroup,

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -1269,11 +1269,6 @@ class WebAbstractGroup(WebObj):
 
     def fullpage_links(self, getpositions=False):
         s = ""
-        if getpositions:
-            s += '<button onclick="getpositions()">Get positions</button><br>\n'
-            s += '<p><div id="positions"></div></p>\n'
-#        s += '<div>\nEach subgroup order has its own level?\n'
-#        s += '<input type="checkbox" id="orderForHeight" onchange="toggleheight()" />\n</div>\n'
         for sub_all in ["subgroup", "normal"]:
             for sub_aut in ["", "aut"]:
                 cls = f'{sub_all}_{sub_aut}diagram'

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -92,7 +92,7 @@ def group_pretty_image(label):
     img = db.gps_images.lookup("?", "image")
     if img:
         return str(img)
-    # we should not get here
+    # we should not get here 
 
 @cached_function(key=lambda label,name,pretty,ambient,aut,profiledata,cache: (label,name,pretty,ambient,aut,profiledata))
 def abstract_group_display_knowl(label, name=None, pretty=True, ambient=None, aut=False, profiledata=None, cache={}):


### PR DESCRIPTION
Subgroups in the diagram for an abstract group were being put in the wrong places, especially when one clicked the box to set vertical positions by the orders of subgroups.  Testing involves trying the various positions (all subs vs normal subs; up to conj vs up to aut; clicking and unclicking the checkbox for vertical positioning).

Simple case:
http://beta.lmfdb.org/Groups/Abstract/4.2
http://127.0.0.1:37777/Groups/Abstract/4.2

More complicated:
http://beta.lmfdb.org/Groups/Abstract/360.118
http://127.0.0.1:37777/Groups/Abstract/360.118

Subgroups only known up to automorphism:
http://beta.lmfdb.org/Groups/Abstract/2116.4
http://127.0.0.1:37777/Groups/Abstract/2116.4