### PR TITLE
Deal with local algebras when Galois groups have not been computed

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -509,7 +509,11 @@ def render_field_webpage(args):
                         myurl = url_for('local_fields.by_label', label=lab)
                         if mm[3]*mm[2] == 1:
                             lab = r'$\Q_{%s}$' % str(p)
-                        loc_alg += '<td><a href="%s">%s</a></td><td>$%s$</td><td>$%d$</td><td>$%d$</td><td>$%d$</td><td>%s</td><td>$%s$</td>' % (myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],show_slope_content(mm[8],mm[6],mm[7]))
+                        if mm[8]:
+                            mysc = '$'+show_slope_content(mm[8],mm[6],mm[7])+'$'
+                        else:
+                            mysc = 'not computed'
+                        loc_alg += '<td><a href="%s">%s</a></td><td>$%s$</td><td>$%d$</td><td>$%d$</td><td>$%d$</td><td>%s</td><td>%s</td>' % (myurl,lab,mm[1],mm[2],mm[3],mm[4],mm[5],mysc)
             loc_alg += '</tr>\n'
         loc_alg += '</tbody></table>\n'
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -964,7 +964,7 @@ class WebNumberField:
 
     # Helper for ramified algebras table
     def get_local_algebras(self):
-        local_algs = self._data.get('local_algs', None)
+        local_algs = self._data.get('local_algs')
         if local_algs is None:
             return None
         local_algebra_dict = {}
@@ -982,14 +982,14 @@ class WebNumberField:
                 LF = db.lf_fields.lookup(lab)
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
-                gglabel = LF.get('galois_label', None)
+                gglabel=LF.get('galois_label')
                 if gglabel:
                     gglabel = transitive_group_display_knowl(gglabel)
                 else:
                     gglabel = 'not computed'
                 thisdat = [lab, f, LF['e'], LF['f'], LF['c'],
                     gglabel,
-                    LF.get('t',None), LF.get('u',None), LF.get('slopes',None)]
+                    LF.get('t'), LF.get('u'), LF.get('slopes')]
                 if str(p) not in local_algebra_dict:
                     local_algebra_dict[str(p)] = [thisdat]
                 else:

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -982,11 +982,11 @@ class WebNumberField:
                 LF = db.lf_fields.lookup(lab)
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
-                gglabel=LF.get('galois_label', None)
+                gglabel = LF.get('galois_label', None)
                 if gglabel:
-                    gglabel=transitive_group_display_knowl(gglabel)
+                    gglabel = transitive_group_display_knowl(gglabel)
                 else:
-                    gglabel='not computed'
+                    gglabel = 'not computed'
                 thisdat = [lab, f, LF['e'], LF['f'], LF['c'],
                     gglabel,
                     LF.get('t',None), LF.get('u',None), LF.get('slopes',None)]

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -982,9 +982,14 @@ class WebNumberField:
                 LF = db.lf_fields.lookup(lab)
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
+                gglabel=LF.get('galois_label', None)
+                if gglabel:
+                    gglabel=transitive_group_display_knowl(gglabel)
+                else:
+                    gglabel='not computed'
                 thisdat = [lab, f, LF['e'], LF['f'], LF['c'],
-                    transitive_group_display_knowl(LF['galois_label']),
-                    LF['t'], LF['u'], LF['slopes']]
+                    gglabel,
+                    LF.get('t',None), LF.get('u',None), LF.get('slopes',None)]
                 if str(p) not in local_algebra_dict:
                     local_algebra_dict[str(p)] = [thisdat]
                 else:

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,11 @@ commands =
     pylint --score=no -d C,R,E,W -e W0129,W0108 start-lmfdb.py user-manager.py lmfdb/
     # see https://pycodequ.al/docs/pylint-messages/Warnings.html
     # E111 indentation is not a multiple of four
-    # E115 Expected an indented block (comment)
+    # E115 Expected an indented block (comment) -- not enabled
     # E211 whitespace before '('
-    # E222 Multiple spaces after operator
-    # E225 Missing whitespace around operator
+    # E222 Multiple spaces after operator -- not enabled
+    # E225 Missing whitespace around operator -- not enabled
     # E702 multiple statements on one line (semicolon)
     # E711 Comparison to None should be 'cond is None:'
     # E722 do not use bare except, specify exception instead
-    ruff check --preview --select=E111,E115,E211,E222,E225,E702,E711,E722 lmfdb/
+    ruff check --preview --select=E111,E211,E702,E711,E722 lmfdb/


### PR DESCRIPTION
Some new local fields do not have Galois groups and slopes computed which affects number field pages.  This fixes that

http://127.0.0.1:37777/NumberField/44.0.18038797319548302242232245613754598807607865052837142211957640472205046331907996909568.1

The version on beta will just give a server error
http://beta.lmfdb.org/NumberField/44.0.18038797319548302242232245613754598807607865052837142211957640472205046331907996909568.1