### PR TITLE
Improve group page titles

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -1671,7 +1671,7 @@ def render_abstract_group(label, data=None):
             info["max_sub_cnt"] = gp.max_sub_cnt
             info["max_quo_cnt"] = gp.max_quo_cnt
 
-        title = f"Abstract group ${gp.tex_name}$"
+        title = f"Abstract group {gp.label}: {gp.nick_name}"
 
         # disable until we can fix downloads
         downloads = [("Group to Gap", url_for(".download_group", label=label, download_type="gap")),

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -730,6 +730,38 @@ class WebAbstractGroup(WebObj):
         return primary_to_smith(self.primary_abelian_invariants)
 
     @lazy_attribute
+    def nick_name(self):
+        if self.label=='7920.a':
+            return r'Mathieu group $M_{11}$'
+        if self.label=='95040.a':
+            return r'Mathieu group $M_{12}$'
+        if self.label=='443520.a':
+            return r'Mathieu group $M_{22}$'
+        if self.label=='10200960.a':
+            return r'Mathieu group $M_{23}$'
+        if self.label=='244823040.a':
+            return r'Mathieu group $M_{24}$'
+        if self.label=='17556.a':
+            return r'Janko group $J_1$'
+        if self.label=='60480.a':
+            return r'Janko group $J_2$'
+        if self.label=='50232960.a':
+            return r'Janko group $J_3$'
+        if self.label=='44352000.a':
+            return r'Higman-Sims group'
+        if self.label=='898128000.a':
+            return r'McLaughlin group'
+        if self.label=='4030387200.a':
+            return r'Held group'
+        if self.label=='145926144000.a':
+            return r'Rudvalis group'
+        if self.label=='495766656000.a':
+            return r'Conway group $\mathrm{Co}_3$'
+        if self.label=='42305421312000.a':
+            return r'Conway group $\mathrm{Co}_2$'
+        return f'${self.tex_name}$'
+
+    @lazy_attribute
     def tex_name(self):
         if self.abelian:
             return abelian_gp_display(self.smith_abelian_invariants)


### PR DESCRIPTION
Most lmfdb home pages have the label in the page title.

For abstract groups, this adds the label to the title.

http://beta.lmfdb.org/Groups/Abstract/64.251
http://127.0.0.1:37777/Groups/Abstract/64.251

For sporadic simple groups, this adds the full name of the group.  For families within these groups (Matthieu, Janko), it also includes the symbol.

Part of family
http://127.0.0.1:37777/Groups/Abstract/10200960.a
http://beta.lmfdb.org/Groups/Abstract/10200960.a

Not part of a family
http://beta.lmfdb.org/Groups/Abstract/145926144000.a
http://127.0.0.1:37777/Groups/Abstract/145926144000.a