### PR TITLE
Fix Dirichlet character for newform orbit whose dimension is 1

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -594,3 +594,58 @@ class CmfTest(LmfdbTest):
                 and 'mf_hecke_charpolys' in data and 'charpoly_factorization' in data
                 and 'mf_newform_portraits' in data and "data:image/png;base64" in data
                 and 'mf_hecke_traces' in data and 'trace_an' in data)
+
+    def test_character_values(self):
+        # A newform orbit of dimension 1
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/12/3/c/a/').get_data(as_text=True)
+        character_values_table = r"""
+<table class="ntdata">
+  <tbody>
+        <tr>
+      <td class="dark border-right border-bottom">\(n\)</td>
+      <td class="light border-bottom">\(5\)</td>
+      <td class="dark border-bottom">\(7\)</td>    </tr>
+    <tr>
+      <td class="dark border-right">\(\chi(n)\)</td>
+      <td class="light">\(-1\)</td>
+      <td class="dark">\(1\)</td>    </tr>
+  </tbody>
+</table>
+"""
+        assert (character_values_table in data)
+
+        # A newform orbit of dimension 2
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/119/1/d/a/').get_data(as_text=True)
+        character_values_table = r"""
+<table class="ntdata">
+  <tbody>
+        <tr>
+      <td class="dark border-right border-bottom">\(n\)</td>
+      <td class="light border-bottom">\(52\)</td>
+      <td class="dark border-bottom">\(71\)</td>    </tr>
+    <tr>
+      <td class="dark border-right">\(\chi(n)\)</td>
+      <td class="light">\(-1\)</td>
+      <td class="dark">\(-1\)</td>    </tr>
+  </tbody>
+</table>
+"""
+        assert (character_values_table in data)
+
+        # An embedded newform
+        data = self.tc.get('/ModularForm/GL2/Q/holomorphic/119/1/d/a/118/1/').get_data(as_text=True)
+        character_values_table = r"""
+<table class="ntdata">
+  <tbody>
+        <tr>
+      <td class="dark border-right border-bottom">\(n\)</td>
+      <td class="light border-bottom">\(52\)</td>
+      <td class="dark border-bottom">\(71\)</td>    </tr>
+    <tr>
+      <td class="dark border-right">\(\chi(n)\)</td>
+      <td class="light">\(-1\)</td>
+      <td class="dark">\(-1\)</td>    </tr>
+  </tbody>
+</table>
+"""
+        assert (character_values_table in data)

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -185,6 +185,9 @@ class WebNewform():
             if self.dim == 1:
                 # avoid using mf_hecke_nf when the dimension is 1
                 vals = ConreyCharacter(self.level, db.char_dirichlet.lookup("%s.%s" % (self.level,self.char_orbit_label),projection="first")).values_gens
+                # ConreyCharacter.values_gens returns the exponent of character values,
+                # But we need the character values themselves here when hecke_ring_cyclotomic_generator is unspecified.
+                vals = [[v[0],[1] if v[1] == 0 else [-1]] for v in vals]
                 eigenvals = { 'hecke_ring_cyclotomic_generator': 0, 'hecke_ring_character_values': vals, 'hecke_ring_power_basis': True, 'maxp': previous_prime(len(self.traces)+1), 'an': self.traces }
             else:
                 eigenvals = db.mf_hecke_nf.lucky({'hecke_orbit_code': self.hecke_orbit_code}, ['an'] + hecke_cols)


### PR DESCRIPTION
This is my attempt of fixing #6309 . The `hecke_ring_character_values` field in this file seems to have double meaning: the generator value can be either the actual dirichlet character value (the complex e^{...}), or the log of it. Which way to interpret it [depends on the existence of non-0 `hecke_ring_cyclotomic_generator`](https://github.com/LMFDB/lmfdb/blob/main/lmfdb/classical_modular_forms/web_newform.py#L919-L926). Meanwhile, `ConreyCharacter.values_gens` always return the log value. This creates a discrepancy in this specific `dim==1` code block, where `hecke_ring_cyclotomic_generator` is set to 0 (meaning `hecke_ring_character_values` should be interpreted as the final values), but `hecke_ring_character_values` stores the log values. A small transformation is needed here

A similar transformation is done here: https://github.com/LMFDB/lmfdb/blob/65713a6fc29034e88eeb78e82106d495b1a4c4cd/lmfdb/classical_modular_forms/download.py#L27