### PR TITLE
Update affiliation + 2 tiny fixes

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -280,8 +280,8 @@ email: aurel.page@normalesup.org
 affil: University of Bordeaux
 ---
 name: Jennifer Paulhus
-affil: Grinnell College
-url: https://www.math.grinnell.edu/~paulhusj/
+affil: Mount Holyoke College
+url: https://www.jenpaulhus.com
 ---
 name: David Platt
 affil: University of Bristol

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -44,9 +44,10 @@
   {{info.boolean_characteristics_string | safe}}
 </p>
 
+{% if gp.order_stats != None %}
 <h2>Group statistics</h2>
 
-<p> {% if gp.order_stats != None %}
+<p> 
   <div class="table-scroll-wrapper">
    <table class="ntdata onesticky" style="margin-left:0;">
     <thead>
@@ -164,7 +165,7 @@
 
 
  {% if not gp.live() %}
-<h2>Minimal Presentations</h2>
+<h2>Minimal presentations</h2>
 
 <table>
   <tr><td>{{KNOWL('group.permutation_degree', 'Permutation degree')}}:</td><td>{{gp.perm_degree()|safe}}</td></tr>

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -44,10 +44,8 @@
   {{info.boolean_characteristics_string | safe}}
 </p>
 
-{% if gp.order_stats != None %}
 <h2>Group statistics</h2>
-
-<p> 
+<p> {% if gp.order_stats != None %} 
   <div class="table-scroll-wrapper">
    <table class="ntdata onesticky" style="margin-left:0;">
     <thead>
@@ -117,10 +115,13 @@
         <td colspan="{{gp.order_stats|length}}">data not computed</td>
         <td class="border-left"></td>
       </tr>
+      
       {% endif %}
     </tbody>
   </table>
-  </div> 
+</div>
+{% else %}
+Statistics about orders of elements in this group have not been computed.
   {% endif %}
 </p>
 

--- a/lmfdb/templates/management.html
+++ b/lmfdb/templates/management.html
@@ -4,7 +4,7 @@
 <h3> Managing Editors</h3>
 <ul>
 <li>John Jones, Arizona State University, USA</li>
-<li>Jennifer Paulhus, Grinnell College, USA</li>
+<li>Jennifer Paulhus, Mount Holyoke College, USA</li>
 <li>Andrew Sutherland, MIT, USA</li>
 <li>John Voight, Dartmouth College, USA</li>
 </ul>


### PR DESCRIPTION
Updated my affiliation and webpage on these two pages:
https://www.lmfdb.org/management
https://www.lmfdb.org/acknowledgment

And took this opportunity to fix 2 tiny things on groups pages.
(1) Made "presentation" lower case in "Minimal presentations". Compare
http://localhost:37777/Groups/Abstract/12.4
http://lmfdb.org/Groups/Abstract/12.4

(2) Made the header for the "Group statistics" section disappear if we don't compute order statistics.  Compare beta and local for groups like: 53687091200.di or 167384925748592640.a

~~EDIT: Don't merge this yet.  Realizing we should make (2) say "not computed" not disappear. Will fix right now.~~