### PR TITLE
belyi to prod

### DIFF
--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -118,7 +118,6 @@
       url_for: "abvarfq.abelian_varieties"
       colspan: onecolumn
     - title: Belyi maps
-      status: beta
       url_for: "belyi.index"
       colspan: onecolumn
 


### PR DESCRIPTION
This PR adds Belyi maps to the production sidebar.

It is available on https://purple.lmfdb.xyz if anyone wants to take a look.  I plan to merge this tomorrow unless there are any objections.