### PR TITLE
Remove negative space

### DIFF
--- a/lmfdb/utils/web_display.py
+++ b/lmfdb/utils/web_display.py
@@ -687,7 +687,7 @@ def compress_poly_Q(rawpoly,
 
     def frac_string(frac):
         if frac.denominator() == 1:
-            return compress_int(frac.numerator(), negative_space=False)[0]
+            return compress_int(frac.numerator())[0]
         return r'\frac{%s}{%s}' % (compress_int(frac.numerator(), negative_space=False)[0], compress_int(frac.denominator(), negative_space=False)[0])
 
     tset = ''


### PR DESCRIPTION
Fix #5786 

In units of a number field, some coefficients are being compressed, but the ... was not always visible.  Turns out, the compression function puts negative space around the ellipsis, so this just removes it.

http://127.0.0.1:37777/NumberField/6.0.4920750000000.7
https://beta.lmfdb.org/NumberField/6.0.4920750000000.7