### PR TITLE
Fix trivial download

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -2255,6 +2255,18 @@ def download_char_table(G,dltype,ul_label):  # G is web abstract group
         return ""
 
 
+def download_trivial_construction(dltype):  #trival gp construction is different
+    if dltype == "gap":
+        s = "GPC := TrivialGroup(); \n"
+        s += "GPerm := SymmetricGroup(1); \n"
+    elif dltype == "magma":
+        s = "GPC := SmallGroup(1,1); \n"
+        s += "GPerm := Sym(1); \n"
+    else:
+        s = ""
+    return s
+
+
 @abstract_page.route("/<label>/download/<download_type>")
 def download_group(**args):
     dltype = args["download_type"]
@@ -2285,18 +2297,25 @@ def download_group(**args):
     s = com1 + " Group " + label + " downloaded from the LMFDB on %s." % (mydate) + " " + com2
     s += "\n \n"
 
-    s += download_preable(com1, com2,dltype, wag.complex_characters_known)
+    if label == "1.1":
+        cc_known = False
+    else:
+        cc_known = wag.complex_characters_known
+    s += download_preable(com1, com2,dltype, cc_known)
     s += "\n \n"
 
     s += com1 + " Constructions " + com2 + "\n"
-    s += download_construction_string(wag,dltype)
+    if label == "1.1":  #special case for trivial subgroup
+        s += download_trivial_construction(dltype)
+    else:
+        s += download_construction_string(wag,dltype)
     s += "\n \n"
 
     s += com1 + " Booleans " + com2 + "\n"
     s += download_boolean_string(wag,dltype, ul_label)
     s += "\n \n"
 
-    if wag.complex_characters_known:
+    if wag.complex_characters_known and label != "1.1":
         s += com1 + " Character Table " + com2 + "\n"
         s += download_char_table(wag,dltype, ul_label)
 


### PR DESCRIPTION
The trivial group needed its own special treatment for magma and gap downloads.

http://localhost:37777/Groups/Abstract/1.1/download/magma
http://beta.lmfdb.org/Groups/Abstract/1.1/download/magma

http://localhost:37777/Groups/Abstract/1.1/download/gap
http://beta.lmfdb.org/Groups/Abstract/1.1/download/gap