### PR TITLE
Comment old-format BHKSSW code

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -994,13 +994,13 @@ def render_bhkssw():
     learnmore = learnmore_list_remove('BHKSSW dataset')
     t = 'Balakrishnan-Ho-Kaplan-Spicer-Stein-Watkins elliptic curve database'
     bread = [("Datasets", url_for("datasets")), ("BHKSSW dataset", " ")]
-    if 'filename' in info:
-        filepath = os.path.join(os.path.expanduser('~/data/bhkssw_ecdb/' + info['filename']))
-        if os.path.isfile(filepath) and os.access(filepath, os.R_OK):
-            return send_file(filepath, as_attachment=True)
-        else:
-            flash_error('File {} not found'.format(info['filename']))
-            return redirect(url_for(".render_bhkssw"))
+    #if 'filename' in info:
+    #    filepath = os.path.join(os.path.expanduser('~/data/bhkssw_ecdb/' + info['filename']))
+    #    if os.path.isfile(filepath) and os.access(filepath, os.R_OK):
+    #        return send_file(filepath, as_attachment=True)
+    #    else:
+    #        flash_error('File {} not found'.format(info['filename']))
+    #        return redirect(url_for(".render_bhkssw"))
     # This format was nice, but not possible with the 30-second timeout limitation
     #info['files'] = [ # number of curves, size in MB, lower bound, upper bound, filename
     #    (2249362, 151, "0", r"1 \cdot 10^8", "1e8db.txt"),


### PR DESCRIPTION
We had to split up the BHKSSW EC database files into smaller pieces due to the 30-second timeout imposed by gunicorn.  Some of the code for handling the old format didn't get commented out, and would cause an error if the underlying data was not present.  Here we just comment it out (in hopes that we can eventually solve the 30-second limit and return to using large data downloads).