### PR TITLE
Allow new p-adic field labels in local algebras of number fields

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -981,7 +981,7 @@ class WebNumberField:
             else:
                 LF = db.lf_fields.lookup(lab)
                 if not LF:
-                    LF = db.lf_fields.lucky({'new_label': lab})
+                    LF = db.lf_fields.lucky({'new_label': lab}) 
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
                 gglabel = LF.get('galois_label')

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -980,6 +980,8 @@ class WebNumberField:
                     local_algebra_dict[str(p)].append([deg,e,f,c])
             else:
                 LF = db.lf_fields.lookup(lab)
+                if not LF:
+                    LF = db.lf_fields.lucky({'new_label': lab})
                 f = latex(R(LF['coeffs']))
                 p = LF['p']
                 gglabel = LF.get('galois_label')


### PR DESCRIPTION
The local field database is transitioning to new labels.  The number field database currently references the old labels (for local algebras).  This change makes it so that the number field code can handle a data update where those references use new labels.  Once this makes it through to prod, I will update those label references, then labels in the p-adic field database get updated, then this change can go away.

There is no change to see now -- after this goes through the data will be updated (updating it now without this change breaks number field pages).