### PR TITLE
Regular families

### DIFF
--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -118,7 +118,6 @@ table.reptable td, table.reptable th {
 
   <p>{{place_code('char_table')}}</p>
 
-
 {% if info.int_reps %}
 <h2>{{ KNOWL('gg.int_modules', title='Indecomposable integral representations') }}</h2>
 <table>
@@ -164,5 +163,18 @@ list of indecomposable integral representations:
     </table>
   {% endif %}
 {% endif %}
+
+<h2>{{ KNOWL('gg.regular_extension', title='Regular extensions') }}</h2>
+      {% if not info.wgg.regulars %}
+        <p>Data not computed</p>
+      {% else %}
+        {% for model in info.wgg.regulars %}
+      <p>
+          <div>{{ model[0]|safe }}</div>
+          <div style="text-indent:15px">{{ model[1]|safe }}</div>
+      </p>
+        {% endfor %}
+      {% endif %}
+
 
 {% endblock %}

--- a/lmfdb/galois_groups/templates/gg-show-group.html
+++ b/lmfdb/galois_groups/templates/gg-show-group.html
@@ -168,12 +168,15 @@ list of indecomposable integral representations:
       {% if not info.wgg.regulars %}
         <p>Data not computed</p>
       {% else %}
-        {% for model in info.wgg.regulars %}
       <p>
-          <div>{{ model[0]|safe }}</div>
-          <div style="text-indent:15px">{{ model[1]|safe }}</div>
-      </p>
+        <table>
+        {% for model in info.wgg.regulars %}
+          <tr><td style="vertical-align: top">$f_{ {{ loop.index }} } =$</td>
+              <td> {{ model[0]|safe }}</td></tr>
+          <tr><td></td><td> {{ model[1]|safe }}</td></tr>
         {% endfor %}
+        </table>
+      </p>
       {% endif %}
 
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -276,7 +276,6 @@ class WebGaloisGroup:
 
             regdata= [[raw_typeset(z['polynomial'], quick_latex(z['polynomial'])), msg(z.get('generic'))] for z in t]
             for j in range(len(regdata)):
-                regdata[j][0] = '$f_{%d} = $'%(j+1) + regdata[j][0]
                 if regdata[j][1]:
                     regdata[j][1] = 'The polynomial $f_{%d}$ '%(j+1)+regdata[j][1]
             return regdata

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -271,7 +271,7 @@ class WebGaloisGroup:
                 if code == []:
                     return ' is '+genknowl+' for any base field $K$'
                 if code == [0]:
-                    return ' is '+genknowl+r' for any base field $\Q$'
+                    return ' is '+genknowl+r' for the base field $\Q$'
                 return ' is '+genknowl+r' for any base field $K$ of characteristic $\neq$ '+','.join([str(z) for z in code])
 
             regdata= [[raw_typeset(z['polynomial'], quick_latex(z['polynomial'])), msg(z.get('generic'))] for z in t]


### PR DESCRIPTION
This addresses issue #6427: it adds the ability to have polynomials for parameterized families of fields on Galois group pages.  There is currently data for degrees through 10, some in degree 11, and a few scattered groups after that.  To see an example,

http://127.0.0.1:37777/GaloisGroup/5T4

which is one of the few cases where it gives more than one family, and shows that individual polynomials can be marked as generic.

http://127.0.0.1:37777/GaloisGroup/4T3

shows that it can display that a family is generic for fields except in certain characteristics.

For a particularly complicated polynomial, view M24

http://127.0.0.1:37777/GaloisGroup/24T24680

In all cases, the user can use the raw/typeset feature to copy polynomial for a computer algebra system.