### PR TITLE
Move compression to right place

### DIFF
--- a/lmfdb/belyi/web_belyi.py
+++ b/lmfdb/belyi/web_belyi.py
@@ -295,7 +295,7 @@ class WebBelyiGalmap():
         data["lambdas"] = [str(c)[1:-1] for c in galmap["lambdas"]]
         # plane model
         if galmap.get("plane_model"):
-            data["plane_model"] = raw_typeset(compress_expression(galmap["plane_model"])+'=0', r'$\displaystyle '+belyi_latex(galmap["plane_model"])+'=0$', extra=curve_ref)
+            data["plane_model"] = raw_typeset(galmap["plane_model"]+'=0', r'$\displaystyle '+compress_expression(belyi_latex(galmap["plane_model"]))+'=0$', extra=curve_ref)
 
         if galmap.get('plane_map_constant_factored'):
             data['plane_map_constant_factored'] = galmap['plane_map_constant_factored']


### PR DESCRIPTION
Fixes issue #6111 on compressed integers in Belyi map vs in raw form

https://beta.lmfdb.org/Belyi/9T34/5.4/4.1.1.1.1.1/4.3.2/a/?abc=5.4_4.1.1.1.1.1_4.3.2
http://127.0.0.1:37777//Belyi/9T34/5.4/4.1.1.1.1.1/4.3.2/a/?abc=5.4_4.1.1.1.1.1_4.3.2