### PR TITLE
Add index to conjugacy class knowl for Galois groups

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -600,7 +600,9 @@ def cclasses(n, t):
     #    return 'not computed'
     html = """<div>
             <table class="ntdata">
-            <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td><td>Representative</td></tr></thead>
+            <thead><tr><td>Cycle Type</td><td>Size</td><td>Order</td>
+            <td><a title = "' + index + ' [gg.index]" knowl="gg.index">Index</a></td>
+            <td>Representative</td></tr></thead>
             <tbody>
          """
     cc = group.conjclasses
@@ -608,6 +610,7 @@ def cclasses(n, t):
         html += f'<tr><td>${c[3]}$</td>'
         html += f'<td>${c[2]}$</td>'
         html += f'<td>${c[1]}$</td>'
+        html += f'<td>${c[5]}$</td>'
         html += f'<td>${c[0]}$</td>'
     html += """</tr></tbody>
              </table>


### PR DESCRIPTION
On most Galois group pages, when the conjugacy class information is shown it includes the index of the class (in the sense of Malle's conjecture).  When the group has too many classes, the information is only shown in a knowl.  This adds the information to the knowl.

http://beta.lmfdb.org/GaloisGroup/40T192782
http://127.0.0.1:37777/GaloisGroup/40T192782