### PR TITLE
Family browse

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -107,7 +107,11 @@ def group_families(deTeX=False):
     L = [(el["family"], el["tex_name"], el["name"]) for el in db.gps_families.search(projection=["family", "tex_name", "name"], sort=["priority"])]
     L = [(fam, name if "fam" in tex else f"${tex}$") for (fam, tex, name) in L]
     if deTeX:
-        L = [(fam, deTeX_name(name)) for (fam, name) in L]
+        # Used for constructing the dropdown
+        return [(fam, deTeX_name(name)) for (fam, name) in L]
+    def hidden(fam):
+        return fam not in ["C", "S", "D", "A", "Q", "GL", "SL", "PSL", "Sp", "SO", "Sporadic"]
+    L = [(fam, name, "fam_more" if hidden(fam) else "fam_always", hidden(fam)) for (fam, name) in L]
     return L
 
 # For dynamic knowls
@@ -175,7 +179,7 @@ def parse_group(inp, query, qfield):
 
 @search_parser
 def parse_family(inp, query, qfield):
-    if inp not in ([el[0] for el in group_families()] + ['any']):
+    if inp not in ([el[0] for el in group_families(deTeX=True)] + ['any']):
         raise ValueError("Not a valid family label.")
     if inp == 'any':
         query[qfield] = {'$in':list(db.gps_special_names.search(projection='label'))}

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -99,12 +99,13 @@ def yesno(val):
     return "yes" if val else "no"
 
 def deTeX_name(s):
-    s = re.sub(r"[{}\\_]", "", s)
+    s = re.sub(r"[{}\\$]", "", s)
     return s
 
 @cached_function
 def group_families(deTeX=False):
-    L = [(el["family"], el["tex_name"]) for el in db.gps_families.search(projection=["family", "tex_name"], sort=["priority"])]
+    L = [(el["family"], el["tex_name"], el["name"]) for el in db.gps_families.search(projection=["family", "tex_name", "name"], sort=["priority"])]
+    L = [(fam, name if "fam" in tex else f"${tex}$") for (fam, tex, name) in L]
     if deTeX:
         L = [(fam, deTeX_name(name)) for (fam, name) in L]
     return L

--- a/lmfdb/groups/abstract/templates/abstract-index.html
+++ b/lmfdb/groups/abstract/templates/abstract-index.html
@@ -2,6 +2,17 @@
 
 {% block content %}
 
+<script type="text/javascript">
+  function show_more_families() {
+    $(".fam_more").show();
+    $(".fam_less").hide();
+  }
+  function show_less_families() {
+    $(".fam_less").show();
+    $(".fam_more").hide();
+  }
+</script>
+
 <div>
   {{ info.stats.short_summary | safe }}
 </div>
@@ -27,9 +38,11 @@
   {% endfor %}
 </p>
 <p>By {{KNOWL('group.families', 'family')}}:
-  {% for family, tex_name in info.families%}
-    <a href="?family={{family}}">{{tex_name}}</a>&nbsp;
+  {% for family, tex_name, morecls, hide in info.families%}
+    <span class="{{morecls}}" {% if hide %}style="display: none;" {% endif %}><a href="?family={{family}}">{{tex_name}}</a>&nbsp;</span>
   {% endfor %}
+  <a class="fam_less" onclick="show_more_families(); return false;" href="#">more...</a>
+  <a class="fam_more" style="display: none;" onclick="show_less_families(); return false;" href="#">less...</a>
 </p>
 <p>Some <a href="{{url_for('.interesting')}}">interesting groups</a> or a <a href="{{url_for('.random_abstract_group')}}">random group</a></p>
 

--- a/lmfdb/groups/abstract/templates/abstract-index.html
+++ b/lmfdb/groups/abstract/templates/abstract-index.html
@@ -28,7 +28,7 @@
 </p>
 <p>By {{KNOWL('group.families', 'family')}}:
   {% for family, tex_name in info.families%}
-    <a href="?family={{family}}">${{tex_name}}$</a>&nbsp;
+    <a href="?family={{family}}">{{tex_name}}</a>&nbsp;
   {% endfor %}
 </p>
 <p>Some <a href="{{url_for('.interesting')}}">interesting groups</a> or a <a href="{{url_for('.random_abstract_group')}}">random group</a></p>

--- a/lmfdb/templates/base.html
+++ b/lmfdb/templates/base.html
@@ -123,6 +123,7 @@ katexOpts = {
   "\\AGammaL": '{\\textrm{A}\\Gamma\\textrm{L}}',
   "\\ASigmaL": '{\\textrm{A}\\Sigma\\textrm{L}}',
   "\\ASigmaSp": '{\\textrm{A}\\Sigma\\textrm{Sp}}',
+  "\\Dic": '{\\textrm{Dic}}',
   "\\SD": '{\\textrm{SD}}',
   "\\OD": '{\\textrm{OD}}',
   "\\He": '{\\textrm{He}}',


### PR DESCRIPTION
Reduces the number of groups show in the "browse by family section" and fixes some display issues.  The difference can be seen by comparing https://red.lmfdb.xyz/Groups/Abstract/ and https://beta.lmfdb.org/Groups/Abstract/, though red also includes some other changes that will not be merged here.