### PR TITLE
Enable reCaptcha for www.lmfdb.org

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -308,31 +308,6 @@ def netloc_redirect():
         return redirect(urlunparse(replaced), code=302)
 
 
-@cached_function
-def bad_bots_list():
-    return [
-        elt.lower()
-        for elt in [
-            "The Knowledge AI",
-            "Wolfram",
-            "petalbot",
-            "Bytespider",
-            "Sogou",
-            "MJ12bot",
-            "Amazonbot",
-            "meta",
-            "facebook",
-        ]
-    ]
-
-
-@app.before_request
-def badbot():
-    ua = request.user_agent.string.lower()
-    for elt in bad_bots_list():
-        if elt in ua:
-            return render_template("404.html", title='Too many requests'), 429
-
 
 def timestamp():
     return '[%s UTC]' % time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())

--- a/lmfdb/static/robots.txt
+++ b/lmfdb/static/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Crawl-delay: 15
+Crawl-delay: 30
 Disallow: /static/
 Disallow: /api/
 

--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -26,7 +26,7 @@
           integrity="sha384-Nlo8b0yiGl7Dn+BgLn4mxhIIBU6We7aeeiulNCjHdUv/eKHx59s3anfSUjExbDxn"
           crossorigin="anonymous">
     <!--reCAPTCHA-->
-    <script src="https://www.google.com/recaptcha/enterprise.js?render=6LchHWwpAAAAACFe52hZNEkUP5Bn5_0FfLiEuF3i"></script>
+    <script src="https://www.google.com/recaptcha/enterprise.js?render=6LchHWwpAAAAACFe52hZNEkUP5Bn5_0FfLiEuF3i&waf=session" async defer></script>
 
 
 

--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -25,6 +25,8 @@
           href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"
           integrity="sha384-Nlo8b0yiGl7Dn+BgLn4mxhIIBU6We7aeeiulNCjHdUv/eKHx59s3anfSUjExbDxn"
           crossorigin="anonymous">
+    <!--reCAPTCHA-->
+    <script src="https://www.google.com/recaptcha/enterprise.js?render=6LchHWwpAAAAACFe52hZNEkUP5Bn5_0FfLiEuF3i"></script>
 
 
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2630,3 +2630,8 @@ span.raw-tset-container:hover > span.raw-tset-copy-btn {
 div.upload_section {
   margin-bottom: 60px;
 }
+
+/* hidge google badge */
+.grecaptcha-badge {
+    visibility: hidden;
+}


### PR DESCRIPTION
First of all, this is already running on www.lmfdb.org, as I needed to:
- test if it worked
- stop the bots from overwhelming our servers

This is the solution I have managed to devise so far that doesn't spoil the user interaction and keeps the bots at bay.
If someone has any other suggestions, I'm all ears, but over the last month, we have been observing severe persistence from bots that often lead to www.lmfdb.org going offline.
In particular, we start to notice serious deprecation of service whenever the servers are handling more than 4 requests a second (the blue/green line is the number of accepted/blocked requests):
![Screen Shot 2024-08-10 at 15 29 46](https://github.com/user-attachments/assets/ff14c29e-9243-4bcf-b355-d194a4deb2a5)
As you can see, until yesterday (when reCaptcha was enabled), I was not succeeding at keeping the bots under control despite several hours spent tuning firewall rules to try to block bots but not humans.


PS: I still would like to restrict the loading of the captcha javascript to only when we are serving www.lmfdb.org; I will figure that out later.

