### PR TITLE
EC/ECNF consistency in local data display

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -359,6 +359,9 @@ class ECNF():
         self.cond_norm = web_latex(self.conductor_norm)
 
         Dnorm = self.normdisc
+        self.model_disc = self.disc.replace('w', Kgen).replace("*","").replace("(","").replace(")","")
+        if Kgen == 'phi':
+            self.model_disc = self.model_disc.replace(Kgen, r"\phi")
         self.disc = pretty_ideal(Kgen, self.disc)
 
         local_data = self.local_data

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -276,7 +276,7 @@ cellpadding="5";
         </tr>
 
         <tr>
-        <td align='left'>{{ KNOWL('ec.period', title='Period') }}:</td>
+        <td align='left'>{{ KNOWL('ec.period', title='Global period') }}:</td>
 	<td>$\Omega(E/K)$</td><td>&approx;</td>
         <td> {{ ec.omega }}</td>
         </tr>
@@ -341,25 +341,41 @@ cellpadding="5";
 <div>
  {{ place_code('localdata') }}
 
+<p>
+  This elliptic curve is {{ '' if ec.semistable else 'not' }} {{KNOWL('ec.semistable', title='semistable')}}.
+  There
+  {% if ec.n_bad_primes==0 %}
+  are no primes
+  {% else %}
+  {% if ec.n_bad_primes==1 %}
+  is only one prime $\frak{p}$
+  {% else %}
+  are {{ec.n_bad_primes }} primes $\frak{p}$
+  {% endif %}
+  {% endif %}
+  of {{KNOWL('ec.q.reduction_type', title='bad reduction')}}.
+
   {% if not ec.is_minimal %}
     Primes of good reduction for the curve but which divide the
     discriminant of the model above (if any) are included.
   {% endif %}
+</p>
+
 
 {% if ec.local_data %}
 <table class="ntdata"><thead>
 <tr>
-<th>prime</th>
-<th>Norm</th>
+<th>$\mathfrak{p}$</th>
+<th>$N(\mathfrak{p})$</th>
 <th>{{KNOWL('ec.tamagawa_number', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.reduction_type', title='Reduction type')}}</th>
 {% if ec.local_data.0.rootno %}
 <th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
 {% endif %}
-<th>{{KNOWL('ec.conductor_valuation', title='ord(\(\mathfrak{N}\))')}}</th>
-<th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\mathfrak{D}\))')}}</th>
-<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
+<th>{{KNOWL('ec.conductor_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathfrak{N}\))')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathfrak{D}_{\mathrm{min}}\))')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathrm{den}(j))\)')}}</th>
 </tr>
 </thead><tbody>
 {% for pr in ec.local_data %}
@@ -397,8 +413,6 @@ cellpadding="5";
 {% endfor %}
 </tbody>
 </table>
-{% else %}
-No primes of bad reduction.
 {% endif %}
 </div>
 

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -107,7 +107,7 @@ cellpadding="5";
       <table id="invariants" style="overflow:auto;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
-	<td>$\frak{n}$</td>
+	<td>$\frak{N}$</td>
 	<td>=</td>
         <td>{{ ec.cond }}</td>
         <td>=</td>
@@ -117,7 +117,7 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor norm')}}:</td>
-	<td>$N(\frak{n})$</td>
+	<td>$N(\frak{N})$</td>
 	<td>=</td>
         <td>{{ ec.cond_norm }}</td>
         <td>=</td>
@@ -127,7 +127,26 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant')}}:</td>
-	<td>$(\Delta)$</td>
+	<td>$\Delta$</td>
+	<td>=</td>
+        <td>${{ ec.model_disc }}$</td>
+        </tr>
+
+        <tr>
+          <td>
+	    {% if ec.is_minimal %}
+	    {{KNOWL('ec.minimal_discriminant', title='Discriminant ideal')}}:
+	    {% else %}
+	    {{KNOWL('ec.discriminant', title='Discriminant ideal')}}:
+	    {% endif %}
+	  </td>
+	<td>
+	  {% if ec.is_minimal %}
+	  $\frak{D}_{\mathrm{min}} = (\Delta)$
+	  {% else %}
+	  $(\Delta)$
+	  {% endif %}
+	</td>
 	<td>=</td>
         <td>{{ ec.disc }}</td>
         {% if ec.fact_disc %}
@@ -138,8 +157,20 @@ cellpadding="5";
 
         <tr><td colspan=4 style="padding:0;">{{ place_code('disc') }}</td></tr>
         <tr>
-        <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
-	<td>$N(\Delta)$</td>
+          <td>
+	    {% if ec.is_minimal %}
+	    {{KNOWL('ec.minimal_discriminant', title='Discriminant norm')}}:
+	    {% else %}
+	    {{KNOWL('ec.discriminant', title='Discriminant norm')}}:
+            {% endif %}
+	  </td>
+	<td>
+	  {% if ec.is_minimal %}
+	  $N(\frak{D}_{\mathrm{min}}) = N(\Delta)$
+	  {% else %}
+	  $N(\Delta)$
+	  {% endif %}
+	</td>
 	<td>=</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
@@ -363,7 +394,7 @@ cellpadding="5";
 
 
 {% if ec.local_data %}
-<table class="ntdata"><thead>
+<table class="ntdata centered"><thead>
 <tr>
 <th>$\mathfrak{p}$</th>
 <th>$N(\mathfrak{p})$</th>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -406,7 +406,7 @@ $\displaystyle {{ data.mwbsd.formula|safe }}$
 	{% endif %}
 	</p>
 
-    <h2> Local data </h2>
+<h2>{{KNOWL('ec.local_data', title='Local data')}} at {{KNOWL('ec.bad_reduction', title='primes of bad reduction')}} </h2>
 
 <style type="text/css">
 #local_data th, #local_data td, #serre_data th, #serre_data td {
@@ -433,9 +433,9 @@ text-align: center;
 <th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
 <th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
-<th>{{KNOWL('ec.conductor_valuation', title='$v_p(N)$')}}</th>
-<th>{{KNOWL('ec.discriminant_valuation', title='$v_p(\Delta)$')}}</th>
-<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='$v_p(\mathrm{den}(j))$')}}</th>
+<th>{{KNOWL('ec.conductor_valuation', title='$\mathrm{ord}_p(N)$')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='$\mathrm{ord}_p(\Delta)$')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='$\mathrm{ord}_p(\mathrm{den}(j))$')}}</th>
 </tr>
 </thead><tbody>
 {% for pr in data.local_data %}


### PR DESCRIPTION
This fixes some points raised at #6275, making the display of local data consistent between ECQ and ECNF:  table headings use the same notation, and ECNF now also has te text above the table saying whether or not the curve is semistable, and how many bad primes are.  (Note that, as before, the table has a row for any primes where the curve has good reduction but the model does not.  Such primes exist when there is no global minimal model; the model we then use has exactly one such prime.)

I also renamed "Period" --> "Global period" for ECNF a that is what the knowl defines, but ECQ still calls it "Real period" as that is what it is always called over Q (and there is a specific knowl too).