### PR TITLE
Updated acknowledgements for congruent number data

### DIFF
--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -259,9 +259,12 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
 
 <p>
 The data files were created by Randall L. Rathbun on February 14, 2013
-with updates on May 18, 2014.  Some data was provided by Allan J
-MacLeod, Ralph Buchholz and Brett Wittby, the rest computed by Rathbun using <tt>PARI/GP</tt>
-and <tt>eclib</tt> (in particular <tt>mwrank</tt>).
+with updates on May 18, 2014.  For the curves of rank one, the generators were computed by him using an implementation
+in PARI/GP originally by Robatino of an algorithm in Robatino's 1996 thesis <i>Computation of mock Heegner points
+on modular elliptic curves</i>, following work of Monsky.
+
+Some data was provided by Allan J. MacLeod, Ralph Buchholz and Brett Wittby, and the rest computed by Rathbun using
+ <tt>PARI/GP</tt> and <tt>eclib</tt> (in particular <tt>mwrank</tt>).
 </p>
 
 <div id='infomessage'>

--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -263,7 +263,8 @@ with updates on May 18, 2014.  For the curves of rank one, the generators were c
 in PARI/GP originally by Robatino of an algorithm in Robatino's 1996 thesis <i>Computation of mock Heegner points
 on modular elliptic curves</i>, following work of Monsky.
 
-Some data was provided by Allan J. MacLeod, Ralph Buchholz and Brett Wittby, and the rest computed by Rathbun using
+Some data was provided by Allan J. MacLeod, and by Ralph Buchholz and
+Brett Wittby, using <tt>Magma</tt>; the rest computed by Rathbun using
  <tt>PARI/GP</tt> and <tt>eclib</tt> (in particular <tt>mwrank</tt>).
 </p>
 


### PR DESCRIPTION
After learning more about how the data was computed and by whom, I have updated the final section of the page https://beta.lmfdb.org/EllipticCurve/Q/CongruentNumbers

**However** looking at that page now, I see that its breadcrumbs place it under the "extra datasets" page -- good -- while the Learn More box still places it within ECQ.  That is because (I think) of the @ec_page.route("/CongruentNumbers")
 appearing within elliptic_curves.  Where is the datasets/ route handled?  Should these "home pages for datasets" such as this one be handled by routes there?  Then they could have their own Source, Completeness and Reliability data.

These remarks need nt stop *this* PR from being merged, it should either be a new Issue or be added to an open issue about datasets (but I could not find one). 