### PR TITLE
Fix missing representatives in 168.42

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1429,8 +1429,6 @@ def complex_char_search(info, query={}):
 #need mathmode for MultiProcessedCol
 def cc_repr(label,code , latex=True):  #default is include dollar signs
     gp = WebAbstractGroup(label)
-    if gp.representations.get("Lie") and gp.representations["Lie"][0]["family"][0] == "P" and gp.order < 2000:
-        return ""   #Problem with PGL, PSL, etc
     if latex:
         return "$" + gp.decode(code,as_str=True) + "$"
     else:  # this is for download postprocess


### PR DESCRIPTION
**Do not merge this until the groups database has been updated.**

This is the first in a series of PR I will post today that should not be merged until the groups database is updated.  (They will fix issues currently on red.lmfdb.xyz but will break things in beta.)

This one just shows the representatives for small PSL groups when you search conjugacy classes for certain groups.

Compare last column in 
https://beta.lmfdb.org/Groups/Abstract/?group=168.42&search_type=ConjugacyClasses
https://localhost:37777/Groups/Abstract/?group=168.42&search_type=ConjugacyClasses