### PR TITLE
Fix hard coded label for a p-adic field

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -1096,7 +1096,7 @@ def render_field_webpage(args):
             if zeta3loc == ["3.2.1.2"]:
                 # Old labels
                 lstr = data["old_label"]
-            elif zeta3loc == ["3.1.2.1a1.2"]:
+            elif zeta3loc == ["3.1.2.1a1.1"]:
                 # New labels
                 lstr = data["new_label"]
             else:


### PR DESCRIPTION
This is connected to the transition in p-adic fields from old to new labels, and the fact that "new labels" changed since the code was first written.  Pretty soon, this whole chuck of code can be removed.