### PR TITLE
change BMF knowl links (Issue 6085)

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -791,7 +791,7 @@ class BianchiStats(StatsDisplay):
     stat_list = [
         {'cols': ['field_label', 'level_norm'],
          'top_title': '%s by %s and %s' % (
-             display_knowl("mf.bianchi.bianchimodularforms",
+             display_knowl("mf.bianchi",
                            "Bianchi modular forms"),
              display_knowl('nf', 'base field'),
              display_knowl('mf.bianchi.level', 'level norm')),
@@ -852,7 +852,7 @@ class BianchiStats(StatsDisplay):
     def summary(self):
         return r"The database currently contains %s %s of weight 2 over %s imaginary quadratic fields, and %s %s over %s imaginary quadratic fields, including all with class number one." % (
             comma(self.nforms),
-            display_knowl("mf.bianchi.bianchimodularforms",
+            display_knowl("mf.bianchi",
                           "Bianchi modular forms"),
             self.nformfields,
             comma(self.ndims),
@@ -862,4 +862,4 @@ class BianchiStats(StatsDisplay):
 
     @property
     def short_summary(self):
-        return r'The database currently contains %s %s of weight 2 over %s imaginary quadratic fields.  Here are some <a href="%s">further statistics</a>.' % (comma(self.nforms), display_knowl("mf.bianchi.bianchimodularforms", "Bianchi modular forms"), self.nformfields, url_for(".statistics"))
+        return r'The database currently contains %s %s of weight 2 over %s imaginary quadratic fields.  Here are some <a href="%s">further statistics</a>.' % (comma(self.nforms), display_knowl("mf.bianchi", "Bianchi modular forms"), self.nformfields, url_for(".statistics"))

--- a/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
@@ -8,7 +8,7 @@
 
 <p>
 Table of the dimensions of the spaces of {{
-KNOWL('mf.bianchi.bianchimodularforms', title='Bianchi cusp forms') }}
+KNOWL('mf.bianchi', title='Bianchi cusp forms') }}
 for \(\Gamma_0(\mathfrak{n})\subseteq {{info.bgroup}}\) for {{
 KNOWL('mf.bianchi.level', title='levels') }} \(\mathfrak{n}\) ordered
 by norm, over \(K=\) {{info.field_pretty}}.


### PR DESCRIPTION
See #6085 .  This changes 4 remaining links to the knowl mf.bianchi.bianchimodularforms to instead link to mf.bianchi (which is very similar), making the one with the longer name redundant.
