### PR TITLE
Update None in search

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1048,6 +1048,10 @@ def field_knowl(fld):
 
 # This function returns a label for the conjugacy class search page for a group
 def display_cc_url(numb,gp):
+    if numb == None:    # for cases where we didn't compute number
+        return 'not computed'
+    elif numb > 512:    # remove url if conjugacy classes are not stored
+        return numb
     return f'<a href = "{url_for(".index", group=gp, search_type="ConjugacyClasses")}">{numb}</a>'
 
 class Group_download(Downloader):

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1048,7 +1048,7 @@ def field_knowl(fld):
 
 # This function returns a label for the conjugacy class search page for a group
 def display_cc_url(numb,gp):
-    if numb == None:    # for cases where we didn't compute number
+    if numb is None:    # for cases where we didn't compute number
         return 'not computed'
     elif numb > 512:    # remove url if conjugacy classes are not stored
         return numb

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -389,7 +389,7 @@ class WebAbstractGroup(WebObj):
             elif isinstance(self._data, GapElement):
                 return self._data
         # Reconstruct the group from the stored data
-        if self.order == 1 or self.element_repr_type == "PC":  # trvial
+        if self.order == 1 or self.element_repr_type == "PC":  # trivial
             return self.PCG
         else:
             if self.element_repr_type == "Lie":   #need to take first entry of Lie type
@@ -1213,11 +1213,11 @@ class WebAbstractGroup(WebObj):
     def _subgroup_summary(self, in_profile):
         if self.subgroup_index_bound != 0:
             if self.normal_index_bound is None or self.normal_index_bound == 0:
-                return f"All subgroup of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as all normal subgroups of any index. <br>"
+                return f"All subgroups of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as all normal subgroups of any index. <br>"
             elif self.normal_order_bound != 0:
-                return f"All subgroup of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as normal subgroups of index up to {self.normal_index_bound} or of order up to {self.normal_order_bound}. <br>"
+                return f"All subgroups of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as normal subgroups of index up to {self.normal_index_bound} or of order up to {self.normal_order_bound}. <br>"
             else:
-                return f"All subgroup of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as normal subgroups of index up to {self.normal_index_bound}. <br>"
+                return f"All subgroups of index up to {self.subgroup_index_bound} (order at least {self.subgroup_order_bound}) are shown, as well as normal subgroups of index up to {self.normal_index_bound}. <br>"
             # TODO: add more verbiage here about Sylow subgroups, maximal subgroups, explain when we don't know subgroups up to automorphism/conjugacy, etc
         return ""
 


### PR DESCRIPTION
Updated search results giving # conjugacy classes to get rid of "none" when we didn't compute that number (it instead says "not computed" now) and also removed the links to searches for conjugacy classes if the group has >512 conjugacy classes (which we did not store).  

You can see some of the numbers hyperlinked and others not on the first page here:
http://localhost:37777/Groups/Abstract/?order=100000-

And here's an example with a "none" that's been changed to "not computed".
http://localhost:37777/Groups/Abstract/?family=Sporadic