### PR TITLE
Fixing issue with Magma groups that are not Ids in Gap

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -67,6 +67,7 @@ from .web_groups import (
     abstract_group_display_knowl,
     cc_data_to_gp_label,
     gp_label_to_cc_data,
+    missing_subs,
 )
 from .stats import GroupStats
 
@@ -2932,9 +2933,10 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
             data = None
             url = url_for("abstract.by_label", label=label)
         gp = WebAbstractGroup(label, data=data)
-        #GAP doesn't have groups of order 3^8 so if not in db, can't be live
-        if label.startswith("6561.") and gp.source == "Missing":
-            return Markup("No additional information for this group of order 6561 is available.")
+        # dealing with groups identified in magma but not in gap so can't do live pages˚
+        ord = label.split(".")[0]
+        if missing_subs(int(ord)) and gp.source == "Missing":
+            return Markup("No additional information for this group of order " + ord + " is available.")
         ans = f"Group ${gp.tex_name}$: "
         ans += create_boolean_string(gp, type="knowl")
         ans += f"<br />Label: {gp.label}<br />"

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -995,7 +995,7 @@ def get_trans_url(label):
     return url_for("galois_groups.by_label", label=trans_gp(label))
 
 def display_url(label, tex):
-    if label is None:
+    if label is None or missing_subs(label):
         if tex is None:
             return ''
         return f'${tex}$'
@@ -2935,7 +2935,7 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         gp = WebAbstractGroup(label, data=data)
         # dealing with groups identified in magma but not in gap so can't do live pages˚
         ord = label.split(".")[0]
-        if missing_subs(int(ord)) and gp.source == "Missing":
+        if missing_subs(label) and gp.source == "Missing":
             ans = 'The group {} is not available in GAP, but see the list of <a href="{}">{}</a>.'.format(
                 label,
                 f"/Groups/Abstract/?subgroup_order={ord}&ambient={ambient}&search_type=Subgroups",

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2922,8 +2922,8 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         if profiledata[1] is None:
             ans += "Isomorphism class has not been identified<br />"
         else:
-            # TODO: add hash knowl and search link to groups with this order and hash
-            ans += f"Hash: {profiledata[1]}<br />"
+            # TODO: add search link to groups with this order and hash
+            ans += f"{display_knowl('group.hash', 'Hash')} : {profiledata[1]}<br />"
         isomorphism_label = "Subgroups with this data:"
     else:
         if label.startswith("ab/"):

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1393,7 +1393,7 @@ conjugacy_class_columns = SearchColumns([
     MultiProcessedCol("label", "group.label_conjugacy_class", "Label",["group_order", "group_counter", "label","highlight_col"],get_cc_url, download_col="label"),
     MathCol("order", "group.order_conjugacy_class", "Order"),
     MathCol("size", "group.size_conjugacy_class", "Size"),
-    MultiProcessedCol("center", "group.subgroup.centralizer", "Centralizer", ["centralizer", "group", "sub_latex"], char_to_sub, download_col="centralizer"),
+    MultiProcessedCol("center", "group.centralizer", "Centralizer", ["centralizer", "group", "sub_latex"], char_to_sub, download_col="centralizer"),
     ColGroup("power_cols","group.conjugacy_class.power_classes", "Powers",
              lambda info: [Power_col(i, info["group_factors"]) for i in range(len(info["group_factors"]))],
              contingent=lambda info: info.get("group_factors",True), # group_factors not present when downloading
@@ -1783,7 +1783,7 @@ def shortsubinfo(ambient, short_label):
     ans += subinfo_getsub(
         "Normal closure", "group.subgroup.normal_closure", wsg.normal_closure
     )
-    ans += subinfo_getsub("Centralizer", "group.subgroup.centralizer", wsg.centralizer)
+    ans += subinfo_getsub("Centralizer", "group.centralizer", wsg.centralizer)
     ans += subinfo_getsub("Core", "group.core", wsg.core)
     # ans += '<tr><td>Coset action</td><td>%s</td></tr>\n' % wsg.coset_action_label
     ## There was a bug in the Magma code computing generators, so we disable this for the moment

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2936,7 +2936,11 @@ def group_data(label, ambient=None, aut=False, profiledata=None):
         # dealing with groups identified in magma but not in gap so can't do live pages˚
         ord = label.split(".")[0]
         if missing_subs(int(ord)) and gp.source == "Missing":
-            return Markup("No additional information for this group of order " + ord + " is available.")
+            ans = 'The group {} is not available in GAP, but see the list of <a href="{}">{}</a>.'.format(
+                label,
+                f"/Groups/Abstract/?subgroup_order={ord}&ambient={ambient}&search_type=Subgroups",
+                "subgroups with this order")
+            return Markup(ans)
         ans = f"Group ${gp.tex_name}$: "
         ans += create_boolean_string(gp, type="knowl")
         ans += f"<br />Label: {gp.label}<br />"

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -195,6 +195,19 @@ def in_small_gp_db(order):
     return False
 
 
+# determine groups which are identified in Magma but not Gap
+def missing_subs(n):
+    if n == 6561:
+        return True
+    f = factor(n)
+    if n > 2000:
+        if sum(f[i][1] for i in range(len(f))) == 4:
+            return True
+        if len(f) == 1 and f[0][1] == 7 and f[0][0] > 11:
+            return True
+    return False
+
+
 def cc_data_to_gp_label(order,counter):
     if in_small_gp_db(order):
         return str(order) + '.' + str(counter)
@@ -3133,7 +3146,8 @@ class WebAbstractSubgroup(WebObj):
                       'aut_group': self.aut_label, 'aut_order': None,
                       'pgroup':len(ZZ(order).abs().factor()) == 1})
             return newgroup
-        if self.subgroup_order == 6561:
+         # issue with groups identifiable in magma but not gap
+        if missing_subs(self.subgroup_order):
             gp = WebAbstractGroup(self.subgroup, None)
             if gp.source == "Missing":
                 order = self.subgroup_order

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -5,6 +5,7 @@ import yaml
 from lmfdb import db
 from flask import url_for
 from urllib.parse import quote_plus
+from psycopg2.sql import SQL, Identifier
 
 from sage.all import (
     Permutations,
@@ -194,14 +195,26 @@ def in_small_gp_db(order):
         return True
     return False
 
+@cached_function
+def groups_from_missing_orders():
+    labels = set()
+    # There was a casting problem comparing smallint[] and the arrays
+    return set(x[0] for x in db._execute(SQL("SELECT label, factors_of_order, exponents_of_order FROM gps_groups WHERE {0} > 2000 AND (exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint [] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[])").format(Identifier("order")), [[8],[7],[4],[3,1],[2,2],[2,1,1],[1,1,1,1]]) if (x[1] == [3] and x[2] == [8] or x[1][0] > 11 and x[2] == [7] or x[2] == [4] or len(x[2]) > 1))
 
 # determine groups which are identified in Magma but not Gap
-def missing_subs(n):
+@cached_function
+def missing_subs(n_or_label):
+    if isinstance(n_or_label, str):
+        if n_or_label in groups_from_missing_orders():
+            return False
+        n = ZZ(label.split(".")[0])
+    else:
+        n = ZZ(n_or_label)
     if n == 6561:
         return True
     f = factor(n)
     if n > 2000:
-        if sum(f[i][1] for i in range(len(f))) == 4:
+        if sum(e for p,e in f) == 4:
             return True
         if len(f) == 1 and f[0][1] == 7 and f[0][0] > 11:
             return True
@@ -3147,7 +3160,7 @@ class WebAbstractSubgroup(WebObj):
                       'pgroup':len(ZZ(order).abs().factor()) == 1})
             return newgroup
          # issue with groups identifiable in magma but not gap
-        if missing_subs(self.subgroup_order):
+        if missing_subs(self.subgroup):
             gp = WebAbstractGroup(self.subgroup, None)
             if gp.source == "Missing":
                 order = self.subgroup_order

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -207,7 +207,7 @@ def missing_subs(n_or_label):
     if isinstance(n_or_label, str):
         if n_or_label in groups_from_missing_orders():
             return False
-        n = ZZ(label.split(".")[0])
+        n = ZZ(n_or_label.split(".")[0])
     else:
         n = ZZ(n_or_label)
     if n == 6561:

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -197,7 +197,6 @@ def in_small_gp_db(order):
 
 @cached_function
 def groups_from_missing_orders():
-    labels = set()
     # There was a casting problem comparing smallint[] and the arrays
     return set(x[0] for x in db._execute(SQL("SELECT label, factors_of_order, exponents_of_order FROM gps_groups WHERE {0} > 2000 AND (exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint [] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[] OR exponents_of_order = %s::smallint[])").format(Identifier("order")), [[8],[7],[4],[3,1],[2,2],[2,1,1],[1,1,1,1]]) if (x[1] == [3] and x[2] == [8] or x[1][0] > 11 and x[2] == [7] or x[2] == [4] or len(x[2]) > 1))
 


### PR DESCRIPTION
This should fix #6322.

The local page does not error:
http://localhost:37777/Groups/Abstract/sub/474552.a.108.b1.a1
http://beta.lmfdb.org/Groups/Abstract/sub/474552.a.108.b1.a1

Also, if you go to the group page itself and scroll down to the subgroup profile and click on the LaTeX name for a subgroup pf order 4394, you'll see that in the knowl there is message saying that we can't display the group instead of an error message.
http://localhost:37777/Groups/Abstract/474552.a
http://beta.lmfdb.org/Groups/Abstract/474552.a
