### PR TITLE
Add stark units

### DIFF
--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -139,6 +139,12 @@
     <td>Galois closure of {{ newform.artin_field_display | safe }}</td>
   </tr>
   {% endif %}
+  {% if newform.weight == 1 and newform.dim == 1 %}
+  <tr>
+    <td>{{ KNOWL('cmf.stark_unit', title='Stark unit')}}:</td>
+    <td>Root of ${{ newform.stark_minpoly }}$</td>
+  </tr>
+  {% endif %}
   {% if newform.weight > 1 %}
   <tr>
     <td>{{ KNOWL('cmf.sato_tate', title='Sato-Tate group') }}: </td>

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -615,6 +615,15 @@ class WebNewform():
     def artin_image_knowl(self):
         return abstract_group_display_knowl(self.artin_image)
 
+    @property
+    def stark_minpoly(self):
+        # For now, the only data is for m = b = 1, so we just use lucky.
+        f = db.mf_stark.lucky({"mf_label": self.label}, "stark_minpoly")
+        if f is not None:
+            R = PolynomialRing(ZZ, 'x')
+            f = R(f)
+            return latex(f)
+
     def rm_and_cm_field_knowl(self, sign=1):
         if self.self_twist_discs:
             disc = [ d for d in self.self_twist_discs if sign*d > 0 ]


### PR DESCRIPTION
See the bottom of the "Newform invariants" section of http://localhost:37777/ModularForm/GL2/Q/holomorphic/2763/1/c/b/ for example.  Before this is merged, the new table `mf_stark` should get pushed to prod.