### PR TITLE
Hide BMF L-ratio while data is fixed

### DIFF
--- a/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
@@ -33,9 +33,9 @@
 <tr><td> {{ KNOWL('mf.bianchi.spaces', title='Newspace')}}:</td><td><a href={{data.newspace_url}}>{{data.newspace_label}}</a> (dimension {{ data.newspace_dimension }}) </td></tr>
 <tr><td> {{ KNOWL('mf.bianchi.sign',title="Sign of functional equation") }}:</td><td> {{data.sign}} </tr>
 <tr><td> {{ KNOWL('mf.bianchi.anr',title="Analytic rank")}}:</td><td> {{data.anrank}}</td> </tr>
-{% if data.Lratio %}
-<tr><td> {{ KNOWL('mf.bianchi.anr',title="L-ratio")}}:</td><td> {{data.Lratio}} </td></tr>
-{% endif %}
+{# See issue #6288
+<tr><td> {{ KNOWL('mf.bianchi.L-ratio',title="L-ratio")}}:</td><td> {{data.Lratio}} </td></tr>
+#}
 </table>
 </p>
 


### PR DESCRIPTION
See #6288 for explanation.  The L-ratio was already not being shown when 0 (not intentional) and some values are incorrect.  This just hides that line of the table while I sort out the data.