### PR TITLE
fixing a redirect

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -146,7 +146,7 @@ def url_for_label(label):
         validate_label(label)
     except ValueError as err:
         flash_error("%s is not a valid label: %s.", label, str(err))
-        return redirect(url_for(".abelian_varieties"))
+        return url_for(".abelian_varieties")
     g, q, iso = split_label(label)
     return url_for(".abelian_varieties_by_gqi", g=g, q=q, iso=iso)
 


### PR DESCRIPTION
```
Exception on /Variety/Abelian/Fq/3.2.acad [GET]
Traceback (most recent call last):
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/abvar/fq/main.py", line 805, in by_label
    return redirect(url_for_label(label))
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/werkzeug/utils.py", line 269, in redirect
    display_location = html.escape(location)
  File "/usr/lib/python3.10/html/__init__.py", line 19, in escape
    s = s.replace("&", "&amp;") # Must be done first!
AttributeError: 'Response' object has no attribute 'replace'
[2024-12-09 00:24:15 UTC] 500 error on URL https://www.lmfdb.org/Variety/Abelian/Fq/3.2.acad ()