### PR TITLE
Show conjugacy class reps for more abstract groups

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2742,11 +2742,8 @@ def cc_data(gp, label, typ="complex", representative=None):
             ans += "<br>Representative: id"
         else:
             gp_value = WebAbstractGroup(gp)
-            if gp_value.representations.get("Lie") and gp_value.representations["Lie"][0]["family"][0] == "P" and gp_value.order < 2000:  #Problem with projective lie groups of order <2000
-                pass
-            else:
-                repn = gp_value.decode(wacc.representative, as_str=True)
-                ans += "<br>Representative: {}".format("$" + repn + "$")
+            repn = gp_value.decode(wacc.representative, as_str=True)
+            ans += "<br>Representative: {}".format("$" + repn + "$")
     return Markup(ans)
 
 


### PR DESCRIPTION
Because of data issues, conjugacy class representatives were being blocked for certain groups.  This removes the block since we thing the data issue has been fixed.

On
  http://127.0.0.1:37777/Groups/Abstract/120.34
  http://beta.lmfdb.org/Groups/Abstract/120.34

the difference can be seen in the dynamic knowls for conjugacy classes down at the character tables.