### PR TITLE
Add relative class number

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -839,7 +839,7 @@ nf_columns = SearchColumns([
     MathCol("torsion_order", "nf.unit_group", "Unit group torsion", align="center", default=False),
     MultiProcessedCol("unit_rank", "nf.rank", "Unit group rank", ["r2", "degree"], lambda r2, degree: degree - r2 - 1, align="center", mathmode=True, default=False),
     MathCol("regulator", "nf.regulator", "Regulator", align="left", default=False)],
-    db_cols=["class_group", "coeffs", "degree", "r2", "disc_abs", "disc_sign", "galois_label", "label", "ramps", "used_grh", "cm", "is_galois", "torsion_order", "regulator", "rd", "grd", "monogenic", "num_ram"])
+    db_cols=["class_group", "coeffs", "degree", "r2", "disc_abs", "disc_sign", "galois_label", "label", "ramps", "used_grh", "cm", "is_galois", "torsion_order", "regulator", "rd", "grd", "monogenic", "num_ram", "relative_class_number"])
 
 def nf_postprocess(res, info, query):
     galois_labels = [rec["galois_label"] for rec in res if rec.get("galois_label")]
@@ -895,6 +895,7 @@ def number_field_search(info, query):
     parse_floats(info, query, 'rd')
     parse_floats(info, query, 'regulator')
     parse_posints(info,query,'class_number')
+    parse_posints(info,query,'relative_class_number')
     parse_ints(info,query,'num_ram')
     parse_bool(info,query,'cm_field',qfield='cm')
     parse_bool(info,query,'is_galois')
@@ -1196,6 +1197,11 @@ class NFSearchArray(SearchArray):
             knowl="nf.ideal_class_group",
             example="[2,4]",
             example_span="[ ], [3], or [2,4]")
+        relative_class_number = TextBox(
+            name="relative_class_number",
+            label="Relative class number",
+            knowl="nf.relative_class_number",
+            example="3")
         num_ram = TextBox(
             name="num_ram",
             label="Ramified prime count",
@@ -1258,13 +1264,20 @@ class NFSearchArray(SearchArray):
             [class_number, class_group],
             [ram_primes, ur_primes],
             [regulator, cm_field],
-            [completion, subfield],
-            [index, inessentialprimes],
-            [monogenic, is_minimal_sibling],
-            [count]]
+            [completion, relative_class_number],
+            [index, subfield],
+            [monogenic, inessentialprimes],
+            [count, is_minimal_sibling]]
 
         self.refine_array = [
-            [degree, signature, class_number, class_group, cm_field],
-            [num_ram, ram_primes, ur_primes, gal, is_galois],
-            [discriminant, rd, grd, regulator, subfield],
-            [completion, is_minimal_sibling, monogenic, index, inessentialprimes]]
+            [degree, signature, num_ram, ram_primes, ur_primes ], 
+            [gal, is_galois, subfield, class_group, class_number],
+            [discriminant, rd, grd, cm_field, relative_class_number],
+            [regulator, completion, monogenic, index, inessentialprimes],
+            [is_minimal_sibling]]
+
+            #[degree, signature, class_number, class_group, cm_field],
+            #[num_ram, ram_primes, ur_primes, gal, is_galois],
+            #[discriminant, rd, grd, regulator, subfield],
+            #[completion, is_minimal_sibling, monogenic, index, inessentialprimes],
+            #[relative_class_number]]

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -84,7 +84,8 @@ table.ntdata a {
         </p>
           {% if nf.is_cm_field() %}
         <p>
-          Relative class number: {{ nf.relh() }}
+          {{KNOWL('nf.relative_class_number','Relative class number')}}: {{ nf.relh() }}
+          {{ info.grh_label|safe }}
         </p>
           {% endif %}
 

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -84,7 +84,7 @@ table.ntdata a {
         </p>
           {% if nf.is_cm_field() %}
         <p>
-          {{KNOWL('nf.relative_class_number','Relative class number')}}: {{ nf.relh() }}
+          {{KNOWL('nf.relative_class_number','Relative class number')}}: ${{ nf.relh() }}$
           {{ info.grh_label|safe }}
         </p>
           {% endif %}

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -84,7 +84,7 @@ table.ntdata a {
         </p>
           {% if nf.is_cm_field() %}
         <p>
-          {{KNOWL('nf.relative_class_number','Relative class number')}}: ${{ nf.relh() }}$
+          {{KNOWL('nf.relative_class_number','Relative class number')}}: {{ nf.relh() }}
           {{ info.grh_label|safe }}
         </p>
           {% endif %}

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -82,6 +82,11 @@ table.ntdata a {
           {{ info.grh_label|safe }}
           {{ place_code('class_group') }}
         </p>
+          {% if nf.is_cm_field() %}
+        <p>
+          Relative class number: {{ nf.relh() }}
+        </p>
+          {% endif %}
 
 
         <p><h2> {{ KNOWL('nf.unit_group', title='Unit group') }}</h2>

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -77,6 +77,9 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/?start=0&degree=6&signature=%5B0%2C3%5D&count=100', '6.0.61131.1')
         self.check_args('/NumberField/?start=0&degree=7&signature=%5B3%2C2%5D&count=100', '7.3.1420409.1')
 
+    def test_relative_class_number(self):
+        self.check_args('/NumberField/4.0.1327873600.2', '2108')
+
     def test_fundamental_units(self):
         self.check_args('NumberField/2.2.10069.1', '43388173')
         self.check_args('NumberField/3.3.10004569.1', '22153437467081345')

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -873,7 +873,7 @@ class WebNumberField:
 
     def relh(self):
         if self.haskey('relative_class_number'):
-            return self._data['relative_class_number']
+            return '$' + self._data['relative_class_number'] + '$'
         return dnc
 
     def is_null(self):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -800,16 +800,18 @@ class WebNumberField:
     def cnf(self):
         if self.degree()==1:
             return r'=\mathstrut &amp \frac{2^1 (2\pi)^0 \cdot 1\cdot 1}{2\cdot\sqrt 1}' + r'\cr' + r'= \mathstrut &amp; 1'
-        if not self.haskey('class_group'):
-            return r'$<td>  '+na_text()
-        # Otherwise we should have what we need
         [r1,r2] = self.signature()
-        reg = self.regulator()
-        h = self.class_number()
         w = self.root_of_1_order()
         r1term= r'2^{%s}\cdot'% r1
         r2term= r'(2\pi)^{%s}\cdot'% r2
         disc = ZZ(self._data['disc_abs'])
+        approx1 = r'= \mathstrut &amp;'
+        if not self.haskey('class_group'):
+            ltx = r'%s\frac{%s%s %s \cdot %s}{%s\cdot\sqrt{%s}}'%(approx1,r1term,r2term,'R','h',w,disc)
+            return ltx+r'\cr\mathstrut &amp; \text{<td> some values not computed }'
+        # Otherwise we should have what we need
+        reg = self.regulator()
+        h = self.class_number()
         approx1 = r'\approx' if self.unit_rank()>0 else r'='
         approx1 += r"\mathstrut &amp;"
         ltx = r'%s\frac{%s%s %s \cdot %s}{%s\cdot\sqrt{%s}}'%(approx1,r1term,r2term,str(reg),h,w,disc)
@@ -868,6 +870,11 @@ class WebNumberField:
         if self.haskey('class_number'):
             return True
         return False
+
+    def relh(self):
+        if self.haskey('relative_class_number'):
+            return self._data['relative_class_number']
+        return dnc
 
     def is_null(self):
         return self._data is None

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -873,7 +873,7 @@ class WebNumberField:
 
     def relh(self):
         if self.haskey('relative_class_number'):
-            return '$' + self._data['relative_class_number'] + '$'
+            return f"${self._data['relative_class_number']}$"
         return dnc
 
     def is_null(self):


### PR DESCRIPTION
Relative class numbers for CM fields has been computed in cases where we had both class numbers already.  They are shown on the page of a CM number field (it is in the class number/class group section).

http://127.0.0.1:37777/NumberField/6.0.399424.1
http://beta.lmfdb.org/NumberField/6.0.399424.1

Here is a case where it has been computed, but the computation assumed GRH

http://127.0.0.1:37777/NumberField/42.0.2281836760183646137444154412268560109828024514076489472840222217265158917203.1

and a case where it has not been computed

http://127.0.0.1:37777/NumberField/42.0.2654972529667057457433107680535256579009544347022866599647016024950419363310098668524052547.1

If the field is not CM, we don't do anything new since it is not relevant.

It is also now a search criterion

http://127.0.0.1:37777/NumberField/

A possible future improvement is if relative_class_number is part of the search, automatically turn is_cm to true (and give a flash error if the user has set it to false).

The database nf_fields should be copied to the cloud before this goes to production.