### PR TITLE
Lessmalle

### DIFF
--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -84,18 +84,20 @@ table.reptable td, table.reptable th {
         {% endfor %}
       </tbody>
       </table>
+   <p>
+   {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
+   {% if info.malle_a is not none %}
+   ${{info.malle_a}}$ 
+   {% else %}
+   not computed
+   {% endif %}
+      {% elif cclasses not in info %}
+        Conjugacy classes not computed
       {% else %}
         {{ info.cclass_knowl | safe }}
       {% endif %}
    </p>
    <p>{{ place_code('ccs') }}</p>
-   <p>
-   {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
-   {% if info.malle_a is not none %}
-   ${{info.malle_a}}$
-   {% else %}
-   not computed
-   {% endif %}
 
 
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -190,6 +190,8 @@ class WebGaloisGroup:
 
     @lazy_attribute
     def conjclasses(self):
+        if self.num_conjclasses()>160:
+            return None
         g = self.gapgroupnt()
         n = self.n()
         wag = self.wag
@@ -222,6 +224,8 @@ class WebGaloisGroup:
     @lazy_attribute
     def malle_a(self):
         ccs = self.conjclasses
+        if not ccs:
+            return None
         inds = [z[5] for z in ccs]
         if len(inds) == 1:
             return 0
@@ -477,6 +481,12 @@ def group_cclasses_knowl_guts(n, t):
     rest += '<blockquote>'
     rest += cclasses(n, t)
     rest += '</blockquote></div>'
+    rest += "<p><a title='Malle's constant $a(G)$' knowl='gg.malle_a'>'Malle's constant $a(G)$</a>: &nbsp; &nbsp;"
+    wgg = WebGaloisGroup(label)
+    if wgg.malle_a:
+        rest += '$%s$'%str(wgg.malle_a)
+    else:
+        rest += 'not computed'
     return rest
 
 
@@ -566,7 +576,7 @@ def resolve_display(resolves):
         if deg != old_deg:
             if old_deg < 0:
                 ans += '<table><tr><th>'
-                ans += '|G/N|<th>Galois groups for <a title = "stem field(s)" knowl="nf.stem_field">stem field(s)</a>'
+                ans += '$\card{(G/N)}$<th>Galois groups for <a title = "stem field(s)" knowl="nf.stem_field">stem field(s)</a>'
             else:
                 ans += '</td></tr>'
             old_deg = deg
@@ -606,6 +616,8 @@ def cclasses(n, t):
             <tbody>
          """
     cc = group.conjclasses
+    if not cc:
+        return None
     for c in cc:
         html += f'<tr><td>${c[3]}$</td>'
         html += f'<td>${c[2]}$</td>'

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -12,6 +12,8 @@ from lmfdb.utils import list_to_latex_matrix, integer_divisors, sparse_cyclotomi
 from lmfdb.groups.abstract.main import abstract_group_namecache, abstract_group_display_knowl
 from lmfdb.groups.abstract.web_groups import WebAbstractGroup
 
+CC_LIMIT = 160
+
 def knowl_cache(galois_labels=None, results=None):
     """
     Returns a dictionary for use in abstract_group_display_knowl, group_display and
@@ -190,7 +192,7 @@ class WebGaloisGroup:
 
     @lazy_attribute
     def conjclasses(self):
-        if self.num_conjclasses()>160:
+        if self.num_conjclasses()>CC_LIMIT:
             return None
         g = self.gapgroupnt()
         n = self.n()
@@ -237,7 +239,7 @@ class WebGaloisGroup:
 
     @lazy_attribute
     def can_chartable(self):
-        if self.num_conjclasses() > 160:
+        if self.num_conjclasses() > CC_LIMIT:
             return False
         if not db.gps_groups.lookup(self.abstract_label()):
             return False
@@ -578,7 +580,7 @@ def resolve_display(resolves):
         if deg != old_deg:
             if old_deg < 0:
                 ans += '<table><tr><th>'
-                ans += '$\card{(G/N)}$<th>Galois groups for <a title = "stem field(s)" knowl="nf.stem_field">stem field(s)</a>'
+                ans += r'$\card{(G/N)}$<th>Galois groups for <a title = "stem field(s)" knowl="nf.stem_field">stem field(s)</a>'
             else:
                 ans += '</td></tr>'
             old_deg = deg

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -237,6 +237,8 @@ class WebGaloisGroup:
 
     @lazy_attribute
     def can_chartable(self):
+        if self.num_conjclasses() > 160:
+            return False
         if not db.gps_groups.lookup(self.abstract_label()):
             return False
         return self.wag.complex_characters_known


### PR DESCRIPTION
Addresses issue #6177 but cutting off the computation of conjugacy classes and the character table when there are more than 160 classes.  These computations are done on-the-fly and gap can have trouble doing it.  These pages mentioned in the issue now load:

http://127.0.0.1:37777/GaloisGroup/34T82
http://127.0.0.1:37777/GaloisGroup/42T8771

This also fixes issue #6170 on the notation for the order of G/N as a header for Low Degree Resolvents

http://127.0.0.1:37777/GaloisGroup/4T5
