### PR TITLE
Few more abstract group fixes

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2096,20 +2096,12 @@ def download_boolean_string(G,dltype,ul_label):
     else:
         return ""
 
-    s += "Agroup := " + str(G.Agroup).lower() + ", \n"
-    s += "Zgroup := " +	str(G.Zgroup).lower() + ", \n"
-    s += "abelian := " + str(G.abelian).lower() + ", \n"
-    s += "almost_simple := " + str(G.almost_simple).lower() + ", \n"
-    s += "cyclic := " + str(G.cyclic).lower() + ", \n"
-    s += "metabelian := " + str(G.metabelian).lower() + ", \n"
-    s += "metacyclic := " + str(G.metacyclic).lower() + ", \n"
-    s += "monomial := " + str(G.monomial).lower() + ", \n"
-    s += "nilpotent := " + str(G.nilpotent).lower() + ", \n"
-    s += "perfect := " + str(G.perfect).lower() + ", \n"
-    s += "quasisimple := " + str(G.quasisimple).lower() + ", \n"
-    s += "rational := " + str(G.rational).lower() + ", \n"
-    s += "solvable := " + str(G.solvable).lower() + ", \n"
-    s += "supersolvable := " + str(G.supersolvable).lower() + " \n" # no comma since last one
+    bool_attr = ['Agroup','Zgroup','abelian', 'almost_simple','cyclic','metabelian','metacyclic','monomial','nilpotent','perfect','quasisimple','rational','solvable','supersolvable']
+    for attr in bool_attr:
+        if getattr(G,attr) is not None:
+            s += "\n"
+            s += attr + " := " + str(getattr(G,attr)).lower() + ","
+    s = s[:-1]   # last comma!
 
     # close record
     if dltype == "gap":
@@ -2122,10 +2114,16 @@ def download_boolean_string(G,dltype,ul_label):
 def download_char_table_magma(G, ul_label):
     gp_type = G.element_repr_type
 
+    # need to work on decode for Lie type for Magma
+    if gp_type == "Lie":
+        return "\n /* Character tables not currently avaialable for download for groups of Lie type. */"
     if gp_type == "PC":
         s = "G:= GPC;\n"
     elif gp_type == "Perm":
         s = "G:= GPerm;\n"
+#    elif gp_type == "Lie":
+#        repr_data = G.representations[gp_type][0]
+#        str_d = str(repr_data['d'])
     else:
         repr_data = G.representations[gp_type]
         str_d = str(repr_data['d'])  # need later
@@ -2139,16 +2137,14 @@ def download_char_table_magma(G, ul_label):
         s = "G:= GLZq;\n"
     if gp_type == "GLFq":
         s = "G:= GLFq;\n"
-    if gp_type == "Lie":   # need to check this for other Lie groups
-        repr_data = G.representations['Lie'][0]
-        str_d = str(repr_data['d'])  # need later
-        s = "G:= " + repr_data['family'] + "(" + str_d + "," + str(repr_data['q']) + "); \n"
+#    if gp_type == "Lie":
+#        s = "G:= " + repr_data['family'] + "(" + str_d + "," + str(repr_data['q']) + "); \n"
 
     s += "C := SequenceToConjugacyClasses([car<Integers(), Integers(), G> |"
     for conj in G.conjugacy_classes:
-        if gp_type == "Lie":
-            s += "< " + str(conj.order) + ", " + str(conj.size) + ", Matrix(" + str_d + ", " + str(G.decode_as_matrix(conj.representative,rep_type=gp_type, ListForm=True, LieType=(gp_type == "Lie"))) + ")>,"
-        elif gp_type != "PC" and gp_type != "Perm":
+#        if gp_type == "Lie":
+#            s += "< " + str(conj.order) + ", " + str(conj.size) + ", G!Matrix(" + str_d + ", " + str(G.decode_as_matrix(conj.representative,rep_type=gp_type, ListForm=True, LieType=(gp_type == "Lie"))) + ")>,"
+        if gp_type != "PC" and gp_type != "Perm":
             s += "< " + str(conj.order) + ", " + str(conj.size) + ", Matrix(" + str_d + ", " + str(G.decode_as_matrix(conj.representative,rep_type=gp_type, ListForm=True, LieType=(gp_type == gp_type))) + ")>,"
         else:
             s += "< " + str(conj.order) + ", " + str(conj.size) + ", " + str(G.decode(conj.representative,rep_type=gp_type, as_magma=True)) + ">,"
@@ -2285,7 +2281,17 @@ def download_group(**args):
     s = com1 + " Group " + label + " downloaded from the LMFDB on %s." % (mydate) + " " + com2
     s += "\n \n"
 
-    s += download_preable(com1, com2,dltype, wag.complex_characters_known)
+    if wag.complex_characters_known is False:
+        cc_known = False
+    elif wag.element_repr_type == "Lie":  # issue with representatives of quotients vs permutations
+            if wag.representations["Lie"][0]["family"][0] == "P":
+                cc_known = False
+            else:
+                cc_known = True
+    else:
+        cc_known = True
+
+    s += download_preable(com1, com2,dltype, cc_known)
     s += "\n \n"
 
     s += com1 + " Constructions " + com2 + "\n"
@@ -2296,7 +2302,7 @@ def download_group(**args):
     s += download_boolean_string(wag,dltype, ul_label)
     s += "\n \n"
 
-    if wag.complex_characters_known:
+    if cc_known:
         s += com1 + " Character Table " + com2 + "\n"
         s += download_char_table(wag,dltype, ul_label)
 

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2116,7 +2116,7 @@ def download_char_table_magma(G, ul_label):
 
     # need to work on decode for Lie type for Magma
     if gp_type == "Lie":
-        return "\n /* Character tables not currently avaialable for download for groups of Lie type. */"
+        return "\n /* Character tables not currently available for download for groups of Lie type. */"
     if gp_type == "PC":
         s = "G:= GPC;\n"
     elif gp_type == "Perm":

--- a/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-subgroup.html
@@ -22,10 +22,8 @@
         not computed
     {% endif %}
     </td></tr>
-    {% if seq.amb.show_subgroup_flag() %}
 	<tr><td>{{KNOWL('group.generators', 'Generators:')}}</td><td>
 		{{seq.amb.show_subgroup_generators(seq)|safe}}</td></tr>
-	{% endif %}
 	{% if seq.nilpotent %}
     <tr><td>{{KNOWL('group.nilpotent', title='Nilpotency
     class:')}}</td>

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -702,8 +702,6 @@ class WebAbstractGroup(WebObj):
 
     @lazy_attribute
     def cc_known(self):
-        # if self.representations.get("Lie") and self.representations["Lie"][0]["family"][0] == "P" and self.order < 2000:
-        #     return False   # problem with PGL, PSL, etc.
         return db.gps_conj_classes.exists({'group_order': self.order, 'group_counter': self.counter})
 
     @lazy_attribute
@@ -2068,11 +2066,6 @@ class WebAbstractGroup(WebObj):
             return list(range(1, 1 + len(self.G.GeneratorsOfGroup())))
         return self.representations["PC"]["gens"]
 
-    def show_subgroup_flag(self):
-        if self.representations.get("Lie"):
-            if self.representations["Lie"][0]["family"][0] == "P" and self.order < 2000: # Issue with projective Lie groups
-                return False
-        return True
 
     def show_subgroup_generators(self, H):
         if H.subgroup_order == 1:
@@ -2519,14 +2512,12 @@ class WebAbstractGroup(WebObj):
     def aut_order_factor(self):
         return latex(factor(self.aut_order))
 
-    def aut_gens_flag(self): #issue with Lie type when family is projective, auto stored as permutations often
+    def aut_gens_flag(self): # issue with Lie type when family is projective, Gap stores these groups as permutations
         if self.aut_gens is None:
             return False
         if self.element_repr_type == "Lie":
             if self.representations["Lie"][0]["family"][0] == "P":
                 return False
-        if self.element_repr_type in ["GLZN", "GLZq", "Lie", "GLFq", "GLFp"]:
-            return False
         return True
 
     # outer automorphism group


### PR DESCRIPTION
This fixes an issue with downloads where if a boolean was "none", it would record it as such in the download instead of disregarding.
https://red.lmfdb.xyz/Groups/Abstract/100000000.bg/download/magma
will fail to load in magma, but this works:
http://localhost:37777/Groups/Abstract/100000000.bg/download/magma


It adds auto_gens pages back for all Lie groups except those whose names start with a "P"  (i.e. the ones that are represented by quotients in the data currently), and for all other matrix groups.
http://localhost:37777/Groups/Abstract/4080.a
https://beta.lmfdb.org/Groups/Abstract/4080.a

It adds generators of subgroups when the ambient group was Lie type with a name that started with "P". 
http://localhost:37771/Groups/Abstract/sub/6072.a.506.b1.a2
http://red.lmfdb.xyz/Groups/Abstract/sub/6072.a.506.b1.a2


It removes magma downloads of character tables from Lie groups since we don't yet have functionality in decode() to create elements of a Lie group.