### PR TITLE
Bmf0curves

### DIFF
--- a/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-newform.html
@@ -39,6 +39,19 @@
 </table>
 </p>
 
+{% if data.dimension == 1 %}
+<h2>  Associated elliptic curves </h2>
+{% if data.ec_status == 1 %}
+This Bianchi newform is associated to the isogeny class <a href={{data.ec_url}}>{{data.label}}</a> of elliptic curves.
+{% endif %}
+{% if data.ec_status == 0 %}
+This Bianchi newform is conjectured to be associated to an isogeny class of elliptic curves, but no matching elliptic curve is currently known.
+{% endif %}
+{% if data.ec_status == -1 %}
+This Bianchi newform is not associated to any elliptic curves.
+{% endif %}
+{% endif %}
+
 <h2>  Atkin-Lehner eigenvalues  </h2>
 
 {% if data.have_AL %} 

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -53,7 +53,7 @@ class BMFTest(LmfdbTest):
         Check that various search combinations work.
         """
         self.check_args(base_url+"?field_label=2.0.7.1&level_norm=322&count=10", 'Results (4 matches)')
-        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", 'ModularForm/GL2/ImaginaryQuadratic/2.0.95.1/16.5/a/')
+        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", 'ModularForm/GL2/ImaginaryQuadratic/2.0.1007.1/9.1/a/')
 
     # tests for newspace pages
     def test_newspace(self):

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -264,23 +264,23 @@ class WebBMF():
         if self.ec_status not in [0,-1]: # so it is +1 (curve does exist) or None (curve_status not set)
             self.ec_url = url_for("ecnf.show_ecnf_isoclass", nf=self.field_label, conductor_label=self.level_label, class_label=self.label_suffix)
             curve_bc = db.ec_nfcurves.lucky({'class_label':self.label}, projection="base_change")
+            self.bc_forms = []
             if curve_bc is not None:
                 self.ec_status = 1 # curve does exist in ec_nfcurves, now see if it is base-change
                 curve_bc = [lab for lab in curve_bc if '?' not in lab]
                 if curve_bc and "." not in curve_bc[0]:
                     curve_bc = [cremona_label_to_lmfdb_label(lab) for lab in curve_bc]
                 curve_bc_parts = [split_lmfdb_label(lab) for lab in curve_bc]
-                bc_urls = [url_for("cmf.by_url_newform_label", level=cond, weight=2, char_orbit_label='a', hecke_orbit=iso) for cond, iso, num in curve_bc_parts]
+                bc_urls = [url_for("cmf.by_url_newform_label", level=cond, weight=2, char_orbit_label='a', hecke_orbit=iso)
+                           for cond, iso, num in curve_bc_parts]
                 bc_labels = [".".join( [str(cond), str(2), 'a', iso] ) for cond,iso,_ in curve_bc_parts]
                 bc_exists = [db.mf_newforms.label_exists(lab) for lab in bc_labels]
                 self.bc_forms = [{'exists':ex, 'label':lab, 'url':url} for ex,lab,url in zip(bc_exists, bc_labels, bc_urls)]
-        else: # ec_status is 0 or -1, we have no matching curve
-            self.bc_forms = []
-            if self.ec_status is None:
-                if self.bct or self.label in bmfs_with_no_curve:
-                    self.ec_status = -1 # there is certainly no curve
-                else:
-                    self.ec_status = 0 # there should be a curve but we do not have one
+        if self.ec_status is None:
+            if self.bct or self.label in bmfs_with_no_curve:
+                self.ec_status = -1 # there is certainly no curve
+            else:
+                self.ec_status = 0 # there should be a curve but we do not have one
 
         self.properties.append(('Sign', self.sign))
         self.properties.append(('Analytic rank', self.anrank))

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -11,6 +11,21 @@ from sage.all import QQ, PolynomialRing, NumberField
 
 logger = make_logger("bmf")
 
+# BMFs which have no elliptic curve: since 2025-03-31 there is a
+# column 'curve_status' in table bmf_forms containing
+# +1 if there is a matching curve in ec_nfcurves
+#  0 if there is no matching curve in the database but one should (conjecturally) exist
+# -1 if there is no matching curve in the database and no matching curve exists (based on theory or on Magma's
+#    EllipticCurveSearch() returning "no elliptic curves have the given traces")
+
+# Prior to the creation and filling of this column, the following was
+# used, based on the fact that in some, but not all, cases, it was
+# possible to tell that no curve exists from other data:
+
+################################################################################################################
+# The next block can be removed once the table bmf_forms with the extra column and this code change are on prod
+################################################################################################################
+
 # Labels of BMFs which have no elliptic curve but are not twists of
 # base change.  Those which have no curve but are twists of base
 # change are detectable automatically in the code below, but these are
@@ -19,11 +34,6 @@ logger = make_logger("bmf")
 # curve over the base field; these curves were found by Ciaran
 # Schembri.  At some point we will want to list these abelian surfaces
 # as friends when there is no curve.
-
-# TODO: make this list into a table, OR add a column to the bmf_forms
-# table to indicate whether or not a curve exists (which could be
-# because we have not found one, but is normally because there really
-# is no curve).
 
 bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.4.1-34225.7-a',
@@ -82,17 +92,16 @@ bmfs_with_no_curve = ['2.0.4.1-34225.7-b',
                       '2.0.56.1-127.1-b',
                       '2.0.56.1-127.2-a',
                       '2.0.56.1-127.2-b',
-                      # '2.0.59.1-675.5-b',
-                      # '2.0.59.1-675.8-b',
                       '2.0.68.1-901.1-a',
                       '2.0.68.1-901.1-b',
                       '2.0.68.1-901.2-a',
                       '2.0.68.1-901.2-b',
                       '2.0.91.1-784.1-a',
                       '2.0.91.1-784.1-b',
-                      # '2.0.95.1-624.5-c',
-                      # '2.0.95.1-624.5-d',
 ]
+################################################################################################################
+# The preceding block can be removed once the table bmf_forms with the extra column and this code change are on prod
+################################################################################################################
 
 def cremona_label_to_lmfdb_label(lab):
     if "." in lab:
@@ -245,24 +254,33 @@ class WebBMF():
             self.bc_extra = r', but is a twist of the base change of a form over \(\mathbb{Q}\) with coefficients in \(\mathbb{Q}(\sqrt{'+str(self.bcd)+r'})\)'
         self.properties.append(('Base change', str(self.bc)))
 
-        curve_bc = db.ec_nfcurves.lucky({'class_label':self.label}, projection="base_change")
-        if curve_bc is not None:
-            curve_bc = [lab for lab in curve_bc if '?' not in lab]
-            if curve_bc and "." not in curve_bc[0]:
-                curve_bc = [cremona_label_to_lmfdb_label(lab) for lab in curve_bc]
-            self.ec_status = 'exists'
-            self.ec_url = url_for("ecnf.show_ecnf_isoclass", nf=self.field_label, conductor_label=self.level_label, class_label=self.label_suffix)
-            curve_bc_parts = [split_lmfdb_label(lab) for lab in curve_bc]
-            bc_urls = [url_for("cmf.by_url_newform_label", level=cond, weight=2, char_orbit_label='a', hecke_orbit=iso) for cond, iso, num in curve_bc_parts]
-            bc_labels = [".".join( [str(cond), str(2), 'a', iso] ) for cond,iso,_ in curve_bc_parts]
-            bc_exists = [db.mf_newforms.label_exists(lab) for lab in bc_labels]
-            self.bc_forms = [{'exists':ex, 'label':lab, 'url':url} for ex,lab,url in zip(bc_exists, bc_labels, bc_urls)]
-        else:
+        # Look at the 'curve_status' column to see if a matching
+        # elliptic curve exists, or if that column is missing, look
+        # for the label in the ec_nfcurves table:
+        try:
+            self.ec_status = self.curve_status
+        except AttributeError:
+            self.ec_status = None
+        if self.ec_status not in [0,-1]: # so it is +1 (curve does exist) or None (curve_status not set)
+            curve_bc = db.ec_nfcurves.lucky({'class_label':self.label}, projection="base_change")
+            if curve_bc is not None:
+                self.ec_status = 1 # curve does exist in ec_nfcurves, now see if it is base-change
+                curve_bc = [lab for lab in curve_bc if '?' not in lab]
+                if curve_bc and "." not in curve_bc[0]:
+                    curve_bc = [cremona_label_to_lmfdb_label(lab) for lab in curve_bc]
+                self.ec_url = url_for("ecnf.show_ecnf_isoclass", nf=self.field_label, conductor_label=self.level_label, class_label=self.label_suffix)
+                curve_bc_parts = [split_lmfdb_label(lab) for lab in curve_bc]
+                bc_urls = [url_for("cmf.by_url_newform_label", level=cond, weight=2, char_orbit_label='a', hecke_orbit=iso) for cond, iso, num in curve_bc_parts]
+                bc_labels = [".".join( [str(cond), str(2), 'a', iso] ) for cond,iso,_ in curve_bc_parts]
+                bc_exists = [db.mf_newforms.label_exists(lab) for lab in bc_labels]
+                self.bc_forms = [{'exists':ex, 'label':lab, 'url':url} for ex,lab,url in zip(bc_exists, bc_labels, bc_urls)]
+        else: # ec_status is 0 or -1, we have no matching curve
             self.bc_forms = []
-            if self.bct or self.label in bmfs_with_no_curve:
-                self.ec_status = 'none'
-            else:
-                self.ec_status = 'missing'
+            if self.ec_status is None:
+                if self.bct or self.label in bmfs_with_no_curve:
+                    self.ec_status = -1 # there is certainly no curve
+                else:
+                    self.ec_status = 0 # there should be a curve but we do not have one
 
         self.properties.append(('Sign', self.sign))
         self.properties.append(('Analytic rank', self.anrank))
@@ -282,11 +300,11 @@ class WebBMF():
         else:
             # old code
             if self.dimension == 1:
-                if self.ec_status == 'exists':
+                if self.ec_status == 1:
                     self.friends += [('Isogeny class {}'.format(self.label), self.ec_url)]
-                elif self.ec_status == 'missing':
+                elif self.ec_status == 0:
                     self.friends += [('Isogeny class {} missing'.format(self.label), "")]
-                else:
+                else: # self.ec_status == -1
                     self.friends += [('No elliptic curve', "")]
 
             self.friends += [ ('L-function not available','')]

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -262,13 +262,13 @@ class WebBMF():
         except AttributeError:
             self.ec_status = None
         if self.ec_status not in [0,-1]: # so it is +1 (curve does exist) or None (curve_status not set)
+            self.ec_url = url_for("ecnf.show_ecnf_isoclass", nf=self.field_label, conductor_label=self.level_label, class_label=self.label_suffix)
             curve_bc = db.ec_nfcurves.lucky({'class_label':self.label}, projection="base_change")
             if curve_bc is not None:
                 self.ec_status = 1 # curve does exist in ec_nfcurves, now see if it is base-change
                 curve_bc = [lab for lab in curve_bc if '?' not in lab]
                 if curve_bc and "." not in curve_bc[0]:
                     curve_bc = [cremona_label_to_lmfdb_label(lab) for lab in curve_bc]
-                self.ec_url = url_for("ecnf.show_ecnf_isoclass", nf=self.field_label, conductor_label=self.level_label, class_label=self.label_suffix)
                 curve_bc_parts = [split_lmfdb_label(lab) for lab in curve_bc]
                 bc_urls = [url_for("cmf.by_url_newform_label", level=cond, weight=2, char_orbit_label='a', hecke_orbit=iso) for cond, iso, num in curve_bc_parts]
                 bc_labels = [".".join( [str(cond), str(2), 'a', iso] ) for cond,iso,_ in curve_bc_parts]


### PR DESCRIPTION
See #3058 for the associated Feature Request.

Some Bianchi newforms (weight 2, rational eigenvalues) do not have associated elliptic curves, though most do, and of those which should do we have curves in almost all cases but not quite all.  The new column 'curve_status' in the table bmf_forms allows this information to be displayed in a better way than just looking up on the fly whether or not there is a curve with some ad hoc method to tell whether it does not exist or is simply missing.  This column has been correctly filled for the BMFs currently in the database: 228896 forms, of which 228687 have curves, 193 do not have curves, and 16 should do but I have not yet found them; the value of 'curve_status' is 1, -1, 0 respectively:

`sage: [(n,db.bmf_forms.count({'curve_status':n})) for n in [-1,0,1]]`
`[(-1, 193), (0, 16), (1, 228687)]`


I added a section on the home page of a BMF headed "Associated elliptic curves" with one of three possible text templates.

Examples:

1. Normal (curve exists):

http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.3.1/106176.1/a/

(text says "This Bianchi newform is associated to the isogeny class 2.0.3.1-106176.1-a of elliptic curves.")

2. Elliptic curve should exist but is missing:

http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.511.1/100.5/a/

(text says: "This Bianchi newform is conjectured to be associated to an isogeny class of elliptic curves, but no matching elliptic curve is currently known.")

3. No elliptic curve exists:

http://localhost:37777/ModularForm/GL2/ImaginaryQuadratic/2.0.568.1/9.1/a/

(text says: "This Bianchi newform is not associated to any elliptic curves.")

I am open to suggestions for alternative wording, and for a knowl to be attached to the section heading.  Note that this is not primarily about modularity of elliptic curves over imaginary quadratic fields, which is now known (thanks to Newton and Caraiani)  for half the fields, but about whether the geometric object attached to a BMF is an elliptic curve or something of higher dimension; there are papers which the knowl should refer to.

I wrote the code so that if this is pushed to prod before the tables are then it should work, but I am also here asking for bmf_forms and ec_nfcurves both to be copied to prod. (The latter because I added a couple of doxen relevant curves recently, see #6112 .)
