### PR TITLE
Use libgap for Galois groups, fix some latex errors

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -4,7 +4,7 @@
 import re
 
 from flask import abort, render_template, request, url_for, redirect, make_response
-from sage.all import ZZ, latex, gap
+from sage.all import ZZ, latex, libgap
 
 from lmfdb import db
 from lmfdb.app import app
@@ -30,7 +30,7 @@ from .transitive_group import (
 # logger = make_logger("GG")
 
 try:
-    G = gap.TransitiveGroup(9, 2)
+    G = libgap.TransitiveGroup(9, 2)
 except Exception:
     logger.fatal("It looks like the SPKGes gap_packages and database_gap are not installed on the server.  Please install them via 'sage -i ...' and try again.")
 


### PR DESCRIPTION
Currently https://beta.lmfdb.org/GaloisGroup/40T192781 times out, since Galois Groups are using the deprecated pexpect interface to gap, rather than the more modern libgap interface.  Switching improves the load time (though perhaps there are more optimizations that could be done).  We also fix a latex error in the conjugacy class knowl (previously, the columns of the knowl accessible by clicking on "The 1912 conjugacy class representatives for C_5^8.C_4^3.C_2^2" were not latexed).