### PR TITLE
Partial fix for making groups display knowl

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -877,7 +877,7 @@ def render_by_label(label):
     info['st0_description'] = st0['description']
     if data['component_group'][:2] == "ab":
         info['component_group'] = r"C_{%s}" % info['components']
-        info['component_group_knowl'] = name=r"$C_{%s}$" % info['components']
+        info['component_group_knowl'] = r"$C_{%s}$" % info['components']
         info['cyclic'] = boolean_name(True)
         info['abelian'] = boolean_name(True)
         info['solvable'] = boolean_name(True)

--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -877,6 +877,7 @@ def render_by_label(label):
     info['st0_description'] = st0['description']
     if data['component_group'][:2] == "ab":
         info['component_group'] = r"C_{%s}" % info['components']
+        info['component_group_knowl'] = name=r"$C_{%s}$" % info['components']
         info['cyclic'] = boolean_name(True)
         info['abelian'] = boolean_name(True)
         info['solvable'] = boolean_name(True)
@@ -886,6 +887,7 @@ def render_by_label(label):
             flash_error("%s is not the label of a Sato-Tate component group currently in the database.", data['component_group'])
             return redirect(url_for(".index"))
         info['component_group'] = G['tex_name']
+        info['component_group_knowl'] = abstract_group_display_knowl(r"%s"% data['component_group'])
         info['cyclic'] = boolean_name(G['cyclic'])
         info['abelian'] = boolean_name(G['abelian'])
         info['solvable'] = boolean_name(G['solvable'])

--- a/lmfdb/sato_tate_groups/templates/st_display.html
+++ b/lmfdb/sato_tate_groups/templates/st_display.html
@@ -28,7 +28,7 @@
 {% if info['components'] > 1 %}
 <h2> {{ KNOWL('st_group.component_group', 'Component group') }} </h2>
 <table>
-    <tr><td>{{ KNOWL('st_group.name', 'Name') }}:</td><td>${{info['component_group']}}$</td></tr>
+    <tr><td>{{ KNOWL('st_group.name', 'Name') }}:</td><td>{{info['component_group_knowl']|safe}}</td></tr>
     <tr><td>{{ KNOWL('group.order', 'Order') }}:</td><td>${{info['components']}}$</td></tr>
     <tr><td>{{ KNOWL('group.abelian', 'Abelian') }}:</td><td>{{info['abelian']}}</td></tr>
     {% if info['numgens'] > 0 %}


### PR DESCRIPTION
Make the Sato-Tate component group a group-knowl.  This only applies to cases where the group id is in the Sato-Tate group database (so not for live groups, which are all cyclic, and they are just displayed as before).