### PR TITLE
fixes for issue #4943

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -196,7 +196,7 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
-        <td>{{ data.data.ST|safe }}</td>
+        <td>$\mathrm{ST}(E)$</td><td>&nbsp;=&nbsp;</td><td>{{ data.data.ST|safe }}</td>
         </tr>
 
         <tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -154,37 +154,37 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.q.conductor', title='Conductor') }}:</td>
-        <td>{{ data.data.cond_latex }}</td>
+        <td>$N$</td>
         <td>&nbsp;=&nbsp;</td>
-        <td>${{ data.data.cond_factor }}$</td>
+        <td>{{ data.data.cond_latex }}</td><td>&nbsp;=&nbsp;</td><td>${{ data.data.cond_factor }}$</td>
         <td>{{ place_code('cond') }} </td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.discriminant', title='Discriminant') }}:</td>
-        <td>${{ data.data.disc }} $</td>
+        <td>$\Delta$</td>
         <td>&nbsp;=&nbsp;</td>
-        <td>${{ data.data.disc_factor }} $</td>
+        <td>${{ data.data.disc }}$</td><td>&nbsp;=&nbsp;</td><td>${{ data.data.disc_factor }} $</td>
         <td>{{ place_code('disc') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.j_invariant', title='j-invariant') }}:</td>
-        <td>{{ data.data.j_inv_latex }}</td>
+        <td>$j$</td>
         <td>&nbsp;=&nbsp;</td>
-        <td>${{ data.data.j_inv_factor }}$</td>
+        <td>{{ data.data.j_inv_latex }}</td><td>&nbsp;=&nbsp;</td><td>${{ data.data.j_inv_factor }}$</td>
         <td>{{ place_code('jinv') }}
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
-        <td>$\mathrm{End}(E)$</td><td>&nbsp;=&nbsp;</td><td>$\Z$</td>
+        <td>$\mathrm{End}(E)$</td><td>&nbsp;=&nbsp;</td><td colspan=3>$\Z$</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
         <td>$\mathrm{End}(E_{\overline{\Q}})$</td><td>&nbsp;=&nbsp;</td>
-	<td>{{ data.data.EndE }}
+	<td colspan=3>{{ data.data.EndE }}
         {%if not data.data.CMD %}
         &nbsp;&nbsp;(no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% else %}
@@ -196,32 +196,30 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
-        <td>$\mathrm{ST}(E)$</td><td>&nbsp;=&nbsp;</td><td>{{ data.data.ST|safe }}</td>
+        <td>$\mathrm{ST}(E)$</td><td>&nbsp;=&nbsp;</td><td colspan=3>{{ data.data.ST|safe }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.faltings_height', title='Faltings height') }}:</td>
-        <td>$h_{\mathrm{Faltings}}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.faltings_height }}$</td>
+        <td>$h_{\mathrm{Faltings}}$</td><td>&nbsp;&approx;&nbsp;</td><td colspan=3>${{ data.faltings_height }}$</td>
         <td>{{ place_code('faltings') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.faltings_height', title='Stable Faltings height') }}:</td>
-        <td>$h_{\mathrm{stable}}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.stable_faltings_height }}$</td>
+        <td>$h_{\mathrm{stable}}$</td><td>&nbsp;&approx;&nbsp;</td><td colspan=3>${{ data.stable_faltings_height }}$</td>
         <td>{{ place_code('stable_faltings') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.abc_quality', title='$abc$ quality') }}:</td>
-        <td>$Q$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.abc_quality }}$</td>
-        <td></td>
+        <td>$Q$</td><td>&nbsp;&approx;&nbsp;</td><td colspan=3>${{ data.abc_quality }}$</td>
         <td>{{ place_code('abc_quality') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.szpiro_ratio', title='Szpiro ratio') }}:</td>
-        <td>$\sigma_{m}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.szpiro_ratio }}$</td>
-        <td></td>
+        <td>$\sigma_{m}$</td><td>&nbsp;&approx;&nbsp;</td><td colspan=3>${{ data.szpiro_ratio }}$</td>
         <td>{{ place_code('szpiro_ratio') }}</td>
         </tr>
 

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -178,20 +178,20 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
-        <td>$\Z$</td>
+        <td>$\mathrm{End}(E)$</td><td>&nbsp;=&nbsp;</td><td>$\Z$</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
-        <td>{{ data.data.EndE }}</td>
-        <td colspan="2">
+        <td>$\mathrm{End}(E_{\overline{\Q}})$</td><td>&nbsp;=&nbsp;</td>
+	<td>{{ data.data.EndE }}
         {%if not data.data.CMD %}
-        (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+        &nbsp;&nbsp;(no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% else %}
-        ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+        &nbsp;&nbsp;({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
         {% endif %}
         </td>
-        <td>{{ place_code('cm') }}
+        <td>{{ place_code('cm') }}</td>
         </tr>
 
         <tr>
@@ -201,29 +201,27 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.q.faltings_height', title='Faltings height') }}:</td>
-        <td>${{ data.faltings_height }}\dots$</td>
-        <td></td><td></td>
+        <td>$h_{\mathrm{Faltings}}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.faltings_height }}$</td>
         <td>{{ place_code('faltings') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.faltings_height', title='Stable Faltings height') }}:</td>
-        <td>${{ data.stable_faltings_height }}\dots$</td>
-        <td></td><td></td>
+        <td>$h_{\mathrm{stable}}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.stable_faltings_height }}$</td>
         <td>{{ place_code('stable_faltings') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.abc_quality', title='$abc$ quality') }}:</td>
-        <td>${{ data.abc_quality }}\dots$</td>
-        <td></td><td></td>
+        <td>$Q$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.abc_quality }}$</td>
+        <td></td>
         <td>{{ place_code('abc_quality') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.q.szpiro_ratio', title='Szpiro ratio') }}:</td>
-        <td>${{ data.szpiro_ratio }}\dots$</td>
-        <td></td><td></td>
+        <td>$\sigma_{m}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.szpiro_ratio }}$</td>
+        <td></td>
         <td>{{ place_code('szpiro_ratio') }}</td>
         </tr>
 
@@ -234,7 +232,7 @@ white-space: pre in order to keep line breaks! #}
         <tbody>
         <tr>
         <td>{{ KNOWL('ec.q.analytic_rank', title='Analytic rank') }}:</td>
-        <td> ${{ data.analytic_rank }}$
+        <td>$r_{\mathrm{an}}$</td><td>&nbsp;=&nbsp;</td><td>$ {{ data.analytic_rank }}$
         </td>
         <td>{{ place_code('analytic_rank') }}</td>
         </tr>
@@ -245,9 +243,9 @@ white-space: pre in order to keep line breaks! #}
         	<td>Not computed</td>
       	{% else %}
           {% if data.rank==0 %}
-            <td> $1$</td>
+            <td> $\mathrm{Reg}(E/\Q)$</td><td>&nbsp;=&nbsp;</td><td>$1$</td>
           {% else %}
-            <td> ${{ data.mwbsd.reg }}\dots$</td>
+            <td> $\mathrm{Reg}(E/\Q)$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.mwbsd.reg }}$</td>
           {% endif %}
         {% endif %}
         <td>{{ place_code('reg') }}
@@ -255,13 +253,13 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.q.real_period', title='Real period') }}:</td>
-        <td> ${{ data.mwbsd.real_period }}\dots$</td>
+        <td> $\Omega$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.mwbsd.real_period }}$</td>
         <td>{{ place_code('real_period') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.tamagawa_number', title='Tamagawa product') }}:</td>
-        <td>$ {{ data.mwbsd.tamagawa_product }} $
+        <td>$\prod_{p}c_p$</td><td>&nbsp;=&nbsp;</td><td>$ {{ data.mwbsd.tamagawa_product }} $
           {% if data.mwbsd.tamagawa_factors %}
             &nbsp;=&nbsp;$ {{ data.mwbsd.tamagawa_factors }} $
           {% endif %}
@@ -271,24 +269,19 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.torsion_order', title='Torsion order') }}:</td>
-        <td>${{ data.mwbsd.torsion }}$</td>
+        <td>$E(\Q)_{\mathrm{tors}}$</td><td>&nbsp;=&nbsp;</td><td>${{ data.mwbsd.torsion }}$</td>
         <td>{{ place_code('ntors') }}</td>
         </tr>
 
         <tr>
         <td>{{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:</td>
-      	<td>
-      	  {% if data.mwbsd.sha == '?' %}
-        	  Not computed
-      	  {% else %}
-            ${{data.mwbsd.sha }}$
-        	  {% if data.mwbsd.sha > 1 %}
-          	  = {{data.mwbsd.sha2}}
-            {% endif %}
+        <td>{% if data.mwbsd.sha == '?' %}Not computed{% else %} &#1064;${}_{\mathrm{an}}$</td>
+	<td>{% if data.mwbsd.sha_is_exact %}&nbsp;=&nbsp;{% else %}&nbsp;&approx;&nbsp;{% endif %}</td>
+	<td>${{data.mwbsd.sha }}$ {% if data.mwbsd.sha > 1 %} = {{data.mwbsd.sha2}} {% endif %}&nbsp;&nbsp;
             {% if data.mwbsd.sha_is_exact %}
-              ({{ KNOWL('ec.analytic_sha_value',title="exact") }})
+              ({{ KNOWL('ec.q.analytic_sha_value',title="exact") }})
             {% else %}
-              ({{ KNOWL('ec.analytic_sha_value',title="rounded") }})
+              ({{ KNOWL('ec.q.analytic_sha_value',title="rounded") }})
             {% endif %}
           {% endif %}
         </td>
@@ -302,7 +295,7 @@ white-space: pre in order to keep line breaks! #}
         {% endif %}
         <tr>
         <td>{{KNOWL('ec.q.special_value', title='Special value', special_value = data.special_value)}}:</td>
-        <td>$ {{ data.mwbsd.lder_name }} $ &approx; $ {{ data.mwbsd.special_value }} $</td>
+        <td>$ {{ data.mwbsd.lder_name }}$</td><td>&nbsp;&approx;&nbsp;</td><td>${{ data.mwbsd.special_value }} $</td>
         <td>{{ place_code('L1') }}</td>
         </tr>
         </tbody>


### PR DESCRIPTION
This addresses #4943  for ECQ.  For the two lists of invariants to look consistent I added a symbol/name for all the quantities there, not just the real ones which may be approximate.  All now do have names except the Sato-Tate group, and the same names appear in the appropriate knowls so a couple of those have had minor edits (Szpiro ratio, abc-quality).  We could show something like ST(E) for the ST group of that is suffiently standard -- @AndrewVSutherland ?

I fixed but left the "(exact)"/"(rounded)" for analytic Sha since the knowl (originally written just for this purpose) does say something concrete, which is not obvious, namely that for both rank 0 and rank 1 the quantity shown is exact, having been computed as a rational, while for ranks 2 and above it is a rounded floating point number (not known theoretically to even be rational, let alone integral).  I think this is markedly different from all the other approximate reals on the page.  But of course I am willing to be persuaded!

Once this is done (with further changes if desired) I will do the same thing for ECNF.