### PR TITLE
Moving things around in galois group pages

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -277,8 +277,6 @@ def render_group_webpage(args):
         data['parity'] = "$%s$" % data['parity']
         data['subinfo'] = subfield_display(n, data['subfields'])
         data['resolve'] = resolve_display(data['quotients'])
-        gp_label = data['abstract_label']
-        data['groupid'] = abstract_group_display_knowl(gp_label, gp_label)
         data['otherreps'] = wgg.otherrep_list()
         ae = data['arith_equiv']
         if ae > 0:
@@ -325,6 +323,8 @@ def render_group_webpage(args):
         if len(pretty) > 0:
             prop2.extend([('Group:', pretty)])
             data['pretty_name'] = pretty
+        gp_label = data['abstract_label']
+        data['groupid'] = abstract_group_display_knowl(gp_label, pretty if pretty else gp_label)
         data['name'] = re.sub(r'_(\d+)',r'_{\1}',data['name'])
         data['name'] = re.sub(r'\^(\d+)',r'^{\1}',data['name'])
         data['nilpotency'] = '$%s$' % data['nilpotency']

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -10,63 +10,69 @@ table.reptable td, table.reptable th {
 }
 </style>
 
-<p> {{ place_code('gg') }}</p> 
-  <p><h2>{{ KNOWL('gg.group_action_invariants', title='Group action invariants') }}</h2>
+<p> {{ place_code('gg') }}</p>
+
+<h2> {{ KNOWL('gg.invariants', title='Group invariants') }}</h2>
+  <div>
     <table>
-      <tr><td>{{KNOWL('gg.degree', 'Degree')}} $n$:<td>&nbsp;&nbsp;<td>${{info.n}}$</td>
+      <tr><td>{{KNOWL('group.small_group_label','Abstract group')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.groupid | safe}}</td>
+        <td>{{place_code('id')}}</td></tr>
+      <tr><td>{{KNOWL('group.order','Order')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.ordermsg }}</td>
+      <td>{{place_code('order')}}</td></tr>
+      <tr><td>{{KNOWL('group.cyclic','Cyclic')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.yesno(info.cyc)}}</td>
+      <td>{{place_code('cyclic')}}</td></tr>
+      <tr><td>{{KNOWL('group.abelian', 'Abelian')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.yesno(info.ab)}}</td>
+      <td>{{place_code('abelian')}}</td></tr>
+      <tr><td>{{KNOWL('group.solvable', 'Solvable')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.yesno(info.solv)}}</td>
+      <td>{{place_code('solvable')}}</td></tr>
+      <tr><td class="nowrap">{{KNOWL('group.nilpotent', 'Nilpotency class')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.nilpotency}}</td><td>{{ place_code('nilpotent') }}</td></tr>
+    </table>
+  </div>
+
+  <h2>{{ KNOWL('gg.group_action_invariants', title='Group action invariants') }}</h2>
+    <table>
+      <tr><td>{{KNOWL('gg.degree', 'Degree')}} $n$:</td><td>&nbsp;&nbsp;</td><td>${{info.n}}$</td>
       <td>{{ place_code('n') }}</td></tr>
-      <tr><td class="nowrap">{{KNOWL('gg.tnumber', 'Transitive number')}} $t$:<td>&nbsp;&nbsp;<td>${{info.t}}$</td>
-      <td>{{ place_code('t') }}</td></tr>
-      {% if info.pretty_name %}
-      <tr><td>{{KNOWL('gg.simple_name', title='Group')}}:<td>&nbsp;&nbsp;<td>{{info.pretty_name}}</tr>
-      {% endif %}
       {% if info.n < 16 %}
-      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:<td>&nbsp;&nbsp;<td>
+      <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:</td><td>&nbsp;&nbsp;</td><td>
       {% if info.n == 1 %}
         {{info.name}}
       {% else %}
         ${{info.name}}$
       {% endif %}
-      </tr>
+      </td></tr>
       {% endif %}
-      <tr><td>{{KNOWL('gg.parity','Parity')}}:<td>&nbsp;&nbsp;<td>{{info.parity}}
+      <tr><td>{{KNOWL('gg.parity','Parity')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.parity}}</td>
       <td>{{ place_code('even') }}</td></tr>
-      <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.prim)}}</td>
+      <tr><td>{{KNOWL('gg.primitive', 'Primitive')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.yesno(info.prim)}}</td>
       <td>{{ place_code('primitive') }}</td></tr>
-      <td>{{ place_code('nilpotent') }}</td></tr>
-      <tr><td class="nowrap">{{KNOWL('gg.field_automorphisms', '$\card{\Aut(F/K)}$')}}:<td>&nbsp;&nbsp;<td>${{info.auts}}$</td>
+      <tr><td class="nowrap">{{KNOWL('gg.field_automorphisms', '$\card{\Aut(F/K)}$')}}:</td><td>&nbsp;&nbsp;</td><td>${{info.auts}}$</td>
       <td>{{ place_code('auts') }}</td></tr>
-      <tr><td>{{KNOWL('group.generators', 'Generators')}}:<td>&nbsp;&nbsp;<td>{{info.gens}}
+      <tr><td>{{KNOWL('group.generators', 'Generators')}}:</td><td>&nbsp;&nbsp;</td><td>{{info.gens}}</td>
       <td>{{ place_code('gens') }}</td></tr>
     </table>
-  </p>
 
-  <p><h2>{{KNOWL('gg.resolvents', 'Low degree resolvents')}}</h2>
+  <h2>{{KNOWL('gg.resolvents', 'Low degree resolvents')}}</h2>
   <blockquote>
   {{info.resolve|safe}}
 
-<p> Resolvents shown for degrees $\leq {{info.wgg.quotient_bound()}}$
+  <p>Resolvents shown for degrees $\leq {{info.wgg.quotient_bound()}}$</p>
   </blockquote>
 
-  <p><h2>{{ KNOWL('gg.subfields', title='Subfields') }}</h2>
-   <p>
+  <h2>{{ KNOWL('gg.subfields', title='Subfields') }}</h2>
    <blockquote>
     {{info.subinfo|safe}}
    </blockquote>
-   </p>
 
-  <p><h2>{{ KNOWL('gg.other_representations', title='Low degree siblings') }}</h2>
-   <p>
+  <h2>{{ KNOWL('gg.other_representations', title='Low degree siblings') }}</h2>
    <blockquote>
     {{info.otherreps|safe}}
    </blockquote>
    <blockquote>
       {{info.arith_equiv|safe}}
    </blockquote>
-   </p>
 
-  <p><h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy classes') }}</h2>
-   <p>
+  <h2>{{ KNOWL('gg.conjugacy_classes', title='Conjugacy classes') }}</h2>
 
       {% if info.cclasses is defined %}
    <table class="ntdata">
@@ -85,9 +91,9 @@ table.reptable td, table.reptable th {
       </tbody>
       </table>
    <p>
-   {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp; 
+   {{KNOWL('gg.malle_a', "Malle's constant $a(G)$")}}: &nbsp; &nbsp;
    {% if info.malle_a is not none %}
-   ${{info.malle_a}}$ 
+   ${{info.malle_a}}$
    {% else %}
    not computed
    {% endif %}
@@ -99,49 +105,24 @@ table.reptable td, table.reptable th {
    </p>
    <p>{{ place_code('ccs') }}</p>
 
-
-
-<p><h2> {{ KNOWL('gg.invariants', title='Group invariants') }}</h2>
-  <div>
-    <table>
-      <tr><td>{{KNOWL('group.order','Order')}}:<td>&nbsp;&nbsp;<td>{{info.ordermsg }}</td>
-      <td>{{place_code('order')}}</td></tr>
-      <tr><td>{{KNOWL('group.cyclic','Cyclic')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.cyc)}}</td>
-      <td>{{place_code('cyclic')}}</td></tr>
-      <tr><td>{{KNOWL('group.abelian', 'Abelian')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.ab)}}</td>
-      <td>{{place_code('abelian')}}</td></tr>
-      <tr><td>{{KNOWL('group.solvable', 'Solvable')}}:<td>&nbsp;&nbsp;<td>{{info.yesno(info.solv)}}</td>
-      <td>{{place_code('solvable')}}</td></tr>
-      <tr><td class="nowrap">{{KNOWL('group.nilpotent', 'Nilpotency class')}}:<td>&nbsp;&nbsp;<td>{{info.nilpotency}}</td>
-      <tr><td>{{KNOWL('group.small_group_label','Label')}}:<td>&nbsp;&nbsp;<td>{{info.groupid | safe}}
-      <td>{{place_code('id')}}</td></tr>
-      <tr><td>{{KNOWL('group.complex_character_table', 'Character table')}}:
+   <h2>{{KNOWL('group.complex_character_table', 'Character table')}}</h2>
       {% if not info.wgg.can_chartable %}
-        <td>&nbsp;&nbsp;
-        <td> not computed
-        </table> </div> </p>
+        <p>Character table not computed</p>
       {% elif info.chartable %}
-        </table>
-        </div>
-        </p>
-        <p>
-         {% include 'character-table.html' %}
+        {% include 'character-table.html' %}
       {% else %}
-      <td>&nbsp;&nbsp;
-      <td>
-         {{ info.chartable_knowl | safe }}
-    </table> </div> </p>
+        {{ info.chartable_knowl | safe }}
       {% endif %}
 
   <p>{{place_code('char_table')}}</p>
 
+
 {% if info.int_reps %}
-<p><h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>
-</p>
+<h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>
 <table>
-<tr><td> 
+<tr><td>
 {% if info['int_reps_complete'] > 0 %}
-Complete 
+Complete
 {% else %}
 Partial
 {% endif %}
@@ -149,14 +130,14 @@ list of indecomposable integral representations:
   <p>
   <div>
     <table class="ntdata reptable">
-        <tr><th>{{ KNOWL('gg.int_modules.names', title='Name') }}</th> <th>Dim</th> 
+        <tr><th>{{ KNOWL('gg.int_modules.names', title='Name') }}</th> <th>Dim</th>
         {% for gen in info['int_rep_classes'] %}
           <th> ${{ gen | safe  }} \mapsto $ </th>
         {% endfor %}
         </tr>
     {% for rep in info['int_reps'] %}
       <tr>
-          <td> {{ rep['name'] | safe }} </td> <td> ${{rep['dim'] }}$ </td> 
+          <td> {{ rep['name'] | safe }} </td> <td> ${{rep['dim'] }}$ </td>
         {% for gen in rep['gens'] %}
           <td> ${{ gen | safe  }}$ </td>
         {% endfor %}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -32,7 +32,9 @@ table.reptable td, table.reptable th {
   <h2>{{ KNOWL('gg.group_action_invariants', title='Group action invariants') }}</h2>
     <table>
       <tr><td>{{KNOWL('gg.degree', 'Degree')}} $n$:</td><td>&nbsp;&nbsp;</td><td>${{info.n}}$</td>
-      <td>{{ place_code('n') }}</td></tr>
+        <td>{{ place_code('n') }}</td></tr>
+      <tr><td class="nowrap">{{KNOWL('gg.tnumber', 'Transitive number')}} $t$:<td>&nbsp;&nbsp;<td>${{info.t}}$</td>
+        <td>{{ place_code('t') }}</td></tr>
       {% if info.n < 16 %}
       <tr><td>{{KNOWL('gg.conway_name', title='CHM label')}}:</td><td>&nbsp;&nbsp;</td><td>
       {% if info.n == 1 %}

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -150,7 +150,7 @@ class WebGaloisGroup:
         if str(self.n()) == "1":
             return "None needed"
         gens = self.gens()
-        gens = [cyclestrings(g) for g in gens]
+        gens = ['$'+cyclestrings(g)+'$' for g in gens]
         gens = ', '.join(gens)
         return gens
 


### PR DESCRIPTION
This is an alternative for #6366.  It does the following:
* Move the Group invariants section from the bottom to the top (with the exception of the Character Table, which becomes its own section).
* Change heading from "Group" to "Abstract Group," make the latex into an abstract group knowl, and have the label of the abstract group now shown implicitly in the knowl, rather than on a separate line
* Remove "Transitive number," since it's not a mathematical invariant and is already included in the label
* Fix a bug for code placement of `magma: NilpotencyClass(G);`
* Add closing `</td>` tags and adjust some spacing.