### PR TITLE
Compress long abstract group labels

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -828,7 +828,7 @@ def auto_gens(label):
         "auto_gens_page.html",
         gp=gp,
         title="Generators of automorphism group for $%s$" % gp.tex_name,
-        bread=get_bread([(label, url_for(".by_label", label=label)), ("Automorphism group generators", " ")]),
+        bread=get_bread([(gp.label_compress(), url_for(".by_label", label=label)), ("Automorphism group generators", " ")]),
                         )
 
 
@@ -867,7 +867,7 @@ def char_table(label):
         gp=gp,
         info=info,
         title=f"Character table for ${gp.tex_name}$",
-        bread=get_bread([(label, url_for(".by_label", label=label)), ("Character table", " ")]),
+        bread=get_bread([(gp.label_compress(), url_for(".by_label", label=label)), ("Character table", " ")]),
     )
 
 
@@ -890,7 +890,7 @@ def Qchar_table(label):
         gp=gp,
         info=info,
         title="Rational character table for $%s$" % gp.tex_name,
-        bread=get_bread([(label, url_for(".by_label", label=label)), ("Rational character table", " ")]),
+        bread=get_bread([(gp.label_compress(), url_for(".by_label", label=label)), ("Rational character table", " ")]),
     )
 
 
@@ -1744,7 +1744,7 @@ def render_abstract_group(label, data=None):
             )
             friends += [("As the component group of a Sato-Tate group", st_url)]
 
-    bread = get_bread([(label, "")])
+    bread = get_bread([(gp.label_compress(), "")])
     learnmore_gp_picture = ('Picture description', url_for(".picture_page"))
 
     return render_template(

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -942,11 +942,17 @@ class WebAbstractGroup(WebObj):
                         ov = None
         return ans
 
+    def label_compress(self):
+        spl_label = self.label.split('.')
+        if len(spl_label[0])>12:
+            spl_label[0] = spl_label[0][:3] + "..." + spl_label[0][-3:]
+        return ".".join(spl_label)
+
     def properties(self):
         nilp_str = "yes" if self.nilpotent else "no"
         solv_str = "yes" if self.solvable else "no"
         props = [
-            ("Label", self.label),
+            ("Label", self.label_compress()),
             ("Order", web_latex(factor(self.order))),
             ("Exponent", web_latex(factor(self.exponent))),
         ]


### PR DESCRIPTION
Fix #6540 .

If a group has large order, its label is very long.  This compresses the order in the label in the properties box and in the bread.

Example with compression:
http://beta.lmfdb.org/Groups/Abstract/403291461126605635584000000.a
http://127.0.0.1:37777/Groups/Abstract/403291461126605635584000000.a

Example with no change:
http://beta.lmfdb.org/Groups/Abstract/39916800.a
http://127.0.0.1:37777/Groups/Abstract/39916800.a
