### PR TITLE
updated BMF browse page field lists after new data added

### DIFF
--- a/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
+++ b/lmfdb/bianchi_modular_forms/bianchi_modular_form.py
@@ -64,13 +64,19 @@ def index():
     """
     info = to_dict(request.args, search_array=BMFSearchArray(), stats=BianchiStats())
     if not request.args:
-        gl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,20,24,7,40,11,52,56,15,68,19,84,88,23]]#,31,35,39,43,47,51,53,55,59,67,71,79,83,87,91,95,163]]
-        sl2_fields = ["2.0.{}.1".format(d) for d in [4,8,3,20,7,11,19,43,67,163]]
-        gl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,5,6,7,10,11,13,14,15,17,19,21,22,23]]#,31,35,39,43,47,51,53,55,59,67,71,79,83,87,91,95,163]]
-        sl2_names = [r"\(\Q(\sqrt{-%s})\)" % d for d in [1,2,3,5,7,11,19,43,67,163]]
+        gl2_fields = [f"2.0.{d}.1" for d in [4,8,3,20,24,7,40,11,52,56,15,68,19,84,88,23]]
+        gl2_forms_max = "2.0.2491.1"
+        gl2_forms_max_name = r"\(\Q(\sqrt{-2491})\)"
+        gl2_dims_max = "2.0.2495.1"
+        gl2_dims_max_name = r"\(\Q(\sqrt{-2495})\)"
+        sl2_fields = [f"2.0.{d}.1" for d in [4,8,3,20,7,11,19,43,67,163]]
+        gl2_names = [r"\(\Q(\sqrt{-{%s}})\)" % d for d in [1,2,3,5,6,7,10,11,13,14,15,17,19,21,22,23]]
+        sl2_names = [r"\(\Q(\sqrt{-{%s}})\)" % d for d in [1,2,3,5,7,11,19,43,67,163]]
         info['gl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
         info['sl2_field_list'] = [{'url':url_for("bmf.render_bmf_field_dim_table_sl2", field_label=f), 'name':n} for f,n in zip(sl2_fields,sl2_names)]
         info['field_forms'] = [{'url':url_for("bmf.index", field_label=f), 'name':n} for f,n in zip(gl2_fields,gl2_names)]
+        info['last_field_forms'] = {'url':url_for("bmf.index", field_label=gl2_forms_max), 'name':gl2_forms_max_name}
+        info['last_field_dims'] = {'url':url_for("bmf.render_bmf_field_dim_table_gl2", field_label=gl2_dims_max), 'name':gl2_dims_max_name}
 
         t = 'Bianchi modular forms'
         bread = get_bread()
@@ -450,6 +456,7 @@ def download_bmf_magma(**args):
     outstr += '\nheckeEigenvaluesList := [*\n' + ',\n'.join(hecke_eigs_processed) + '\n*];\n'
     outstr += '\nheckeEigenvalues := AssociativeArray();\n'
     outstr += 'for i in [1..#heckeEigenvaluesList] do\n    heckeEigenvalues[primes[i]] := heckeEigenvaluesList[i];\nend for;\n'
+
 
     if f.have_AL:
         AL_eigs = f.AL_table_data

--- a/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-browse.html
@@ -10,13 +10,13 @@
 <table class="browse">
   <tr>
     <td>{{ KNOWL('mf.bianchi.newform', 'Newforms')}} by base field:</td>
-    <td>{% for f in info.field_forms %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {%-endfor %} ...</td>
+    <td>{% for f in info.field_forms %} <a href={{f.url}}>{{f.name}}</a>&nbsp; {%-endfor %} ... <a href={{info.last_field_forms.url}}>{{info.last_field_forms.name}}</a></td>
   </tr><tr>
     <td>{{ KNOWL('mf.bianchi.level', '\(\GL_2\)')}} {{ KNOWL('mf.bianchi.spaces', 'newform spaces')}} by base field:</td>
-    <td>{% for f in info.gl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {% endfor %} ...</td>
+    <td>{% for f in info.gl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp; {% endfor %} ... <a href={{info.last_field_dims.url}}>{{info.last_field_dims.name}}</a></td>
   </tr><tr>
     <td>{{ KNOWL('mf.bianchi.level', '\(\SL_2\)')}}  {{ KNOWL('mf.bianchi.spaces', 'newform spaces')}} by base field:</td>
-    <td>{% for f in info.sl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp;&nbsp; {% endfor %}</td>
+    <td>{% for f in info.sl2_field_list %} <a href={{f.url}}>{{f.name}}</a>&nbsp; {% endfor %}</td>
   </tr><tr>
     <td colspan="2">Some <a href="{{url_for('.interesting')}}">interesting Bianchi modular forms</a> or a <a href={{url_for('.random_bmf')}}>random Bianchi modular form</a></td>
   </tr>

--- a/lmfdb/bianchi_modular_forms/test_bmf.py
+++ b/lmfdb/bianchi_modular_forms/test_bmf.py
@@ -53,7 +53,7 @@ class BMFTest(LmfdbTest):
         Check that various search combinations work.
         """
         self.check_args(base_url+"?field_label=2.0.7.1&level_norm=322&count=10", 'Results (4 matches)')
-        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", 'ModularForm/GL2/ImaginaryQuadratic/2.0.95.1/16.5/a/')
+        self.check_args(base_url+"?start=0&include_base_change=off&include_cm=only&count=100", 'ModularForm/GL2/ImaginaryQuadratic/2.0.119.1/9.1/a/')
 
     # tests for newspace pages
     def test_newspace(self):


### PR DESCRIPTION
This updates the fields displayed on the BMF main browse page to reflect the extra data recently added (now on beta, not yet on prod).  Instead of ending the lists with ...  I added at the end (after the ...) the last relevant field.  This is 2.0.2495.1 for dimension data but 2.0.2491.1 for newforms, since the actual last field (2.0.2495.1) has no rational newforms in the level range computed so far.

It would be possible to use db.bmf_dims.max('field_absdisc') and db.bmf_forms.min('field_disc') instead of hard-coding these in python (and until now I had not noticed the inconsistency in these column names and contents!) but I have no plans to compute any BMFs for fields of larger discriminant.  [Strictly speaking I  have put in dims for 2.0.2683.1 as well as that is the last field of class number 1-5, but there are no rational newforms there anyway in the small range so far computed.]

When this is merged I will update the relevant knowls.

This PR is independent of #6353 .