### PR TITLE
Sort related objects for a mod-l gal rep

### DIFF
--- a/lmfdb/modl_galois_representations/web_modlgal.py
+++ b/lmfdb/modl_galois_representations/web_modlgal.py
@@ -99,6 +99,7 @@ class WebModLGalRep(WebObj):
         has_dirichlet = False
         if not hasattr(self, "related_objects"):
             self.related_objects = []
+        self.related_objects.sort()
         for r in self.related_objects:
             if r[0] == "Dirichlet":
                 c = r[1].split(".")


### PR DESCRIPTION
Just a one-liner.  e.g. for https://beta.lmfdb.org/ModLGaloisRepresentation/Q/2.2.101.1/ the associated modular forms are currently in a random order, but with this they are in a reasonable order.

In case a mod-ell gal rep has friends of several tyoes (the example only has Modular forms and an  Artin Rep) these will be sorted too, alphabetically: Artin, ECQ, G2C, MF.  The code would be more complicated if we wanted that order to be different.  Also, currently the related Number Field and Determinant (if dim>1) or Dirichlet char (if dim=1) are hard-wired to come after these; it would be possible to put them earlier, or even alphabetically with the other 4 by adding them to the related_objects list before the sort.