### PR TITLE
ECNF better display of invariants

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -487,7 +487,7 @@ class ECNF():
         self.ntors = web_latex(self.torsion_order)
         self.tr = len(self.torsion_structure)
         if self.tr == 0:
-            self.tor_struct_pretty = "trivial"
+            self.tor_struct_pretty = "$0$"
         if self.tr == 1:
             self.tor_struct_pretty = r"\(\Z/%s\Z\)" % self.torsion_structure[0]
         if self.tr == 2:

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -76,6 +76,8 @@ cellpadding="5";
       <table id="invariants" style="overflow:auto;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
+	<td>$\frak{n}$</td>
+	<td>=</td>
         <td>{{ ec.cond }}</td>
         <td>=</td>
         <td>{{ ec.fact_cond }}</td>
@@ -84,6 +86,8 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor norm')}}:</td>
+	<td>$N(\frak{n})$</td>
+	<td>=</td>
         <td>{{ ec.cond_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_cond_norm }}</td>
@@ -92,6 +96,8 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant')}}:</td>
+	<td>$(\Delta)$</td>
+	<td>=</td>
         <td>{{ ec.disc }}</td>
         {% if ec.fact_disc %}
         <td>=</td>
@@ -102,6 +108,8 @@ cellpadding="5";
         <tr><td colspan=4 style="padding:0;">{{ place_code('disc') }}</td></tr>
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
+	<td>$N(\Delta)$</td>
+	<td>=</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_disc_norm }}</td>
@@ -111,6 +119,8 @@ cellpadding="5";
 {% if not ec.is_minimal %}
         <tr>
         <td>{{KNOWL('ec.minimal_discriminant', title='Minimal discriminant')}}:</td>
+	<td>$\frak{D}_{\mathrm{min}}$</td>
+	<td>=</td>
         <td>{{ ec.mindisc }}</td>
         {% if ec.fact_mindisc %}
         <td>=</td>
@@ -120,6 +130,8 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.minimal_discriminant', title='Minimal discriminant norm')}}:</td>
+	<td>$N(\frak{D}_{\mathrm{min}})$</td>
+	<td>=</td>
         <td>{{ ec.mindisc_norm }}</td>
         <td>=</td>
         <td>{{ ec.fact_mindisc_norm }}</td>
@@ -128,6 +140,8 @@ cellpadding="5";
 
         <tr>
         <td>{{ KNOWL('ec.j_invariant','j-invariant')}}:</td>
+	<td>$j$</td>
+	<td>=</td>
         {% if ec.fact_j %}
         <td>{{ ec.j }}</td>
         <td>=</td>
@@ -140,12 +154,16 @@ cellpadding="5";
 
         <tr>
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
+	<td>$\mathrm{End}(E)$</td>
+	<td>=</td>
         <td>{% if ec.rational_cm %} {{ ec.End }} {% else %} \(\Z\) {% endif %}</td>
         <td colspan="2">{% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}</td>
         </tr>
         
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
+	<td>$\mathrm{End}(E_{\overline{\Q}})$</td>
+	<td>=</td>
         <td>{{ ec.End }}</td>
         <td colspan="2">
         {%if not ec.cm %}
@@ -159,6 +177,8 @@ cellpadding="5";
         <tr><td colspan=4 style="padding:0;">{{ place_code('cm') }}</td></tr>
         <tr>
         <td>{{ KNOWL('st_group.definition', title='Sato-Tate group') }}:</td>
+	<td>$\mathrm{ST}(E)$</td>
+	<td>=</td>
         <td>{{ ec.ST|safe }}</td>
         </td>
         </tr>
@@ -175,9 +195,13 @@ cellpadding="5";
 {% if ec.rank_bounds != "not available" %}
   <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
 {% else %}
+  <td>$r$</td>
+  <td>&nbsp;</td>
   <td>not available</td>
 {% endif %}
 {% else %}
+  <td>$r$</td>
+  <td>=</td>
   <td>\({{ ec.rank }}\)</td>
 {% endif %}
 </tr>
@@ -194,6 +218,7 @@ cellpadding="5";
   {% if ec.gens == 'not available' %}
   <td>not available</td>
   {% else %}
+  <td>$P$</td><td>=</td>
   {% for gen in ec.gens %}
   <td>{{ gen }}</td>
   {% endfor %}
@@ -210,6 +235,7 @@ cellpadding="5";
     {{ KNOWL('ec.canonical_height', title="Heights") }}
     {% endif %}
   </td>
+  <td>$\hat{h}(P)$</td><td>&approx;</td>
   {% for h in ec.heights %}
   <td>\({{ h }}\)</td>
   {% endfor %}
@@ -218,13 +244,17 @@ cellpadding="5";
 
 <tr>
 <td align='left'>{{KNOWL('ec.torsion_subgroup','Torsion structure')}}:</td>
+  <td>$E(K)_{\mathrm{tors}}$</td>
+  <td>$\cong$</td>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
 <tr><td colspan=2> {{ place_code('tors') }}</td></tr>
 <!-- <tr><td colspan=2> {{ place_code('ntors') }}</td></tr> -->
     {% if ec.tr %}
 <tr>
-<td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}:</td>
+  <td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}:</td>
+  <td>{% if ec.tr==1 %} $T$ {% else %} $T_1,T_2$ {% endif %}</td>
+  <td>=</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>
 {% endfor %}
@@ -242,6 +272,7 @@ cellpadding="5";
 
         <tr>
         <td align='left'>{{ KNOWL('lfunction.analytic_rank', title='Analytic rank') }}:</td>
+	<td>$r_{\mathrm{an}}$</td><td>=</td>
         <td>
 	  {{ ec.ar }}
         </td>
@@ -256,12 +287,16 @@ cellpadding="5";
 	<tr>
 	  <td align='left'>{{ KNOWL('ec.rank', title="Mordell-Weil rank")}}:</td>
 	  {% if ec.rk == "not available" %}
+	  <td>$r$?</td>
+	  <td>&nbsp;</td>
 	  {% if ec.rank_bounds != "not available" %}
 	  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
 	  {% else %}
 	  <td>not available</td>
 	  {% endif %}
 	  {% else %}
+	  <td>$r$</td>
+	  <td>=</td>
 	  <td>\({{ ec.rank }}\)</td>
 	  {% endif %}
 	</tr>
@@ -273,6 +308,8 @@ cellpadding="5";
 	    {{ KNOWL('ec.regulator', title='Regulator') }}:
 	    {% endif %}
 	  </td>
+	  <td>$\mathrm{Reg}(E/K)$</td>
+	  <td>{% if ec.rk == 0 %}={% else %}&approx;{% endif %}</td>
           <td>
 	  {% if ec.reg=='not available' %}
 	  not available
@@ -284,11 +321,13 @@ cellpadding="5";
 
         <tr>
         <td align='left'>{{ KNOWL('ec.period', title='Period') }}:</td>
+	<td>$\Omega(E/K)$</td><td>&approx;</td>
         <td> {{ ec.omega }}</td>
         </tr>
 
         <tr>
         <td align='left'>{{ KNOWL('ec.tamagawa_number', title='Tamagawa product') }}:</td>
+	<td>$\prod_{\frak{p}}c_{\frak{p}}$</td><td>=</td>
         <td> {{ ec.tamagawa_product }}
           {% if ec.tamagawa_factors %}
           &nbsp;=&nbsp; \({{ ec.tamagawa_factors }}\)
@@ -298,18 +337,18 @@ cellpadding="5";
 
         <tr>
         <td align='left'>{{ KNOWL('ec.torsion_order', title='Torsion order') }}:</td>
+	<td>$E(K)_{\mathrm{tors}}$</td><td>=</td>
         <td>\({{ ec.torsion_order }}\)</td>
         </tr>
 
         <tr>
         <td align='left'>{{ KNOWL('lfunction.leading_coeff', title='Leading coefficient') }}:</td>
-        <td>
-	  {% if ec.Lvalue=='not available' %}
-	  not available
-	  {% else %}
-	  {{ ec.Lvalue }}
-	  {% endif %}
-	</td>
+	<td>$L^{(r)}(E/K,1)/r!$</td>
+	{% if ec.Lvalue=='not available' %}
+	<td></td><td>not available</td>
+	{% else %}
+	<td>&approx;</td><td>{{ ec.Lvalue }}</td>
+	{% endif %}
         </tr>
 
         <tr>
@@ -320,7 +359,8 @@ cellpadding="5";
 	    {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064;') }}:
 	    {% endif %}
 	  </td>
-        <td> {{ ec.sha }} </td>
+	  <td>&#1064;${}_{\mathrm{an}}$</td><td>=</td>
+          <td> {{ ec.sha }} </td>
         </tr>
         </table>
     </p>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -156,21 +156,25 @@ cellpadding="5";
         <td>{{ KNOWL('ec.endomorphism_ring', title='Endomorphism ring') }}:</td>
 	<td>$\mathrm{End}(E)$</td>
 	<td>=</td>
-        <td>{% if ec.rational_cm %} {{ ec.End }} {% else %} \(\Z\) {% endif %}</td>
-        <td colspan="2">{% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}</td>
+        <td colspan="3">
+	  {% if ec.rational_cm %} {{ ec.End }} {% else %} \(\Z\) {% endif %}
+	  &nbsp;&nbsp;
+          {% if ec.rational_cm %} ({{ KNOWL('ec.complex_multiplication', title='complex multiplication')}}) {% endif %}
+	</td>
         </tr>
         
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
 	<td>$\mathrm{End}(E_{\overline{\Q}})$</td>
 	<td>=</td>
-        <td>{{ ec.End }}</td>
-        <td colspan="2">
-        {%if not ec.cm %}
+        <td colspan="3">
+	  {{ ec.End }}
+	  &nbsp;&nbsp;
+          {%if not ec.cm %}
           (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
-        {% elif not ec.rational_cm %}
+          {% elif not ec.rational_cm %}
           ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
-        {% endif %}
+          {% endif %}
         </td>
         </tr>
 
@@ -210,9 +214,9 @@ cellpadding="5";
 <tr>
   <td align = 'left'>
     {% if ec.ngens==1 %}
-    {{KNOWL('ec.mw_generators','Generator')}}
+    {{KNOWL('ec.mw_generators','Non-torsion generator')}}:
     {% else %}
-    {{KNOWL('ec.mw_generators','Generators')}}
+    {{KNOWL('ec.mw_generators','Non-torsion generators')}}:
     {% endif %}
   </td>
   {% if ec.gens == 'not available' %}
@@ -230,9 +234,9 @@ cellpadding="5";
 <tr>
   <td align = 'left'>
     {% if ec.ngens==1 %}
-    {{ KNOWL('ec.canonical_height', title="Height") }}
+    {{ KNOWL('ec.canonical_height', title="Height") }}:
     {% else %}
-    {{ KNOWL('ec.canonical_height', title="Heights") }}
+    {{ KNOWL('ec.canonical_height', title="Heights") }}:
     {% endif %}
   </td>
   <td>$\hat{h}(P)$</td><td>&approx;</td>
@@ -244,7 +248,7 @@ cellpadding="5";
 
 <tr>
 <td align='left'>{{KNOWL('ec.torsion_subgroup','Torsion structure')}}:</td>
-  <td>$E(K)_{\mathrm{tors}}$</td>
+  <td>$E(K)_{\mathrm{tor}}$</td>
   <td>$\cong$</td>
 <td>{{ ec.tor_struct_pretty }}</td>
 </tr>
@@ -253,7 +257,7 @@ cellpadding="5";
     {% if ec.tr %}
 <tr>
   <td align='left'>{% if ec.tr==1 %}{{KNOWL('ec.mw_generators','Torsion generator')}}{% else %}{{KNOWL('ec.mw_generators','Torsion generators')}}{% endif %}:</td>
-  <td>{% if ec.tr==1 %} $T$ {% else %} $T_1,T_2$ {% endif %}</td>
+  <td>$T$</td>
   <td>=</td>
 {% for gen in ec.torsion_gens %}
 <td>{{ gen }}</td>

--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -119,7 +119,7 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
       </form>
     </td>
     <td>
-      {{ KNOWL('ec.q.canonical_height', 'Heights') }}
+      {{ KNOWL('ec.canonical_height', 'Heights') }}
     </td>
     <td>
     <pre>000137    [8.4621365965410101565417149184287484305,10.575571190572966907642306531966335545]</pre>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -104,9 +104,9 @@ white-space: pre in order to keep line breaks! #}
 
     {% if data.mwbsd.rank!=0 %}
     {% if data.mwbsd.rank==1 %}
-    <h3> Infinite order Mordell-Weil generator and {{KNOWL('ec.q.canonical_height','height')}}</h3>
+    <h3> {{ KNOWL('ec.mw_generators', title='Non-torsion Mordell-Weil generator') }} and {{KNOWL('ec.canonical_height','height')}}</h3>
     {% else %}
-    <h3> Infinite order Mordell-Weil generators and {{KNOWL('ec.q.canonical_height','heights')}}</h3>
+    <h3> {{ KNOWL('ec.mw_generators', title='Non-torsion Mordell-Weil generators') }} and {{KNOWL('ec.canonical_height','heights')}}</h3>
     {% endif %}
       {% if data.mwbsd.ngens==0 %}
     No {% if data.mwbsd.rank==1 %} generator {% else %} generators  {% endif %} computed
@@ -130,7 +130,7 @@ white-space: pre in order to keep line breaks! #}
     {%endif%}
 
     {% if data.mwbsd.torsion!=1 %}
-    <h2> {{ KNOWL('ec.torsion_subgroup', title='Torsion generators') }}</h2>
+    <h2> {{ KNOWL('ec.mw_generators', title='Torsion generators') }}</h2>
     <p> {{ data.mwbsd.tor_gens |safe }} </p>
       {{ place_code('tors') }}
     {%endif %}
@@ -183,13 +183,15 @@ white-space: pre in order to keep line breaks! #}
 
         <tr>
         <td>{{ KNOWL('ec.geom_endomorphism_ring', title='Geometric endomorphism ring') }}:</td>
-        <td>$\mathrm{End}(E_{\overline{\Q}})$</td><td>&nbsp;=&nbsp;</td>
+        <td>$\mathrm{End}(E_{\overline{\Q}})$</td>
+	<td>&nbsp;=&nbsp;</td>
 	<td colspan=3>{{ data.data.EndE }}
-        {%if not data.data.CMD %}
-        &nbsp;&nbsp;(no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
-        {% else %}
-        &nbsp;&nbsp;({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
-        {% endif %}
+	  &nbsp;&nbsp;
+          {%if not data.data.CMD %}
+          (no {{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+          {% else %}
+          ({{ KNOWL('ec.complex_multiplication', title='potential complex multiplication')}})
+          {% endif %}
         </td>
         <td>{{ place_code('cm') }}</td>
         </tr>


### PR DESCRIPTION
Dealing with #4943 for ECNF as already done for ECQ.

Complications to consider include: 

 - sometimes we do not have rank data at all, sometimes just bounds, in which case instead of having r (in one column) = (in the next) and the value, I have r? in the first, nothing in the second, and "not available" or a range e.g. $0\le r\le 2$.   I am open to other suggestions.
 - Under torsion structure the columns are (e.g.) | E(K)_tors | \cong | Z/3Z | so for when it is trivial I kept the isomorphism sign but changed "trivial" to "0" (this is set in the python code, all else here is in the template).  Other suggestions?
 - There are lots of combinations depending on how much data we do (or do not) have.  I hope I checked them all but please look at many random curves
 - The knowl for "Discriminant" gives the usual definition for a field element (from the Weierstrass model) but what is displayed is the ideal this generates, so I denoted it $(\Delta)$ not just $\Delta$.  Perhaps the title of that row should be "discriminant ideal"?  For curves with no global minimal model (for an example see the "some interesting curves" list) there are two more lines for the minimal discriminant, and that is always an ideal by definition.