### PR TITLE
Resolves #6215

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1184,7 +1184,7 @@ space_columns = SearchColumns([
                       short_title="character"),
     MathCol("char_order", "character.dirichlet.order", r"$\operatorname{ord}(\chi)$", short_title="character order"),
     MathCol("dim", "cmf.display_dim", "Dim.", short_title="dimension"),
-    MathCol("num_forms", "cmf.galois_oribit", "Orbits", short_title="Galois orbits"),
+    MathCol("num_forms", "cmf.galois_orbit", "Orbits", short_title="Galois orbits"),
     MultiProcessedCol("decomp", "cmf.dim_decomposition", "Decomposition", ["level", "weight", "char_orbit_label", "hecke_orbit_dims"], display_decomp, align="center", short_title="decomposition", td_class=" nowrap"),
     MultiProcessedCol("al_dims", "cmf.atkin_lehner_dims", "AL-decomposition.", ["level", "weight", "ALdims"], display_ALdims, contingent=show_ALdims_col, short_title="AL-decomposition", align="center", td_class=" nowrap")])
 

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -303,7 +303,7 @@ def make_oldspace_data(newspace_label, char_conductor, prim_orbit_index):
         entry['sub_char_orbit_index'] = sub_chars[sub_level]['orbit']
         entry['sub_conrey_index'] = sub_chars[sub_level]['first']
         entry['sub_mult'] = number_of_divisors(level/sub_level)
-        if int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
+        if weight == 1 or int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
             # only include subspaces with cusp forms
             # https://pari.math.u-bordeaux.fr/pub/pari/manuals/2.15.4/users.pdf  p.595
             oldspaces.append(entry)

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -303,10 +303,13 @@ def make_oldspace_data(newspace_label, char_conductor, prim_orbit_index):
         entry['sub_char_orbit_index'] = sub_chars[sub_level]['orbit']
         entry['sub_conrey_index'] = sub_chars[sub_level]['first']
         entry['sub_mult'] = number_of_divisors(level/sub_level)
-        if weight == 1 or int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 1)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
-            # only include subspaces with cusp forms
-            # https://pari.math.u-bordeaux.fr/pub/pari/manuals/2.15.4/users.pdf  p.595
-            oldspaces.append(entry)
+        # only include subspaces with positive dimension (computed on the fly unless with weight is 1)
+        if weight == 1:
+            if db.mf_newspaces.lucky({'level':sub_level,'weight':weight,'char_orbit_index':entry['sub_char_orbit_index']},projection='dim') > 0:
+                oldspaces.append(entry)
+        else:
+            if int(gp('mfdim([%i, %i, znchar(Mod(%i,%i))], 0)' % (sub_level, weight, entry['sub_conrey_index'], sub_level))) > 0:
+                oldspaces.append(entry)
     return oldspaces
 
 class WebNewformSpace():


### PR DESCRIPTION
The timeout noted in #6215 is a result of trying to compute dimensions of subspaces on the fly when computing the old space decomposition (this is done to avoid listing summands of dimension zero); this is very quick in general, but for weight 1 spaces it can be very slow.

This PR changes the code to instead perform a database lookup when the weight is 1.  It also modifies the code to only list newspaces of lower level that have positive dimension in the oldspace decomposition (this was incorrectly implemented in the update that changed the code to compute dimensions on the fly, which was using the cusp dim rather than the new dim in the call to Pari/GP).

Also fixes a knowl name typo I noticed while fixing this.