### PR TITLE
ECNF:  BSD invariants and display

### DIFF
--- a/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
@@ -33,9 +33,9 @@
 <tr><td> {{ KNOWL('mf.bianchi.spaces', title='Newspace')}}:</td><td><a href={{data.newspace_url}}>{{data.newspace_label}}</a> (dimension {{ data.newspace_dimension }}) </td></tr>
 <tr><td> {{ KNOWL('mf.bianchi.sign',title="Sign of functional equation") }}:</td><td> {{data.sign}} </tr>
 <tr><td> {{ KNOWL('mf.bianchi.anr',title="Analytic rank")}}:</td><td> {{data.anrank}}</td> </tr>
-{% if data.Lratio %}
-<tr><td> {{ KNOWL('mf.bianchi.anr',title="L-ratio")}}:</td><td> {{data.Lratio}} </td></tr>
-{% endif %}
+{# See issue #6288
+<tr><td> {{ KNOWL('mf.bianchi.L-ratio',title="L-ratio")}}:</td><td> {{data.Lratio}} </td></tr>
+#}
 </table>
 </p>
 

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -359,6 +359,9 @@ class ECNF():
         self.cond_norm = web_latex(self.conductor_norm)
 
         Dnorm = self.normdisc
+        self.model_disc = self.disc.replace('w', Kgen).replace("*","").replace("(","").replace(")","")
+        if Kgen == 'phi':
+            self.model_disc = self.model_disc.replace(Kgen, r"\phi")
         self.disc = pretty_ideal(Kgen, self.disc)
 
         local_data = self.local_data

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -566,15 +566,24 @@ class ECNF():
         if self.bsd_status in ["conditional", "unconditional"]:
             if self.ar == 0:
                 self.reg = web_latex(1)  # otherwise we only get 1.00000...
+                self.NTreg = web_latex(1)  # otherwise we only get 1.00000...
             else:
                 try:
-                    self.reg = web_latex(self.reg)
+                    R = self.reg
+                    self.reg = web_latex(R)
+                    self.NTreg = web_latex(R * K.degree()**self.rank)
                 except AttributeError:
                     self.reg = "not available"
+                    self.NTreg = "not available"
         elif self.rk != "not available":
-            self.reg = web_latex(self.reg) if self.rank else web_latex(1)
+            R = self.reg
+            self.reg = web_latex(R) if self.rank else web_latex(1)
+            self.NTreg = web_latex(R * K.degree()**self.rank) if self.rank else web_latex(1)
         else:
             self.reg = "not available"
+            self.NTreg = "not available"
+        print(f"reg = {self.reg}")
+        print(f"NTreg = {self.NTreg}")
 
         # Generators
         try:

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -639,38 +639,43 @@ class ECNF():
         # Check analytic Sha value compatible with formula in the knowl (see issue #5409)
 
         BSDrootdisc = RR(K.discriminant().abs()).sqrt()
-        if BSDLvalue and BSDsha and BSDReg and BSDsha:
+        if BSDLvalue and BSDsha and BSDReg and (self.rank is not None):
             BSDsha_numerator = BSDrootdisc * BSDntors**2
             BSDsha_denominator = BSDReg * BSDomega * BSDprodcp
             BSDsha_from_formula = BSDLvalue * BSDsha_numerator / BSDsha_denominator
             BSDLvalue_from_formula = BSDsha * BSDsha_denominator / BSDsha_numerator
             self.BSDsha = web_latex(BSDsha_from_formula)
             self.BSDLvalue = web_latex(BSDLvalue_from_formula)
+
+            # The BSD formula for display
+
+            dot = '\\cdot'
+            approx = '\\approx'
+            frac = '\\frac'
+            Sha = '\\# &#1064;(E/K)'
+            Om = '\\Omega(E/K)'
+            Reg = '\\mathrm{Reg}_{\\mathrm{NT}}(E/K)'
+            prodcp = '\\prod_{\\mathfrak{p}} c_{\\mathfrak{p}}'
+            tors2 = '\\#E(K)_{\\mathrm{tor}}^2'
+            rootD = '\\left|d_K\\right|^{1/2}'
+
+            lder_name  = rf"L^{{({r})}}(E/K,1)/{r}!" if r>=2 else "L'(E/K,1)" if r else "L(E/K,1)"
+            lhs_num    = rf'{Sha} {dot} {Om} {dot} {Reg} {dot} {prodcp}'
+            lhs_den    = rf'{tors2} {dot} {rootD}'
+            lhs        = rf'{frac}{{ {lhs_num} }} {{ {lhs_den} }}'
+            rhs_num    = rf'{BSDsha} {dot} {BSDomega:0.6f} {dot} {BSDReg} {dot} {BSDprodcp}'
+            if r:
+                rhs_num    = rf'{BSDsha} {dot} {BSDomega:0.6f} {dot} {BSDReg:0.6f} {dot} {BSDprodcp}'
+            rhs_den    = rf'{{{BSDntors}^2 {dot} {BSDrootdisc:0.6f}}}'
+            rhs        = rf'{frac}{{ {rhs_num} }} {{ {rhs_den} }}'
+            self.bsd_formula = rf'{BSDLvalue:0.9f} {approx} {lder_name} = {lhs} {approx} {rhs} {approx} {BSDLvalue_from_formula:0.9f}'
+
         else:
             self.BSDsha = "not available"
             self.BSDLvalue = "not available"
+            self.bsd_formula = None
 
-        # The BSD formula for display
-
-        dot = '\\cdot'
-        approx = '\\approx'
-        frac = '\\frac'
-        Sha = '\\# &#1064;(E/K)'
-        Om = '\\Omega(E/K)'
-        Reg = '\\mathrm{Reg}_{\\mathrm{NT}}(E/K)'
-        prodcp = '\\prod_{\\mathfrak{p}} c_{\\mathfrak{p}}'
-        tors2 = '\\#E(K)_{\\mathrm{tor}}^2'
-        rootD = '\\left|D_K\\right|'
-
-        lder_name  = rf"L^{({r})}(E,1)/{r}!" if r>=2 else "L'(E,1)" if r else "L(E,1)"
-        lhs_num    = rf'{Sha} {dot} {Om} {dot} {Reg} {dot} {prodcp}'
-        lhs_den    = rf'{tors2} {dot} {rootD}'
-        lhs        = rf'{frac}{{ {lhs_num} }} {{ {lhs_den} }}'
-        rhs_num    = rf'{BSDsha} {dot} {BSDomega:0.6f} {dot} {BSDReg:0.6f} {dot} {BSDprodcp}'
-        rhs_den    = rf'{{{BSDntors}^2 {dot} {BSDrootdisc:0.6f}}}'
-        rhs        = rf'{frac}{{ {rhs_num} }} {{ {rhs_den} }}'
-        self.bsd_formula = rf'{BSDLvalue:0.9f} {approx} {lder_name} = {lhs} {approx} {rhs} {approx} {BSDLvalue_from_formula:0.9f}'
-
+        print(f"BSD: {self.bsd_formula}")
         # Local data
 
         # The Kodaira symbol is stored as an int in pari encoding. The

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -274,7 +274,7 @@ cellpadding="5";
 	<tr>
 	  <td align='left'>{{ KNOWL('ec.rank', title="Mordell-Weil rank")}}:</td>
 	  {% if ec.rk == "not available" %}
-	  <td>$r$?</td>
+	  <td>$r?$</td>
 	  <td>&nbsp;</td>
 	  {% if ec.rank_bounds != "not available" %}
 	  <td>\({{ ec.rk_lb }} \le r \le {{ec.rk_ub}}\)</td>
@@ -395,6 +395,8 @@ cellpadding="5";
 {% endif %}
 </div>
 
+{% if ec.bsd_formula %}
+
 <h2> {{ KNOWL('ec.bsdconjecture', title='BSD formula') }}</h2>
 <div>
 <p style="margin:10px 280px;">
@@ -404,6 +406,8 @@ $\displaystyle {{ ec.bsd_formula|safe }}$
 {{ place_code('bsd_formula') }}
 </center>
 </div>
+
+{% endif %}
 
 <h2>{{KNOWL('ec.local_data', title='Local data')}} at {{KNOWL('ec.bad_reduction', title='primes of bad reduction')}} </h2>
 <div>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -276,7 +276,7 @@ cellpadding="5";
         </tr>
 
         <tr>
-        <td align='left'>{{ KNOWL('ec.period', title='Period') }}:</td>
+        <td align='left'>{{ KNOWL('ec.period', title='Global period') }}:</td>
 	<td>$\Omega(E/K)$</td><td>&approx;</td>
         <td> {{ ec.omega }}</td>
         </tr>
@@ -341,25 +341,41 @@ cellpadding="5";
 <div>
  {{ place_code('localdata') }}
 
+<p>
+  This elliptic curve is {{ '' if ec.semistable else 'not' }} {{KNOWL('ec.semistable', title='semistable')}}.
+  There
+  {% if ec.n_bad_primes==0 %}
+  are no primes
+  {% else %}
+  {% if ec.n_bad_primes==1 %}
+  is only one prime $\frak{p}$
+  {% else %}
+  are {{ec.n_bad_primes }} primes $\frak{p}$
+  {% endif %}
+  {% endif %}
+  of {{KNOWL('ec.q.reduction_type', title='bad reduction')}}.
+
   {% if not ec.is_minimal %}
     Primes of good reduction for the curve but which divide the
     discriminant of the model above (if any) are included.
   {% endif %}
+</p>
+
 
 {% if ec.local_data %}
 <table class="ntdata"><thead>
 <tr>
-<th>prime</th>
-<th>Norm</th>
+<th>$\mathfrak{p}$</th>
+<th>$N(\mathfrak{p})$</th>
 <th>{{KNOWL('ec.tamagawa_number', title='Tamagawa number')}}</th>
 <th>{{KNOWL('ec.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.reduction_type', title='Reduction type')}}</th>
 {% if ec.local_data.0.rootno %}
 <th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
 {% endif %}
-<th>{{KNOWL('ec.conductor_valuation', title='ord(\(\mathfrak{N}\))')}}</th>
-<th>{{KNOWL('ec.discriminant_valuation', title='ord(\(\mathfrak{D}\))')}}</th>
-<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='ord\((j)_{-}\)')}}</th>
+<th>{{KNOWL('ec.conductor_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathfrak{N}\))')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathfrak{D}_{\mathrm{min}}\))')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='\(\mathrm{ord}_{\mathfrak{p}}(\mathrm{den}(j))\)')}}</th>
 </tr>
 </thead><tbody>
 {% for pr in ec.local_data %}
@@ -397,8 +413,6 @@ cellpadding="5";
 {% endfor %}
 </tbody>
 </table>
-{% else %}
-No primes of bad reduction.
 {% endif %}
 </div>
 

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -107,7 +107,7 @@ cellpadding="5";
       <table id="invariants" style="overflow:auto;">
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor')}}:</td>
-	<td>$\frak{n}$</td>
+	<td>$\frak{N}$</td>
 	<td>=</td>
         <td>{{ ec.cond }}</td>
         <td>=</td>
@@ -117,7 +117,7 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.conductor', title='Conductor norm')}}:</td>
-	<td>$N(\frak{n})$</td>
+	<td>$N(\frak{N})$</td>
 	<td>=</td>
         <td>{{ ec.cond_norm }}</td>
         <td>=</td>
@@ -127,7 +127,26 @@ cellpadding="5";
 
         <tr>
         <td>{{KNOWL('ec.discriminant', title='Discriminant')}}:</td>
-	<td>$(\Delta)$</td>
+	<td>$\Delta$</td>
+	<td>=</td>
+        <td>${{ ec.model_disc }}$</td>
+        </tr>
+
+        <tr>
+          <td>
+	    {% if ec.is_minimal %}
+	    {{KNOWL('ec.minimal_discriminant', title='Discriminant ideal')}}:
+	    {% else %}
+	    {{KNOWL('ec.discriminant', title='Discriminant ideal')}}:
+	    {% endif %}
+	  </td>
+	<td>
+	  {% if ec.is_minimal %}
+	  $\frak{D}_{\mathrm{min}} = (\Delta)$
+	  {% else %}
+	  $(\Delta)$
+	  {% endif %}
+	</td>
 	<td>=</td>
         <td>{{ ec.disc }}</td>
         {% if ec.fact_disc %}
@@ -138,8 +157,20 @@ cellpadding="5";
 
         <tr><td colspan=4 style="padding:0;">{{ place_code('disc') }}</td></tr>
         <tr>
-        <td>{{KNOWL('ec.discriminant', title='Discriminant norm')}}:</td>
-	<td>$N(\Delta)$</td>
+          <td>
+	    {% if ec.is_minimal %}
+	    {{KNOWL('ec.minimal_discriminant', title='Discriminant norm')}}:
+	    {% else %}
+	    {{KNOWL('ec.discriminant', title='Discriminant norm')}}:
+            {% endif %}
+	  </td>
+	<td>
+	  {% if ec.is_minimal %}
+	  $N(\frak{D}_{\mathrm{min}}) = N(\Delta)$
+	  {% else %}
+	  $N(\Delta)$
+	  {% endif %}
+	</td>
 	<td>=</td>
         <td>{{ ec.disc_norm }}</td>
         <td>=</td>
@@ -363,7 +394,7 @@ cellpadding="5";
 
 
 {% if ec.local_data %}
-<table class="ntdata"><thead>
+<table class="ntdata centered"><thead>
 <tr>
 <th>$\mathfrak{p}$</th>
 <th>$N(\mathfrak{p})$</th>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -367,8 +367,19 @@ cellpadding="5";
 	  <td>&#1064;${}_{\mathrm{an}}$</td><td>=</td>
           <td> {{ ec.sha }} </td>
         </tr>
+{#
+	<tr>
+	  <td align='left'>
+	    {{ KNOWL('ec.analytic_sha_order', title='Analytic order of &#1064; (from formula)') }}:
+	  </td>
+	  <td>&#1064;${}_{\mathrm{an}}$</td><td>=</td>
+          <td> {{ ec.BSDsha }} </td>
+        </tr>
+#}
         </table>
-    </p>
+{# %%%%%%%%%%%%%%%% END OF TABLE %%%%%%%%%%%%%%%%%%% #}
+</p>
+
 {% if ec.bsd_status == "conditional" %}
 <p>
   * Conditional on {{ KNOWL('ec.bsdconjecture', title='BSD') }}: assuming rank = analytic rank.
@@ -382,8 +393,16 @@ cellpadding="5";
 </p>
 {% endif %}
 {% endif %}
+</div>
 
-{# %%%%%%%%%%%%%%%% END OF TABLE %%%%%%%%%%%%%%%%%%% #}
+<h2> {{ KNOWL('ec.bsdconjecture', title='BSD formula') }}</h2>
+<div>
+<p style="margin:10px 280px;">
+$\displaystyle {{ ec.bsd_formula|safe }}$
+</p>
+<center>
+{{ place_code('bsd_formula') }}
+</center>
 </div>
 
 <h2>{{KNOWL('ec.local_data', title='Local data')}} at {{KNOWL('ec.bad_reduction', title='primes of bad reduction')}} </h2>

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -296,12 +296,30 @@ cellpadding="5";
 	    {% endif %}
 	  </td>
 	  <td>$\mathrm{Reg}(E/K)$</td>
-	  <td>{% if ec.rk == 0 %}={% else %}&approx;{% endif %}</td>
+	  <td>{% if ec.rank == 0 %}={% else %}&approx;{% endif %}</td>
           <td>
 	  {% if ec.reg=='not available' %}
 	  not available
 	  {% else %}
 	  {{ ec.reg }}
+	  {% endif %}
+	</td>
+        </tr>
+        <tr>
+	  <td align='left'>
+	    {% if ec.bsd_status == "conditional" %}
+            {{ KNOWL('ec.regulator', title='N&eacute;ron-Tate Regulator*') }}:
+	    {% else %}
+	    {{ KNOWL('ec.regulator', title='N&eacute;ron-Tate Regulator') }}:
+	    {% endif %}
+	  </td>
+	  <td>$\mathrm{Reg}_{\mathrm{NT}}(E/K)$</td>
+	  <td>{% if ec.rank == 0 %}={% else %}&approx;{% endif %}</td>
+          <td>
+	  {% if ec.NTreg=='not available' %}
+	  not available
+	  {% else %}
+	  {{ ec.NTreg }}
 	  {% endif %}
 	</td>
         </tr>

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -406,7 +406,7 @@ $\displaystyle {{ data.mwbsd.formula|safe }}$
 	{% endif %}
 	</p>
 
-    <h2> Local data </h2>
+<h2>{{KNOWL('ec.local_data', title='Local data')}} at {{KNOWL('ec.bad_reduction', title='primes of bad reduction')}} </h2>
 
 <style type="text/css">
 #local_data th, #local_data td, #serre_data th, #serre_data td {
@@ -433,9 +433,9 @@ text-align: center;
 <th>{{KNOWL('ec.q.kodaira_symbol', title='Kodaira symbol')}}</th>
 <th>{{KNOWL('ec.q.reduction_type', title='Reduction type')}}</th>
 <th>{{KNOWL('ec.local_root_number', title='Root number')}}</th>
-<th>{{KNOWL('ec.conductor_valuation', title='$v_p(N)$')}}</th>
-<th>{{KNOWL('ec.discriminant_valuation', title='$v_p(\Delta)$')}}</th>
-<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='$v_p(\mathrm{den}(j))$')}}</th>
+<th>{{KNOWL('ec.conductor_valuation', title='$\mathrm{ord}_p(N)$')}}</th>
+<th>{{KNOWL('ec.discriminant_valuation', title='$\mathrm{ord}_p(\Delta)$')}}</th>
+<th>{{KNOWL('ec.j_invariant_denominator_valuation', title='$\mathrm{ord}_p(\mathrm{den}(j))$')}}</th>
 </tr>
 </thead><tbody>
 {% for pr in data.local_data %}


### PR DESCRIPTION
This is based on #6287 so should not be merged before that.

This addresses the remaining issues from #5409 .  Both usual regulator and the Neron-Tate regulator are now displayed.  The global period displayed is the stored value times 2**(#complex places) for reasons explained at #5409.

I have also added a BSD Formula section with a display like the one for ECQ.  When reviewing that, look at examples for all current ranks (0,1,2,3) and also one where not all the data is available, such as 
http://localhost:37777/EllipticCurve/2.0.10691.1/1.0.1/a/1  where the formula section is missing.

There are a lot of details in that formula, so I would welcome comment as I have probably missed something.

**Wait**:   for some of the recently uploaded curves over imaginary quadratic fields, the data was computed and uploaded *after* I fixed the issue with scaling the complex periods, so the doubling *should not* be done.  And this is made very clear when looking at the new displayed formula (e.g. http://localhost:37777/EllipticCurve/2.0.699.1/93.2/a/1) where the number on the extreme right is double the one on the extreme left, instead of being equal!

It will be possible for me to work out exactly which data this applies to and put in a fix, updating the PR.  But everything else is ready for review.
