### PR TITLE
Tweaking search results

### DIFF
--- a/lmfdb/modl_galois_representations/templates/modlgal_rep.html
+++ b/lmfdb/modl_galois_representations/templates/modlgal_rep.html
@@ -24,6 +24,13 @@
     $\cong$ {{ rep.image_abstract | safe }}
   {% endif %}
     </td></tr>
+  <tr><td>{{ KNOWL('modlgal.determinant_index', 'Determinant index') }}:<td>{{ rep.determinant_index }}
+  {% if rep.determinant_index == 1 %}
+  (determinant is surjective)
+  {% else %}
+  (determinant is not surjective)
+  {% endif %}
+  </td></tr>
   {% if rep.frobenius_generators %}
   <tr><td>{{ KNOWL('modlgal.generating_primes', 'Generating primes') }}:<td>${{ rep.frobenius_primes }}$</td></tr>
   {% endif %}
@@ -38,9 +45,12 @@
 <h2>Associated number fields</h2>
 
 <table>
-  <tr><td>{{ KNOWL('modlgal.min_sib_splitting_field','Minimal sibling of the splitting field') }} of $\rho$:</td><td>{{ rep.kernel_sibling | safe }}</td></tr>
+  <tr><td>{{ KNOWL('nf.minimal_sibling','Minimal sibling') }}  of the 
+  {{ KNOWL('modlgal.splitting_field', 'splitting field') }} of $\rho$:</td><td>{{ rep.kernel_sibling | safe }}</td></tr>
   {% if rep.base_ring_characteristic != 2 %}
-  <tr><td>{{ KNOWL('modlgal.min_sib_splitting_field','Minimal sibling of the splitting field') }} of the {{ KNOWL('modlgal.projective_representation','projective representation') }} $\mathbb{P}\rho$:</td><td>{{ rep.projective_kernel_sibling | safe }}</td></tr>
+  <tr><td> {{ KNOWL('nf.minimal_sibling','Minimal sibling') }}  of the 
+  {{ KNOWL('modlgal.splitting_field', 'splitting field') }}
+  of the {{ KNOWL('modlgal.projective_representation','projective representation') }} $\mathbb{P}\rho$:</td><td>{{ rep.projective_kernel_sibling | safe }}</td></tr>
   {% endif %}
 </table>
 

--- a/lmfdb/modl_galois_representations/web_modlgal.py
+++ b/lmfdb/modl_galois_representations/web_modlgal.py
@@ -20,12 +20,21 @@ def _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field):
 def codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field):
     return "$" + _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field) + "$"
 
-def image_pretty(image_label, is_surjective, algebraic_group, dimension, base_ring_order, base_ring_is_field, codomain=True):
+def image_pretty(image_label, is_surjective, algebraic_group, dimension, base_ring_order, base_ring_is_field, codomain=False):
     s = _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field)
     if is_surjective:
         return "$" + s + "$"
     t = display_knowl('gl2.subgroup_data', title=image_label, kwargs={'label':image_label}) if dimension == 2 else image_label
     return t + r" $< " + s + "$" if codomain else t
+
+def image_pretty_with_abstract(image_label, is_surjective, algebraic_group, dimension, base_ring_order, base_ring_is_field, image_abstract_group, codomain=False):
+    s = _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field)
+    if is_surjective:
+        return "$" + s + "$"
+    t = display_knowl('gl2.subgroup_data', title=image_label, kwargs={'label':image_label}) if dimension == 2 else image_label
+    if image_abstract_group:
+        t += "$\ \cong$ "+ abstract_group_display_knowl(image_abstract_group)
+    return t
 
 def rep_pretty(algebraic_group, dimension, base_ring_order, base_ring_is_field):
     return r"$\rho\colon\Gal_\Q\to" + _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field) + "$"


### PR DESCRIPTION
For mod-ell Galois reps, this 
 - adds determinant-is-surjective to the possible search parameters
 - add index of the image of the determinant to object pages
 - fixes knowls in the headers of the search result page
 - splits the display of image into image and codomain
 - image now shows the abstract group if possible along with the subgroup label
