### PR TITLE
Disable symmetric power l-function friends

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -148,10 +148,10 @@ class ECisog_class():
             self.CMfield = field_pretty(lab)
         else:
             self.CMfield = "no"
-            if self.conductor <= 300:
-                self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', conductor=self.conductor, isogeny=self.iso_label))]
-            if self.conductor <= 50:
-                self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', conductor=self.conductor, isogeny=self.iso_label))]
+            #if self.conductor <= 300:
+            #    self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', conductor=self.conductor, isogeny=self.iso_label))]
+            #if self.conductor <= 50:
+            #    self.friends += [('Symmetric cube L-function', url_for("l_functions.l_function_ec_sym_page", power='3', conductor=self.conductor, isogeny=self.iso_label))]
         if self.newform_exists_in_db:
             self.friends += [('Modular form ' + self.newform_label, self.newform_link)]
 

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -561,7 +561,8 @@ class WebEC():
         else:
             self.friends += [('L-function not available', "")]
 
-        if not self.cm:
+        # kill symmetric power L-functions for now
+        if False and not self.cm:
             if N <= 300:
                 self.friends += [('Symmetric square L-function', url_for("l_functions.l_function_ec_sym_page", power='2', conductor=N, isogeny=iso))]
             if N <= 50:


### PR DESCRIPTION
Fix #6245 

This removes symmetric power L-function friends for elliptic curves.  The code was changed in a way that it can be easily re-enabled.

Isogeny class:
http://127.0.0.1:37777/EllipticCurve/Q/14/a/
https://beta.lmfdb.org/EllipticCurve/Q/14/a/

curve page:

http://127.0.0.1:37777/EllipticCurve/Q/11/a/2
https://beta.lmfdb.org/EllipticCurve/Q/11/a/2
