### PR TITLE
Add code snippets to groups

### DIFF
--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -22,44 +22,45 @@ not-implemented:
 
 presentation:
   comment: Define the group with the given generators and relations
-  magma: F<{gens}> := FreeGroup({ngens});  G := quo<F | {reln}>;
-  gap: G := quo(a*b+c);
+  magma: G := PCGroup({pccodelist}); {gens} := Explode({used_gens});
+  gap: G := PcGroupCode({pccode},{ordgp});
 
 
 permutation:
   comment: Define the group as a permutation group
   magma: G := PermutationGroup< {deg} | {perms} >;
-  gap: G := Group( perms );
+  gap: G := Group( {perms} );
 
 
 GLZ:
   comment: Define the group as a matrix group with coefficients in Z
   magma: G := MatrixGroup< {nZ}, Integers() | {LZ} >;
-  gap: \\\\
+  gap: G := Group({LZsplit});
 
 
 GLFp:
+  comment: Define the group as a matrix group with coefficients in GLFp
   magma: G := MatrixGroup< {nFp}, GF({Fp}) | {LFp} >;
-  gap: \\\\
+  gap: Not yet implemented
 
 GLZN:
-  comment: Define the group as a matrix group with coefficients in GLFp
+  comment: Define the group as a matrix group with coefficients in GLZN
   magma: G := MatrixGroup< {nZN}, Integers({N}) | {LZN} >;
-  gap: \\\\
+  gap: G := Group({LZNsplit});
 
 GLZq:
-  comment: Define the group as a matrix group with coefficients in GLFp
+  comment: Define the group as a matrix group with coefficients in GLZq
   magma: G := MatrixGroup< {nZq}, Integers({Zq}) | {LZq} >;
-  gap: \\\\
+  gap: G := Group({LZqsplit});
 
 
 GLFq:
-  comment: Define the group as a matrix group with coefficients in GLFp
+  comment: Define the group as a matrix group with coefficients in GLFq
   magma: G := MatrixGroup< {nFq}, GL({Fq}) | {LFq} >;
-  gap: \\\\
-
+  gap: Not yet implemented
 
 transitive:
   comment: Define the group from the transitive group database
   magma: G := TransitiveGroup(d,n);
-  gap: \\\\
+  gap: Not yet implemented
+

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -22,8 +22,8 @@ not-implemented:
 
 presentation:
   comment: Define the group with the given generators and relations
-  magma: G := PCGroup({pccodelist}); {gens} := Explode({used_gens});
-  gap: G := PcGroupCode({pccode},{ordgp}); gens := GeneratorsOfGroup(G); {gens_assign}
+  magma: G := PCGroup({pccodelist}); {gens} := Explode({used_gens}); AssignNames(~G, {magma_assign});
+  gap: G := PcGroupCode({pccode},{ordgp}); {gap_assign}
 
 
 permutation:

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -1,0 +1,65 @@
+prompt:
+  magma: 'magma'
+  gap: 'gap'
+
+logo:
+  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
+  gap: <img src = "https://gap.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_GAP-GP_Couleurs_L150px.png" width="50px">
+
+comment:
+  magma: |
+    //
+  gap: |
+    #
+
+not-implemented:
+  magma: |
+    // (not yet implemented)
+  gap: |
+    \\\\ (not yet implemented)
+
+
+
+presentation:
+  comment: Define the group with the given generators and relations
+  magma: F<{gens}> := FreeGroup({ngens});  G := quo<F | {reln}>;
+  gap: G := quo(a*b+c);
+
+
+permutation:
+  comment: Define the group as a permutation group
+  magma: G := PermutationGroup< {deg} | {perms} >;
+  gap: G := Group( perms );
+
+
+GLZ:
+  comment: Define the group as a matrix group with coefficients in Z
+  magma: G := MatrixGroup< {nZ}, Integers() | {LZ} >;
+  gap: \\\\
+
+
+GLFp:
+  magma: G := MatrixGroup< {nFp}, GF({Fp}) | {LFp} >;
+  gap: \\\\
+
+GLZN:
+  comment: Define the group as a matrix group with coefficients in GLFp
+  magma: G := MatrixGroup< {nZN}, Integers({N}) | {LZN} >;
+  gap: \\\\
+
+GLZq:
+  comment: Define the group as a matrix group with coefficients in GLFp
+  magma: G := MatrixGroup< {nZq}, Integers({Zq}) | {LZq} >;
+  gap: \\\\
+
+
+GLFq:
+  comment: Define the group as a matrix group with coefficients in GLFp
+  magma: G := MatrixGroup< {nFq}, GL({Fq}) | {LFq} >;
+  gap: \\\\
+
+
+transitive:
+  comment: Define the group from the transitive group database
+  magma: G := TransitiveGroup(d,n);
+  gap: \\\\

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -58,10 +58,10 @@ GLZq:
 #GLFq:
 #  comment: Define the group as a matrix group with coefficients in GLFq
 #  magma: G := MatrixGroup< {nFq}, GL({Fq}) | {LFq} >;
-#  gap: G := Group({LFqsplit}); 
+#  gap: G := Group({LFqsplit});
 
 transitive:
   comment: Define the group from the transitive group database
   magma: G := TransitiveGroup(d,n);
-  gap: Not yet implemented
+  gap: G := TransitiveGroup(d,n);
 

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -16,14 +16,14 @@ not-implemented:
   magma: |
     // (not yet implemented)
   gap: |
-    \\\\ (not yet implemented)
+    # (not yet implemented)
 
 
 
 presentation:
   comment: Define the group with the given generators and relations
   magma: G := PCGroup({pccodelist}); {gens} := Explode({used_gens});
-  gap: G := PcGroupCode({pccode},{ordgp});
+  gap: G := PcGroupCode({pccode},{ordgp}); gens := GeneratorsOfGroup(G); {gens_assign}
 
 
 permutation:

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -41,7 +41,8 @@ GLZ:
 GLFp:
   comment: Define the group as a matrix group with coefficients in GLFp
   magma: G := MatrixGroup< {nFp}, GF({Fp}) | {LFp} >;
-  gap: Not yet implemented
+  gap: G := not yet implemented
+#  gap: G := Group({LFpsplit});
 
 GLZN:
   comment: Define the group as a matrix group with coefficients in GLZN
@@ -54,10 +55,10 @@ GLZq:
   gap: G := Group({LZqsplit});
 
 
-GLFq:
-  comment: Define the group as a matrix group with coefficients in GLFq
-  magma: G := MatrixGroup< {nFq}, GL({Fq}) | {LFq} >;
-  gap: Not yet implemented
+#GLFq:
+#  comment: Define the group as a matrix group with coefficients in GLFq
+#  magma: G := MatrixGroup< {nFq}, GL({Fq}) | {LFq} >;
+#  gap: G := Group({LFqsplit}); 
 
 transitive:
   comment: Define the group from the transitive group database

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1646,26 +1646,19 @@ def render_abstract_group(label, data=None):
 
     bread = get_bread([(label, "")])
     learnmore_gp_picture = ('Picture description', url_for(".picture_page"))
-    gp.code_snippets()
-    if gp.live():
-        code = None
-    else:
-        code = gp.code
 
-    
     return render_template(
         "abstract-show-group.html",
         title=title,
         bread=bread,
         info=info,
         gp=gp,
- #       code=gp.code,
-        code=code,
+        code=gp.code_snippets(),
         properties=gp.properties(),
         friends=friends,
         learnmore=learnmore_list_add(*learnmore_gp_picture),
         KNOWL_ID=f"group.abstract.{label}",
-        downloads=downloads, 
+        downloads=downloads,
     )
 
 
@@ -3099,7 +3092,7 @@ sorted_code_names = ['presentation', 'permutation', 'matrix', 'transitive']
 code_names = {'presentation': 'Define the group using generators and relations',
               'permutation': 'Define the group as a permutation group',
               'matrix': 'Define the group as a matrix group',
-              'transitivei': 'Define the group from the transitive group database'}
+              'transitive': 'Define the group from the transitive group database'}
 
 Fullname = {'magma': 'Magma', 'gap': 'Gap'}
 Comment = {'magma': '//', 'gap': '#'}

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1347,7 +1347,6 @@ def diagram_js_string(gp, only=None):
 
 # Writes individual pages
 def render_abstract_group(label, data=None):
-
     info = {}
     if data is None:
         label = clean_input(label)
@@ -1451,13 +1450,22 @@ def render_abstract_group(label, data=None):
 
     bread = get_bread([(label, "")])
     learnmore_gp_picture = ('Picture description', url_for(".picture_page"))
+    gp.code_snippets()
+    if gp.live():
+        code = None
+    else:
+        code = gp.code
+#    print("HERE IS gp.code", gp.code)
 
+    
     return render_template(
         "abstract-show-group.html",
         title=title,
         bread=bread,
         info=info,
         gp=gp,
+ #       code=gp.code,
+        code=code,
         properties=gp.properties(),
         friends=friends,
         learnmore=learnmore_list_add(*learnmore_gp_picture),
@@ -2845,3 +2853,16 @@ def order_stats_list_to_string(o_list):
         if o_list.index(pair) != len(o_list) - 1:
             s += ","
     return s
+
+
+sorted_code_names = ['presentation', 'permutation', 'matrix', 'transitive']
+
+code_names = {'presentation': 'Define the group using generators and relations',
+              'permutation': 'Define the group as a permutation group',
+              'matrix': 'Define the group as a matrix group',
+              'transitivei': 'Define the group from the transitive group database'}
+
+Fullname = {'magma': 'Magma', 'gap': 'Gap'}
+Comment = {'magma': '//', 'gap': '#'}
+
+

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1377,12 +1377,15 @@ def render_abstract_group(label, data=None):
 
         title = f"Abstract group ${gp.tex_name}$"
 
+        # disable until we can fix downloads
         downloads = [
-            ("Group to Gap", url_for(".download_group", label=label, download_type="gap")),
-            ("Group to Magma", url_for(".download_group", label=label, download_type="magma")),
-            ("Group to Oscar", url_for(".download_group", label=label, download_type="oscar")),
-            ("Underlying data", url_for(".gp_data", label=label)),
+           ("Underlying data", url_for(".gp_data", label=label)),
         ]
+#            ("Group to Gap", url_for(".download_group", label=label, download_type="gap")),
+#            ("Group to Magma", url_for(".download_group", label=label, download_type="magma")),
+#            ("Group to Oscar", url_for(".download_group", label=label, download_type="oscar")),
+ #          ("Underlying data", url_for(".gp_data", label=label)),
+#       ]
 
         # "internal" friends
         sbgp_of_url = (
@@ -1455,7 +1458,6 @@ def render_abstract_group(label, data=None):
         code = None
     else:
         code = gp.code
-#    print("HERE IS gp.code", gp.code)
 
     
     return render_template(
@@ -1470,7 +1472,7 @@ def render_abstract_group(label, data=None):
         friends=friends,
         learnmore=learnmore_list_add(*learnmore_gp_picture),
         KNOWL_ID=f"group.abstract.{label}",
-        downloads=downloads,
+        downloads=downloads, 
     )
 
 

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -1,7 +1,7 @@
 {% extends "homepage.html" %}
 
-
 {% block content %}
+
 
 <script type="text/javascript" src="{{ url_for('static', filename='groups.js') }}"></script>
 <script type="text/javascript">
@@ -13,6 +13,7 @@
 </script>
 
 <script type="text/javascript" src="{{ url_for('static', filename='graphs/graph.js') }}"></script>
+
 
 
 {% if gp.live() %}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -184,6 +184,16 @@
 {% if not (gp.live() and gp.abelian) %}
 
 <h2>Constructions</h2>
+  {% if code %}<div align="right" style="float: left;">
+            Show commands:
+            {% set slash = joiner("/ ") %}
+            {% for lang in code['show']|sort %}
+            {# override show names for standard languages to ensure consistency #}
+            {% set show = 'PariGP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else 'Oscar' if lang == 'oscar' else "Gap" if lang == 'gap' else code['show']['lang'] %}
+            {{slash()}}<a onclick="show_code('{{lang}}'); return false" href='#'>{{show}}</a>
+            {% endfor %}
+        </div><br><br>
+    {% endif %}
 
 <table class=nowrap>
   {{ gp.stored_representations | safe }}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -115,7 +115,7 @@ def create_magma_assignment(G):
         if j == ngens - 1:
             icap = len(rel_ords)
         else:
-            icap = used[i+1]
+            icap = used[j+1]
         power = 1
         v = var_name(j)
         for i0 in range(i, icap):
@@ -2627,7 +2627,7 @@ class WebAbstractGroup(WebObj):
             circles = ""
         return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="-{R} -{R} {2*R} {2*R}" width="200" height="150">\n{circles}</svg>'
 
-    #JP
+
     def create_snippet(self,item):
         # mimics jinja macro place_code to be included in Constructions section
         # this is specific for embedding in a table. eg. we need to replace "<" with "&lt;"
@@ -2648,7 +2648,6 @@ class WebAbstractGroup(WebObj):
         return snippet_str
 
 
-    #JP NEED TO ADD IFS IF IN DATA TYPE.
     @cached_method
     def code_snippets(self):
         if self.live():

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -98,11 +98,13 @@ def group_pretty_image(label):
     # we should not get here
 
 def create_gens_list(genslist):
-    used_gens = "["
-    for i in genslist:
-        used_gens = used_gens + "G." + str(i) + ","
-    used_gens = used_gens[:-1] + "]"
-    return used_gens
+    # For Magma
+    gens_list = [f"G.{i}" for i in genslist]
+    return str(gens_list).replace("'", "")
+
+def create_gens_assignment(genslist):
+    # For GAP; gens := GeneratorsOfGroup(G); has already been included
+    return " ".join(f"{var_name(j)} := gens[{i}];" for j, i in enumerate(genslist))
 
 def split_matrix_list(longList,d):
     # for code snippets, turns d^2 list into d lists of length d for Gap matrices
@@ -2635,13 +2637,14 @@ class WebAbstractGroup(WebObj):
         code = yaml.load(open(os.path.join(_curdir, "code.yaml")), Loader=yaml.FullLoader)
         code['show'] = { lang:'' for lang in code['prompt'] }
         if "PC" in self.representations:
-            gens =  self.presentation_raw(as_str = False)
+            gens =  self.presentation_raw(as_str=False)
             pccodelist = self.representations["PC"]["pres"]
             pccode = self.representations["PC"]["code"]
             ordgp = self.order
             used_gens = create_gens_list(self.representations["PC"]["gens"])
+            gens_assign = create_gens_assignment(self.representations["PC"]["gens"])
         else:
-            gens, pccodelist, pccode, ordgp, used_gens = None, None, None, None, None
+            gens, pccodelist, pccode, ordgp, used_gens, gens_assign = None, None, None, None, None, None
         if "Perm" in self.representations:
             rdata = self.representations["Perm"]
             perms = ", ".join(self.decode_as_perm(g, as_str=True) for g in rdata["gens"])
@@ -2687,12 +2690,13 @@ class WebAbstractGroup(WebObj):
 #            nFq, Fq, LFq, LFqsplit = None, None, None, None
 
         data = {'gens' : gens, 'pccodelist': pccodelist, 'pccode': pccode,
-                'ordgp': ordgp, 'used_gens' : used_gens, 'deg' : deg, 'perms' : perms,
-                'nZ' : nZ, 'nFp' : nFp, 'nZN' : nZN, 'nZq': nZq, #'nFq' : nFq,
-                'Fp' : Fp, 'N' : N, 'Zq' : Zq, #'Fq' : Fq,
-                'LZ' : LZ, 'LFp': LFp, 'LZN' : LZN, 'LZq' : LZq, #'LFq': LFq,
-                'LZsplit' : LZsplit, 'LZNsplit' : LZNsplit, 'LZqsplit' :LZqsplit,
-               # 'LFpsplit' : LFpsplit, 'LFqsplit' : LFqsplit, # add for GLFq GAP
+                'ordgp': ordgp, 'used_gens': used_gens, 'gens_assign': gens_assign,
+                'deg': deg, 'perms' : perms,
+                'nZ': nZ, 'nFp': nFp, 'nZN': nZN, 'nZq': nZq, #'nFq': nFq,
+                'Fp': Fp, 'N': N, 'Zq': Zq, #'Fq': Fq,
+                'LZ': LZ, 'LFp': LFp, 'LZN': LZN, 'LZq': LZq, #'LFq': LFq,
+                'LZsplit': LZsplit, 'LZNsplit': LZNsplit, 'LZqsplit': LZqsplit,
+               # 'LFpsplit': LFpsplit, 'LFqsplit': LFqsplit, # add for GLFq GAP
         }
         for prop in code:
             for lang in code['prompt']:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -104,14 +104,12 @@ def create_gens_list(genslist):
     used_gens = used_gens[:-1] + "]"
     return used_gens
 
-def split_matrix_list(longList,d):   #, Znfld = None, Fqfld = None):
-    # for code snippets, turns d^2 list into d lists of length d for gap matrices
+def split_matrix_list(longList,d): 
+    # for code snippets, turns d^2 list into d lists of length d for Gap matrices
     counter = 0
     BigList = []
     for i in range(d):
-        SmList = []
-        for j in range(d):
-            SmList.append(longList[j+counter])
+        SmList = [longList[j+counter] for j in range(d)]
         BigList.append(SmList)
         counter = counter + d
     return BigList
@@ -123,6 +121,24 @@ def split_matrix_list_ZN(longList,d, Znfld):
         SmList = "["
         for j in range(d):
             SmList = SmList + "ZmodnZObj(" +str(longList[j+counter])+ "," +str(Znfld) +"),"
+        SmList =SmList[:-1] + "]"
+        BigList = BigList + SmList + ","
+        counter = counter +d
+    BigList =BigList[:-1] + "]"
+    return BigList
+
+#not currently in use.  Should work if elements of Fp and Fq are given as
+#power of mult. generator
+def split_matrix_list_Fq(longList,d, Fqfld):
+    counter = 0
+    BigList = "["
+    for i in range(d):
+        SmList = "["
+        for j in range(d):
+            if longList[j+counter] == 0:
+                SmList =SmList + "0*Z("+str(Fqfld) + "),"
+            else:    
+                SmList = SmList + "Z("+str(Fqfld) + ")^" + str(longList[j+counter]-1)+","
         SmList =SmList[:-1] + "]"
         BigList = BigList + SmList + ","
         counter = counter +d
@@ -2188,6 +2204,11 @@ class WebAbstractGroup(WebObj):
             R, N, k, d, _ = self._matrix_coefficient_data(rep_type, as_str=True)
             gens = ", ".join(self.decode_as_matrix(g, rep_type, as_str=True) for g in rdata["gens"])
             gens = fr"$\left\langle {gens} \right\rangle \subseteq \GL_{{{d}}}({R})$"
+            if rep_type == "GLFq":
+                if skip_head:
+                    return f'<tr><td></td><td colspan="5">{gens}</td></tr>'
+                else:
+                    return f'<tr><td>{display_knowl("group.matrix_group", "Matrix group")}:</td><td colspan="10">{gens}</td></tr>'
             code_cmd = self.create_snippet(rep_type)
             if skip_head:
                 return f'<tr><td></td><td colspan="5">{gens}</td></tr>{code_cmd}'
@@ -2670,9 +2691,11 @@ class WebAbstractGroup(WebObj):
         if "GLFp" in self.representations:
             nFp = self.representations["GLFp"]["d"]
             Fp = self.representations["GLFp"]["p"]
-            LFp = [self.decode_as_matrix(g, "GLFp", ListForm=True) for g in self.representations["GLFp"]["gens"]] 
+            LFp = [self.decode_as_matrix(g, "GLFp", ListForm=True) for g in self.representations["GLFp"]["gens"]]
+#            LFpsplit = "[" + ",".join([split_matrix_list_Fq(self.decode_as_matrix(g, "GLFp", ListForm=True), nFp, Fp) for g in self.representations["GLFp"]["gens"]]) +"]"
         else:
             nFp, Fp, LFp = None, None, None
+            #nFp, Fp, LFp, LFpsplit = None, None, None, None
         if "GLZN" in self.representations:
             nZN = self.representations["GLZN"]["d"]
             N = self.representations["GLZN"]["p"]
@@ -2687,20 +2710,23 @@ class WebAbstractGroup(WebObj):
             LZqsplit ="[" + ",".join([split_matrix_list_ZN(self.decode_as_matrix(g, "GLZq", ListForm=True) , nZq, Zq) for g in self.representations["GLZq"]["gens"]]) +"]"
         else:
             nZq, Zq, LZq, LZqsplit = None, None, None, None
-        if  "GLFq" in self.representations:
-            nFq = self.representations["GLFq"]["d"]
-            Fq = self.representations["GLFq"]["q"]
-            LFq = [self.decode_as_matrix(g, "GLFq", ListForm=True) for g in self.representations["GLFq"]["gens"]]
-        else:
-            nFq, Fq, LFq = None, None, None
+# add below for GLFq implementation
+#        if  "GLFq" in self.representations:
+#            nFq = self.representations["GLFq"]["d"]
+#            Fq = self.representations["GLFq"]["q"]
+#            LFq = [self.decode_as_matrix(g, "GLFq", ListForm=True) for g in self.representations["GLFq"]["gens"]]
+#            LFqsplit = "[" + ",".join([split_matrix_list_Fq(self.decode_as_matrix(g, "GLFq", ListForm=True), nFq, Fq) for g in self.representations["GLFq"]["gens"]]) +"]"
+#        else:
+#            nFq, Fq, LFq, LFqsplit = None, None, None, None
 
-            
+           
         data = {'gens' : gens, 'pccodelist': pccodelist, 'pccode': pccode,
                 'ordgp': ordgp, 'used_gens' : used_gens, 'deg' : deg, 'perms' : perms,
-                'nZ' : nZ, 'nFp' : nFp, 'nZN' : nZN, 'nZq': nZq, 'nFq' : nFq,
-                'Fp' : Fp, 'N' : N, 'Zq' : Zq, 'Fq' : Fq,
-                'LZ' : LZ, 'LFp': LFp, 'LZN' : LZN, 'LZq' : LZq, 'LFq': LFq,
-                'LZsplit' : LZsplit, 'LZNsplit' : LZNsplit, 'LZqsplit' :LZqsplit, 
+                'nZ' : nZ, 'nFp' : nFp, 'nZN' : nZN, 'nZq': nZq, #'nFq' : nFq,
+                'Fp' : Fp, 'N' : N, 'Zq' : Zq, #'Fq' : Fq,
+                'LZ' : LZ, 'LFp': LFp, 'LZN' : LZN, 'LZq' : LZq, #'LFq': LFq,
+                'LZsplit' : LZsplit, 'LZNsplit' : LZNsplit, 'LZqsplit' :LZqsplit,
+               # 'LFpsplit' : LFpsplit, 'LFqsplit' : LFqsplit, # add for GLFq GAP
         }
         for prop in self.code:
             for lang in self.code['prompt']:

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -231,7 +231,7 @@
             {% set slash = joiner("/ ") %}
             {% for lang in code['show']|sort %}
             {# override show names for standard languages to ensure consistency #}
-            {% set show = 'PariGP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else 'Oscar' if lang == 'oscar' else code['show']['lang'] %}
+            {% set show = 'PariGP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else 'Oscar' if lang == 'oscar' else "Gap" if lang == 'gap' else code['show']['lang'] %}
             {{slash()}}<a onclick="show_code('{{lang}}'); return false" href='#'>{{show}}</a>
             {% endfor %}
         </div>

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1956,18 +1956,6 @@ div.codebox {
 }
 
 
-tr.codebox {
-    text-align: left;
-    padding: 5px;
-    text-padding: 10px;
-    border: 1px solid {{color.knowl_thin_border}};
-    border-radius: 5px;
-    background-color: {{color.knowl_background}};
-    box-shadow: 3px 3px 3px {{color.knowl_shadow}};
-    white-space: pre;
-}
-
-
 
 /* Styling of Maass form plot */
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1955,6 +1955,20 @@ div.codebox {
     white-space: pre;
 }
 
+
+tr.codebox {
+    text-align: left;
+    padding: 5px;
+    text-padding: 10px;
+    border: 1px solid {{color.knowl_thin_border}};
+    border-radius: 5px;
+    background-color: {{color.knowl_background}};
+    box-shadow: 3px 3px 3px {{color.knowl_shadow}};
+    white-space: pre;
+}
+
+
+
 /* Styling of Maass form plot */
 
 div.maassformplot {


### PR DESCRIPTION
As title says.

This will add snippets for entries in the "Construction" section, except for matrices with entries in Fq.  Navigate to your favorite group page, scroll to "Construction" and hit the "Magma" or "Gap" links to show snippets.

It also temporarily disables downloads on the groups pages until we can make them robust (in some places the downloads are currently blank).
