### PR TITLE
Deal with empty search

### DIFF
--- a/lmfdb/modl_galois_representations/main.py
+++ b/lmfdb/modl_galois_representations/main.py
@@ -64,7 +64,7 @@ def index():
 @modlgal_page.route("/Q/")
 def index_Q():
     info = to_dict(request.args, search_array=ModLGalRepSearchArray())
-    if len(info) > 1:
+    if request.args:
         return modlgal_search(info)
     title = r"Mod-$\ell$ Galois representations"
     codomains = ["GL,1,2,1","GL,2,2,1","GL,2,3,1","GL,2,5,1","GSp,4,2,1"]

--- a/lmfdb/modl_galois_representations/web_modlgal.py
+++ b/lmfdb/modl_galois_representations/web_modlgal.py
@@ -31,9 +31,11 @@ def image_pretty_with_abstract(image_label, is_surjective, algebraic_group, dime
     s = _codomain(algebraic_group, dimension, base_ring_order, base_ring_is_field)
     if is_surjective:
         return "$" + s + "$"
+    if dimension==1:
+        return image_label
     t = display_knowl('gl2.subgroup_data', title=image_label, kwargs={'label':image_label}) if dimension == 2 else image_label
     if image_abstract_group:
-        t += r"$\ \cong$ "+ abstract_group_display_knowl(image_abstract_group)
+        t += r" $\ \cong$ "+ abstract_group_display_knowl(image_abstract_group)
     return t
 
 def rep_pretty(algebraic_group, dimension, base_ring_order, base_ring_is_field):


### PR DESCRIPTION
If there are no search arguments in mod-ell Galois reps and the user hits search, return everything.