### PR TITLE
Added narrow class groups

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -425,6 +425,7 @@ def render_field_webpage(args):
     info['wnf'] = nf
     data['degree'] = nf.degree()
     data['class_number'] = nf.class_number_latex()
+    data['narrow_class_number'] = nf.narrow_class_number_latex()
     ram_primes = nf.ramified_primes()
     t = nf.galois_t()
     n = nf.degree()
@@ -451,6 +452,7 @@ def render_field_webpage(args):
     data['cclasses'] = cclasses_display_knowl(n, t)
     data['character_table'] = character_table_display_knowl(n, t)
     data['class_group'] = nf.class_group()
+    data['narrow_class_group'] = nf.narrow_class_group()
     data['class_group_invs'] = nf.class_group_invariants()
     data['signature'] = nf.signature()
     data['coefficients'] = nf.coeffs()
@@ -902,6 +904,7 @@ def number_field_search(info, query):
     parse_floats(info, query, 'regulator')
     parse_posints(info,query,'class_number')
     parse_posints(info,query,'relative_class_number')
+    parse_posints(info,query,'narrow_class_number')
     parse_ints(info,query,'num_ram')
     parse_bool(info,query,'cm_field',qfield='cm')
     fi = info.get("field_is")
@@ -947,6 +950,7 @@ def number_field_search(info, query):
         query["gal_is_solvable"] = False
 
     parse_bracketed_posints(info,query,'class_group',check_divisibility='increasing',process=int)
+    parse_bracketed_posints(info,query,'narrow_class_group',check_divisibility='increasing',process=int)
     parse_primes(info,query,'ur_primes',name='Unramified primes',
                  qfield='ramps',mode='exclude')
     parse_primes(info,query,'ram_primes',name='Ramified primes',
@@ -968,6 +972,7 @@ def residue_field_degrees_function(nf):
             output: the residue field degrees at the prime p
     """
     D = nf.disc()
+
 
     def decomposition(p):
         if not ZZ(p).divides(D):
@@ -1163,7 +1168,6 @@ def nf_code(**args):
             code += nf.code[k][lang] + ('\n' if '\n' not in nf.code[k][lang] else '')
     return code
 
-
 class NFSearchArray(SearchArray):
     noun = "field"
     sorts = [("", "degree", ['degree', 'disc_abs', 'disc_sign', 'iso_number']),
@@ -1255,6 +1259,17 @@ class NFSearchArray(SearchArray):
             knowl="nf.ideal_class_group",
             example="[2,4]",
             example_span="[ ], [3], or [2,4]")
+        narrow_class_number = TextBox(
+            name="narrow_class_number",
+            label="Narrow class number",
+            knowl="nf.narrow_class_number",
+            example="5")
+        narrow_class_group = TextBox(
+            name="class_group",
+            label="Narrow class group structure",
+            knowl="nf.narrow_class_group",
+            example="[2,4]",
+            example_span="[ ], [3], or [2,4]")
         relative_class_number = TextBox(
             name="relative_class_number",
             label="Relative class number",
@@ -1320,6 +1335,7 @@ class NFSearchArray(SearchArray):
             [gal, field_is],
             [num_ram, grd],
             [class_number, class_group],
+            [narrow_class_number, narrow_class_group],
             [ram_primes, ur_primes],
             [regulator, cm_field],
             [completion, relative_class_number],
@@ -1330,9 +1346,9 @@ class NFSearchArray(SearchArray):
         self.refine_array = [
             [degree, signature, num_ram, ram_primes, ur_primes ],
             [gal, field_is, subfield, class_group, class_number],
-            [discriminant, rd, grd, cm_field, relative_class_number],
-            [regulator, completion, monogenic, index, inessentialprimes],
-            [is_minimal_sibling]]
+            [narrow_class_number, narrow_class_group, discriminant, rd, grd],
+            [cm_field, relative_class_number, regulator, completion, monogenic],
+            [index, inessentialprimes, is_minimal_sibling]]
 
             #[degree, signature, class_number, class_group, cm_field],
             #[num_ram, ram_primes, ur_primes, gal, field_is],

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -844,10 +844,11 @@ nf_columns = SearchColumns([
     CheckMaybeCol("monogenic", "nf.monogenic", "Monogenic", default=False),
     SearchCol("galois", "nf.galois_group", "Galois group", download_col="galois_label"),
     ClassGroupCol("class_group_desc", "nf.ideal_class_group", "Class group", download_col="class_group"),
+    ClassGroupCol("narrow_class_group_desc", "nf.narrow_class_group", "Narrow class group", download_col="narrow_class_group", default=False),
     MathCol("torsion_order", "nf.unit_group", "Unit group torsion", align="center", default=False),
     MultiProcessedCol("unit_rank", "nf.rank", "Unit group rank", ["r2", "degree"], lambda r2, degree: degree - r2 - 1, align="center", mathmode=True, default=False),
     MathCol("regulator", "nf.regulator", "Regulator", align="left", default=False)],
-    db_cols=["class_group", "coeffs", "degree", "r2", "disc_abs", "disc_sign", "galois_label", "label", "ramps", "used_grh", "cm", "is_galois", "torsion_order", "regulator", "rd", "grd", "monogenic", "num_ram", "relative_class_number"])
+    db_cols=["class_group", "narrow_class_group", "coeffs", "degree", "r2", "disc_abs", "disc_sign", "galois_label", "label", "ramps", "used_grh", "cm", "is_galois", "torsion_order", "regulator", "rd", "grd", "monogenic", "num_ram", "relative_class_number"])
 
 def nf_postprocess(res, info, query):
     galois_labels = [rec["galois_label"] for rec in res if rec.get("galois_label")]
@@ -858,6 +859,7 @@ def nf_postprocess(res, info, query):
         rec["disc"] = wnf.disc_factored_latex()
         rec["galois"] = wnf.galois_string(cache=cache)
         rec["class_group_desc"] = wnf.class_group_invariants()
+        rec["narrow_class_group_desc"] = wnf.narrow_class_group_invariants()
     return res
 
 class NFDownloader(Downloader):
@@ -1267,6 +1269,7 @@ class NFSearchArray(SearchArray):
         narrow_class_group = TextBox(
             name="class_group",
             label="Narrow class group structure",
+            short_label='Narrow class group',
             knowl="nf.narrow_class_group",
             example="[2,4]",
             example_span="[ ], [3], or [2,4]")
@@ -1346,7 +1349,7 @@ class NFSearchArray(SearchArray):
         self.refine_array = [
             [degree, signature, num_ram, ram_primes, ur_primes ],
             [gal, field_is, subfield, class_group, class_number],
-            [narrow_class_number, narrow_class_group, discriminant, rd, grd],
+            [discriminant, rd, grd, narrow_class_group, narrow_class_number],
             [cm_field, relative_class_number, regulator, completion, monogenic],
             [index, inessentialprimes, is_minimal_sibling]]
 

--- a/lmfdb/number_fields/templates/nf-show-field.html
+++ b/lmfdb/number_fields/templates/nf-show-field.html
@@ -89,17 +89,14 @@ table.ntdata a {
 
         <h2> {{ KNOWL('nf.ideal_class_group', title='Class group') }} and  {{ KNOWL('nf.class_number', title='class number') }}</h2>
         <p>
-          {{ info.class_group }}
-          {{ info.grh_label|safe }}
-          {{ place_code('class_group') }}
-        </p>
+          <table>
+          <tr><td>{{ KNOWL('nf.ideal_class_group', title='Ideal class group')}}:<td>&nbsp;&nbsp;<td>{{ info.class_group }} {{ info.grh_label|safe }} {{ place_code('class_group') }}
+          <tr><td>{{ KNOWL('nf.narrow_class_group', title='Narrow class group')}}:<td>&nbsp;&nbsp;<td>{{ info.narrow_class_group }}  {{ info.grh_label|safe }} {{ place_code('narrow_class_group') }}
           {% if nf.is_cm_field() %}
-        <p>
-          {{KNOWL('nf.relative_class_number','Relative class number')}}: {{ nf.relh() }}
-          {{ info.grh_label|safe }}
-        </p>
+          <tr><td>{{KNOWL('nf.relative_class_number','Relative class number')}}:<td>&nbsp;&nbsp;<td> {{ nf.relh() }} {{ info.grh_label|safe }}
           {% endif %}
-
+          </table>
+        </p>   
 
         <p><h2> {{ KNOWL('nf.unit_group', title='Unit group') }}</h2>
         <p>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -851,6 +851,23 @@ class WebNumberField:
         if not self.haskey('class_group'):
             return [-1]
         return self._data['class_group']
+    
+    def narrow_class_group_invariants(self, in_search_results=False):
+        if not self.haskey('narrow_class_group'):
+            return "n/a" if in_search_results else na_text()
+        cg_list = self._data['narrow_class_group']
+        if not cg_list:
+            invs = 'trivial'
+        else:
+            invs = cg_list
+        if in_search_results:
+            invs += " " + self.short_grh_string()
+        return invs
+
+    def narrow_class_group_invariants_raw(self):
+        if not self.haskey('narrow_class_group'):
+            return [-1]
+        return self._data['narrow_class_group']
 
     def class_group(self):
         if self.haskey('class_group'):

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -862,6 +862,16 @@ class WebNumberField:
             return '$%s$, which has order %s' % (cg_string, self.class_number_latex())
         return na_text()
 
+    def narrow_class_group(self):
+        if self.haskey('narrow_class_group'):
+            cg_list = self._data['narrow_class_group']
+            if not cg_list:
+                return 'Trivial group, which has order $1$'
+            cg_list = [r'C_{%s}' % z for z in cg_list]
+            cg_string = r'\times '.join(cg_list)
+            return '$%s$, which has order %s' % (cg_string, self.narrow_class_number_latex())
+        return na_text()
+
     def class_number(self):
         if self.haskey('class_number'):
             return self._data['class_number']
@@ -870,6 +880,16 @@ class WebNumberField:
     def class_number_latex(self):
         if self.haskey('class_number'):
             return '$%s$' % str(self._data['class_number'])
+        return na_text()
+    
+    def narrow_class_number(self):
+        if self.haskey('narrow_class_number'):
+            return self._data['narrow_class_number']
+        return na_text()
+    
+    def narrow_class_number_latex(self):
+        if self.haskey('narrow_class_number'):
+            return '$%s$' % str(self._data['narrow_class_number'])
         return na_text()
 
     def can_class_number(self):


### PR DESCRIPTION
Added functionality for narrow class groups (`narrow_class_group` and `narrow_class_number` added to `nf_fields`); this resolves issue #994. 

An example of a number field with class group $C_3$, and narrow class group $C_6$:
http://localhost:37777/NumberField/3.3.2597.1
Current beta version:
https://beta.lmfdb.org/NumberField/3.3.2597.1

An example of a number field where computations are conditional on GRH:
http://localhost:37777/NumberField/21.3.3219905755813179726837607.1
Current beta version:
https://beta.lmfdb.org/NumberField/21.3.3219905755813179726837607.1

An example of a number field where class group and narrow class group not computed:
http://localhost:37777/NumberField/47.1.3847243917163654348435987752506690356998556730699127064362242968132131231881167.1
Current beta version:
https://beta.lmfdb.org/NumberField/47.1.3847243917163654348435987752506690356998556730699127064362242968132131231881167.1

A huge thank you to @jwj61 for helping with this issue!