### PR TITLE
remove references to galT in the p-adic fields database. 

### DIFF
--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -308,7 +308,7 @@ def render_group_webpage(args):
         friends = []
         if db.nf_fields.exists({'degree': n, 'galt': t}):
             friends.append(('Number fields with this Galois group', url_for('number_fields.number_field_render_webpage')+"?galois_group=%dT%d" % (n, t) ))
-        if db.lf_fields.exists({'n': n, 'galT': t}):
+        if db.lf_fields.exists({'n': n, 'gal': t}):
             friends.append(('$p$-adic fields with this Galois group', url_for('local_fields.index')+"?gal=%dT%d" % (n, t) ))
         if db.gps_groups.exists({'label': data['abstract_label']}):
             friends.append(('As an abstract group', url_for('abstract.by_label', label=data['abstract_label'])))

--- a/lmfdb/local_fields/family.py
+++ b/lmfdb/local_fields/family.py
@@ -355,7 +355,7 @@ class pAdicSlopeFamily:
     def fields(self):
         fields = list(db.lf_fields.search(
             {"family": self.label_absolute},
-            ["label", "coeffs", "galT", "galois_label", "galois_degree", "slopes", "ind_of_insep", "associated_inertia", "t", "u", "aut", "hidden", "subfield", "jump_set"]))
+            ["label", "coeffs", "gal", "galois_label", "galois_degree", "slopes", "ind_of_insep", "associated_inertia", "t", "u", "aut", "hidden", "subfield", "jump_set"]))
         if self.n0 > 1:
             fields = [rec for rec in fields if self.base in rec["subfield"] or self.oldbase in rec["subfield"]]
         glabels = list(set(rec["galois_label"] for rec in fields if rec.get("galois_label")))
@@ -371,7 +371,7 @@ class pAdicSlopeFamily:
             return False
         fields, cache = self.fields
         for rec in fields:
-            if not all(rec.get(col) for col in ["galT", "galois_label", "hidden"]):
+            if not all(rec.get(col) for col in ["gal", "galois_label", "hidden"]):
                 return False
         return True
 
@@ -384,14 +384,14 @@ class pAdicSlopeFamily:
             return False
         fields, cache = self.fields
         for rec in fields:
-            if all(rec.get(col) for col in ["galT", "galois_label", "hidden"]):
+            if all(rec.get(col) for col in ["gal", "galois_label", "hidden"]):
                 return True
         return False
 
     @lazy_attribute
     def galois_groups(self):
         fields, cache = self.fields
-        opts = sorted(Counter((rec["galT"], rec["galois_label"]) for rec in fields if "galT" in rec and "galois_label" in rec).items())
+        opts = sorted(Counter((rec["gal"], rec["galois_label"]) for rec in fields if "gal" in rec and "galois_label" in rec).items())
         if not opts:
             return "No Galois groups in this family have been computed"
 

--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -1524,7 +1524,7 @@ def common_boxes():
 class FamilySearchArray(EmbeddedSearchArray):
     sorts = [
         ("", "Label", ['ctr_subfamily', 'ctr']),
-        ("gal", "Galois group", ['galT', 'ctr_subfamily', 'ctr']),
+        ("gal", "Galois group", ['gal', 'ctr_subfamily', 'ctr']),
         ("s", "top slope", ['top_slope', 'ctr_subfamily', 'ctr']),
         ("ind_of_insep", "Index of insep", ['ind_of_insep', 'ctr_subfamily', 'ctr']),
     ]
@@ -1728,7 +1728,7 @@ class LFSearchArray(SearchArray):
              ("c", "discriminant exponent", ['c', 'p', 'n', 'e', 'ctr_family', 'ctr_subfamily', 'ctr']),
              ("e", "ramification index", ['n', 'e', 'p', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
              ("f", "residue degree", ['f', 'n', 'p', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
-             ("gal", "Galois group", ['n', 'galT', 'p', 'e', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
+             ("gal", "Galois group", ['n', 'gal', 'p', 'e', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
              ("u", "Galois unramified degree", ['u', 'f', 'n', 'p', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
              ("t", "Galois tame degree", ['t', 'e', 'n', 'p', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),
              ("s", "top slope", ['top_slope', 'p', 'n', 'e', 'c', 'ctr_family', 'ctr_subfamily', 'ctr']),


### PR DESCRIPTION
The table lf_fields has fields gal and galT which are exactly the same.  This changes references to galT to gal so that galT can be deleted in the future.

Testing (which should show no change) can be

a family:
https://beta.lmfdb.org/padicField/family/3.1.9.12a
http://localhost:37777/padicField/family/3.1.9.12a

a field:
https://beta.lmfdb.org/padicField/3.1.9.12a3.2
http://localhost:37777/padicField/3.1.9.12a3.2