### PR TITLE
ECNF: sort non-torsion gens by height for display

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -577,9 +577,10 @@ class ECNF():
         try:
             self.gens = [web_point(parse_point(K, P)) for P in self.gens]
             self.gens_and_heights = list(zip(self.gens,self.heights))
+            self.gens_and_heights.sort(key = lambda Ph: Ph[1])
         except AttributeError:
             self.gens = []
-            self.gens_and_orders = []
+            self.gens_and_heights = []
 
         # Global period
         try:


### PR DESCRIPTION
As suggested in #6276 : Mordell-Weil generators of infinite order are now sorted by height for display.

An example: http://localhost:37777/EllipticCurve/2.0.11.1/34225.5/a/1