### PR TITLE
Adding a check for level types 

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1426,8 +1426,6 @@ def statistics():
 @cmf.route("/dynamic_stats")
 def dynamic_statistics():
     info = to_dict(request.args, search_array=CMFSearchArray())
-    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    print(info)
     CMF_stats().dynamic_setup(info)
     title = 'Classical modular forms: Dynamic statistics'
     return render_template("dynamic_stats.html", info=info, title=title, bread=get_bread(other='Dynamic Statistics'), learnmore=learnmore_list())

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -747,8 +747,11 @@ def common_parse(info, query, na_check=False):
                 query['level'] = {'$in': integer_divisors(ZZ(query['level']))}
             else:
                 query['level'] = {'$mod': [0, ZZ(query['level'])]}
-        else:
+        elif info['level_type'] in ['prime', 'prime_power', 'square', 'squarefree']: 
             query['level_is_' + info['level_type']] = True
+        else:
+            flash_error("The level type %s is invalid.", info['level_type'])
+            return redirect(url_for(".index"))
     parse_floats(info, query, 'analytic_conductor', name="Analytic conductor")
     parse_ints(info, query, 'Nk2', name=r"\(Nk^2\)")
     parse_ints(info, query, 'char_order', name="Character order")
@@ -1423,6 +1426,8 @@ def statistics():
 @cmf.route("/dynamic_stats")
 def dynamic_statistics():
     info = to_dict(request.args, search_array=CMFSearchArray())
+    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    print(info)
     CMF_stats().dynamic_setup(info)
     title = 'Classical modular forms: Dynamic statistics'
     return render_template("dynamic_stats.html", info=info, title=title, bread=get_bread(other='Dynamic Statistics'), learnmore=learnmore_list())


### PR DESCRIPTION
Level types in search for classical modular forms now checks the string provided and gives an error if this doesn't match something in the table. 