### PR TITLE
Fix bug in knowl is_locked

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -738,7 +738,7 @@ class KnowlBackend(PostgresBase):
         tdelta = timedelta(minutes=delta_min)
         time = now - tdelta
         selecter = SQL("SELECT username, timestamp FROM kwl_locks WHERE id = %s AND timestamp >= %s LIMIT 1")
-        L = list(self._execute(selecter, (knowlid, time)))
+        L = self._safe_execute(selecter, (knowlid, time))
         if L:
             return dict(zip(["username", "timestamp"], L[0]))
 

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -738,7 +738,7 @@ class KnowlBackend(PostgresBase):
         tdelta = timedelta(minutes=delta_min)
         time = now - tdelta
         selecter = SQL("SELECT username, timestamp FROM kwl_locks WHERE id = %s AND timestamp >= %s LIMIT 1")
-        L = self._execute(selecter, (knowlid, time))
+        L = list(self._execute(selecter, (knowlid, time)))
         if L:
             return dict(zip(["username", "timestamp"], L[0]))
 


### PR DESCRIPTION
I hit a bug in editing a knowl, which this PR fixes.  Here's the traceback from the flasklog on beta:
```
Exception on /knowledge/edit/nf.field_is [GET]
Traceback (most recent call last):
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/home/lmfdb/lmfdb-git-dev/lmfdb/knowledge/main.py", line 333, in edit
    lock = knowldb.is_locked(knowl.id)
  File "/home/lmfdb/lmfdb-git-dev/lmfdb/knowledge/knowl.py", line 743, in is_locked
    return dict(zip(["username", "timestamp"], L[0]))
TypeError: 'psycopg2.extensions.cursor' object is not subscriptable
[2024-11-16 04:24:12 UTC] 500 error on URL https://beta.lmfdb.org/knowledge/edit/nf.field_is ()

```