### PR TITLE
Exclude self newspace from oldspace decomposition

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -443,4 +443,6 @@ affil: The University of North Carolina Greensboro
 name: David Yuen
 affil: Lake Forest College
 url: https://www.lakeforest.edu/academics/faculty/yuen/
-
+---
+name: Weiyi Wang
+email: wwylele@gmail.com

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -264,6 +264,12 @@ class CmfTest(LmfdbTest):
             assert elt + '.a' in page.get_data(as_text=True)
         for elt in ['Decomposition', r"S_{9}^{\mathrm{old}}(\Gamma_1(38))", "lower level spaces"]:
             assert elt in page.get_data(as_text=True)
+        decomposition = r"""
+<div class="center">
+  \( S_{9}^{\mathrm{old}}(\Gamma_1(38)) \cong \) <a href=/ModularForm/GL2/Q/holomorphic/1/9/>\(S_{9}^{\mathrm{new}}(\Gamma_1(1))\)</a>\(^{\oplus 4}\)\(\oplus\)<a href=/ModularForm/GL2/Q/holomorphic/2/9/>\(S_{9}^{\mathrm{new}}(\Gamma_1(2))\)</a>\(^{\oplus 2}\)\(\oplus\)<a href=/ModularForm/GL2/Q/holomorphic/19/9/>\(S_{9}^{\mathrm{new}}(\Gamma_1(19))\)</a>\(^{\oplus 2}\)
+</div>
+"""
+        assert decomposition in page.get_data(as_text=True)
 
     def test_convert_conreylabels(self):
         for c in [27, 31]:

--- a/lmfdb/classical_modular_forms/web_space.py
+++ b/lmfdb/classical_modular_forms/web_space.py
@@ -481,7 +481,7 @@ class WebGamma1Space():
         self.has_trace_form = (data.get('traces') is not None)
         # By default we sort on char_orbit_index
         newspaces = list(db.mf_newspaces.search({'level':level, 'weight':weight, 'char_parity': self.weight_parity}))
-        self.oldspaces = [(sublevel, number_of_divisors(level/sublevel)) for sublevel in divisors(level)]
+        self.oldspaces = [(sublevel, number_of_divisors(level/sublevel)) for sublevel in divisors(level) if sublevel != level]
         self.oldspaces.sort()
         self.dim_grid = DimGrid.from_db(data)
         self.decomp = []


### PR DESCRIPTION
This partially fixes #6104 in the affected newspace pages (knowl still has the problem). I chose the approach to keep this as oldspace decomposition and remove the extra self newspace. I find it better to keep the semantics of this section, as it contrast with the previous section ("Decomposition of $S^{new}$" and "Decomposition of $S^{old}$")