### PR TITLE
Add Malle's a(G) and index of elements for Galois groups

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -332,6 +332,7 @@ def render_group_webpage(args):
         if data['nilpotency'] == '$-1$':
             data['nilpotency'] = ' not nilpotent'
         data['dispv'] = sparse_cyclotomic_to_mathml
+        data['malle_a'] = wgg.malle_a
         downloads = []
         for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("SageMath", "sage")]:
             downloads.append(('Code to {}'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -70,7 +70,7 @@ table.reptable td, table.reptable th {
 
       {% if info.cclasses is defined %}
    <table class="ntdata">
-      <thead><tr><td>Label</td><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
+      <thead><tr><td>Label</td><td>Cycle Type</td><td>Size</td><td>Order</td><td>{{KNOWL('gg.index', 'Index')}}</td><td>Representative</td></tr></thead>
       <tbody>
         {% for c in info.cclasses %}
            <tr>
@@ -78,6 +78,7 @@ table.reptable td, table.reptable th {
               <td> ${{c[3]}}$</td>
               <td> ${{c[2]}}$</td>
               <td> ${{c[1]}}$</td>
+              <td> ${{c[5]}}$</td>
               <td> ${{c[0]}}$</td>
            </tr>
         {% endfor %}
@@ -88,7 +89,13 @@ table.reptable td, table.reptable th {
       {% endif %}
    </p>
    <p>{{ place_code('ccs') }}</p>
-
+   <p>
+   {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
+   {% if info.malle_a %}
+   {{info.malle_a}}
+   {% else %}
+   not computed
+   {% endif %}
 
 
 

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -91,7 +91,7 @@ table.reptable td, table.reptable th {
    <p>{{ place_code('ccs') }}</p>
    <p>
    {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
-   {% if info.malle_a %}
+   {% if info.malle_a is not none %}
    ${{info.malle_a}}$
    {% else %}
    not computed

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -92,7 +92,7 @@ table.reptable td, table.reptable th {
    <p>
    {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
    {% if info.malle_a %}
-   {{info.malle_a}}
+   ${{info.malle_a}}$
    {% else %}
    not computed
    {% endif %}

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -3,7 +3,7 @@ from collections import defaultdict, Counter
 
 from lmfdb import db
 
-from sage.all import ZZ, gap, cached_function, lazy_attribute, Permutations
+from sage.all import ZZ, gap, cached_function, lazy_attribute, Permutations, QQ
 import os
 import yaml
 from flask import render_template
@@ -195,7 +195,7 @@ class WebGaloisGroup:
         self.conjugacy_classes = wag.conjugacy_classes
         if int(n) == 1:
             self.conjugacy_classes[0].force_repr('()')
-            return [['()', 1, 1, '1', '1A']]
+            return [['()', 1, 1, '1', '1A',0]]
         elif self.have_isomorphism():
             isom = self.getisom
             cc = [z.representative for z in self.conjugacy_classes]
@@ -214,9 +214,22 @@ class WebGaloisGroup:
             cc2 = [gap(f"CycleLengths({x}, [1..{n}])") for x in cc]
             for j in range(len(self.conjugacy_classes)):
                 self.conjugacy_classes[j].force_repr(' ')
+        inds = [n-len(z) for z in cc2]
         cc2 = [compress_cycle_type(z) for z in cc2]
-        ans = [[cc[j], cc[j].Order(), ccn[j], cc2[j],cclabels[j]] for j in range(len(cc))]
+        ans = [[cc[j], cc[j].Order(), ccn[j], cc2[j],cclabels[j],inds[j]] for j in range(len(cc))]
         return ans
+
+    @lazy_attribute
+    def malle_a(self):
+        ccs = self.conjclasses
+        inds = [z[5] for z in ccs]
+        if len(inds)==1:
+            return 0
+        if len(inds)==0:
+            return None
+        inds = [z for z in inds if z>0]
+
+        return QQ(f"1/{min(inds)}")
 
     @lazy_attribute
     def can_chartable(self):


### PR DESCRIPTION
Addresses issue #6105 adding ind(g) in the table of conjugacy classes, and a(G) just below that table.

http://127.0.0.1:37777/GaloisGroup/19T6
http://beta.lmfdb.org/GaloisGroup/19T6

Some special cases which come up:

- 1T1: a(G) is defined to be 0
- 2T1: a(G) is an integer
- 46T46: a(G) not computed because we don't have conjugacy class information
