### PR TITLE
New codeblocks for all pages

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -131,13 +131,14 @@ def ctx_proc_userdata():
     # overwrite this variable when you want to customize it
     # For example, [ ('Bread', '.'), ('Crumb', '.'), ('Hierarchy', '.')]
     vars['bread'] = None
-
+    from lmfdb.utils import CodeSnippet
+    vars['CodeSnippet'] = CodeSnippet
     # default title
     vars['title'] = r'LMFDB'
 
     # LMFDB version number displayed in footer
     vars['version'] = LMFDB_VERSION
-
+    
     # meta_description appears in the meta tag "description"
     vars['meta_description'] = r'Welcome to the LMFDB, the database of L-functions, modular forms, and related objects. These pages are intended to be a modern handbook including tables, formulas, links, and references for L-functions and their underlying objects.'
     vars['shortthanks'] = r'This project is supported by <a href="%s">grants</a> from the US National Science Foundation, the UK Engineering and Physical Sciences Research Council, and the Simons Foundation.' % (url_for('acknowledgment') + "#sponsors")

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -370,6 +370,10 @@ def render_newform_webpage(label):
         for e in errs:
             flash_error("%s", e)
     learnmore_cmf_picture = ('Picture description', url_for(".picture_page"))
+    from lmfdb.utils import CodeSnippet
+    def place_code(item):
+        return CodeSnippet(newform.code,item).place_code()
+
     return render_template("cmf_newform.html",
                            info=info,
                            newform=newform,
@@ -380,7 +384,9 @@ def render_newform_webpage(label):
                            title=newform.title,
                            friends=newform.friends,
                            code=newform.code,
-                           KNOWL_ID="cmf.%s" % label)
+                           KNOWL_ID="cmf.%s" % label,
+                           place_code = place_code,
+                           )
 
 def render_embedded_newform_webpage(newform_label, embedding_label):
     try:

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -370,10 +370,6 @@ def render_newform_webpage(label):
         for e in errs:
             flash_error("%s", e)
     learnmore_cmf_picture = ('Picture description', url_for(".picture_page"))
-    from lmfdb.utils import CodeSnippet
-    def place_code(item):
-        return CodeSnippet(newform.code,item).place_code()
-
     return render_template("cmf_newform.html",
                            info=info,
                            newform=newform,
@@ -384,9 +380,7 @@ def render_newform_webpage(label):
                            title=newform.title,
                            friends=newform.friends,
                            code=newform.code,
-                           KNOWL_ID="cmf.%s" % label,
-                           place_code = place_code,
-                           )
+                           KNOWL_ID="cmf.%s" % label)
 
 def render_embedded_newform_webpage(newform_label, embedding_label):
     try:

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -7,7 +7,7 @@
 
 <h2> {{KNOWL('cmf.newspace',title='Newspace')}} parameters </h2>
 
-{{ place_code('initialize-newspace') }}
+{{ place_code('initialize-newspace') | safe }}
 
 <table>
   <tr>

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -7,7 +7,7 @@
 
 <h2> {{KNOWL('cmf.newspace',title='Newspace')}} parameters </h2>
 
-{{ place_code('initialize-newspace') | safe }}
+{{ place_code('initialize-newspace')}}
 
 <table>
   <tr>

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -412,11 +412,11 @@ class WebNewform():
             label = '%s.%s' % (self.label, self.embedding_label)
             downloads.append(('Coefficient data to text', url_for('.download_embedded_newform', label=label)))
         downloads.append(
-                ('Code to Magma', url_for(".cmf_code_download", label=self.label, download_type='magma')))
+                ('Magma commands', url_for(".cmf_code_download", label=self.label, download_type='magma')))
         downloads.append(
-                ('Code to PariGP', url_for(".cmf_code_download", label=self.label, download_type='pari')))
+                ('PariGP commands', url_for(".cmf_code_download", label=self.label, download_type='pari')))
         downloads.append(
-                ('Code to SageMath', url_for(".cmf_code_download", label=self.label, download_type='sage')))
+                ('SageMath commands', url_for(".cmf_code_download", label=self.label, download_type='sage')))
 
         downloads.append(('Underlying data', url_for('.mf_data', label=label)))
         return downloads

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -13,7 +13,7 @@ from sage.databases.cremona import cremona_letter_code, class_to_int
 
 from lmfdb import db
 from lmfdb.utils import (
-    coeff_to_power_series,
+    coeff_to_power_series, coeff_to_poly,
     display_float, display_complex, round_CBF_to_half_int, polyquo_knowl,
     display_knowl, factor_base_factorization_latex,
     integer_options, names_and_urls, web_latex_factored_integer, prop_int_pretty,
@@ -724,9 +724,12 @@ class WebNewform():
                                                           display_knowl('cmf.newspace','newspace'),self.display_newspace())
         return desc
 
-    def defining_polynomial(self, separator=''):
+    def defining_polynomial(self, separator='', latex_only=False):
         if self.field_poly:
-            return raw_typeset_poly(self.field_poly, superscript=True, extra=separator)
+            if latex_only:
+                return r'\(%s\)' % latex(coeff_to_poly(self.field_poly))
+            else:
+                return raw_typeset_poly(self.field_poly, superscript=True, extra=separator)
         return None
 
     def Qnu(self):
@@ -870,7 +873,7 @@ function switch_basis(btype) {
                 Frac = r'\frac{1}{%s}(%s)' % (den, Num)
             return r'\(\beta = %s\)' % Frac
         elif self.hecke_ring_power_basis:
-            return r'a root \(\beta\) of the polynomial %s' % (self.defining_polynomial())
+            return r'a root \(\beta\) of the polynomial %s' % (self.defining_polynomial(latex_only=True))
         else:
             if self.dim <= 5:
                 betas = ",".join(r"\beta_%s" % (i) for i in range(1, self.dim))

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -854,7 +854,7 @@ class ECNF():
 
         self.downloads = [('All stored data to text', url_for(".download_ECNF_all", nf=self.field_label, conductor_label=quote(self.conductor_label), class_label=self.iso_label, number=self.number))]
         for lang in [["Magma","magma"], ["PariGP", "gp"], ["SageMath","sage"]]:
-            self.downloads.append(('Code to {}'.format(lang[0]),
+            self.downloads.append(('{} commands'.format(lang[0]),
                                    url_for(".ecnf_code_download", nf=self.field_label, conductor_label=quote(self.conductor_label),
                                            class_label=self.iso_label, number=self.number, download_type=lang[1])))
         self.downloads.append(('Underlying data', url_for(".ecnf_data", label=self.label)))
@@ -887,24 +887,6 @@ sorted_code_names = ['field', 'curve', 'is_min', 'cond', 'cond_norm',
                      'disc', 'disc_norm', 'jinv', 'cm', 'rank',
                      'gens', 'heights', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
 
-code_names = {'field': 'Define the base number field',
-              'curve': 'Define the curve',
-              'is_min': 'Test whether it is a global minimal model',
-              'cond': 'Compute the conductor',
-              'cond_norm': 'Compute the norm of the conductor',
-              'disc': 'Compute the discriminant',
-              'disc_norm': 'Compute the norm of the discriminant',
-              'jinv': 'Compute the j-invariant',
-              'cm': 'Test for Complex Multiplication',
-              'rank': 'Compute the Mordell-Weil rank',
-              'ntors': 'Compute the order of the torsion subgroup',
-              'gens': 'Compute the generators (of infinite order)',
-              'heights': 'Compute the heights of the generators (of infinite order)',
-              'reg': 'Compute the regulator',
-              'tors': 'Compute the torsion subgroup',
-              'torgens': 'Compute the generators of the torsion subgroup',
-              'localdata': 'Compute the local reduction data at primes of bad reduction'
-}
 
 Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP', 'pari': 'Pari/GP'}
 Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\'}

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -16,83 +16,105 @@ not-implemented:
   magma: |
     // (not yet implemented)
 
+frontmatter:
+  all: |
+    {lang} code for working with elliptic curve {label}
+    (Note that not all these functions may be available, and some may take a long time to execute.)
+    
 field:
+  comment: Define the base number field
   sage:  R.<x> = PolynomialRing(QQ);  K.<a> = NumberField(R(%s))
   pari:  K = nfinit(Polrev(%s));
   magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(R!%s);
 
 curve:
+  comment: Define the curve
   sage:  E = EllipticCurve(%s)
   pari:  E = ellinit(%s);
   magma: E := EllipticCurve(%s);
 
 is_min:
+  comment: Test whether it is a global minimal model
   sage:  E.is_global_minimal_model()
 
 cond:
+  comment: Compute the conductor
   sage:  E.conductor()
   pari:  ellglobalred(E)[1]
   magma: Conductor(E);
 
 cond_norm:
+  comment: Compute the norm of the conductor
   sage:  E.conductor().norm()
   pari:  idealnorm(ellglobalred(E)[1])
   magma: Norm(Conductor(E));
 
 disc:
+  comment: Compute the discriminant
   sage:  E.discriminant()
   pari:  E.disc
   magma: Discriminant(E);
 
 disc_norm:
+  comment: Compute the norm of the discriminant
   sage:  E.discriminant().norm()
   pari:  norm(E.disc)
   magma: Norm(Discriminant(E));
 
 jinv:
+  comment: Compute the j-invariant
   sage:  E.j_invariant()
   pari:  E.j
   magma: jInvariant(E);
 
 cm:
+  comment: Test for Complex Multiplication
   sage:  E.has_cm(), E.cm_discriminant()
   magma: HasComplexMultiplication(E);
 
 rank:
+  comment: Compute the Mordell-Weil rank
   sage:  E.rank()
   magma: Rank(E);
 
 gens:
+  comment: Compute the generators (of infinite order)
   sage:  gens = E.gens(); gens
   magma: |
          gens := [P:P in Generators(E)|Order(P) eq 0]; gens;
 
 reg:
+  comment: Compute the regulator
   sage:  E.regulator_of_points(gens)
   magma: Regulator(gens);
 
 heights:
+  comment: Compute the heights of the generators (of infinite order)
   sage:  |
          [P.height() for P in gens]
   magma: |
          [Height(P):P in gens];
 
 tors:
+  comment: Compute the torsion subgroup
   sage:  T = E.torsion_subgroup(); T.invariants()
   pari:  T = elltors(E); T[2]
   magma: T,piT := TorsionSubgroup(E); Invariants(T);
 
 torgens:
+  comment: Compute the generators of the torsion subgroup
   sage:  T.gens()
   pari:  T[3]
   magma: |
          [piT(P) : P in Generators(T)];
 
 ntors:
+  comment: Compute the order of the torsion subgroup
   sage:  T.order()
   pari:  T[1]
   magma: Order(T);
 
 localdata:
+  comment: Compute the local reduction data at primes of bad reduction
   sage:  E.local_data()
   magma: LocalInformation(E);

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -15,7 +15,7 @@ from lmfdb.utils import (
     parse_ints, parse_ints_to_list_flash, parse_noop, nf_string_to_label, parse_element_of,
     parse_nf_string, parse_nf_jinv, parse_bracketed_posints, parse_floats, parse_primes,
     SearchArray, TextBox, SelectBox, CountBox, SubsetBox, TextBoxWithSelect,
-    search_wrap, redirect_no_cache, web_latex, web_latex_factored_integer
+    search_wrap, redirect_no_cache, web_latex, web_latex_factored_integer, CodeSnippet
     )
 from lmfdb.utils.search_parsing import search_parser
 
@@ -680,18 +680,10 @@ def ecnf_code(**args):
     if not LABEL_RE.fullmatch(label):
         return abort(404)
     lang = args['download_type']
-    if lang == 'gp':
-        lang = 'pari'
 
-    from lmfdb.ecnf.WebEllipticCurve import make_code, Comment, Fullname, code_names, sorted_code_names
-    Ecode = make_code(label, lang)
-    code = "{} {} code for working with elliptic curve {}\n\n".format(Comment[lang],Fullname[lang],label)
-    code += "{} (Note that not all these functions may be available, and some may take a long time to execute.)\n".format(Comment[lang])
-    for k in sorted_code_names:
-        if Ecode[k]:
-            code += "\n{} {}: \n".format(Comment[lang],code_names[k])
-            code += Ecode[k] + ('\n' if '\n' not in Ecode[k] else '')
-    return code
+    from lmfdb.ecnf.WebEllipticCurve import make_code, sorted_code_names
+    code = CodeSnippet(make_code(label))
+    return code.export_code(label, lang, sorted_code_names)
 
 
 def disp_tor(t):

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -67,9 +67,9 @@ class EllCurveTest(LmfdbTest):
         Check that the code download links work
         """
         L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
-        assert 'Code to Magma' in L.get_data(as_text=True)
-        assert 'Code to SageMath' in L.get_data(as_text=True)
-        assert 'Code to PariGP' in L.get_data(as_text=True)
+        assert 'Magma commands' in L.get_data(as_text=True)
+        assert 'SageMath commands' in L.get_data(as_text=True)
+        assert 'PariGP commands' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/magma')
         assert 'Magma code for working with elliptic curve 2.2.89.1-81.1-a1' in L.get_data(as_text=True)
         L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1/download/sage')

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -30,6 +30,10 @@ not-implemented:
   oscar: |
     # (not yet implemented)
 
+frontmatter:
+  all: |
+    {lang} code for working with elliptic curve {label}
+
 curve:
   comment: Define the curve
   sage:  E = EllipticCurve({ainvs})
@@ -38,14 +42,17 @@ curve:
   oscar: E = elliptic_curve({ainvs})
 
 simple_curve:
+  comment: Simplified equation
   sage: E.short_weierstrass_model()
   magma: WeierstrassModel(E);
   oscar: short_weierstrass_model(E)
 
 mwgroup:
+  comment: Mordell-Weil group
   magma: MordellWeilGroup(E);
 
 gens:
+  comment: Mordell-Weil generators
   sage:  E.gens()
   magma: Generators(E);
   pari: E.gen
@@ -84,26 +91,30 @@ jinv:
   oscar: j_invariant(E)
 
 cm:
+  comment: Potential complex multiplication
   sage: E.has_cm()
   magma: HasComplexMultiplication(E);
 
 faltings:
+  comment: Faltings height
   pari: ellheight(E)
   magma: FaltingsHeight(E);
   oscar: faltings_height(E)
 
 stable_faltings:
+  comment: Stable Faltings height
   magma: StableFaltingsHeight(E);
   oscar: stable_faltings_height(E)
 
 rank:
-  comment: Rank
+  comment: Mordell-Weil rank
   sage:  E.rank()
   pari: |
     [lower,upper] = ellrank(E)
   magma: Rank(E);
 
 analytic_rank:
+  comment: Analytic rank
   sage: E.analytic_rank()
   pari: ellanalyticrank(E)
   magma: AnalyticRank(E);
@@ -142,6 +153,7 @@ sha:
   magma: MordellWeilShaInformation(E);
 
 L1:
+  comment: Special L-value
   sage:  |
     r = E.rank(); E.lseries().dokchitser().derivative(1,r)/r.factorial()
   pari:  |
@@ -150,6 +162,7 @@ L1:
     Lr1 where r,Lr1 := AnalyticRank(E: Precision:=12);
 
 bsd_formula:
+  comment: BSD formula
   sage: |
     # self-contained SageMath code snippet for the BSD formula (checks rank, computes analytic sha)
     E = EllipticCurve(%s); r = E.rank(); ar = E.analytic_rank(); assert r == ar;
@@ -204,13 +217,14 @@ localdata:
     [(p,tamagawa_number(E,p), kodaira_symbol(E,p), reduction_type(E,p)) for p in bad_primes(E)]
 
 galrep:
-  comment: mod p Galois image
+  comment: Mod p Galois image
   sage:  |
     rho = E.galois_representation(); [rho.image_type(p) for p in rho.non_surjective()]
   magma: |
     [GaloisRepresentation(E,p): p in PrimesUpTo(20)];
 
 adelicimage:
+  comment: Adelic image of Galois representation
   sage:   |
     gens = {adelic_gens}
     GL(2,Integers({level})).subgroup(gens)
@@ -227,4 +241,5 @@ padicreg:
     [ellpadicregulator(E,p,10,G) | p <- primes([5,20])]
 
 isogenies:
+  comment: Isogenies
   pari: ellisomat(E)

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -165,13 +165,13 @@ bsd_formula:
   comment: BSD formula
   sage: |
     # self-contained SageMath code snippet for the BSD formula (checks rank, computes analytic sha)
-    E = EllipticCurve(%s); r = E.rank(); ar = E.analytic_rank(); assert r == ar;
+    E = EllipticCurve({ainvs}); r = E.rank(); ar = E.analytic_rank(); assert r == ar;
     Lr1 = E.lseries().dokchitser().derivative(1,r)/r.factorial(); sha = E.sha().an_numerical();
     omega = E.period_lattice().omega(); reg = E.regulator(); tam = E.tamagawa_product(); tor = E.torsion_order();
     assert r == ar; print("analytic sha: " + str(RR(Lr1) * tor^2 / (omega * reg * tam)))
   magma: |
     /* self-contained Magma code snippet for the BSD formula (checks rank, computes analytic sha) */
-    E := EllipticCurve(%s); r := Rank(E); ar,Lr1 := AnalyticRank(E: Precision := 12); assert r eq ar;
+    E := EllipticCurve({ainvs}); r := Rank(E); ar,Lr1 := AnalyticRank(E: Precision := 12); assert r eq ar;
     sha := MordellWeilShaInformation(E); omega := RealPeriod(E) * (Discriminant(E) gt 0 select 2 else 1);
     reg := Regulator(E); tam := &*TamagawaNumbers(E); tor := #TorsionSubgroup(E);
     assert r eq ar; print "analytic sha:", Lr1 * tor^2 / (omega * reg * tam);

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -1059,32 +1059,6 @@ def render_bhkssw():
 
 sorted_code_names = ['curve', 'simple_curve', 'mwgroup', 'gens', 'tors', 'intpts', 'cond', 'disc', 'jinv', 'cm', 'faltings', 'stable_faltings', 'rank', 'analytic_rank', 'reg', 'real_period', 'cp', 'ntors', 'sha', 'L1', 'bsd_formula', 'qexp', 'moddeg', 'manin', 'localdata', 'galrep']
 
-# code_names = {'curve': '',
-#                  'simple_curve': '',
-#                  'mwgroup': '',
-#                  'gens': '',
-#                  'tors': '',
-#                  'intpts': 'Integral points',
-#                  'cond': 'Conductor',
-#                  'disc': 'Discriminant',
-#                  'jinv': 'j-invariant',
-#                  'cm': '',
-#                  'faltings': '',
-#                  'stable_faltings': '',
-#                  'rank': '',
-#                  'analytic_rank': '',
-#                  'reg': 'Regulator',
-#                  'real_period': 'Real Period',
-#                  'cp': 'Tamagawa numbers',
-#                  'ntors': 'Torsion order',
-#                  'sha': 'Order of Sha',
-#                  'L1': '',
-#                  'bsd_formula': '',
-#                  'qexp': '',
-#                  'moddeg': 'Modular degree',
-#                  'manin': 'Manin constant',
-#                  'localdata': 'Local data',
-#                  'galrep': 'mod p Galois image'}
 
 Fullname = {
     'magma': 'Magma',

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -18,7 +18,7 @@ from lmfdb.utils import (coeff_to_poly, coeff_to_poly_multi,
     web_latex, to_dict, comma, flash_error, display_knowl, raw_typeset, integer_divisors, integer_squarefree_part,
     parse_rational_to_list, parse_ints, parse_floats, parse_bracketed_posints, parse_primes,
     SearchArray, TextBox, SelectBox, SubsetBox, TextBoxWithSelect, CountBox, Downloader,
-    StatsDisplay, parse_element_of, parse_signed_ints, search_wrap, redirect_no_cache, web_latex_factored_integer)
+    StatsDisplay, parse_element_of, parse_signed_ints, search_wrap, redirect_no_cache, web_latex_factored_integer, CodeSnippet)
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, MathCol, LinkCol, ProcessedCol, MultiProcessedCol, CheckCol, FloatCol, ListCol
 from lmfdb.utils.common_regex import ZLLIST_RE
@@ -1059,32 +1059,32 @@ def render_bhkssw():
 
 sorted_code_names = ['curve', 'simple_curve', 'mwgroup', 'gens', 'tors', 'intpts', 'cond', 'disc', 'jinv', 'cm', 'faltings', 'stable_faltings', 'rank', 'analytic_rank', 'reg', 'real_period', 'cp', 'ntors', 'sha', 'L1', 'bsd_formula', 'qexp', 'moddeg', 'manin', 'localdata', 'galrep']
 
-code_names = {'curve': 'Define the curve',
-                 'simple_curve': 'Simplified equation',
-                 'mwgroup': 'Mordell-Weil group',
-                 'gens': 'Mordell-Weil generators',
-                 'tors': 'Torsion subgroup',
-                 'intpts': 'Integral points',
-                 'cond': 'Conductor',
-                 'disc': 'Discriminant',
-                 'jinv': 'j-invariant',
-                 'cm': 'Potential complex multiplication',
-                 'faltings': 'Faltings height',
-                 'stable_faltings': 'Stable Faltings height',
-                 'rank': 'Mordell-Weil rank',
-                 'analytic_rank': 'Analytic rank',
-                 'reg': 'Regulator',
-                 'real_period': 'Real Period',
-                 'cp': 'Tamagawa numbers',
-                 'ntors': 'Torsion order',
-                 'sha': 'Order of Sha',
-                 'L1': 'Special L-value',
-                 'bsd_formula': 'BSD formula',
-                 'qexp': 'q-expansion of modular form',
-                 'moddeg': 'Modular degree',
-                 'manin': 'Manin constant',
-                 'localdata': 'Local data',
-                 'galrep': 'mod p Galois image'}
+# code_names = {'curve': '',
+#                  'simple_curve': '',
+#                  'mwgroup': '',
+#                  'gens': '',
+#                  'tors': '',
+#                  'intpts': 'Integral points',
+#                  'cond': 'Conductor',
+#                  'disc': 'Discriminant',
+#                  'jinv': 'j-invariant',
+#                  'cm': '',
+#                  'faltings': '',
+#                  'stable_faltings': '',
+#                  'rank': '',
+#                  'analytic_rank': '',
+#                  'reg': 'Regulator',
+#                  'real_period': 'Real Period',
+#                  'cp': 'Tamagawa numbers',
+#                  'ntors': 'Torsion order',
+#                  'sha': 'Order of Sha',
+#                  'L1': '',
+#                  'bsd_formula': '',
+#                  'qexp': '',
+#                  'moddeg': 'Modular degree',
+#                  'manin': 'Manin constant',
+#                  'localdata': 'Local data',
+#                  'galrep': 'mod p Galois image'}
 
 Fullname = {
     'magma': 'Magma',
@@ -1104,18 +1104,8 @@ def ec_code(**args):
     lang = args['download_type']
     if lang not in Fullname:
         abort(404,"Invalid code language specified: " + lang)
-    name = Fullname[lang]
-    if lang == 'gp':
-        lang = 'pari'
-    comment = Ecode.pop('comment').get(lang).strip()
-    code = f"{comment} {name} code for working with elliptic curve {label}\n\n"
-    for k in Ecode: # OrderedDict
-        if 'comment' not in Ecode[k] or lang not in Ecode[k]:
-            continue
-        code += f"\n{comment} {Ecode[k]['comment']}: \n"
-        code += Ecode[k][lang] + ('\n' if '\n' not in Ecode[k][lang] else '')
-
-    return code
+    code = CodeSnippet(Ecode)
+    return code.export_code(label, lang, sorted_code_names)
 
 
 def tor_struct_search_Q(prefill="any"):

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -571,10 +571,10 @@ class WebEC():
 
         self.downloads = [('q-expansion to text', url_for(".download_EC_qexp", label=self.lmfdb_label, limit=1000)),
                           ('All stored data to text', url_for(".download_EC_all", label=self.lmfdb_label)),
-                          ('Code to Magma', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
-                          ('Code to Oscar', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='oscar')),
-                          ('Code to PariGP', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp')),
-                          ('Code to SageMath', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
+                          ('Magma commands', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='magma')),
+                          ('Oscar commands', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='oscar')),
+                          ('PariGP commands', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='gp')),
+                          ('SageMath commands', url_for(".ec_code_download", conductor=cond, iso=iso, number=num, label=self.lmfdb_label, download_type='sage')),
                           ('Underlying data', url_for(".EC_data", label=self.lmfdb_label)),
         ]
 
@@ -815,9 +815,12 @@ class WebEC():
                 adelic_level = self.data['adelic_data']['adelic_image'].split('.',1)[0]
             else:
                 adelic_gens = adelic_level = ''
-            data = { 'ainvs': self.data['ainvs'],
-                     'level': adelic_level,
-                     'adelic_gens': adelic_gens }
+            data = {
+                'label': "{label}",
+                'lang' : "{lang}",
+                'ainvs': self.data['ainvs'],
+                'level': adelic_level,
+                'adelic_gens': adelic_gens }
             for prop in code:
                 for lang in code[prop]:
                     code[prop][lang] = code[prop][lang].format(**data)

--- a/lmfdb/galois_groups/main.py
+++ b/lmfdb/galois_groups/main.py
@@ -337,7 +337,7 @@ def render_group_webpage(args):
         data['malle_a'] = wgg.malle_a
         downloads = []
         for lang in [("Magma", "magma"), ("Oscar", "oscar"), ("SageMath", "sage")]:
-            downloads.append(('Code to {}'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))
+            downloads.append(('{} commands'.format(lang[0]), url_for(".gg_code", label=label, download_type=lang[1])))
         downloads.append(('Underlying data', url_for(".gg_data", label=label)))
         # split the label so that breadcrumbs point to a search for this object's degree
         parent_id, child_id = label.split("T")

--- a/lmfdb/genus2_curves/code.yaml
+++ b/lmfdb/genus2_curves/code.yaml
@@ -16,7 +16,12 @@ not-implemented:
   magma: |
     // (not yet implemented)
 
+frontmatter:
+  all: |
+    {lang} code for working with genus 2 curve {label}.
+
 curve:
+  comment: Define the curve
   magma: |
     R<x> := PolynomialRing(Rationals());
     fh := %s;
@@ -25,22 +30,29 @@ curve:
     C := HyperellipticCurve(f, h);
 
 aut:
+  comment: Automorphism group
   magma: AutomorphismGroup(C);
 
 jacobian:
+  comment: Jacobian
   magma: J := Jacobian(SimplifiedModel(C));
 
 tors:
+  comment: Torsion subgroup
   magma: TorsionSubgroup(J);
 
 cond:
+  comment: Conductor
   magma: Conductor(LSeries(C));
 
 disc:
+  comment: Discriminant
   magma: Discriminant(C);
 
 ntors:
+  comment: Torsion order of Jacobian
   magma: Order(TorsionSubgroup(J));
 
 mwgroup:
+  comment: Mordell-Weil group
   magma: MordellWeilGroupGenus2(J);

--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -36,6 +36,7 @@ from lmfdb.utils import (
     to_dict,
     web_latex,
     web_latex_factored_integer,
+    CodeSnippet
 )
 from lmfdb.utils.interesting import interesting_knowls
 from lmfdb.utils.search_columns import SearchColumns, MathCol, CheckCol, LinkCol, ProcessedCol, MultiProcessedCol, ProcessedLinkCol, ListCol, RationalListCol
@@ -916,16 +917,6 @@ def labels_page():
 
 sorted_code_names = ['curve', 'aut', 'jacobian', 'tors', 'cond', 'disc', 'ntors', 'mwgroup']
 
-code_names = {'curve': 'Define the curve',
-                 'tors': 'Torsion subgroup',
-                 'cond': 'Conductor',
-                 'disc': 'Discriminant',
-                 'ntors': 'Torsion order of Jacobian',
-                 'jacobian': 'Jacobian',
-                 'aut': 'Automorphism group',
-                 'mwgroup': 'Mordell-Weil group'}
-
-Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP'}
 Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\'}
 
 def g2c_code(**args):
@@ -936,16 +927,9 @@ def g2c_code(**args):
         return genus2_jump_error(label, {}), False
     except KeyError:
         return genus2_jump_error(label, {}, missing_curve=True), False
-    Ccode = C.get_code()
     lang = args['download_type']
-    code = "%s %s code for working with genus 2 curve %s\n\n" % (Comment[lang],Fullname[lang],label)
-    if lang == 'gp':
-        lang = 'pari'
-    for k in sorted_code_names:
-        if lang in Ccode[k]:
-            code += "\n%s %s: \n" % (Comment[lang],code_names[k])
-            code += Ccode[k][lang] + ('\n' if '\n' not in Ccode[k][lang] else '')
-    return code, True
+    code = CodeSnippet(C.get_code())
+    return code.export_code(label, lang, sorted_code_names), True
 
 @g2c_page.route('/Q/<conductor>/<iso>/<discriminant>/<number>/download/<download_type>')
 def g2c_code_download(**args):

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -19,7 +19,6 @@ not-implemented:
     # (not yet implemented)
 
 
-
 presentation:
   comment: Define the group with the given generators and relations
   magma: G := PCGroup({pccodelist}); {gens} := Explode({used_gens}); AssignNames(~G, {magma_assign});
@@ -52,7 +51,6 @@ GLZq:
   comment: Define the group as a matrix group with coefficients in GLZq
   magma: G := MatrixGroup< {nZq}, Integers({Zq}) | {LZq} >;
   gap: G := Group({LZqsplit});
-
 
 GLFq:
   comment: Define the group as a matrix group with coefficients in GLFq

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -3436,10 +3436,10 @@ def order_stats_list_to_string(o_list):
 
 sorted_code_names = ['presentation', 'permutation', 'matrix', 'transitive']
 
-code_names = {'presentation': 'Define the group using generators and relations',
-              'permutation': 'Define the group as a permutation group',
-              'matrix': 'Define the group as a matrix group',
-              'transitive': 'Define the group from the transitive group database'}
+# code_names = {'presentation': 'Define the group using generators and relations',
+#               'permutation': 'Define the group as a permutation group',
+#               'matrix': 'Define the group as a matrix group',
+#               'transitive': 'Define the group from the transitive group database'}
 
 Fullname = {'magma': 'Magma', 'gap': 'Gap'}
 Comment = {'magma': '//', 'gap': '#'}

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -3436,10 +3436,5 @@ def order_stats_list_to_string(o_list):
 
 sorted_code_names = ['presentation', 'permutation', 'matrix', 'transitive']
 
-# code_names = {'presentation': 'Define the group using generators and relations',
-#               'permutation': 'Define the group as a permutation group',
-#               'matrix': 'Define the group as a matrix group',
-#               'transitive': 'Define the group from the transitive group database'}
-
 Fullname = {'magma': 'Magma', 'gap': 'Gap'}
 Comment = {'magma': '//', 'gap': '#'}

--- a/lmfdb/groups/abstract/templates/abstract-show-group.html
+++ b/lmfdb/groups/abstract/templates/abstract-show-group.html
@@ -195,15 +195,9 @@ Statistics about orders of elements in this group have not been computed.
 
 <h2>Constructions</h2>
   {% if code %}<div align="right" style="float: left;">
-            Show commands:
-            {% set slash = joiner("/ ") %}
-            {% for lang in code['show']|sort %}
-            {# override show names for standard languages to ensure consistency #}
-            {% set show = 'PariGP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else 'Oscar' if lang == 'oscar' else "Gap" if lang == 'gap' else code['show']['lang'] %}
-            {{slash()}}<a onclick="show_code('{{lang}}'); return false" href='#'>{{show}}</a>
-            {% endfor %}
-        </div><br><br>
-    {% endif %}
+  {{CodeSnippet(code).show_commands_box() | safe}}
+</div><br><br>
+{% endif %}
 
 <table class=nowrap>
   {{ gp.stored_representations | safe }}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -38,6 +38,7 @@ from lmfdb.utils import (
     WebObj,
     pos_int_and_factor,
     raw_typeset,
+    CodeSnippet
 )
 from .circles import find_packing
 
@@ -2751,33 +2752,11 @@ class WebAbstractGroup(WebObj):
         return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="-{R} -{R} {2*R} {2*R}" width="200" height="150">\n{circles}</svg>'
 
     def create_snippet(self,item):
-        # mimics jinja macro place_code to be included in Constructions section
-        # this is specific for embedding in a table. eg. we need to replace "<" with "&lt;"
-        code = self.code_snippets()
-        snippet_str = "" # initiate new string
-        if code[item]:
-            for L in code[item]:
-                if isinstance(code[item][L],str):
-                    lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]]
-                    lines = [line.replace("<", "&lt;").replace(">", "&gt;") for line in lines]
-                else:   # not currently used in groups
-                    lines = code[item][L]
-                prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L
-                class_str = " ".join([L,'nodisplay','codebox'])
-                col_span_val = '"6"'
-                for line in lines:
-                    snippet_str += f"""
-<tr>
-    <td colspan={col_span_val}>
-        <div class="{class_str}">
-            <span class="raw-tset-copy-btn" onclick="copycode(this)"><img alt="Copy content" class="tset-icon"></span>
-            <span class="prompt">{prompt}:&nbsp;</span><span class="code">{line}</span>
-            <div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>
-        </div>
-    </td>
-</tr>
-"""
-        return snippet_str
+        snippet = CodeSnippet(self.code_snippets()
+                              pre=defaultdict(lambda: f"<tr> <td colspan={col_span_val}>")
+                              post=defaultdict(lambda: "</td></tr>"))
+        col_span_val = '"6"'
+        return snippet.place_code(item, pre, post)
 
     @cached_method
     def code_snippets(self):

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2752,11 +2752,11 @@ class WebAbstractGroup(WebObj):
         return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="-{R} -{R} {2*R} {2*R}" width="200" height="150">\n{circles}</svg>'
 
     def create_snippet(self,item):
-        snippet = CodeSnippet(self.code_snippets()
-                              pre=defaultdict(lambda: f"<tr> <td colspan={col_span_val}>")
-                              post=defaultdict(lambda: "</td></tr>"))
         col_span_val = '"6"'
-        return snippet.place_code(item, pre, post)
+        snippet = CodeSnippet(self.code_snippets(), item,
+                              pre=f"<tr> <td colspan={col_span_val}>",
+                              post="</td></tr>")
+        return snippet.place_code()
 
     @cached_method
     def code_snippets(self):

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -20,31 +20,45 @@ not-implemented:
   oscar: |
     # (not yet implemented)
 
+# Valid keys are: 'all' any key appearing in prompt, and 'rest'
+frontmatter:
+  all: |
+    {lang} code for working with number field {label}.
+  oscar: |
+    If you have not already loaded the Oscar package, you should type "using Oscar;" before running the code below.
+  rest: |
+    Some of these functions may take a long time to execute (this depends on the field).
+
 field:
+  comment: Define the number field
   sage: x = polygen(QQ);  K.<a> = NumberField(%s)
   pari: K = bnfinit(%s, 1)
   magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(%s);
   oscar: Qx, x = polynomial_ring(QQ); K, a = number_field(%s)
 
 poly:
+  comment: Defining polynomial
   sage:  K.defining_polynomial()
   pari:  K.pol
   magma: DefiningPolynomial(K);
   oscar: defining_polynomial(K)
 
 degree:
+  comment: Degree over Q
   sage:  K.degree()
   pari:  poldegree(K.pol)
   magma: Degree(K);
   oscar: degree(K)
 
 signature:
+  comment: Signature
   sage:  K.signature()
   pari:  K.sign
   magma: Signature(K);
   oscar: signature(K)
 
 discriminant:
+  comment: Discriminant
   sage:  K.disc()
   pari:  K.disc
   magma: OK := Integers(K); Discriminant(OK);
@@ -57,46 +71,54 @@ rd:
   oscar: (1.0 * dK)^(1/degree(K))
 
 automorphisms:
+  comment: Autmorphisms
   sage: K.automorphisms()
   magma: Automorphisms(K);
   oscar: automorphisms(K)
 
 ramified_primes:
+  comment: Ramified primes
   sage:  K.disc().support()
   pari:  factor(abs(K.disc))[,1]~
   magma: PrimeDivisors(Discriminant(OK));
   oscar: prime_divisors(discriminant((OK)))
 
 integral_basis:
+  comment: Integral basis
   sage:  K.integral_basis()
   pari:  K.zk
   magma: IntegralBasis(K);
   oscar: basis(OK)
 
 class_group:
+  comment: Class group
   sage:  K.class_group().invariants()
   pari:  K.clgp
   magma: ClassGroup(K); 
   oscar: class_group(K)
 
 unit_group:
+  comment: Unit group
   sage:  UK = K.unit_group()
   magma: UK, fUK := UnitGroup(K);
   oscar: UK, fUK = unit_group(OK)
 
 unit_rank:
+  comment: Unit rank
   sage:  UK.rank()
   pari:  K.fu
   magma: UnitRank(K);
   oscar: rank(UK)
 
 unit_torsion_gen:
+  comment: Generator for roots of unity
   sage:  UK.torsion_generator()
   pari:  K.tu[2]
   magma: K!f(TU.1) where TU,f is TorsionUnitGroup(K);
   oscar: torsion_units_generator(OK)
 
 fundamental_units:
+  comment: Fundamental units
   sage:  UK.fundamental_units()
   pari:  K.fu
   magma: |
@@ -105,12 +127,14 @@ fundamental_units:
     [K(fUK(a)) for a in gens(UK)]
 
 regulator:
+  comment: Regulator
   sage:  K.regulator()
   pari:  K.reg
   magma: Regulator(K);
   oscar: regulator(K)
 
 class_number_formula:
+  comment: Analytic class number formula
   sage: |
     # self-contained SageMath code snippet to compute the analytic class number formula
     x = polygen(QQ);  K.<a> = NumberField(%s)
@@ -139,18 +163,21 @@ class_number_formula:
     2^r1 * (2*pi)^r2 * RK * hK / (wK * sqrt(RR(abs(DK))))
 
 galois_group:
+  comment: Galois group
   sage:  K.galois_group(type='pari')
   pari:  polgalois(K.pol)
   magma: G = GaloisGroup(K);
   oscar: G, Gtx = galois_group(K); G, transitive_group_identification(G)
 
 intermediate_fields:
+  comment: Intermediate fields
   sage: K.subfields()[1:-1]
   pari: L = nfsubfields(K); L[2..length(b)]
   magma: L := Subfields(K); L[2..#L];
   oscar: subfields(K)[2:end-1]
 
 prime_cycle_types:
+  comment: Frobenius cycle types
   sage: |
     # to obtain a list of [e_i,f_i] for the factorization of the ideal pO_K for p=7 in Sage:
     p = 7; [(e, pr.norm().valuation(p)) for pr,e in K.factor(p)]

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -142,7 +142,7 @@ class_number_formula:
     hK = K.class_number(); wK = K.unit_group().torsion_generator().order();
     2^r1 * (2*RR(pi))^r2 * RK * hK / (wK * RR(sqrt(abs(DK))))  
   pari: |
-    # self-contained Pari/GP code snippet to compute the analytic class number formula
+    \\ self-contained Pari/GP code snippet to compute the analytic class number formula
     K = bnfinit(%s, 1);
     [polcoeff (lfunrootres (lfuncreate (K))[1][1][2], -1), 2^K.r1 * (2*Pi)^K.r2 * K.reg * K.no / (K.tu[1] * sqrt (abs (K.disc)))]
   magma: |

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -152,14 +152,14 @@ intermediate_fields:
 
 prime_cycle_types:
   sage: |
-    # to obtain a list of $[e_i,f_i]$ for the factorization of the ideal $p\mathcal{O}_K$ for $p=7$ in Sage:
+    # to obtain a list of [e_i,f_i] for the factorization of the ideal pO_K for p=7 in Sage:
     p = 7; [(e, pr.norm().valuation(p)) for pr,e in K.factor(p)]
   pari: |
-    \\ to obtain a list of $[e_i,f_i]$ for the factorization of the ideal $p\mathcal{O}_K$ for $p=7$ in Pari:
+    \\ to obtain a list of [e_i,f_i] for the factorization of the ideal pO_K for p=7 in Pari:
     p = 7; pfac = idealprimedec(K, p); vector(length(pfac), j, [pfac[j][3], pfac[j][4]])
   magma: |
-    // to obtain a list of $[e_i,f_i]$ for the factorization of the ideal $p\mathcal{O}_K$ for $p=7 in Magma:
+    // to obtain a list of [e_i,f_i] for the factorization of the ideal pO_K for p=7 in Magma:
     p := 7; [<pr[2], Valuation(Norm(pr[1]), p)> : pr in Factorization(p*Integers(K))];
   oscar: |
-    # to obtain a list of $[e_i,f_i]$ for the factorization of the ideal $p\mathcal{O}_K$ for $p=7$ in Oscar:
+    # to obtain a list of [e_i,f_i] for the factorization of the ideal pO_K for p=7 in Oscar:
     p = 7; pfac = factor(ideal(ring_of_integers(K), p)); [(e, valuation(norm(pr),p)) for (pr,e) in pfac]

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1126,9 +1126,6 @@ def nf_code(**args):
     label = args['nf']
     if not FIELD_LABEL_RE.fullmatch(label):
         raise ValueError(f"Invalid label {label}")
-    Comment = {'magma': '//', 'sage': '#',
-                     'gp': '\\\\', 'pari': '\\\\', 'oscar': '#'}
-    
     lang = args['download_type']
     nf = WebNumberField(label)
     if nf.is_null():

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1149,19 +1149,16 @@ def nf_code(**args):
     if nf.is_null():
         raise ValueError(f"There is no number field with label {label}")
     nf.make_code_snippets()
-    code = "{} {} code for working with number field {}\n\n".format(Comment[lang],Fullname[lang],label)
+    frontmatter = "{} {} code for working with number field {}\n\n".format(Comment[lang],Fullname[lang],label)
+    # MAYBE: This should be in the yaml file! eg. "frontmatter"
     if lang == 'oscar':
-        code += '{} If you have not already loaded the Oscar package, you should type "using Oscar;" before running the code below.\n'.format(Comment[lang])
-        code += "{} Some of these functions may take a long time to compile (this depends on the state of your Julia REPL), and/or to execute (this depends on the field).\n".format(Comment[lang])
+        frontmatter += '{} If you have not already loaded the Oscar package, you should type "using Oscar;" before running the code below.\n'.format(Comment[lang])
+        frontmatter += "{} Some of these functions may take a long time to compile (this depends on the state of your Julia REPL), and/or to execute (this depends on the field).\n".format(Comment[lang])
     else:
-        code += "{} Some of these functions may take a long time to execute (this depends on the field).\n".format(Comment[lang])
+        frontmatter += "{} Some of these functions may take a long time to execute (this depends on the field).\n".format(Comment[lang])
     if lang == 'gp':
         lang = 'pari'
-    for k in sorted_code_names:
-        if lang in nf.code[k]:
-            code += "\n{} {}: \n".format(Comment[lang],code_names[k])
-            code += nf.code[k][lang] + ('\n' if '\n' not in nf.code[k][lang] else '')
-    return code
+    return CreateSnippet(nf.code).export_code(lang,sorted_code_names,frontmatter)
 
 
 class NFSearchArray(SearchArray):

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -1,24 +1,8 @@
 {% extends "base.html" %}
 
-{% macro place_code(item) %}
+{% macro place_code2(item) %}
 {% if code and code[item] %}
-{% for L in code[item] %}
-{% if code[item][L] %}
-{# currently there are two uses of multiline code:
-   - either strings containing newlines and ending with a newline
-   - or arrays of lines
-   first convert the first case to the second
-#}
-{% if code[item][L] is string %}
-{% set lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]] %}
-{% else %}
-{% set lines = code[item][L] %}
-{% endif %}
-{% set prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L %}
-{# keep the line below as is to avoid annoying line breaks #}
-<div class="{{ [L,'nodisplay','code','codebox'] | join(' ')}}">{% for line in lines %}{% if lines | length == 1 %}{{prompt}}:&nbsp;{% endif %}{{line}}<br /><div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>{# this div is a workaround for a copy-tex bug where if a code block followed a hidden code block followed by math was selected and copied the hidden block would be also it is important that it has display: block #}{% endfor %}</div>
-{% endif %}
-{% endfor %}
+{{code.place_code(item)}}
 {% endif %}
 {% endmacro %}
 
@@ -211,30 +195,7 @@
     {%- endwith %}
     <div align="right" style="float: right; padding-left:10px;" id="rawtseticonspot" title="raw/typeset toggle"></div>
     {% if code %}
-        <script>
-        var cur_lang = null;
-        function show_code(new_lang) {
-           {% for lang in code['show'] %}
-           $('.{{lang}}').hide();
-           {% endfor %}
-            if (cur_lang == new_lang) {
-              cur_lang = null;
-            } else {
-              $('.'+new_lang).show();
-              $('.'+new_lang).css('display','inline-block');
-              cur_lang = new_lang;
-            }
-        }
-        </script>
-        <div align="right" style="float: right; margin-top:2px;">
-            Show commands:
-            {% set slash = joiner("/ ") %}
-            {% for lang in code['show']|sort %}
-            {# override show names for standard languages to ensure consistency #}
-            {% set show = 'PariGP' if lang == 'pari' else 'SageMath' if lang == 'sage' else 'Magma' if lang == 'magma' else 'Oscar' if lang == 'oscar' else "Gap" if lang == 'gap' else code['show']['lang'] %}
-            {{slash()}}<a onclick="show_code('{{lang}}'); return false" href='#'>{{show}}</a>
-            {% endfor %}
-        </div>
+    {{ CodeSnippet(code).show_commands_box() | safe}}
     {% endif %}
     {% if KNOWL_ID %}
     {% if BACKUP_KNOWL_ID %}

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% macro place_code2(item) %}
+{% macro place_code(item) %}
 {% if code and code[item] %}
-{{code.place_code(item)}}
+{{CodeSnippet(code, item).place_code()}}
 {% endif %}
 {% endmacro %}
 

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -51,7 +51,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'raw_typeset_qexp', 'raw_typeset_int', 'compress_poly_Q',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat',
            'compress_expression',
-           'pos_int_and_factor', 'compress_polynomial']
+           'pos_int_and_factor', 'compress_polynomial', 'create_snippet']
 
 from flask import (request, make_response, flash, url_for,
                    render_template, send_file)
@@ -165,3 +165,4 @@ from .config import Configuration
 from .names_and_urls import names_and_urls, name_and_object_from_url
 from .trace_hash import TraceHash, TraceHashClass
 from .random_wrap import redirect_no_cache
+from .place_code import CodeSnippet

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -51,7 +51,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'raw_typeset_qexp', 'raw_typeset_int', 'compress_poly_Q',
            'input_string_to_poly', 'dispZmat', 'dispcyclomat',
            'compress_expression',
-           'pos_int_and_factor', 'compress_polynomial', 'create_snippet']
+           'pos_int_and_factor', 'compress_polynomial', 'CodeSnippet']
 
 from flask import (request, make_response, flash, url_for,
                    render_template, send_file)

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -49,7 +49,7 @@ class CodeSnippet():
 
     def show_commands_box(self):
         """Display 'Show commands' box and corresponding logic"""
-        lang_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar"}
+        lang_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar", "gap": "Gap"}
         box_str = r"""<div align="right" style="float: right; margin-top:2px;">""" + "Show commands: "
         lang_strs = []
         for lang in self.langs:

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -18,19 +18,19 @@ class CodeSnippet():
         """
         self.code = code
         self.item = item
-        if 'prompt' in code.keys():
-            self.langs = sorted(list(code['prompt'].keys()))
-        elif 'show' in code.keys():
-            self.langs = sorted(list(code['show'].keys()))
-
+        if 'prompt' in code:
+            self.langs = sorted(code['prompt'])
+        elif 'show' in code:
+            self.langs = sorted(code['show'])
         else:
+            # for backwards compatibility
             self.langs = []
         
         self.pre, self.post = pre, post
 
         # edit these when adding support for more languages 
         self.comments = {'magma': '//', 'sage': '#',
-                         'gp': '\\\\', 'pari': '\\\\', 'oscar': '#'}
+                         'gp': '\\\\', 'pari': '\\\\', 'oscar': '#', 'gap': '#'}
         self.full_names = {"pari": "Pari/GP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar", "gap": "Gap"}
         
 
@@ -39,7 +39,6 @@ class CodeSnippet():
         if self.item is None:
             raise ValueError("No code to place, please init with code item")
         item = self.item 
-        # replaces jinja macro place_code 
         snippet_str = self.pre # initiate new string
         prompt_style = "color: gray;"
         code_style = "user-select: text; flex: 1"
@@ -96,11 +95,10 @@ class CodeSnippet():
         """ Build frontmatter for export_code
         """
         codefrmt = self.code['frontmatter']
-        keys = list(codefrmt.keys())
         cmt = self.comments[lang]
         frmt = cmt + " "
         for key in ['all', lang, 'rest']:
-                frmt += codefrmt[key] if key in keys else ""
+                frmt += codefrmt[key] if key in codefrmt else ""
         
         frmt = frmt.replace('\n', '\n' + cmt + " ", frmt.count("\n")-1)
         return frmt.format(lang=self.full_names[lang], label=label) + "\n"
@@ -112,8 +110,8 @@ class CodeSnippet():
             lang = 'pari'
         code = self.build_frontmatter(label,lang)
         for key in sorted_code_names:
-            assert key in self.code.keys()
-            if not self.code[key] is None and lang in self.code[key]:
+            assert key in self.code
+            if lang in self.code[key] is not None:
                 code += "\n{} {}: \n".format(self.comments[lang], self.code[key]['comment'])
                 code += self.code[key][lang] + ('\n' if '\n' not in self.code[key][lang] else '')
         return code

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -37,10 +37,11 @@ class CodeSnippet():
 
                 prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L
                 class_str = " ".join([L,'nodisplay','codebox'])
+                sep = "\n"
                 snippet_str += f"""
     <div class="{class_str}" style="user-select: none; margin-bottom: 12px; align-items: top">
         <span class="raw-tset-copy-btn" onclick="copycode(this)" style="max-height: 12px; margin: 3px"><img alt="Copy content" class="tset-icon"></span> 
-        <span class="prompt" style="{prompt_style}">{prompt}:&nbsp;</span><span class="code" style="{code_style}">{"\n".join(lines)}</span>
+        <span class="prompt" style="{prompt_style}">{prompt}:&nbsp;</span><span class="code" style="{code_style}">{sep.join(lines)}</span>
         <div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>
     </div>
     """
@@ -48,7 +49,6 @@ class CodeSnippet():
 
     def show_commands_box(self):
         """Display 'Show commands' box and corresponding logic"""
-        lang_str = ""
         lang_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar"}
         box_str = r"""<div align="right" style="float: right; margin-top:2px;">""" + "Show commands: "
         lang_strs = []

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -1,0 +1,78 @@
+###
+#  code snippet rendering utilities
+###
+
+# This makes the html safe by default,
+# so you don't have to pass "| safe"
+# whenever you call .place_code()
+from markupsafe import Markup
+# TODO: remove annoying white space at the end of code box
+
+class CodeSnippet():
+    """ Utility class for displaying code snippets on lmfdb pages
+    """
+    def __init__(self, code, item=None, pre="", post=""):
+        self.code = code
+        self.item = item
+        self.langs = sorted([lang for lang in code['show']])
+        self.pre, self.post = pre, post
+                
+    def place_code(self):
+        """Return HTML string which displays code in code box, with copying functionality."""
+        if self.item is None:
+            raise ValueError("No code to place, please init with code item")
+        item = self.item 
+        # replaces jinja macro place_code 
+        snippet_str = self.pre # initiate new string
+        prompt_style = "color: gray;"
+        code_style = "user-select: text; flex: 1"
+        code = self.code
+        if code[item]:
+            for L in code[item]:
+                if isinstance(code[item][L],str):
+                    lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]]
+                    lines = [line.replace("<", "&lt;").replace(">", "&gt;") for line in lines]
+                else:   
+                    lines = code[item][L]
+
+                prompt = code['prompt'][L] if 'prompt' in code and L in code['prompt'] else L
+                class_str = " ".join([L,'nodisplay','codebox'])
+                snippet_str += f"""
+    <div class="{class_str}" style="user-select: none; margin-bottom: 12px; align-items: top">
+        <span class="raw-tset-copy-btn" onclick="copycode(this)" style="max-height: 12px; margin: 3px"><img alt="Copy content" class="tset-icon"></span> 
+        <span class="prompt" style="{prompt_style}">{prompt}:&nbsp;</span><span class="code" style="{code_style}">{"\n".join(lines)}</span>
+        <div style="margin: 0; padding: 0; height: 0;">&nbsp;</div>
+    </div>
+    """
+        return Markup(snippet_str + self.post)
+
+    def show_commands_box(self):
+        """Display 'Show commands' box and corresponding logic"""
+        lang_str = ""
+        lang_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar"}
+        box_str = r"""<div align="right" style="float: right; margin-top:2px;">""" + "Show commands: "
+        lang_strs = []
+        for lang in self.langs:
+            name = lang_names[lang] if lang in lang_names.keys() else lang
+            lang_strs.append(rf"""<a onclick="show_code('{lang}',{self.langs} ); return false" href='#'>{name}</a>""")
+
+        box_str += " / ".join(lang_strs) + "</div>"
+        # NB: unlike the past jinja2 macro, this formats as inline-flex 
+        # instead of inline-block in order to correctly render copy symbol in blocks
+        js_str = r"""
+        <script>
+        var cur_lang = null;
+        function show_code(new_lang, langs) {
+           for(var lang of langs){$('.'+lang).hide()}
+            if (cur_lang == new_lang) {
+              cur_lang = null;
+            } else {
+              $('.'+new_lang).show();
+              $('.'+new_lang).css('display','inline-flex');
+              cur_lang = new_lang;
+            }
+        }
+        </script>
+        """
+        return js_str + box_str
+    

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -111,7 +111,7 @@ class CodeSnippet():
         code = self.build_frontmatter(label,lang)
         for key in sorted_code_names:
             assert key in self.code
-            if lang in self.code[key] is not None:
+            if self.code[key] is not None and lang in self.code[key]:
                 code += "\n{} {}: \n".format(self.comments[lang], self.code[key]['comment'])
                 code += self.code[key][lang] + ('\n' if '\n' not in self.code[key][lang] else '')
         return code

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -12,10 +12,19 @@ class CodeSnippet():
     """ Utility class for displaying code snippets on lmfdb pages
     """
     def __init__(self, code, item=None, pre="", post=""):
+        """NB: Pre and post are used exclusively for placing code
+        and is useful for displaying codes in table, for example.
+        """
         self.code = code
         self.item = item
         self.langs = sorted([lang for lang in code['show']])
         self.pre, self.post = pre, post
+
+        # edit these when adding support for more languages 
+        self.comments = {'magma': '//', 'sage': '#',
+                         'gp': '\\\\', 'pari': '\\\\', 'oscar': '#'}
+        self.full_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar", "gap": "Gap"}
+
                 
     def place_code(self):
         """Return HTML string which displays code in code box, with copying functionality."""
@@ -49,11 +58,10 @@ class CodeSnippet():
 
     def show_commands_box(self):
         """Display 'Show commands' box and corresponding logic"""
-        lang_names = {"pari": "PariGP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar", "gap": "Gap"}
         box_str = r"""<div align="right" style="float: right; margin-top:2px;">""" + "Show commands: "
         lang_strs = []
         for lang in self.langs:
-            name = lang_names[lang] if lang in lang_names.keys() else lang
+            name = self.full_names[lang] if lang in self.full_names.keys() else lang
             lang_strs.append(rf"""<a onclick="show_code('{lang}',{self.langs} ); return false" href='#'>{name}</a>""")
 
         box_str += " / ".join(lang_strs) + "</div>"
@@ -76,3 +84,13 @@ class CodeSnippet():
         """
         return js_str + box_str
     
+
+    def export_code(self, lang, code_names, frontmatter=""):
+        """ Export code via 'Code to LANG' button for properties box
+        """
+        code = ""
+        for k in code_names:
+            if lang in self.code[k]:
+                code += "\n{} {}: \n".format(self.comments[lang], code_names[k])
+                code += self.code[k][lang] + ('\n' if '\n' not in self.code[k][lang] else '')
+

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -18,7 +18,6 @@ class CodeSnippet():
         """
         self.code = code
         self.item = item
-        # print(type(code['prompt'].keys()))
         if 'prompt' in code.keys():
             self.langs = sorted(list(code['prompt'].keys()))
         elif 'show' in code.keys():


### PR DESCRIPTION
Work in progress, feedback appreciated! 

All the "place_code" functionality is moved from the jinja macro in homepage.html to a new class in utils/place_code.py. This includes copying functionality, and more reasonable defaults for selecting the code.

Here's a preview: 
<img width="1390" height="834" alt="Screenshot 2025-07-14 at 18 01 48" src="https://github.com/user-attachments/assets/e03452ed-7b1b-4ffa-9825-81cd29ff6fe3" />

A lot of the code is inspired by the version for the groups page by @jenpaulhus and @edgarcosta in #6141.
