### PR TITLE
Show Aut groups for fields

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -155,7 +155,7 @@ class WebGaloisGroup:
         return gens
 
     def aut_knowl(self):
-        return abstract_group_display_knowl(f"{self._data['auts']}.{self._data['aut_sg_no']}")
+        return abstract_group_display_knowl(self._data['aut_label'])
 
     def gapgroupnt(self):
         if int(self.n()) == 1:

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -154,6 +154,9 @@ class WebGaloisGroup:
         gens = ', '.join(gens)
         return gens
 
+    def aut_knowl(self):
+        return abstract_group_display_knowl(f"{self._data['auts']}.{self._data['aut_sg_no']}")
+
     def gapgroupnt(self):
         if int(self.n()) == 1:
             G = libgap.SmallGroup(1, 1)

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -416,7 +416,7 @@ def render_field_webpage(args):
         f = data['f']
         cc = data['c']
         gn = data['n']
-        autstring = r'\Aut'
+        auttype = 'aut'
         if data.get('galois_label'):
             gt = int(data['galois_label'].split('T')[1])
             the_gal = WebGaloisGroup.from_nt(gn,gt)
@@ -424,7 +424,7 @@ def render_field_webpage(args):
             abelian = ' and abelian' if the_gal.is_abelian() else ''
             galphrase = 'This field is'+isgal+abelian+r' over $\Q_{%d}.$' % p
             if the_gal.order() == gn:
-                autstring = r'\Gal'
+                auttype = 'gal'
             info['aut_gp_knowl']= the_gal.aut_knowl()
         # we don't know the Galois group, but maybe the Aut group is obvious
         elif data['aut']==1:
@@ -504,7 +504,7 @@ def render_field_webpage(args):
                     'ind_insep': show_slopes(str(data['ind_of_insep'])),
                     'eisen': eisenp,
                     'gsm': gsm,
-                    'autstring': autstring,
+                    'auttype': auttype,
                     'subfields': format_subfields(data['subfield'],data['subfield_mult'],p),
                     'aut': data['aut'],
                     })

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -859,7 +859,7 @@ class LFStats(StatsDisplay):
 
     @property
     def summary(self):
-        return r'The database currently contains %s %s, including all with $p < 200$ and %s $n < 16$.' % (
+        return r'The database currently contains %s %s, including all with $p < 200$ and %s $n < 24$.' % (
             comma(self.numfields),
             display_knowl("lf.padic_field", r"$p$-adic fields"),
             display_knowl("lf.degree", "degree")

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -3,7 +3,7 @@
 
 from flask import abort, render_template, request, url_for, redirect
 from sage.all import (
-    PolynomialRing, ZZ, QQ, RR, latex, cached_function, Integers)
+    PolynomialRing, ZZ, QQ, RR, latex, cached_function, Integers, is_prime)
 from sage.plot.all import line, points, text, Graphics
 
 from lmfdb import db
@@ -425,6 +425,12 @@ def render_field_webpage(args):
             galphrase = 'This field is'+isgal+abelian+r' over $\Q_{%d}.$' % p
             if the_gal.order() == gn:
                 autstring = r'\Gal'
+            info['aut_gp_knowl']= the_gal.aut_knowl()
+        # we don't know the Galois group, but maybe the Aut group is obvious
+        elif data['aut']==1:
+            info['aut_gp_knowl']=abstract_group_display_knowl('1.1')
+        elif is_prime(data['aut']):
+            info['aut_gp_knowl']=abstract_group_display_knowl(f"{data['aut']}.1")
         prop2 = [
             ('Label', label),
             ('Base', r'\(%s\)' % Qp),

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -19,7 +19,18 @@
       <tr><td>{{ KNOWL('lf.root_number', title='Root number') }}:</td> <td>{{info.hw}}</td></tr>
 
   {% if info.aut_gp_knowl %}
-      <tr><td> $ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) $:</td> <td>{{info.aut_gp_knowl|safe}}</td></tr>
+      <tr><td> 
+      {% set ktitle = '$\Aut(K/\Q_{' ~ info.p ~ '})$' -%}
+      {{ KNOWL('lf.automorphism_group', title=ktitle) -}}
+      {%- if info.auttype=='aut' -%}
+      :
+      {% else %}
+      $=$
+      {% set ktitle = '$\Gal(K/\Q_{' ~ info.p ~ '})$' %}
+      {{ KNOWL('nf.galois_group', title=ktitle) }}:
+      {% endif %}
+      </td> 
+      <td>{{info.aut_gp_knowl|safe}}</td></tr>
   {% else %}
       <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) }$:</td> <td>${{info.aut}}$</td></tr>
   {% endif %}

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -17,7 +17,13 @@
       <tr><td>{{ KNOWL('lf.discriminant_exponent', title='Discriminant exponent') }} $c$:</td> <td>${{info.c}}$</td></tr>
       <tr><td>{{ KNOWL('lf.discriminant_root_field', title='Discriminant root field') }}:</td> <td>{{info.rf|safe}}</td></tr>
       <tr><td>{{ KNOWL('lf.root_number', title='Root number') }}:</td> <td>{{info.hw}}</td></tr>
+
+  {% if info.aut_gp_knowl %}
+      <tr><td> $ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) $:</td> <td>{{info.aut_gp_knowl|safe}}</td></tr>
+  {% else %}
       <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) }$:</td> <td>${{info.aut}}$</td></tr>
+  {% endif %}
+
       <tr><td colspan="2">{{info.galphrase}}</td></tr>
       <tr><td>{{ KNOWL('lf.visible_slopes', title='Visible slopes')}}:</td><td>{{info.visible}}</td></tr>
 </table>

--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -20,19 +20,20 @@
 
   {% if info.aut_gp_knowl %}
       <tr><td> 
-      {% set ktitle = '$\Aut(K/\Q_{' ~ info.p ~ '})$' -%}
+      {%- set ktitle = '$\Aut(K/\Q_{' ~ info.p ~ '})$' -%}
       {{ KNOWL('lf.automorphism_group', title=ktitle) -}}
       {%- if info.auttype=='aut' -%}
       :
       {% else %}
       $=$
-      {% set ktitle = '$\Gal(K/\Q_{' ~ info.p ~ '})$' %}
+      {%- set ktitle = '$\Gal(K/\Q_{' ~ info.p ~ '})$' -%}
       {{ KNOWL('nf.galois_group', title=ktitle) }}:
       {% endif %}
       </td> 
       <td>{{info.aut_gp_knowl|safe}}</td></tr>
-  {% else %}
-      <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q_{ {{info.p}} }) }$:</td> <td>${{info.aut}}$</td></tr>
+    {% else %}
+      {%- set ktitle = '$\Aut(K/\Q_{' ~ info.p ~ '})$' -%}
+      <tr><td> $\#$ {{ KNOWL('lf.automorphism_group', title=ktitle) }}:</td> <td>${{info.aut}}$</td></tr>
   {% endif %}
 
       <tr><td colspan="2">{{info.galphrase}}</td></tr>

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -27,6 +27,7 @@ from lmfdb.galois_groups.transitive_group import (
     group_cclasses_knowl_guts, group_pretty_and_nTj, knowl_cache,
     group_character_table_knowl_guts, group_alias_table,
     dihedral_gal, dihedral_ngal, multiquad)
+from lmfdb.groups.abstract.main import abstract_group_display_knowl
 from lmfdb.number_fields import nf_page, nf_logger
 from lmfdb.number_fields.web_number_field import (
     field_pretty, WebNumberField, nf_knowl_guts, factor_base_factor,
@@ -447,7 +448,8 @@ def render_field_webpage(args):
             factored_conductor = factor_base_factorization_latex(factored_conductor, cutoff=30)
             data['conductor'] = r"\(%s=%s\)" % (str(data['conductor']), factored_conductor)
     data['galois_group'] = group_pretty_and_nTj(n,t,True)
-    data['auts'] = db.gps_transitive.lookup(r'{}T{}'.format(n,t))['auts']
+    ggdata = db.gps_transitive.lookup(rf'{n}T{t}')
+    data['aut_gp_knowl'] = abstract_group_display_knowl(f"{ggdata['auts']}.{ggdata['aut_sg_no']}")
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
     data['class_group'] = nf.class_group()

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -429,7 +429,6 @@ def render_field_webpage(args):
     t = nf.galois_t()
     n = nf.degree()
     data['is_galois'] = nf.is_galois()
-    data['autstring'] = r'\Gal' if data['is_galois'] else r'\Aut'
     data['is_abelian'] = nf.is_abelian()
     if nf.is_abelian():
         conductor = nf.conductor()
@@ -448,8 +447,7 @@ def render_field_webpage(args):
             factored_conductor = factor_base_factorization_latex(factored_conductor, cutoff=30)
             data['conductor'] = r"\(%s=%s\)" % (str(data['conductor']), factored_conductor)
     data['galois_group'] = group_pretty_and_nTj(n,t,True)
-    ggdata = db.gps_transitive.lookup(rf'{n}T{t}')
-    data['aut_gp_knowl'] = abstract_group_display_knowl(f"{ggdata['auts']}.{ggdata['aut_sg_no']}")
+    data['aut_gp_knowl'] = abstract_group_display_knowl(db.gps_transitive.lookup(f'{n}T{t}', 'aut_label'))
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
     data['class_group'] = nf.class_group()

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -31,7 +31,18 @@ table.ntdata a {
        <tr><td>{{ KNOWL('nf.galois_root_discriminant', title="Galois root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.grd}}
       <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>{{info.ram_primes|safe}}<td>{{ place_code('ramified_primes') }}
       <tr><td>{{ KNOWL('nf.discriminant_root_field', title="Discriminant root field") }}:<td>&nbsp;&nbsp;<td>{{nf.discrootfield()|safe}}
-      <tr><td> ${ {{ info.autstring|safe }}(K/\Q) }$:<td>&nbsp;&nbsp;<td>{{info.aut_gp_knowl|safe}}<td>{{ place_code('automorphisms') }}
+
+      <tr><td> 
+        {% if info.is_galois %}
+          {{ KNOWL('lf.automorphism_group', title='$\Aut(K/\Q)$') }}
+          $=$
+          {{ KNOWL('nf.galois_group', title='$\Gal(K/\Q)$') }}:
+          <td>&nbsp;&nbsp;<td>{{info.aut_gp_knowl|safe}}<td>{{ place_code('automorphisms') }}
+        {% else %}
+          {{ KNOWL('lf.automorphism_group', title='$\Aut(K/\Q)$') }}:
+          <td>&nbsp;&nbsp;<td>{{info.aut_gp_knowl|safe}}<td>{{ place_code('automorphisms') }}
+        {% endif %}
+
 {% if info.is_abelian %}
     <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>
         <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -31,7 +31,7 @@ table.ntdata a {
        <tr><td>{{ KNOWL('nf.galois_root_discriminant', title="Galois root discriminant") }}:<td>&nbsp;&nbsp;<td>{{info.grd}}
       <tr><td>{{ KNOWL('nf.ramified_primes', title="Ramified primes") }}:<td>&nbsp;&nbsp;<td>{{info.ram_primes|safe}}<td>{{ place_code('ramified_primes') }}
       <tr><td>{{ KNOWL('nf.discriminant_root_field', title="Discriminant root field") }}:<td>&nbsp;&nbsp;<td>{{nf.discrootfield()|safe}}
-      <tr><td> $\card{ {{ info.autstring|safe }}(K/\Q) }$:<td>&nbsp;&nbsp;<td>${{info.auts}}$<td>{{ place_code('automorphisms') }}
+      <tr><td> ${ {{ info.autstring|safe }}(K/\Q) }$:<td>&nbsp;&nbsp;<td>{{info.aut_gp_knowl|safe}}<td>{{ place_code('automorphisms') }}
 {% if info.is_abelian %}
     <tr><td colspan="3">This field is Galois and abelian over $\Q$.</tr>
         <tr><td>{{KNOWL('nf.conductor', title='Conductor')}}:<td>&nbsp;&nbsp;<td>{{info.conductor}}</tr>


### PR DESCRIPTION
For both number fields and p-adic fields, this displays the automorphism group and not just the order.

http://127.0.0.1:37777/NumberField/16.0.3571460308796416.1
http://beta.lmfdb.org/NumberField/16.0.3571460308796416.1

http://127.0.0.1:37777/padicField/2.8.8.3
http://beta.lmfdb.org/padicField/2.8.8.3

This keys off of the Galois group.  For p-adic fields, we don't always have the Galois group, but sometimes the group is obvious from its order, so we give it even if we haven't computed the Galois group:
http://127.0.0.1:37777/padicField/7.21.21.10

As a last resort, we just display the order:
http://127.0.0.1:37777/padicField/2.22.22.274

When we have the group, we don't display its order separately since it is almost always (maybe always) completely obvious from the group name (most are cyclic).  In the rare case it is not already clear, the group is a knowl so clicking will reveal its order.
