### PR TITLE
datetime.utcnow is deprecated

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -7,7 +7,7 @@ from psycopg2.extensions import QueryCanceledError
 from lmfdb import db
 from psycodict.encoding import Json
 from lmfdb.utils import flash_error
-from datetime import datetime
+from datetime import datetime, UTC
 from flask import (render_template, request, url_for, current_app,
                    abort, redirect, Response)
 from lmfdb.api import api_page, api_logger
@@ -323,7 +323,7 @@ def api_query(table, id=None):
     # the collected result
     data = {
         "table": table,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "data": data,
         "start": start,
         "offset": offset,
@@ -426,7 +426,7 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
         "labels": labels,
         "tables": tables,
         "label_cols": label_cols,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "data": data,
     }
     if format.lower() == "json":

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -18,7 +18,7 @@ import time
 from xml.etree import ElementTree
 from collections import Counter, defaultdict
 from lmfdb.app import app, is_beta
-from datetime import datetime
+from datetime import datetime, UTC
 from flask import (abort, flash, jsonify, make_response,
                    redirect, render_template, render_template_string,
                    request, url_for)
@@ -628,7 +628,7 @@ def columns():
 
 @knowledge_page.route("/new_comment/<ID>")
 def new_comment(ID):
-    time = datetime_to_timestamp_in_ms(datetime.utcnow())
+    time = datetime_to_timestamp_in_ms(datetime.now(UTC))
     cid = '%s.%s.comment' % (ID, time)
     return edit(ID=cid)
 
@@ -692,7 +692,7 @@ def save_form():
             flash(Markup("Knowl successfully created.  Note that a knowl with this id existed previously but was deleted; its history has been restored."))
         k.title = new_title
         k.content = new_content
-        k.timestamp = datetime.utcnow()
+        k.timestamp = datetime.now(UTC)
         k.status = 0
         k.save(who=who)
     if NEWID:

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -96,7 +96,7 @@ class LMFDBSearchTable(PostgresSearchTable):
             for col, knowl in knowls.items():
                 if col in self.col_type:
                     if keep_old:
-                        new_knowl = knowl.copy(ID=f'columns.{self.search_table}.{col}', timestamp=datetime.datetime.utcnow())
+                        new_knowl = knowl.copy(ID=f'columns.{self.search_table}.{col}', timestamp=datetime.datetime.now(datetime.UTC))
                         who = self._db.login()
                         new_knowl.save(who, most_recent=knowl, minor=True)
                     else:
@@ -362,7 +362,7 @@ class LMFDBDatabase(PostgresDatabase):
             "INSERT INTO userdb.dbrecord (username, time, tablename, operation, data) "
             "VALUES (%s, %s, %s, %s, %s)"
         )
-        self._execute(inserter, [uid, datetime.datetime.utcnow(), tablename, operation, data])
+        self._execute(inserter, [uid, datetime.datetime.now(datetime.UTC), tablename, operation, data])
 
     def verify(
         self,

--- a/lmfdb/modular_curves/upload.py
+++ b/lmfdb/modular_curves/upload.py
@@ -1,6 +1,6 @@
 
 import re
-from datetime import datetime
+from datetime import datetime, UTC
 from flask import url_for
 from sage.all import ZZ, QQ, lazy_attribute, NumberField
 from lmfdb import db
@@ -232,7 +232,7 @@ class GonalityBounds(UploadSection):
         else:
             status = 3
             comment = ""
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(UTC).isoformat()
         ids = {upid: (status, timestamp, comment) for upid, data in self.delayed}
 
         # If other columns are added later, it's important that these be sorted (see lmfdb/uploads/process.py)

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -49,7 +49,7 @@ class DynamicKnowlTest(LmfdbTest):
             # Create a different connection to devmirror to compare timestamps
             from lmfdb.utils.config import Configuration
             from psycopg2.sql import SQL
-            from datetime import timedelta, datetime
+            from datetime import timedelta, datetime, UTC
             dev_config = Configuration()
             # Modify configuration to connect to devmirror
             for D in [dev_config.default_args["postgresql"], dev_config.postgresql_options, dev_config.options["postgresql"]]:
@@ -62,7 +62,7 @@ class DynamicKnowlTest(LmfdbTest):
             dev_db = PostgresDatabase(dev_config)
 
             # Updates happen every 20 minutes, so we only compare knowls older than that (plus a buffer).
-            cutoff = datetime.utcnow() - timedelta(minutes=30)
+            cutoff = datetime.now(UTC) - timedelta(minutes=30)
 
             t_query = SQL("SELECT timestamp FROM kwl_knowls WHERE timestamp < %s LIMIT 1")
             dev_t = dev_db._execute(t_query, [cutoff]).fetchone()[0]

--- a/lmfdb/uploads/process.py
+++ b/lmfdb/uploads/process.py
@@ -8,7 +8,7 @@ import os
 import sys
 import tempfile
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, UTC
 here = os.path.dirname(os.path.abspath(__file__))
 data_folder = os.path.join(here, "data")
 upone, _ = os.path.split(here)
@@ -51,7 +51,7 @@ def process_all():
             else:
                 status = 3
                 comment = ""
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(UTC).isoformat()
             status_update[rec["section"]][rec["id"]] = (status, timestamp, comment)
 
         # There are some sections (like gonality propagation) that want to do more
@@ -65,7 +65,7 @@ def process_all():
         db.data_uploads.update_from_file(F.name, "id")
         db.data_uploads.cleanup_from_reload()
         os.unlink(F.name)
-    timestamp = datetime.utcnow().isoformat().replace(":", "-").replace("T", "-").replace(".", "-")
+    timestamp = datetime.now(UTC).isoformat().replace(":", "-").replace("T", "-").replace(".", "-")
     uploads = []
     for (table, newrows), lines in by_table.items():
         nr = "t" if newrows else "f"

--- a/lmfdb/uploads/verify.py
+++ b/lmfdb/uploads/verify.py
@@ -7,7 +7,7 @@ This script is used to perform additional verification on uploads before review 
 import os
 import sys
 import tempfile
-from datetime import datetime
+from datetime import datetime, UTC
 here = os.path.dirname(os.path.abspath(__file__))
 upone, _ = os.path.split(here)
 uptwo, _ = os.path.split(upone)
@@ -34,7 +34,7 @@ def verify_all():
             else:
                 status = 1
                 comment = ""
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(UTC).isoformat()
             _ = F.write(f"{rec['id']}|{status}|{timestamp}|{timestamp}|{comment}\n")
         F.close()
         db.data_uploads.update_from_file(F.name, "id")

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -11,7 +11,7 @@ from lmfdb import db
 from psycodict.base import PostgresBase
 from psycodict.encoding import Array
 from psycopg2.sql import SQL, Identifier, Placeholder
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from .main import logger
 
@@ -96,7 +96,7 @@ class PostgresUserTable(PostgresBase):
         password = self.bchash(pwd)
         #TODO: use identifiers
         insertor = SQL("INSERT INTO userdb.users (username, bcpassword, created, full_name, about, url) VALUES (%s, %s, %s, %s, %s, %s)")
-        self._execute(insertor, [uid, password, datetime.utcnow(), full_name, about, url])
+        self._execute(insertor, [uid, password, datetime.now(UTC), full_name, about, url])
         new_user = LmfdbUser(uid)
         return new_user
 
@@ -197,7 +197,7 @@ class PostgresUserTable(PostgresBase):
             return
 
         insertor = SQL("INSERT INTO userdb.tokens (id, expire) VALUES %s")
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         tdelta = timedelta(days=1)
         exp = now + tdelta
         self._execute(insertor, [(t, exp) for t in tokens], values_list=True)
@@ -215,7 +215,7 @@ class PostgresUserTable(PostgresBase):
             logger.info("no attempt to delete old tokens, not enough privileges")
             return
         deletor = SQL("DELETE FROM userdb.tokens WHERE expire < %s")
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         tdelta = timedelta(days=8)
         cutoff = now - tdelta
         self._execute(deletor, [cutoff])

--- a/lmfdb/utils/uploader.py
+++ b/lmfdb/utils/uploader.py
@@ -16,7 +16,7 @@ import csv
 import io
 import codecs
 import tempfile
-from datetime import datetime
+from datetime import datetime, UTC
 from flask import request, flash, send_file, render_template
 from flask_login import current_user
 from sage.misc.lazy_attribute import lazy_attribute
@@ -323,7 +323,7 @@ class UploadSection():
             columns = ["section", "status", "submitter", "data", "submitted", "verified", "reviewed", "processed", "updated", "version", "comment"]
             types = ["text", "smallint", "text", "jsonb", "timestamp without time zone", "timestamp without time zone", "timestamp without time zone", "timestamp without time zone", "timestamp without time zone", "smallint", "text"]
             _ = F.write("|".join(columns) + "\n" + "|".join(types) + "\n\n")
-            timestamp = datetime.utcnow().isoformat()
+            timestamp = datetime.now(UTC).isoformat()
             for rec in data:
                 _ = F.write(f"{self.name}|0|{current_user.id}|{copy_dumps(rec, 'jsonb')}|{timestamp}|\\N|\\N|\\N|{timestamp}|{self.version}|\n")
             F.close()
@@ -424,7 +424,7 @@ class Uploader():
                 elif new_status in [2, -2] and not all(status == 1 for status in db.data_uploads.search({"id":{"$in":ids}}, "status")):
                     flash_error("You must select only rows that need review")
                 else:
-                    t0 = datetime.utcnow()
+                    t0 = datetime.now(UTC)
                     payload = {"status": new_status, "reviewed": t0, "updated": t0}
                     if comment:
                         payload["comment"] = comment


### PR DESCRIPTION
This also might related to the knowl bugs

> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  self.timestamp = data.get('timestamp', datetime.utcnow())
