### PR TITLE
Reduce down to 1 error message

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -928,6 +928,7 @@ def group_jump(info):
                 return redirect(url_for(".by_label", label=lab))
             else:
                 flash_error("The group %s has not yet been added to the database." % jump)
+                return redirect(url_for(".index"))
     flash_error("%s is not a valid name for a group or subgroup; see %s for a list of possible families" % (jump, display_knowl('group.families', 'here')))
     return redirect(url_for(".index"))
 


### PR DESCRIPTION
In the "Find" box, if you enter a valid group family name but one that's not in the DB (eg A50, PSL(5,13)) we were getting 2 error messages, instead of one. This PR just makes it so that only one error message is appearing.

Try searching for "A50" or  "PSL(5,13)" on this branch vs on beta.

