### PR TITLE
Add test to check that knowls are syncing between dev and prod

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -689,7 +689,7 @@ def save_form():
             flash(Markup("Knowl successfully created.  Note that a knowl with this id existed previously but was deleted; its history has been restored."))
         k.title = new_title
         k.content = new_content
-        k.timestamp = datetime.now()
+        k.timestamp = datetime.utcnow()
         k.status = 0
         k.save(who=who)
     if NEWID:

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -39,3 +39,38 @@ class DynamicKnowlTest(LmfdbTest):
     def test_galois_alias_knowl(self):
         L = self.tc.get('/knowledge/show/nf.galois_group.name', follow_redirects=True)
         assert '11T6' in L.get_data(as_text=True)
+
+    def test_prod_knowl_sync(self):
+        # This test checks that the script at https://github.com/edgarcosta/lmfdb-gce/blob/master/server_scripts/update_knowls_and_userdb.sh is successully syncing the knowl databases on beta.lmfdb.org and www.lmfdb.org
+        # It will be run as part of the CI for PRs against dev or prod.
+
+        from lmfdb import db
+        if db.config.postgresql_options["host"] == "proddb.lmfdb.xyz":
+            # Create a different connection to devmirror to compare timestamps
+            from lmfdb.utils.config import Configuration
+            from psycopg2.sql import SQL
+            from datetime import timedelta, datetime
+            dev_config = Configuration()
+            # Modify configuration to connect to devmirror
+            for D in [dev_config.default_args["postgresql"], dev_config.postgresql_options, dev_config.options["postgresql"]]:
+                D["host"] = "devmirror.lmfdb.xyz"
+                D["port"] = 5432
+                D["dbname"] = "lmfdb"
+                D["user"] = "lmfdb"
+                D["password"] = "lmfdb"
+            from psycodict.database import PostgresDatabase
+            dev_db = PostgresDatabase(dev_config)
+
+            # Updates happen every 20 minutes, so we only compare knowls older than that (plus a buffer).
+            cutoff = datetime.utcnow() - timedelta(minutes=30)
+
+            t_query = SQL("SELECT timestamp FROM kwl_knowls WHERE timestamp < %s LIMIT 1")
+            dev_t = dev_db._execute(t_query, [cutoff]).fetchone()[0]
+            prod_t = db._execute(t_query, [cutoff]).fetchone()[0]
+
+            cnt_query = SQL("SELECT COUNT(*) FROM kwl_knowls WHERE timestamp < %s")
+            dev_cnt = dev_db._execute(cnt_query, [cutoff]).fetchone()[0]
+            prod_cnt = db._execute(cnt_query, [cutoff]).fetchone()[0]
+
+            # The timestamps and counts should be the same
+            assert dev_cnt == prod_cnt and dev_t == prod_t


### PR DESCRIPTION
Adds a check for #6228.  It also fixes an inconsistency in how we were recording timestamps for knowls.  Now I think we use `datetime.utcnow()` everywhere.  If we want to switch to `datetime.now()` everywhere instead we could; I just thought it would be helpful to not have to worry about different servers with different time zones.  Note that this change will mean new timestamps on knowls are in UTC (rather than EST or EDT).  I don't think we care enough about the 5-6 hour difference to worry about updating old timestamps.