### PR TITLE
Added enhancement for Issue 6359

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -101,6 +101,14 @@ real_geom_end_alg_to_ST0_dict = {
     "R x R": "SU(2) x SU(2)",
     "R": "USp(4)",
 }
+real_geom_end_alg_to_latex_dict = {
+    "M_2(C)": "$M_2(\\mathbb{C})$",
+    "M_2(R)": "$M_2(\\mathbb{R})$",
+    "C x C": "$\\mathbb{C} \\times \\mathbb{C}$",
+    "C x R": "$\\mathbb{C} \\times \\mathbb{R}$",
+    "R x R": "$\\mathbb{R} \\times \\mathbb{R}$",
+    "R": "$\\mathbb{R}$",
+}
 
 # End tensored with QQ
 end_alg_list = ["Q", "RM", "CM", "Q x Q", "M_2(Q)"]
@@ -796,6 +804,7 @@ class G2C_stats(StatsDisplay):
         "is_gl2_type": formatters.boolean,
         "real_geom_end_alg": lambda x: "\\(" + st0_group_name(x) + "\\)",
         "st_group": lambda x: st_link_by_name(1, 4, x),
+        "real geometric endomorphism algebra": lambda x: real_geom_end_alg_to_latex_dict[x],
     }
     query_formatters = {
         "aut_grp_label": lambda x: "aut_grp_label=%s" % x,
@@ -815,10 +824,18 @@ class G2C_stats(StatsDisplay):
         {"cols": "analytic_sha", "totaler": {"avg": True}},
         {"cols": "locally_solvable"},
         {"cols": "is_gl2_type"},
-        {"cols": "real_geom_end_alg"},
+        {"cols": "real_geom_end_alg", 
+         "addl_row_title": "real geometric endomorphism algebra"
+        },
         {"cols": "st_group"},
         {"cols": "torsion_order", "totaler": {"avg": True}},
     ]
+
+
+    addl_row_data_dict = {
+        'real_geometric_endomorphism_algebra': 'test'
+    }
+
 
 
 @g2c_page.route("/Q/stats")

--- a/lmfdb/templates/stat_1d.html
+++ b/lmfdb/templates/stat_1d.html
@@ -8,6 +8,14 @@
     <td>{{c.value|safe}}</td>
     {% endfor %}
   </tr>
+  {% if d.attribute.addl_row_title | safe %}
+    <tr>
+      <th>{{d.attribute.addl_row_title | safe}}</th>
+      {% for c in r %}
+        <td>{{c.value2|safe}}</td>
+      {% endfor %}
+    </tr>
+  {% endif %}
   <tr>
     <th>count</th>
     {% for c in r %}

--- a/lmfdb/templates/stat_1d.html
+++ b/lmfdb/templates/stat_1d.html
@@ -8,7 +8,7 @@
     <td>{{c.value|safe}}</td>
     {% endfor %}
   </tr>
-  {% if d.attribute.addl_row_title | safe %}
+  {% if d.attribute.addl_row_title %}
     <tr>
       <th>{{d.attribute.addl_row_title | safe}}</th>
       {% for c in r %}

--- a/lmfdb/utils/display_stats.py
+++ b/lmfdb/utils/display_stats.py
@@ -564,7 +564,6 @@ class StatsDisplay(UniqueRepresentation):
                 if 'addl_row_title' in kwds.keys():
                     addl_row_title = kwds['addl_row_title']
                     D['value2'] = formatter[addl_row_title](old_val)
-                    print("addl_row_title:", addl_row_title)
 
             if proportioner is None or show_total:
                 self._overall = total

--- a/lmfdb/utils/display_stats.py
+++ b/lmfdb/utils/display_stats.py
@@ -544,6 +544,7 @@ class StatsDisplay(UniqueRepresentation):
             col = cols[0]
             split_list = self._split_lists[col]
             headers, counts = table._get_values_counts(cols, constraint, split_list=split_list, formatter=formatter, query_formatter=query_formatter, base_url=base_url, buckets=buckets)
+            old_headers = headers  ## Preserve the original headers for later lookups
             if not buckets:
                 if show_total or proportioner is None:
                     total, avg = table._get_total_avg(cols, constraint, avg, split_list)
@@ -557,8 +558,14 @@ class StatsDisplay(UniqueRepresentation):
             else:
                 raise ValueError("Bucket keys must be subset of columns")
             counts = [counts[val] for val in headers]
-            for D, val in zip(counts, headers):
+
+            for D, val, old_val in zip(counts, headers, old_headers):
                 D['value'] = val
+                if 'addl_row_title' in kwds.keys():
+                    addl_row_title = kwds['addl_row_title']
+                    D['value2'] = formatter[addl_row_title](old_val)
+                    print("addl_row_title:", addl_row_title)
+
             if proportioner is None or show_total:
                 self._overall = total
             if proportioner is None or isinstance(proportioner, dict):


### PR DESCRIPTION
Added an additional row to display the real geometric endomorphism algebra information in the Distribution of Sato-Tate group identity components table on the genus 2 curves page.  

This also adds some minor general functionality to put an additional row of data in a table.