### PR TITLE
Family pages code refactored 

### DIFF
--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -48,18 +48,6 @@ class ModCurveFamily_base:
     def title(self):
         return f"Modular curve family ${self.name}$"
 
-    @lazy_attribute
-    def hypell_description(self):
-        if self.hypell_description_text:
-            return self.hypell_description_text.replace("NAME", self.name)
-        return None
-
-    @lazy_attribute
-    def biell_description(self):
-        if self.biell_description_text:
-            return self.biell_description_text.replace("NAME", self.name)
-        return None
-
 
 X0 = ModCurveFamily_base(
     famname="X0",

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -57,8 +57,6 @@ class X0N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
 
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -85,8 +83,6 @@ class X1N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
 
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -109,8 +105,6 @@ class XN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     hypell_description = "None."
     biell_description = "None."
-
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
     def properties(self):
@@ -136,8 +130,6 @@ class Xpm1N(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -160,8 +152,6 @@ class Xarith1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
     def properties(self):
@@ -186,8 +176,6 @@ class Xarithpm1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
     def properties(self):
@@ -214,8 +202,6 @@ class XspN(ModCurveFamily_base):
     biell_description = "Unknown."
     #notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -240,8 +226,6 @@ class XspplusN(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
     #notation = r"<ul> <li>$\delta = \begin{cases}1& \text{if } 2\mid N, \\ 0& \text{otherwise.}\end{cases}$ </li> </ul>"
-
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
     def properties(self):
@@ -268,8 +252,6 @@ class XnsN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -295,8 +277,6 @@ class XnsplusN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
@@ -320,8 +300,6 @@ class XS4p(ModCurveFamily_base):
     genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
     def properties(self):
@@ -349,7 +327,6 @@ class XarithN(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
 
 
-    elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -1,19 +1,34 @@
-
 from sage.misc.lazy_attribute import lazy_attribute
 from lmfdb.modular_curves.web_curve import get_bread
 
+
 def ModCurveFamily(name):
     return get_family(name)
+
 
 def get_family(name):
     try:
         return ALL_FAMILIES[name]
     except KeyError:
-        raise ValueError(f"Invalid name '{name}'. Valid names: {list(ALL_FAMILIES.keys())}")
+        raise ValueError(
+            f"Invalid name '{name}'. Valid names: {list(ALL_FAMILIES.keys())}"
+        )
 
-class ModCurveFamily_base():
 
-    def __init__(self, famname=None, name=None, psl2index=None, nu2=None, nu3=None, cusps=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description_text=None, biell_description_text=None, knowl_ID=None, notation=None):
+class ModCurveFamily_base:
+
+    def __init__(
+        self,
+        famname=None,
+        name=None,
+        psl2index=None,
+        nu2=None,
+        nu3=None,
+        cusps=None,
+        genus_formula=None,
+        knowl_ID=None,
+        notation=None,
+    ):
         self.famname = famname
         self.name = name
         self.psl2index = psl2index
@@ -21,14 +36,9 @@ class ModCurveFamily_base():
         self.nu3 = nu3
         self.cusps = cusps
         self.genus_formula = genus_formula
-        self.hypell_level = hypell_level
-        self.biell_level = biell_level
-        self.biell_nonhypell_level = biell_nonhypell_level
-        self.hypell_description_text = hypell_description_text
-        self.biell_description_text = biell_description_text
         self.notation = notation
         self.knowl_ID = knowl_ID
-        self.knowl_ID_remarks = knowl_ID + ".remarks"
+        self.knowl_ID_remarks = self.knowl_ID + ".remarks"
 
     @lazy_attribute
     def bread(self):
@@ -41,14 +51,15 @@ class ModCurveFamily_base():
     @lazy_attribute
     def hypell_description(self):
         if self.hypell_description_text:
-            return self.hypell_description_text.replace('NAME', self.name)
+            return self.hypell_description_text.replace("NAME", self.name)
         return None
 
     @lazy_attribute
     def biell_description(self):
         if self.biell_description_text:
-            return self.biell_description_text.replace('NAME', self.name)
+            return self.biell_description_text.replace("NAME", self.name)
         return None
+
 
 X0 = ModCurveFamily_base(
     famname="X0",
@@ -57,19 +68,11 @@ X0 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{4}, \\ \prod\limits_{p|N, \text{prime}} \big( 1 + \big( \frac{-1}{p} \big) \big), & \text{otherwise.} \end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{9}, \\ \prod\limits_{p|N, \text{ prime}} \big( 1 + \big( \frac{-3}{p} \big) \big), & \text{otherwise.} \end{cases}$",
     cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
-    knowl_ID = "modcurve.x0",
+    knowl_ID="modcurve.x0",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
-    biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
-    biell_nonhypell_level="?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0",
-    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves
-                         in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves.
-                         See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.""",
-    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves
-                       in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves.
-                       Among them, there are 30 values for which they are non-hyperelliptic. See the
-                       [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>]
-                       for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list."""
+    #hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
+    #biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
+    #biell_nonhypell_level="?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0",
 )
 
 X1 = ModCurveFamily_base(
@@ -79,14 +82,10 @@ X1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
-    knowl_ID = "modcurve.x1",
+    knowl_ID="modcurve.x1",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
-    hypell_level="?level=13%2C16%2C18&family=X1",
-    biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
-    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic
-                        curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.""",
-    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic
-                       curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list."""
+    #hypell_level="?level=13%2C16%2C18&family=X1",
+    #biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
 )
 
 X = ModCurveFamily_base(
@@ -96,10 +95,8 @@ X = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/N, & \text{ if } N > 1. \end{cases}$",
-    knowl_ID = "modcurve.xfull",
+    knowl_ID="modcurve.xfull",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
-    hypell_description_text="None.",
-    biell_description_text="None."
 )
 
 Xpm1 = ModCurveFamily_base(
@@ -109,8 +106,8 @@ Xpm1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
-    knowl_ID = "modcurve.xpm1",
-    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+    knowl_ID="modcurve.xpm1",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
 )
 
 Xarith1 = ModCurveFamily_base(
@@ -120,8 +117,8 @@ Xarith1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    knowl_ID = "modcurve.x1mn",
-    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+    knowl_ID="modcurve.x1mn",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
 )
 
 Xarithpm1 = ModCurveFamily_base(
@@ -131,8 +128,8 @@ Xarithpm1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    knowl_ID = "modcurve.xpm1mn",
-    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+    knowl_ID="modcurve.xpm1mn",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
 )
 
 Xsp = ModCurveFamily_base(
@@ -142,8 +139,8 @@ Xsp = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}0 & \text{if $2\mid N$,} \\ \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
-    knowl_ID = "modcurve.xsp",
-    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
+    knowl_ID="modcurve.xsp",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
 )
 
 Xspplus = ModCurveFamily_base(
@@ -153,8 +150,8 @@ Xspplus = ModCurveFamily_base(
     nu2=r"$\nu_2 =  \left( \frac{N}{2}\cdot \prod\limits_{p\mid N, p \equiv 1 \bmod 4}\left( 1 - \frac{1}{p}\right) \cdot \prod\limits_{p\mid N, p \equiv 3 \bmod 4}\left(1 + \frac{1}{p}\right)\right) + \begin{cases}0 & \text{if $2\mid N$, } \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases} $",
     cusps=r"$\nu_\infty = \frac{N}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
-    knowl_ID = "modcurve.xsp_plus",
-    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
+    knowl_ID="modcurve.xsp_plus",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
 )
 
 Xns = ModCurveFamily_base(
@@ -164,9 +161,9 @@ Xns = ModCurveFamily_base(
     nu2=r"$\nu_2 = \prod\limits_{p\mid N, p \text{ prime}} \left( 1 - \left(\frac{-1}{p}\right)\right)$",
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \varphi(N)$",
-    knowl_ID = "modcurve.xns",
+    knowl_ID="modcurve.xns",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
+    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>",
 )
 
 Xnsplus = ModCurveFamily_base(
@@ -176,9 +173,9 @@ Xnsplus = ModCurveFamily_base(
     nu2=r"$\nu_2 = \sum\limits_{p\mid N} \frac{1- \left( \frac{-1}{p} \right)}{2} \ + \ \left(\frac{1}{2}N \cdot \prod\limits_{p|N}\left(1 + \frac{1}{p}\right) -\#S\right)$",
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)-1} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$",
-    knowl_ID = "modcurve.xns_plus",
+    knowl_ID="modcurve.xns_plus",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
+    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>",
 )
 
 XS4 = ModCurveFamily_base(
@@ -188,8 +185,8 @@ XS4 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \frac{1}{4}\cdot \left(\ell - \left(\frac{-1}{\ell}\right)\right)$",
     nu3=r"$\nu_3 = \frac{1}{3}\cdot \left(\ell - \left(\frac{-3}{\ell}\right)\right)$",
     cusps=r"$\nu_\infty = \frac{1}{24}\cdot (\ell^2 - 1)$",
-    knowl_ID = "modcurve.xs4",
-    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
+    knowl_ID="modcurve.xs4",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
 )
 
 Xarith = ModCurveFamily_base(
@@ -199,14 +196,9 @@ Xarith = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$",
-    knowl_ID = "modcurvexarith",
+    knowl_ID="modcurve.xarith",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    biell_level="?level=7%2C8&family=Xarith",
-    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that
-                        there are no hyperelliptic curves in this family.""",
-    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic
-                       curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$
-                       is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list."""
+    #biell_level="?level=7%2C8&family=Xarith",
 )
 
 ALL_FAMILIES = {
@@ -223,4 +215,3 @@ ALL_FAMILIES = {
     "XS4": XS4,
     "Xarith": Xarith,
 }
-

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -53,6 +53,7 @@ X0 = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
     knowl_ID="modcurve.x0",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    notation=r'''<ul> <li>$\varphi(d)$ is the Euler totient function </li></ul>''',
 )
 
 X1 = ModCurveFamily_base(
@@ -86,6 +87,7 @@ Xpm1 = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
     knowl_ID="modcurve.xpm1",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
+    notation=r'''<ul> <li>$\varphi(d)$ is the Euler totient function </li>  </ul>''',
 )
 
 Xarith1 = ModCurveFamily_base(
@@ -108,6 +110,7 @@ Xarithpm1 = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
     knowl_ID="modcurve.xpm1mn",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
+    notation=r'''<ul>    <li>$\varphi(d)$ is the Euler totient function </li>    </ul>''',
 )
 
 Xsp = ModCurveFamily_base(
@@ -141,7 +144,9 @@ Xns = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \varphi(N)$",
     knowl_ID="modcurve.xns",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>",
+    notation=r'''<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> 
+    <li>$\varphi(N)$ is the Euler totient function </li>
+    </ul>''',
 )
 
 Xnsplus = ModCurveFamily_base(
@@ -153,7 +158,10 @@ Xnsplus = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$",
     knowl_ID="modcurve.xns_plus",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>",
+    notation=r'''<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> 
+    <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li>
+    <li>$\varphi(N)$ is the Euler totient function </li>
+    </ul>''',
 )
 
 XS4 = ModCurveFamily_base(

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -57,10 +57,6 @@ class X0N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
 
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -89,10 +85,6 @@ class X1N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
 
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -117,10 +109,6 @@ class XN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     hypell_description = "None."
     biell_description = "None."
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
@@ -148,10 +136,6 @@ class Xpm1N(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -176,10 +160,6 @@ class Xarith1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
@@ -206,10 +186,6 @@ class Xarithpm1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
@@ -238,10 +214,6 @@ class XspN(ModCurveFamily_base):
     biell_description = "Unknown."
     #notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -268,10 +240,6 @@ class XspplusN(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
     #notation = r"<ul> <li>$\delta = \begin{cases}1& \text{if } 2\mid N, \\ 0& \text{otherwise.}\end{cases}$ </li> </ul>"
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
@@ -300,10 +268,6 @@ class XnsN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -331,10 +295,6 @@ class XnsplusN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
 
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
-
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
     @lazy_attribute
@@ -360,10 +320,6 @@ class XS4p(ModCurveFamily_base):
     genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
 
@@ -392,10 +348,6 @@ class XarithN(ModCurveFamily_base):
     hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.'
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
 
-
-    @lazy_attribute
-    def cusps_orbits_display(self):
-        return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
     @lazy_attribute

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -24,6 +24,10 @@ def ModCurveFamily(name):
         raise ValueError(f"Invalid name '{name}'. Valid names: {list(FAMILY_CLASSES.keys())}")
 
 class ModCurveFamily_base():
+    sl2level = None
+    index = None
+    genus = None
+
     @lazy_attribute
     def bread(self):
         return get_bread([(f"${self.name}$", " ")])
@@ -35,6 +39,13 @@ class ModCurveFamily_base():
     @lazy_attribute
     def cusps_display(self):
         return self.cusps
+
+    @lazy_attribute
+    def properties(self):
+        return [("Level", "$N$"),
+                (r"$SL_2$-level", str(self.sl2level)),
+                ("Index", str(self.index)),
+                ("Genus", str(self.genus))]
 
 
 class X0N(ModCurveFamily_base):
@@ -57,13 +68,6 @@ class X0N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
 
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 class X1N(ModCurveFamily_base):
     famname = "X1"
     name = "X_1(N)"
@@ -83,13 +87,6 @@ class X1N(ModCurveFamily_base):
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
 
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 class XN(ModCurveFamily_base):
     famname = "X"
     name = "X(N)"
@@ -105,13 +102,6 @@ class XN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     hypell_description = "None."
     biell_description = "None."
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 
 
 class Xpm1N(ModCurveFamily_base):
@@ -130,13 +120,6 @@ class Xpm1N(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 
 class Xarith1MMN(ModCurveFamily_base):
     famname = "Xarith1"
@@ -152,13 +135,6 @@ class Xarith1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 
 
 class Xarithpm1MMN(ModCurveFamily_base):
@@ -176,13 +152,6 @@ class Xarithpm1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 
 
 class XspN(ModCurveFamily_base):
@@ -202,13 +171,6 @@ class XspN(ModCurveFamily_base):
     biell_description = "Unknown."
     #notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 
 class XspplusN(ModCurveFamily_base):
     famname = "Xspplus"
@@ -226,13 +188,6 @@ class XspplusN(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
     #notation = r"<ul> <li>$\delta = \begin{cases}1& \text{if } 2\mid N, \\ 0& \text{otherwise.}\end{cases}$ </li> </ul>"
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 
 
 class XnsN(ModCurveFamily_base):
@@ -252,13 +207,6 @@ class XnsN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 
 class XnsplusN(ModCurveFamily_base):
     famname = "Xnsplus"
@@ -277,13 +225,6 @@ class XnsplusN(ModCurveFamily_base):
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
 
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
 
 class XS4p(ModCurveFamily_base):
     famname = "XS4"
@@ -300,13 +241,6 @@ class XS4p(ModCurveFamily_base):
     genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 
 
 class XarithN(ModCurveFamily_base):
@@ -325,12 +259,4 @@ class XarithN(ModCurveFamily_base):
     biell_level = "?level=7%2C8&family=Xarith"
     hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.'
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
-
-
-    @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
 

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -53,9 +53,6 @@ X0 = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
     knowl_ID="modcurve.x0",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    #hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
-    #biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
-    #biell_nonhypell_level="?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0",
 )
 
 X1 = ModCurveFamily_base(
@@ -67,8 +64,6 @@ X1 = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
     knowl_ID="modcurve.x1",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
-    #hypell_level="?level=13%2C16%2C18&family=X1",
-    #biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
 )
 
 X = ModCurveFamily_base(
@@ -181,7 +176,6 @@ Xarith = ModCurveFamily_base(
     cusps=r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$",
     knowl_ID="modcurve.xarith",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    #biell_level="?level=7%2C8&family=Xarith",
 )
 
 ALL_FAMILIES = {

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -36,10 +36,6 @@ class ModCurveFamily_base():
     @lazy_attribute
     def title(self):
         return f"Modular curve family ${self.name}$"
-    
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
 
     @lazy_attribute
     def hypell_description(self):

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -5,28 +5,46 @@ from lmfdb.utils import display_knowl
 
 def ModCurveFamily(name):
     FAMILY_CLASSES = {
-        "X0": X0N,
-        "X1": X1N,
-        "X": XN,
-        "Xpm1": Xpm1N,
-        "Xarith1": Xarith1MMN,
-        "Xarithpm1": Xarithpm1MMN,
-        "Xsp": XspN,
-        "Xspplus": XspplusN,
-        "Xns": XnsN,
-        "Xnsplus": XnsplusN,
-        "XS4": XS4p,
-        "Xarith": XarithN,
+        "X0": X0,
+        "X1": X1,
+        "X": X,
+        "Xpm1": Xpm1,
+        "Xarith1": Xarith1,
+        "Xarithpm1": Xarithpm1,
+        "Xsp": Xsp,
+        "Xspplus": Xspplus,
+        "Xns": Xns,
+        "Xnsplus": Xnsplus,
+        "XS4": XS4,
+        "Xarith": Xarith,
     }
     try:
-        return FAMILY_CLASSES[name]()
+        return FAMILY_CLASSES[name]
     except KeyError:
         raise ValueError(f"Invalid name '{name}'. Valid names: {list(FAMILY_CLASSES.keys())}")
 
 class ModCurveFamily_base():
-    sl2level = None
-    index = None
-    genus = None
+
+    def __init__(self, famname=None, name=None, sl2level=None, index=None, psl2index=None, genus=None, nu2=None, nu3=None, cusps=None, rational_cusps=None, moduli_description=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description=None, biell_description=None, temp_name=None, notation=None):
+        self.famname = famname
+        self.name = name
+        self.sl2level = sl2level
+        self.index = index
+        self.psl2index = psl2index
+        self.genus = genus
+        self.nu2 = nu2
+        self.nu3 = nu3
+        self.cusps = cusps
+        self.rational_cusps = rational_cusps
+        self.moduli_description = moduli_description
+        self.genus_formula = genus_formula
+        self.hypell_level = hypell_level
+        self.biell_level = biell_level
+        self.biell_nonhypell_level = biell_nonhypell_level
+        self.hypell_description = hypell_description
+        self.biell_description = biell_description
+        self.temp_name = temp_name
+        self.notation = notation
 
     @lazy_attribute
     def bread(self):
@@ -47,216 +65,200 @@ class ModCurveFamily_base():
                 ("Index", str(self.index)),
                 ("Genus", str(self.genus))]
 
+X0 = ModCurveFamily_base(
+    famname="X0",
+    name="X_0(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{4}, \\ \prod\limits_{p|N, \text{prime}} \big( 1 + \big( \frac{-1}{p} \big) \big), & \text{otherwise.} \end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{9}, \\ \prod\limits_{p|N, \text{ prime}} \big( 1 + \big( \frac{-3}{p} \big) \big), & \text{otherwise.} \end{cases}$",
+    cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
+    rational_cusps="1",
+    moduli_description=fr"$X_0(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \ast & \ast \\ 0 & \ast \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,C)$, where $E$ is an elliptic curve over $k$, and $C$ is a $\Gal_k$-stable cyclic subgroup of $E[N](\overline{{k}})$ of order $N$ that is the kernel of a rational isogeny $E\to E'$ of degree $N$.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
+    biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
+    biell_nonhypell_level="?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0",
+    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.',
+    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
+)
 
-class X0N(ModCurveFamily_base):
-    famname = "X0"
-    name = "X_0(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{4}, \\ \prod\limits_{p|N, \text{prime}} \big( 1 + \big( \frac{-1}{p} \big) \big), & \text{otherwise.} \end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{9}, \\ \prod\limits_{p|N, \text{ prime}} \big( 1 + \big( \frac{-3}{p} \big) \big), & \text{otherwise.} \end{cases}$"
-    cusps = r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_0(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \ast & \ast \\ 0 & \ast \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,C)$, where $E$ is an elliptic curve over $k$, and $C$ is a $\Gal_k$-stable cyclic subgroup of $E[N](\overline{{k}})$ of order $N$ that is the kernel of a rational isogeny $E\to E'$ of degree $N$."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    hypell_level = "?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0"
-    biell_level = "?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0"
-    biell_nonhypell_level = "?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0"
-    hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.'
-    biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
+X1 = ModCurveFamily_base(
+    famname="X1",
+    name="X_1(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
+    rational_cusps="1",
+    moduli_description=fr"$X_1(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & * \\ 0 & * \end{{pmatrix}} < \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N](\overline{{k}})$ is a point of exact order $N$.",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
+    hypell_level="?level=13%2C16%2C18&family=X1",
+    biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
+    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.',
+    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
+)
 
+X = ModCurveFamily_base(
+    famname="X",
+    name="X(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \begin{cases} 6, & \text{ if } N = 2, \\ \frac{N^3}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ if } N >2. \end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/N, & \text{ if } N > 1. \end{cases}$",
+    rational_cusps=r"\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/2, & \text{ if } N > 1. \end{cases}",
+    moduli_description=fr"$X(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the trivial subgroup of $\GL_2(\Z/N\Z)$. As a moduli space it parameterizes triples $(E,P,Q)$, where $E$ is an elliptic curve over $k$, and $P,Q \in E(k)$ form a basis for $E[N](\overline{{k}})$. There are other {display_knowl('modcurve.xn','variants')}. The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X(N)$ is $\Q(\zeta_N)$, which means that the database of modular curves $X_H/\Q$ only includes $X(N)$ for $N\le 2$.",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
+    hypell_description="None.",
+    biell_description="None."
+)
 
-class X1N(ModCurveFamily_base):
-    famname = "X1"
-    name = "X_1(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_1(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & * \\ 0 & * \end{{pmatrix}} < \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N](\overline{{k}})$ is a point of exact order $N$."
-    genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
-    hypell_level = "?level=13%2C16%2C18&family=X1"
-    biell_level = "?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1"
-    hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.'
-    biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
+Xpm1 = ModCurveFamily_base(
+    famname="Xpm1",
+    name=r"X_{\pm 1}(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
+    rational_cusps="1",
+    moduli_description=fr"$X_{{\pm 1}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm 1 & * \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,\pm P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N]$ is a point of order $N$ with $\pm P$ defined over $k$ (this condition translates to the $x$-coordinate lying in $k$ when $E$ is in short Weierstrass form). <p> The modular curve {display_knowl('modcurve.x1','$X_1(N)$')} is a {display_knowl('modcurve.quadratic_refinements', 'quadratic refinement')} of $X_{{\pm1}}(N)$. </p>",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+)
 
+Xarith1 = ModCurveFamily_base(
+    famname="Xarith1",
+    name=r"X_{\mathrm{arith},1}(M,MN)",
+    sl2level="N",
+    index="N",
+    psl2index=r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
+    moduli_description=fr"$X_{{\mathrm{{arith}},1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. As a moduli space it parameterizes triples $(E,P,C)$, where $E$ is an elliptic curve over $k$, $P \in E[MN](k)$ is a point of order $MN$, and $C\leq E[M](\overline{{k}})$ is a $\Gal_k$-stable cyclic subgroup of order $M$ such that $E[M]=\langle NP\rangle \oplus C$. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},1}}(M,MN)$ is $\Q$.</p>",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+)
 
-class XN(ModCurveFamily_base):
-    famname = "X"
-    name = "X(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \begin{cases} 6, & \text{ if } N = 2, \\ \frac{N^3}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ if } N >2. \end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/N, & \text{ if } N > 1. \end{cases}$"
-    rational_cusps = r"\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/2, & \text{ if } N > 1. \end{cases}"
-    moduli_description = fr"$X(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the trivial subgroup of $\GL_2(\Z/N\Z)$. As a moduli space it parameterizes triples $(E,P,Q)$, where $E$ is an elliptic curve over $k$, and $P,Q \in E(k)$ form a basis for $E[N](\overline{{k}})$. There are other {display_knowl('modcurve.xn','variants')}. The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X(N)$ is $\Q(\zeta_N)$, which means that the database of modular curves $X_H/\Q$ only includes $X(N)$ for $N\le 2$."
-    genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
-    hypell_description = "None."
-    biell_description = "None."
+Xarithpm1 = ModCurveFamily_base(
+    famname="Xarithpm1",
+    name=r"X_{\mathrm{arith},\pm 1}(M,MN)",
+    temp_name=r'$X_{{\mathrm{{arith}},1}}(M,MN)$',
+    sl2level="N",
+    index="N",
+    psl2index=r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
+    moduli_description=fr"$X_{{\mathrm{{arith}},\pm1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve {display_knowl('modcurve.x1mn', '$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},\pm 1}}(M,MN)$ is $\Q$. </p>",
+    genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
+)
 
+Xsp = ModCurveFamily_base(
+    famname="Xsp",
+    name=r"X_{\mathrm{sp}}(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = N^2\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases}0 & \text{if $2\mid N$,} \\ \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
+    rational_cusps="1",
+    moduli_description=fr"$X_{{\text{{sp}}}}(N)$ is the {display_knowl('modcurve','modular curve')} for the subgroup $H\le \GL_2(\widehat\Z)$ given by the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} $\begin{{pmatrix}} * & 0\\ 0& * \end{{pmatrix}}$ that is split at every prime dividing $N$. As a moduli space it parameterizes triples $(E,C,D)$ where $E$ is an elliptic curve over $k$, and $C$ and $D$ are $\Gal_k$-stable cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3532138">MR:3532138</a>] showed that there is only 1 hyperelliptic curve in this family, namely $X_{\mathrm{sp}}(11)$. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=11&family=Xsp">following table</a>] for the full list.',
+    biell_description="Unknown."
+)
 
-class Xpm1N(ModCurveFamily_base):
-    famname = "Xpm1"
-    name = r"X_{\pm 1}(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_{{\pm 1}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm 1 & * \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,\pm P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N]$ is a point of order $N$ with $\pm P$ defined over $k$ (this condition translates to the $x$-coordinate lying in $k$ when $E$ is in short Weierstrass form). <p> The modular curve {display_knowl('modcurve.x1','$X_1(N)$')} is a {display_knowl('modcurve.quadratic_refinements', 'quadratic refinement')} of $X_{{\pm1}}(N)$. </p>"
-    genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
+Xspplus = ModCurveFamily_base(
+    famname="Xspplus",
+    name=r"X_{\mathrm{sp}}^+(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
+    genus="g",
+    nu2=r"$\nu_2 =  \left( \frac{N}{2}\cdot \prod\limits_{p\mid N, p \equiv 1 \bmod 4}\left( 1 - \frac{1}{p}\right) \cdot \prod\limits_{p\mid N, p \equiv 3 \bmod 4}\left(1 + \frac{1}{p}\right)\right) + \begin{cases}0 & \text{if $2\mid N$, } \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases} $",
+    cusps=r"$\nu_\infty = \frac{N}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
+    rational_cusps="1",
+    moduli_description=fr"$X_{{\text{{sp}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} $\begin{{pmatrix}} * & 0 \\ 0 & * \end{{pmatrix}} \cup \begin{{pmatrix}} 0 & * \\ * & 0 \end{{pmatrix}}\subseteq \GL_2(\Z/N\Z)$ that is split at every prime dividing $N$. As a moduli space it parameterizes pairs $(E,\{{C,D\}})$ where $E$ is an elliptic curve over $k$, and $\{{C,D\}}$ is a $\Gal_k$-stable pair of cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$. (Neither $C$ nor $D$ need be $\Gal_k$-stable.)",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
+)
 
+Xns = ModCurveFamily_base(
+    famname="Xns",
+    name=r"X_{\mathrm{ns}}(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = N \cdot \varphi(N)",
+    genus="g",
+    nu2=r"$\nu_2 = \prod\limits_{p\mid N, p \text{ prime}} \left( 1 - \left(\frac{-1}{p}\right)\right)$",
+    nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \varphi(N)$",
+    rational_cusps="1",
+    moduli_description=fr"$X_{{\text{{ns}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
+)
 
-class Xarith1MMN(ModCurveFamily_base):
-    famname = "Xarith1"
-    name = r"X_{\mathrm{arith},1}(M,MN)"
-    sl2level = "N"
-    index = "N"
-    psl2index = r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$"
-    moduli_description = fr"$X_{{\mathrm{{arith}},1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. As a moduli space it parameterizes triples $(E,P,C)$, where $E$ is an elliptic curve over $k$, $P \in E[MN](k)$ is a point of order $MN$, and $C\leq E[M](\overline{{k}})$ is a $\Gal_k$-stable cyclic subgroup of order $M$ such that $E[M]=\langle NP\rangle \oplus C$. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},1}}(M,MN)$ is $\Q$.</p>"
-    genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
+Xnsplus = ModCurveFamily_base(
+    famname="Xnsplus",
+    name=r"X_{\mathrm{ns}}^+(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \frac{N}{2} \cdot \varphi(N)",
+    genus="g",
+    nu2=r"$\nu_2 = \sum\limits_{p\mid N} \frac{1- \left( \frac{-1}{p} \right)}{2} \ + \ \left(\frac{1}{2}N \cdot \prod\limits_{p|N}\left(1 + \frac{1}{p}\right) -\#S\right)$",
+    nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)-1} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$",
+    rational_cusps=r"$\nu_\infty = 0$",
+    moduli_description=fr"$X_{{\text{{ns}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
+)
 
+XS4 = ModCurveFamily_base(
+    famname="XS4",
+    name="X_{S_4}(p)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \frac{1}{24}\cdot p\cdot (p^2 - 1)",
+    genus="g",
+    nu2=r"$\nu_2 = \frac{1}{4}\cdot \left(p - \left(\frac{-1}{p}\right)\right)$",
+    nu3=r"$\nu_3 = \frac{1}{3}\cdot \left(p - \left(\frac{-3}{p}\right)\right)$",
+    cusps=r"$\nu_\infty = \frac{1}{24}\cdot (p^2 - 1)$",
+    rational_cusps="1",
+    moduli_description=fr"For $p$ an odd prime, $X_{{S_4}}(p)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the subgroup of $\PGL_2(\Z/p\Z)$ isomorphic to $S_4$ (which is unique up to conjugacy). It parameterizes elliptic curves whose {display_knowl('ec.galois_rep_modell_image','mod-$p$ Galois representation')} has projective image $S_4$, one of the three exceptional groups $A_4$, $A_5$, $S_4$ of $\PGL_2(p)$ that can arise as projective mod-$p$ images, and the only one that can arise for elliptic curves over $\Q$. The subgroup $H$ contains $-I$ and has surjective determinant when $p \equiv \pm 3\bmod 8$, but not otherwise.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
+)
 
-class Xarithpm1MMN(ModCurveFamily_base):
-    famname = "Xarithpm1"
-    name = r"X_{\mathrm{arith},\pm 1}(M,MN)"
-    temp_name = r'$X_{{\mathrm{{arith}},1}}(M,MN)$'
-    sl2level = "N"
-    index = "N"
-    psl2index = r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$"
-    moduli_description = fr"$X_{{\mathrm{{arith}},\pm1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve {display_knowl('modcurve.x1mn',temp_name)} is one of its {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},\pm 1}}(M,MN)$ is $\Q$. </p>"
-    genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
-
-
-class XspN(ModCurveFamily_base):
-    famname = "Xsp"
-    name = r"X_{\mathrm{sp}}(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = N^2\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases}0 & \text{if $2\mid N$,} \\ \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_{{\text{{sp}}}}(N)$ is the {display_knowl('modcurve','modular curve')} for the subgroup $H\le \GL_2(\widehat\Z)$ given by the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} $\begin{{pmatrix}} * & 0\\ 0& * \end{{pmatrix}}$ that is split at every prime dividing $N$. As a moduli space it parameterizes triples $(E,C,D)$ where $E$ is an elliptic curve over $k$, and $C$ and $D$ are $\Gal_k$-stable cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3532138">MR:3532138</a>] showed that there is only 1 hyperelliptic curve in this family, namely $X_{\mathrm{sp}}(11)$. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=11&family=Xsp">following table</a>] for the full list.'
-    biell_description = "Unknown."
-    #notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
-
-
-class XspplusN(ModCurveFamily_base):
-    famname = "Xspplus"
-    name = r"X_{\mathrm{sp}}^+(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)"
-    genus = "g"
-    nu2 = r"$\nu_2 =  \left( \frac{N}{2}\cdot \prod\limits_{p\mid N, p \equiv 1 \bmod 4}\left( 1 - \frac{1}{p}\right) \cdot \prod\limits_{p\mid N, p \equiv 3 \bmod 4}\left(1 + \frac{1}{p}\right)\right) + \begin{cases}0 & \text{if $2\mid N$, } \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases} $"
-    cusps = r"$\nu_\infty = \frac{N}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_{{\text{{sp}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} $\begin{{pmatrix}} * & 0 \\ 0 & * \end{{pmatrix}} \cup \begin{{pmatrix}} 0 & * \\ * & 0 \end{{pmatrix}}\subseteq \GL_2(\Z/N\Z)$ that is split at every prime dividing $N$. As a moduli space it parameterizes pairs $(E,\{{C,D\}})$ where $E$ is an elliptic curve over $k$, and $\{{C,D\}}$ is a $\Gal_k$-stable pair of cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$. (Neither $C$ nor $D$ need be $\Gal_k$-stable.)"
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
-    #notation = r"<ul> <li>$\delta = \begin{cases}1& \text{if } 2\mid N, \\ 0& \text{otherwise.}\end{cases}$ </li> </ul>"
-
-
-class XnsN(ModCurveFamily_base):
-    famname = "Xns"
-    name = r"X_{\mathrm{ns}}(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = N \cdot \varphi(N)"
-    genus = "g"
-    nu2 = r"$\nu_2 = \prod\limits_{p\mid N, p \text{ prime}} \left( 1 - \left(\frac{-1}{p}\right)\right)$"
-    nu3 = r"$\nu_3 = \begin{cases}2^{\omega(N)} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \varphi(N)$"
-    rational_cusps = "1"
-    moduli_description = fr"$X_{{\text{{ns}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
-    notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
-
-
-class XnsplusN(ModCurveFamily_base):
-    famname = "Xnsplus"
-    name = r"X_{\mathrm{ns}}^+(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \frac{N}{2} \cdot \varphi(N)"
-    genus = "g"
-    nu2 = r"$\nu_2 = \sum\limits_{p\mid N} \frac{1- \left( \frac{-1}{p} \right)}{2} \ + \ \left(\frac{1}{2}N \cdot \prod\limits_{p|N}\left(1 + \frac{1}{p}\right) -\#S\right)$"
-    nu3 = r"$\nu_3 = \begin{cases}2^{\omega(N)-1} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$"
-    rational_cusps = r"$\nu_\infty = 0$"
-    moduli_description = fr"$X_{{\text{{ns}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
-    notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
-
-
-class XS4p(ModCurveFamily_base):
-    famname = "XS4"
-    name = "X_{S_4}(p)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \frac{1}{24}\cdot p\cdot (p^2 - 1)"
-    genus = "g"
-    nu2 = r"$\nu_2 = \frac{1}{4}\cdot \left(p - \left(\frac{-1}{p}\right)\right)$"
-    nu3 = r"$\nu_3 = \frac{1}{3}\cdot \left(p - \left(\frac{-3}{p}\right)\right)$"
-    cusps = r"$\nu_\infty = \frac{1}{24}\cdot (p^2 - 1)$"
-    rational_cusps = "1"
-    moduli_description = fr"For $p$ an odd prime, $X_{{S_4}}(p)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the subgroup of $\PGL_2(\Z/p\Z)$ isomorphic to $S_4$ (which is unique up to conjugacy). It parameterizes elliptic curves whose {display_knowl('ec.galois_rep_modell_image','mod-$p$ Galois representation')} has projective image $S_4$, one of the three exceptional groups $A_4$, $A_5$, $S_4$ of $\PGL_2(p)$ that can arise as projective mod-$p$ images, and the only one that can arise for elliptic curves over $\Q$. The subgroup $H$ contains $-I$ and has surjective determinant when $p \equiv \pm 3\bmod 8$, but not otherwise."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    #hypell_description = "Unknown."
-    #biell_description = "Unknown."
-
-
-class XarithN(ModCurveFamily_base):
-    famname = "Xarith"
-    name = r"X_{\mathrm{arith}}(N)"
-    sl2level = "N"
-    index = "N+1"
-    psl2index = r"i = \begin{cases}6, & \text{if } N=1, \\ \frac{N^3}{2}\cdot \prod\limits_{p\mid N, \text{prime}}\left(1-\frac{1}{p^2}\right), & \text{if } N>2. \end{cases}"
-    genus = "g"
-    nu2 = r"$\nu_2 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$"
-    nu3 = r"$\nu_3 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$"
-    cusps = r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$"
-    rational_cusps = ""
-    moduli_description = fr"$X_{{\mathrm{{arith}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\leq \GL_2(\widehat{{\Z}})$ the inverse image of $\begin{{pmatrix}}1&0\\0&*\end{{pmatrix}}\leq \GL_2(\Z/N\Z)$. As a moduli space, $X_{{\mathrm{{arith}}}}$ parametrizes isomorphism classes of triples $(E,\phi,P)$, where $E$ is a generalized elliptic curve, $P$ is a point of exact order $N$, and $\phi \colon E \to E'$ is a cyclic $N$-isogeny such that $E[N]$ is generated by $P$ and $\ker\phi$. Alternatively, it parametrizes isomorphism classes of pairs $(E,\psi)$ where $E$ is a generalized elliptic curve and $\psi \colon \mu_N\times \Z/N\Z\xrightarrow{{\sim}} E[N]$ is a symplectic isomorphism."
-    genus_formula = r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
-    biell_level = "?level=7%2C8&family=Xarith"
-    hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.'
-    biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
+Xarith = ModCurveFamily_base(
+    famname="Xarith",
+    name=r"X_{\mathrm{arith}}(N)",
+    sl2level="N",
+    index="N+1",
+    psl2index=r"i = \begin{cases}6, & \text{if } N=1, \\ \frac{N^3}{2}\cdot \prod\limits_{p\mid N, \text{prime}}\left(1-\frac{1}{p^2}\right), & \text{if } N>2. \end{cases}",
+    genus="g",
+    nu2=r"$\nu_2 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
+    nu3=r"$\nu_3 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
+    cusps=r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$",
+    rational_cusps="",
+    moduli_description=fr"$X_{{\mathrm{{arith}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\leq \GL_2(\widehat{{\Z}})$ the inverse image of $\begin{{pmatrix}}1&0\\0&*\end{{pmatrix}}\leq \GL_2(\Z/N\Z)$. As a moduli space, $X_{{\mathrm{{arith}}}}$ parametrizes isomorphism classes of triples $(E,\phi,P)$, where $E$ is a generalized elliptic curve, $P$ is a point of exact order $N$, and $\phi \colon E \to E'$ is a cyclic $N$-isogeny such that $E[N]$ is generated by $P$ and $\ker\phi$. Alternatively, it parametrizes isomorphism classes of pairs $(E,\psi)$ where $E$ is a generalized elliptic curve and $\psi \colon \mu_N\times \Z/N\Z\xrightarrow{{\sim}} E[N]$ is a symplectic isomorphism.",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
+    biell_level="?level=7%2C8&family=Xarith",
+    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.',
+    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
+)
 

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -4,31 +4,24 @@ from lmfdb.modular_curves.web_curve import get_bread
 from lmfdb.utils import display_knowl
 
 def ModCurveFamily(name):
-    if name == "X0":
-        return X0N()
-    elif name == "X1":
-        return X1N()
-    elif name == "X":
-        return XN()
-    elif name == "Xpm1":
-        return Xpm1N()
-    elif name == "Xarith1":
-        return Xarith1MMN()
-    elif name == "Xarithpm1":
-        return Xarithpm1MMN()
-    elif name == "Xsp":
-        return XspN()
-    elif name == "Xspplus":
-        return XspplusN()
-    elif name == "Xns":
-        return XnsN()
-    elif name == "Xnsplus":
-        return XnsplusN()
-    elif name == "XS4":
-        return XS4p()
-    elif name == "Xarith":
-        return XarithN()
-    raise ValueError("Invalid name")
+    FAMILY_CLASSES = {
+        "X0": X0N,
+        "X1": X1N,
+        "X": XN,
+        "Xpm1": Xpm1N,
+        "Xarith1": Xarith1MMN,
+        "Xarithpm1": Xarithpm1MMN,
+        "Xsp": XspN,
+        "Xspplus": XspplusN,
+        "Xns": XnsN,
+        "Xnsplus": XnsplusN,
+        "XS4": XS4p,
+        "Xarith": XarithN,
+    }
+    try:
+        return FAMILY_CLASSES[name]()
+    except KeyError:
+        raise ValueError(f"Invalid name '{name}'. Valid names: {list(FAMILY_CLASSES.keys())}")
 
 class ModCurveFamily_base():
     @lazy_attribute
@@ -38,6 +31,10 @@ class ModCurveFamily_base():
     @lazy_attribute
     def title(self):
         return f"Modular curve family ${self.name}$"
+    
+    @lazy_attribute
+    def cusps_display(self):
+        return self.cusps
 
 
 class X0N(ModCurveFamily_base):
@@ -59,13 +56,6 @@ class X0N(ModCurveFamily_base):
     hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.'
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
 
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -98,13 +88,6 @@ class X1N(ModCurveFamily_base):
     hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.'
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
 
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -134,14 +117,6 @@ class XN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     hypell_description = "None."
     biell_description = "None."
-
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -174,14 +149,6 @@ class Xpm1N(ModCurveFamily_base):
     #biell_description = "Unknown."
 
     @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
-
-    @lazy_attribute
     def cusps_orbits_display(self):
         return "one is rational"
 
@@ -209,14 +176,6 @@ class Xarith1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -247,14 +206,6 @@ class Xarithpm1MMN(ModCurveFamily_base):
     genus_formula = r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
-
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -288,14 +239,6 @@ class XspN(ModCurveFamily_base):
     #notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
     @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
-
-    @lazy_attribute
     def cusps_orbits_display(self):
         return "one is rational"
 
@@ -325,14 +268,6 @@ class XspplusN(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
     #notation = r"<ul> <li>$\delta = \begin{cases}1& \text{if } 2\mid N, \\ 0& \text{otherwise.}\end{cases}$ </li> </ul>"
-
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -366,14 +301,6 @@ class XnsN(ModCurveFamily_base):
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 
     @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
-
-    @lazy_attribute
     def cusps_orbits_display(self):
         return "one is rational"
 
@@ -403,14 +330,6 @@ class XnsplusN(ModCurveFamily_base):
     #hypell_description = "Unknown."
     #biell_description = "Unknown."
     notation = r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
-
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
@@ -443,14 +362,6 @@ class XS4p(ModCurveFamily_base):
     #biell_description = "Unknown."
 
     @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
-
-    @lazy_attribute
     def cusps_orbits_display(self):
         return "one is rational"
 
@@ -481,23 +392,16 @@ class XarithN(ModCurveFamily_base):
     hypell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.'
     biell_description = r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
 
-    @lazy_attribute
-    def cusps_display(self):
-        return self.cusps
-
-    @lazy_attribute
-    def cusps_width_display(self):
-        return "unknown"
 
     @lazy_attribute
     def cusps_orbits_display(self):
         return "one is rational"
 
     elliptic_points = "There are no elliptic points, unless N=1, in which case there are 2"
-
     @lazy_attribute
     def properties(self):
         return [("Level", "$N$"),
                 (r"$SL_2$-level", str(self.sl2level)),
                 ("Index", str(self.index)),
                 ("Genus", str(self.genus))]
+

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -14,18 +14,13 @@ def get_family(name):
 
 class ModCurveFamily_base():
 
-    def __init__(self, famname=None, name=None, sl2level=None, index=None, psl2index=None, genus=None, nu2=None, nu3=None, cusps=None, rational_cusps=None, moduli_description_text=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description_text=None, biell_description_text=None, temp_name=None, notation=None):
+    def __init__(self, famname=None, name=None, psl2index=None, nu2=None, nu3=None, cusps=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description_text=None, biell_description_text=None, knowl_ID=None, notation=None):
         self.famname = famname
         self.name = name
-        self.sl2level = sl2level
-        self.index = index
         self.psl2index = psl2index
-        self.genus = genus
         self.nu2 = nu2
         self.nu3 = nu3
         self.cusps = cusps
-        self.rational_cusps = rational_cusps
-        self.moduli_description_text = moduli_description_text
         self.genus_formula = genus_formula
         self.hypell_level = hypell_level
         self.biell_level = biell_level
@@ -33,6 +28,7 @@ class ModCurveFamily_base():
         self.hypell_description_text = hypell_description_text
         self.biell_description_text = biell_description_text
         self.notation = notation
+        self.knowl_ID = knowl_ID
 
     @lazy_attribute
     def bread(self):
@@ -47,19 +43,6 @@ class ModCurveFamily_base():
         return self.cusps
 
     @lazy_attribute
-    def properties(self):
-        return [("Level", "$N$"),
-                (r"$SL_2$-level", str(self.sl2level)),
-                ("Index", str(self.index)),
-                ("Genus", str(self.genus))]
-
-    @lazy_attribute
-    def moduli_description(self):
-        if self.moduli_description_text:
-            return self.moduli_description_text.replace('NAME', self.name)
-        return None
-
-    @lazy_attribute
     def hypell_description(self):
         if self.hypell_description_text:
             return self.hypell_description_text.replace('NAME', self.name)
@@ -70,22 +53,15 @@ class ModCurveFamily_base():
         if self.biell_description_text:
             return self.biell_description_text.replace('NAME', self.name)
         return None
-    
+
 X0 = ModCurveFamily_base(
     famname="X0",
     name="X_0(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{4}, \\ \prod\limits_{p|N, \text{prime}} \big( 1 + \big( \frac{-1}{p} \big) \big), & \text{otherwise.} \end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{9}, \\ \prod\limits_{p|N, \text{ prime}} \big( 1 + \big( \frac{-3}{p} \big) \big), & \text{otherwise.} \end{cases}$",
     cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of
-                         $\begin{{pmatrix}} \ast & \ast \\ 0 & \ast \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it
-                         parameterizes pairs $(E,C)$, where $E$ is an elliptic curve over $k$, and $C$ is a $\Gal_k$-stable cyclic
-                         subgroup of $E[N](\overline{{k}})$ of order $N$ that is the kernel of a rational isogeny $E\to E'$ of degree $N$.""",
+    knowl_ID = "modcurve.x0",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
     biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
@@ -103,17 +79,11 @@ X0 = ModCurveFamily_base(
 X1 = ModCurveFamily_base(
     famname="X1",
     name="X_1(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
-                        image of $\begin{{pmatrix}} 1 & * \\ 0 & * \end{{pmatrix}} < \GL_2(\Z/N\Z)$. As a moduli space it
-                        parameterizes pairs $(E,P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N](\overline{{k}})$ is a point of exact order $N$.""",
+    knowl_ID = "modcurve.x1",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
     hypell_level="?level=13%2C16%2C18&family=X1",
     biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
@@ -126,19 +96,11 @@ X1 = ModCurveFamily_base(
 X = ModCurveFamily_base(
     famname="X",
     name="X(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \begin{cases} 6, & \text{ if } N = 2, \\ \frac{N^3}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ if } N >2. \end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/N, & \text{ if } N > 1. \end{cases}$",
-    rational_cusps=r"\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/2, & \text{ if } N > 1. \end{cases}",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image
-                        of the trivial subgroup of $\GL_2(\Z/N\Z)$. As a moduli space it parameterizes triples $(E,P,Q)$, where
-                        $E$ is an elliptic curve over $k$, and $P,Q \in E(k)$ form a basis for $E[N](\overline{{k}})$. There are
-                        other {display_knowl('modcurve.xn','variants')}. The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
-                        of $NAME$ is $\Q(\zeta_N)$, which means that the database of modular curves $X_H/\Q$ only includes $NAME$ for $N\le 2$.""",
+    knowl_ID = "modcurve.xfull",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
     hypell_description_text="None.",
     biell_description_text="None."
@@ -147,112 +109,66 @@ X = ModCurveFamily_base(
 Xpm1 = ModCurveFamily_base(
     famname="Xpm1",
     name=r"X_{\pm 1}(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \begin{cases} 1, & \text{ if } N = 1, \\ 3, & \text{ if } N = 2, \\ \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left( 1 - \frac{1}{p^2} \right), & \text{ otherwise.}\end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases} 1, & \text{ if } N =1,2, \\ 0, & \text{ otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le GL_2(\widehat\Z)$
-                        the inverse image of $\begin{{pmatrix}} \pm 1 & * \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$.
-                        As a moduli space it parameterizes pairs $(E,\pm P)$, where $E$ is an elliptic curve over $k$, and
-                        $P \in E[N]$ is a point of order $N$ with $\pm P$ defined over $k$ (this condition translates to the
-                        $x$-coordinate lying in $k$ when $E$ is in short Weierstrass form). <p> The modular curve
-                        {display_knowl('modcurve.x1','$X_1(N)$')} is a {display_knowl('modcurve.quadratic_refinements', 'quadratic refinement')} of $NAME$. </p>""",
+    knowl_ID = "modcurve.xpm1",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
 Xarith1 = ModCurveFamily_base(
     famname="Xarith1",
     name=r"X_{\mathrm{arith},1}(M,MN)",
-    sl2level="N",
-    index="N",
     psl2index=r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$
-                        the inverse image of $\begin{{pmatrix}} 1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$.
-                        As a moduli space it parameterizes triples $(E,P,C)$, where $E$ is an elliptic curve over $k$, $P \in E[MN](k)$
-                        is a point of order $MN$, and $C\leq E[M](\overline{{k}})$ is a $\Gal_k$-stable cyclic subgroup of order $M$
-                        such that $E[M]=\langle NP\rangle \oplus C$. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
-                        of $NAME$ is $\Q$.</p>""",
+    knowl_ID = "modcurve.x1mn",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
 Xarithpm1 = ModCurveFamily_base(
     famname="Xarithpm1",
     name=r"X_{\mathrm{arith},\pm 1}(M,MN)",
-    sl2level="N",
-    index="N",
     psl2index=r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    moduli_description_text=fr"""
-    $NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image
-    of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve
-    {display_knowl('modcurve.x1mn', r'$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its
-    {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
-    of $NAME$ is $\Q$. </p>
-    """,
+    knowl_ID = "modcurve.xpm1mn",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
 Xsp = ModCurveFamily_base(
     famname="Xsp",
     name=r"X_{\mathrm{sp}}(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = N^2\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases}0 & \text{if $2\mid N$,} \\ \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} for the subgroup $H\le \GL_2(\widehat\Z)$ given by
-                        the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} $\begin{{pmatrix}} * & 0\\ 0& * \end{{pmatrix}}$
-                        that is split at every prime dividing $N$. As a moduli space it parameterizes triples $(E,C,D)$ where $E$ is an
-                        elliptic curve over $k$, and $C$ and $D$ are $\Gal_k$-stable cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.""",
+    knowl_ID = "modcurve.xsp",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
 Xspplus = ModCurveFamily_base(
     famname="Xspplus",
     name=r"X_{\mathrm{sp}}^+(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \frac{N^2}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)",
-    genus="g",
     nu2=r"$\nu_2 =  \left( \frac{N}{2}\cdot \prod\limits_{p\mid N, p \equiv 1 \bmod 4}\left( 1 - \frac{1}{p}\right) \cdot \prod\limits_{p\mid N, p \equiv 3 \bmod 4}\left(1 + \frac{1}{p}\right)\right) + \begin{cases}0 & \text{if $2\mid N$, } \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left( 1 + \left(\frac{-1}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases} $",
     cusps=r"$\nu_\infty = \frac{N}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
-                        image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} $\begin{{pmatrix}} * & 0 \\ 0 & * \end{{pmatrix}} \cup \begin{{pmatrix}} 0 & * \\ * & 0 \end{{pmatrix}}\subseteq \GL_2(\Z/N\Z)$
-                        that is split at every prime dividing $N$. As a moduli space it parameterizes pairs $(E,\{{C,D\}})$ where $E$ is an elliptic
-                        curve over $k$, and $\{{C,D\}}$ is a $\Gal_k$-stable pair of cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.
-                        (Neither $C$ nor $D$ need be $\Gal_k$-stable.)""",
+    knowl_ID = "modcurve.xsp_plus",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
 Xns = ModCurveFamily_base(
     famname="Xns",
     name=r"X_{\mathrm{ns}}(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = N \cdot \varphi(N)",
-    genus="g",
     nu2=r"$\nu_2 = \prod\limits_{p\mid N, p \text{ prime}} \left( 1 - \left(\frac{-1}{p}\right)\right)$",
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \varphi(N)$",
-    rational_cusps="1",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
-                        image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.""",
+    knowl_ID = "modcurve.xns",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 )
@@ -260,57 +176,34 @@ Xns = ModCurveFamily_base(
 Xnsplus = ModCurveFamily_base(
     famname="Xnsplus",
     name=r"X_{\mathrm{ns}}^+(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \frac{N}{2} \cdot \varphi(N)",
-    genus="g",
     nu2=r"$\nu_2 = \sum\limits_{p\mid N} \frac{1- \left( \frac{-1}{p} \right)}{2} \ + \ \left(\frac{1}{2}N \cdot \prod\limits_{p|N}\left(1 + \frac{1}{p}\right) -\#S\right)$",
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)-1} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$",
-    rational_cusps=r"$\nu_\infty = 0$",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
-                        image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.""",
+    knowl_ID = "modcurve.xns_plus",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
 )
 
 XS4 = ModCurveFamily_base(
     famname="XS4",
-    name="X_{S_4}(p)",
-    sl2level="N",
-    index="N+1",
-    psl2index=r"i = \frac{1}{24}\cdot p\cdot (p^2 - 1)",
-    genus="g",
-    nu2=r"$\nu_2 = \frac{1}{4}\cdot \left(p - \left(\frac{-1}{p}\right)\right)$",
-    nu3=r"$\nu_3 = \frac{1}{3}\cdot \left(p - \left(\frac{-3}{p}\right)\right)$",
-    cusps=r"$\nu_\infty = \frac{1}{24}\cdot (p^2 - 1)$",
-    rational_cusps="1",
-    moduli_description_text=fr"""For $p$ an odd prime, $NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$
-                        the inverse image of the subgroup of $\PGL_2(\Z/p\Z)$ isomorphic to $S_4$ (which is unique up to conjugacy).
-                        It parameterizes elliptic curves whose {display_knowl('ec.galois_rep_modell_image','mod-$p$ Galois representation')}
-                        has projective image $S_4$, one of the three exceptional groups $A_4$, $A_5$, $S_4$ of $\PGL_2(p)$ that can arise
-                        as projective mod-$p$ images, and the only one that can arise for elliptic curves over $\Q$. The subgroup $H$ contains
-                        $-I$ and has surjective determinant when $p \equiv \pm 3\bmod 8$, but not otherwise.""",
+    name=r"X_{S_4}(\ell)",
+    psl2index=r"i = \frac{1}{24}\cdot \ell\cdot (\ell^2 - 1)",
+    nu2=r"$\nu_2 = \frac{1}{4}\cdot \left(\ell - \left(\frac{-1}{\ell}\right)\right)$",
+    nu3=r"$\nu_3 = \frac{1}{3}\cdot \left(\ell - \left(\frac{-3}{\ell}\right)\right)$",
+    cusps=r"$\nu_\infty = \frac{1}{24}\cdot (\ell^2 - 1)$",
+    knowl_ID = "modcurve.xs4",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
 Xarith = ModCurveFamily_base(
     famname="Xarith",
     name=r"X_{\mathrm{arith}}(N)",
-    sl2level="N",
-    index="N+1",
     psl2index=r"i = \begin{cases}6, & \text{if } N=1, \\ \frac{N^3}{2}\cdot \prod\limits_{p\mid N, \text{prime}}\left(1-\frac{1}{p^2}\right), & \text{if } N>2. \end{cases}",
-    genus="g",
     nu2=r"$\nu_2 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$",
-    rational_cusps="",
-    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\leq \GL_2(\widehat{{\Z}})$
-                        the inverse image of $\begin{{pmatrix}}1&0\\0&*\end{{pmatrix}}\leq \GL_2(\Z/N\Z)$. As a moduli space,
-                        $NAME$ parametrizes isomorphism classes of triples $(E,\phi,P)$, where $E$ is a generalized
-                        elliptic curve, $P$ is a point of exact order $N$, and $\phi \colon E \to E'$ is a cyclic $N$-isogeny such that
-                        $E[N]$ is generated by $P$ and $\ker\phi$. Alternatively, it parametrizes isomorphism classes of pairs $(E,\psi)$
-                        where $E$ is a generalized elliptic curve and $\psi \colon \mu_N\times \Z/N\Z\xrightarrow{{\sim}} E[N]$ is a symplectic isomorphism.""",
+    knowl_ID = "modcurvexarith",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     biell_level="?level=7%2C8&family=Xarith",
     hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -1,7 +1,6 @@
 
 from sage.misc.lazy_attribute import lazy_attribute
 from lmfdb.modular_curves.web_curve import get_bread
-from lmfdb.utils import display_knowl
 
 def ModCurveFamily(name):
     return get_family(name)

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -4,28 +4,17 @@ from lmfdb.modular_curves.web_curve import get_bread
 from lmfdb.utils import display_knowl
 
 def ModCurveFamily(name):
-    FAMILY_CLASSES = {
-        "X0": X0,
-        "X1": X1,
-        "X": X,
-        "Xpm1": Xpm1,
-        "Xarith1": Xarith1,
-        "Xarithpm1": Xarithpm1,
-        "Xsp": Xsp,
-        "Xspplus": Xspplus,
-        "Xns": Xns,
-        "Xnsplus": Xnsplus,
-        "XS4": XS4,
-        "Xarith": Xarith,
-    }
+    return get_family(name)
+
+def get_family(name):
     try:
-        return FAMILY_CLASSES[name]
+        return ALL_FAMILIES[name]
     except KeyError:
-        raise ValueError(f"Invalid name '{name}'. Valid names: {list(FAMILY_CLASSES.keys())}")
+        raise ValueError(f"Invalid name '{name}'. Valid names: {list(ALL_FAMILIES.keys())}")
 
 class ModCurveFamily_base():
 
-    def __init__(self, famname=None, name=None, sl2level=None, index=None, psl2index=None, genus=None, nu2=None, nu3=None, cusps=None, rational_cusps=None, moduli_description=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description=None, biell_description=None, temp_name=None, notation=None):
+    def __init__(self, famname=None, name=None, sl2level=None, index=None, psl2index=None, genus=None, nu2=None, nu3=None, cusps=None, rational_cusps=None, moduli_description_text=None, genus_formula=None, hypell_level=None, biell_level=None, biell_nonhypell_level=None, hypell_description_text=None, biell_description_text=None, temp_name=None, notation=None):
         self.famname = famname
         self.name = name
         self.sl2level = sl2level
@@ -36,14 +25,13 @@ class ModCurveFamily_base():
         self.nu3 = nu3
         self.cusps = cusps
         self.rational_cusps = rational_cusps
-        self.moduli_description = moduli_description
+        self.moduli_description_text = moduli_description_text
         self.genus_formula = genus_formula
         self.hypell_level = hypell_level
         self.biell_level = biell_level
         self.biell_nonhypell_level = biell_nonhypell_level
-        self.hypell_description = hypell_description
-        self.biell_description = biell_description
-        self.temp_name = temp_name
+        self.hypell_description_text = hypell_description_text
+        self.biell_description_text = biell_description_text
         self.notation = notation
 
     @lazy_attribute
@@ -65,6 +53,24 @@ class ModCurveFamily_base():
                 ("Index", str(self.index)),
                 ("Genus", str(self.genus))]
 
+    @lazy_attribute
+    def moduli_description(self):
+        if self.moduli_description_text:
+            return self.moduli_description_text.replace('NAME', self.name)
+        return None
+
+    @lazy_attribute
+    def hypell_description(self):
+        if self.hypell_description_text:
+            return self.hypell_description_text.replace('NAME', self.name)
+        return None
+
+    @lazy_attribute
+    def biell_description(self):
+        if self.biell_description_text:
+            return self.biell_description_text.replace('NAME', self.name)
+        return None
+    
 X0 = ModCurveFamily_base(
     famname="X0",
     name="X_0(N)",
@@ -76,13 +82,22 @@ X0 = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases} 0, & \text{ if } N \equiv 0 \pmod{9}, \\ \prod\limits_{p|N, \text{ prime}} \big( 1 + \big( \frac{-3}{p} \big) \big), & \text{otherwise.} \end{cases}$",
     cusps=r"$\nu_\infty = \sum\limits_{d|N, d>0} \varphi\left(\left(d,\frac{N}{d}\right)\right)$",
     rational_cusps="1",
-    moduli_description=fr"$X_0(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \ast & \ast \\ 0 & \ast \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,C)$, where $E$ is an elliptic curve over $k$, and $C$ is a $\Gal_k$-stable cyclic subgroup of $E[N](\overline{{k}})$ of order $N$ that is the kernel of a rational isogeny $E\to E'$ of degree $N$.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of
+                         $\begin{{pmatrix}} \ast & \ast \\ 0 & \ast \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it
+                         parameterizes pairs $(E,C)$, where $E$ is an elliptic curve over $k$, and $C$ is a $\Gal_k$-stable cyclic
+                         subgroup of $E[N](\overline{{k}})$ of order $N$ that is the kernel of a rational isogeny $E\to E'$ of degree $N$.""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     hypell_level="?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0",
     biell_level="?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0",
     biell_nonhypell_level="?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0",
-    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.',
-    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves. Among them, there are 30 values for which they are non-hyperelliptic. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>] for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list.'
+    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=364259">MR:364259</a>] showed that there are only 19 hyperellipic curves
+                         in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=1150566">MR:1150566</a>] provided equations for these curves.
+                         See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+23%2C+26%2C+28%2C+29%2C+30%2C+31%2C+33%2C+35%2C+37%2C+39%2C+40%2C+41%2C+46%2C+47%2C+48%2C+50%2C+59%2C+71&family=X0">following table</a>] for the full list.""",
+    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1688168">MR:1688168</a>] showed that there are only 41 biellipic curves
+                       in this family and [<a href="https://mathscinet.ams.org/mathscinet/article?mr=3086199">MR:3086199</a>] provided equations for these curves.
+                       Among them, there are 30 values for which they are non-hyperelliptic. See the
+                       [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=22%2C+26%2C+28%2C+30%2C+33%2C+34%2C+35%2C+37%2C+38%2C+39%2C+40%2C+42%2C+43%2C+44%2C+45%2C+48%2C+50%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+101%2C+119%2C+131&family=X0">following table</a>]
+                       for the full list and the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=34%2C+38%2C+42%2C+43%2C+44%2C+45%2C+51%2C+53%2C+54%2C+55%2C+56%2C+60%2C+61%2C+62%2C+63%2C+64%2C+65%2C+69%2C+72%2C+75%2C+79%2C+81%2C+83%2C+89%2C+92%2C+94%2C+95%2C+102%2C+119%2C+131&family=X0">following table</a>] for the non-hyperelliptic list."""
 )
 
 X1 = ModCurveFamily_base(
@@ -96,12 +111,16 @@ X1 = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
     rational_cusps="1",
-    moduli_description=fr"$X_1(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & * \\ 0 & * \end{{pmatrix}} < \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N](\overline{{k}})$ is a point of exact order $N$.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
+                        image of $\begin{{pmatrix}} 1 & * \\ 0 & * \end{{pmatrix}} < \GL_2(\Z/N\Z)$. As a moduli space it
+                        parameterizes pairs $(E,P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N](\overline{{k}})$ is a point of exact order $N$.""",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
     hypell_level="?level=13%2C16%2C18&family=X1",
     biell_level="?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1",
-    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.',
-    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list.'
+    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=1138196">MR:1138196</a>] showed that there are only 3 hyperelliptic
+                        curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C18&family=X1">following table</a>] for the full list.""",
+    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=2040593">MR:2040593</a>] showed that there are only 8 bielliptic
+                       curves in this family. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=13%2C16%2C17%2C18%2C20%2C21%2C22%2C24&family=X1">following table</a>] for the full list."""
 )
 
 X = ModCurveFamily_base(
@@ -115,10 +134,14 @@ X = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N = 1, \\ 0, & \text{ if } N >1.\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/N, & \text{ if } N > 1. \end{cases}$",
     rational_cusps=r"\nu_\infty = \begin{cases} 1, & \text{ if } N = 1, \\ i/2, & \text{ if } N > 1. \end{cases}",
-    moduli_description=fr"$X(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the trivial subgroup of $\GL_2(\Z/N\Z)$. As a moduli space it parameterizes triples $(E,P,Q)$, where $E$ is an elliptic curve over $k$, and $P,Q \in E(k)$ form a basis for $E[N](\overline{{k}})$. There are other {display_knowl('modcurve.xn','variants')}. The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X(N)$ is $\Q(\zeta_N)$, which means that the database of modular curves $X_H/\Q$ only includes $X(N)$ for $N\le 2$.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image
+                        of the trivial subgroup of $\GL_2(\Z/N\Z)$. As a moduli space it parameterizes triples $(E,P,Q)$, where
+                        $E$ is an elliptic curve over $k$, and $P,Q \in E(k)$ form a basis for $E[N](\overline{{k}})$. There are
+                        other {display_knowl('modcurve.xn','variants')}. The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
+                        of $NAME$ is $\Q(\zeta_N)$, which means that the database of modular curves $X_H/\Q$ only includes $NAME$ for $N\le 2$.""",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$",
-    hypell_description="None.",
-    biell_description="None."
+    hypell_description_text="None.",
+    biell_description_text="None."
 )
 
 Xpm1 = ModCurveFamily_base(
@@ -132,7 +155,12 @@ Xpm1 = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases} 1, & \text{ if } N =1,3, \\ 0, & \text{ otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases} 1, & \text{ if } N =1, \\ 2, & \text{ if } N = 2, \\ 3, & \text{ if } N = 4, \\ \frac{1}{2} \cdot \sum\limits_{d|N,d>0} \varphi(d)\varphi\left(\frac{N}{d}\right), & \text{ otherwise.} \end{cases}$",
     rational_cusps="1",
-    moduli_description=fr"$X_{{\pm 1}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm 1 & * \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$. As a moduli space it parameterizes pairs $(E,\pm P)$, where $E$ is an elliptic curve over $k$, and $P \in E[N]$ is a point of order $N$ with $\pm P$ defined over $k$ (this condition translates to the $x$-coordinate lying in $k$ when $E$ is in short Weierstrass form). <p> The modular curve {display_knowl('modcurve.x1','$X_1(N)$')} is a {display_knowl('modcurve.quadratic_refinements', 'quadratic refinement')} of $X_{{\pm1}}(N)$. </p>",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le GL_2(\widehat\Z)$
+                        the inverse image of $\begin{{pmatrix}} \pm 1 & * \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/N\Z)$.
+                        As a moduli space it parameterizes pairs $(E,\pm P)$, where $E$ is an elliptic curve over $k$, and
+                        $P \in E[N]$ is a point of order $N$ with $\pm P$ defined over $k$ (this condition translates to the
+                        $x$-coordinate lying in $k$ when $E$ is in short Weierstrass form). <p> The modular curve
+                        {display_knowl('modcurve.x1','$X_1(N)$')} is a {display_knowl('modcurve.quadratic_refinements', 'quadratic refinement')} of $NAME$. </p>""",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
@@ -146,14 +174,18 @@ Xarith1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    moduli_description=fr"$X_{{\mathrm{{arith}},1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} 1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. As a moduli space it parameterizes triples $(E,P,C)$, where $E$ is an elliptic curve over $k$, $P \in E[MN](k)$ is a point of order $MN$, and $C\leq E[M](\overline{{k}})$ is a $\Gal_k$-stable cyclic subgroup of order $M$ such that $E[M]=\langle NP\rangle \oplus C$. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},1}}(M,MN)$ is $\Q$.</p>",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$
+                        the inverse image of $\begin{{pmatrix}} 1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$.
+                        As a moduli space it parameterizes triples $(E,P,C)$, where $E$ is an elliptic curve over $k$, $P \in E[MN](k)$
+                        is a point of order $MN$, and $C\leq E[M](\overline{{k}})$ is a $\Gal_k$-stable cyclic subgroup of order $M$
+                        such that $E[M]=\langle NP\rangle \oplus C$. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
+                        of $NAME$ is $\Q$.</p>""",
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
 Xarithpm1 = ModCurveFamily_base(
     famname="Xarithpm1",
     name=r"X_{\mathrm{arith},\pm 1}(M,MN)",
-    temp_name=r'$X_{{\mathrm{{arith}},1}}(M,MN)$',
     sl2level="N",
     index="N",
     psl2index=r"i = \begin{cases}1 & \text{if } M,N=1, \\ 3 & \text{if } M=1, \ N=2, \\ 6 & \text{if } M=2, \ N=1, \\ \frac{M^3N^2}{2} \cdot \prod\limits_{p|MN} \left(1 - \frac{1}{p^2}\right) & \text{otherwise.}\end{cases}",
@@ -161,7 +193,13 @@ Xarithpm1 = ModCurveFamily_base(
     nu2=r"$\nu_2 = \begin{cases}1 & \text{if } M,N=1, \\ 1 & \text{if } M=2, \ N=1, \\ 0 & \text{otherwise.}\end{cases}$",
     nu3=r"$\nu_3 = \begin{cases}1 & \text{if } M=1 \text{ and } N=1,3, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } M,N=1, \\ 2 & \text{if } M=1, \ N=2, \\ 3 & \text{if } M=1, \ N=4, \\ \frac{1}{2}\cdot \sum\limits_{d \mid MN } \varphi \left(\frac{MN}{d}\right) \varphi(d) \gcd \left(M,\frac{MN}{d}\right) & \text{otherwise.}\end{cases}$",
-    moduli_description=fr"$X_{{\mathrm{{arith}},\pm1}}(M,MN)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve {display_knowl('modcurve.x1mn', '$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')} of $X_{{\mathrm{{arith}},\pm 1}}(M,MN)$ is $\Q$. </p>",
+    moduli_description_text=fr"""
+    $NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image
+    of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve
+    {display_knowl('modcurve.x1mn', '$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its
+    {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
+    of $NAME$ is $\Q$. </p>
+    """,
     genus_formula=r"$$g = 1 + \frac{i}{12} - \frac{\nu_2}{4} - \frac{\nu_3}{3} - \frac{\nu_\infty}{2}$$"
 )
 
@@ -176,10 +214,11 @@ Xsp = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = N\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
     rational_cusps="1",
-    moduli_description=fr"$X_{{\text{{sp}}}}(N)$ is the {display_knowl('modcurve','modular curve')} for the subgroup $H\le \GL_2(\widehat\Z)$ given by the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} $\begin{{pmatrix}} * & 0\\ 0& * \end{{pmatrix}}$ that is split at every prime dividing $N$. As a moduli space it parameterizes triples $(E,C,D)$ where $E$ is an elliptic curve over $k$, and $C$ and $D$ are $\Gal_k$-stable cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.",
-    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
-    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3532138">MR:3532138</a>] showed that there is only 1 hyperelliptic curve in this family, namely $X_{\mathrm{sp}}(11)$. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=11&family=Xsp">following table</a>] for the full list.',
-    biell_description="Unknown."
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} for the subgroup $H\le \GL_2(\widehat\Z)$ given by
+                        the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} $\begin{{pmatrix}} * & 0\\ 0& * \end{{pmatrix}}$
+                        that is split at every prime dividing $N$. As a moduli space it parameterizes triples $(E,C,D)$ where $E$ is an
+                        elliptic curve over $k$, and $C$ and $D$ are $\Gal_k$-stable cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.""",
+    genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
 Xspplus = ModCurveFamily_base(
@@ -193,7 +232,11 @@ Xspplus = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases}0 & \text{if $2\mid N$ or $3\mid N$,} \\ \frac{1}{2}\cdot \prod\limits_{p|N} \left(1 + \left(\frac{-3}{p}\right) \right) & \text{otherwise.}\end{cases} $",
     cusps=r"$\nu_\infty = \frac{N}{2}\cdot \prod\limits_{p|N, \text{ prime}} \left(1 + \frac{1}{p}\right)$",
     rational_cusps="1",
-    moduli_description=fr"$X_{{\text{{sp}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} $\begin{{pmatrix}} * & 0 \\ 0 & * \end{{pmatrix}} \cup \begin{{pmatrix}} 0 & * \\ * & 0 \end{{pmatrix}}\subseteq \GL_2(\Z/N\Z)$ that is split at every prime dividing $N$. As a moduli space it parameterizes pairs $(E,\{{C,D\}})$ where $E$ is an elliptic curve over $k$, and $\{{C,D\}}$ is a $\Gal_k$-stable pair of cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$. (Neither $C$ nor $D$ need be $\Gal_k$-stable.)",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
+                        image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} $\begin{{pmatrix}} * & 0 \\ 0 & * \end{{pmatrix}} \cup \begin{{pmatrix}} 0 & * \\ * & 0 \end{{pmatrix}}\subseteq \GL_2(\Z/N\Z)$
+                        that is split at every prime dividing $N$. As a moduli space it parameterizes pairs $(E,\{{C,D\}})$ where $E$ is an elliptic
+                        curve over $k$, and $\{{C,D\}}$ is a $\Gal_k$-stable pair of cyclic subgroups such that $E[N](\overline{{k}})\simeq C \oplus D$.
+                        (Neither $C$ nor $D$ need be $\Gal_k$-stable.)""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
@@ -208,7 +251,8 @@ Xns = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \varphi(N)$",
     rational_cusps="1",
-    moduli_description=fr"$X_{{\text{{ns}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
+                        image of a {display_knowl('gl2.cartan', 'Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> </ul>"
 )
@@ -224,7 +268,8 @@ Xnsplus = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases}2^{\omega(N)-1} & \text{if } p \equiv 2 \bmod 3 \text{ for all } p \mid N, \\ 0 & \text{otherwise.}\end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1 & \text{if } N=2, \\ \frac{1}{2}\cdot \varphi(N) & \text{otherwise.}\end{cases}$",
     rational_cusps=r"$\nu_\infty = 0$",
-    moduli_description=fr"$X_{{\text{{ns}}}}^+(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse
+                        image of an {display_knowl('gl2.cartan', 'extended Cartan subgroup')} of $\GL_2(\Z/N\Z)$ that is nonsplit at every prime dividing $N$.""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     notation=r"<ul> <li>$\omega(N)$ is the number of primes dividing $N$.</li> <li>$S = \{a+b\alpha \in (\mathbb{Z}/N\mathbb{Z})[\alpha]^\times/\pm 1 : N(a+b\alpha) = -1, \operatorname{gcd}(b,N) >1\}.$ </li> </ul>"
 )
@@ -240,7 +285,12 @@ XS4 = ModCurveFamily_base(
     nu3=r"$\nu_3 = \frac{1}{3}\cdot \left(p - \left(\frac{-3}{p}\right)\right)$",
     cusps=r"$\nu_\infty = \frac{1}{24}\cdot (p^2 - 1)$",
     rational_cusps="1",
-    moduli_description=fr"For $p$ an odd prime, $X_{{S_4}}(p)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image of the subgroup of $\PGL_2(\Z/p\Z)$ isomorphic to $S_4$ (which is unique up to conjugacy). It parameterizes elliptic curves whose {display_knowl('ec.galois_rep_modell_image','mod-$p$ Galois representation')} has projective image $S_4$, one of the three exceptional groups $A_4$, $A_5$, $S_4$ of $\PGL_2(p)$ that can arise as projective mod-$p$ images, and the only one that can arise for elliptic curves over $\Q$. The subgroup $H$ contains $-I$ and has surjective determinant when $p \equiv \pm 3\bmod 8$, but not otherwise.",
+    moduli_description_text=fr"""For $p$ an odd prime, $NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$
+                        the inverse image of the subgroup of $\PGL_2(\Z/p\Z)$ isomorphic to $S_4$ (which is unique up to conjugacy).
+                        It parameterizes elliptic curves whose {display_knowl('ec.galois_rep_modell_image','mod-$p$ Galois representation')}
+                        has projective image $S_4$, one of the three exceptional groups $A_4$, $A_5$, $S_4$ of $\PGL_2(p)$ that can arise
+                        as projective mod-$p$ images, and the only one that can arise for elliptic curves over $\Q$. The subgroup $H$ contains
+                        $-I$ and has surjective determinant when $p \equiv \pm 3\bmod 8$, but not otherwise.""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$"
 )
 
@@ -255,10 +305,33 @@ Xarith = ModCurveFamily_base(
     nu3=r"$\nu_3 = \begin{cases}1, & \text{if } N=1, \\ 0, & \text{if } N>1. \end{cases}$",
     cusps=r"$\nu_\infty = \begin{cases}1, & \text{if } N=1,\\ i/N, & \text{if } N>1.\end{cases}$",
     rational_cusps="",
-    moduli_description=fr"$X_{{\mathrm{{arith}}}}(N)$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\leq \GL_2(\widehat{{\Z}})$ the inverse image of $\begin{{pmatrix}}1&0\\0&*\end{{pmatrix}}\leq \GL_2(\Z/N\Z)$. As a moduli space, $X_{{\mathrm{{arith}}}}$ parametrizes isomorphism classes of triples $(E,\phi,P)$, where $E$ is a generalized elliptic curve, $P$ is a point of exact order $N$, and $\phi \colon E \to E'$ is a cyclic $N$-isogeny such that $E[N]$ is generated by $P$ and $\ker\phi$. Alternatively, it parametrizes isomorphism classes of pairs $(E,\psi)$ where $E$ is a generalized elliptic curve and $\psi \colon \mu_N\times \Z/N\Z\xrightarrow{{\sim}} E[N]$ is a symplectic isomorphism.",
+    moduli_description_text=fr"""$NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\leq \GL_2(\widehat{{\Z}})$
+                        the inverse image of $\begin{{pmatrix}}1&0\\0&*\end{{pmatrix}}\leq \GL_2(\Z/N\Z)$. As a moduli space,
+                        $NAME$ parametrizes isomorphism classes of triples $(E,\phi,P)$, where $E$ is a generalized
+                        elliptic curve, $P$ is a point of exact order $N$, and $\phi \colon E \to E'$ is a cyclic $N$-isogeny such that
+                        $E[N]$ is generated by $P$ and $\ker\phi$. Alternatively, it parametrizes isomorphism classes of pairs $(E,\psi)$
+                        where $E$ is a generalized elliptic curve and $\psi \colon \mu_N\times \Z/N\Z\xrightarrow{{\sim}} E[N]$ is a symplectic isomorphism.""",
     genus_formula=r"$$ g = 1 + \frac{ i }{12} - \frac{ \nu_2 }{4} - \frac{ \nu_3}{3} - \frac{ \nu_\infty}{2}$$",
     biell_level="?level=7%2C8&family=Xarith",
-    hypell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are no hyperelliptic curves in this family.',
-    biell_description=r'[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$ is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list.'
+    hypell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that
+                        there are no hyperelliptic curves in this family.""",
+    biell_description_text=r"""[<a href="https://mathscinet.ams.org/mathscinet/article?mr=3145452">MR:3145452</a>] showed that there are only 2 bielliptic
+                       curves in this family. $X_{\textup{arith}}(7)$ is isomorphic to the Klein quartic and $X_{\textup{arith}}(8)$
+                       is isomorphic to the Wiman curve. See the [<a href="https://beta.lmfdb.org/ModularCurve/Q/?level=7%2C8&family=Xarith">following table</a>] for the full list."""
 )
+
+ALL_FAMILIES = {
+    "X0": X0,
+    "X1": X1,
+    "X": X,
+    "Xpm1": Xpm1,
+    "Xarith1": Xarith1,
+    "Xarithpm1": Xarithpm1,
+    "Xsp": Xsp,
+    "Xspplus": Xspplus,
+    "Xns": Xns,
+    "Xnsplus": Xnsplus,
+    "XS4": XS4,
+    "Xarith": Xarith,
+}
 

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -28,6 +28,7 @@ class ModCurveFamily_base():
         self.biell_description_text = biell_description_text
         self.notation = notation
         self.knowl_ID = knowl_ID
+        self.knowl_ID_remarks = knowl_ID + ".remarks"
 
     @lazy_attribute
     def bread(self):

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -196,7 +196,7 @@ Xarithpm1 = ModCurveFamily_base(
     moduli_description_text=fr"""
     $NAME$ is the {display_knowl('modcurve','modular curve')} $X_H$ for $H\le \GL_2(\widehat\Z)$ the inverse image
     of $\begin{{pmatrix}} \pm1 & M* \\ 0 & * \end{{pmatrix}} \subset \GL_2(\Z/MN\Z)$. The modular curve
-    {display_knowl('modcurve.x1mn', '$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its
+    {display_knowl('modcurve.x1mn', r'$X_{{\mathrm{{arith}},1}}(M,MN)$')} is one of its
     {display_knowl('modcurve.quadratic_refinements','quadratic refinements')}. <p> The {display_knowl('modcurve.canonical_field', 'canonical field of definition')}
     of $NAME$ is $\Q$. </p>
     """,

--- a/lmfdb/modular_curves/family.py
+++ b/lmfdb/modular_curves/family.py
@@ -3,17 +3,12 @@ from lmfdb.modular_curves.web_curve import get_bread
 
 
 def ModCurveFamily(name):
-    return get_family(name)
-
-
-def get_family(name):
     try:
         return ALL_FAMILIES[name]
     except KeyError:
         raise ValueError(
-            f"Invalid name '{name}'. Valid names: {list(ALL_FAMILIES.keys())}"
+            f"Invalid name '{name}'. Valid names: {list(ALL_FAMILIES)}"
         )
-
 
 class ModCurveFamily_base:
 

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -28,15 +28,17 @@
       <td> {{ family.cusps | safe }}</td><td style="width:20px;"></td>
     </tr>
     <tr>
-      <td>{{ KNOWL("modcurve.genus", "Genus") }}:</td><td>{{ family.genus_formula }}</td>
+      <td>{{ KNOWL("modcurve.genus", "Genus") }}:</td><td>{{ family.genus_formula | safe }}</td>
     </tr>
 </table>
 
 
-{% if family.hypell_description or family.biell_description %}
-<h2> Remarks </h2>
+<!-- {% if family.hypell_description or family.biell_description %} -->
+<!-- <h2> Remarks </h2>
 <p>{{KNOWL('ag.hyperelliptic_curve', 'Hyperelliptic curves')}}: {{ family.hypell_description|safe }}</p>
-<p>{{KNOWL('ag.bielliptic_curve', 'Bielliptic curves')}}: {{ family.biell_description|safe }}</p>
-{% endif %}
+<p>{{KNOWL('ag.bielliptic_curve', 'Bielliptic curves')}}: {{ family.biell_description|safe }}</p> -->
+<!-- {% endif %} -->
+<p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p>
+
 
 {% endblock %}

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -1,4 +1,5 @@
 {% extends 'embedded_results.html' %}
+
 {% block embedding_content %}
 
 <p>{{ KNOWL_INC(family.knowl_ID) }}</p>

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -25,21 +25,11 @@
     </tr>
     <tr>
       <td>{{ KNOWL("modcurve.cusps", "Cusps") }}:</td>
-      <td> {{ family.cusps_display }}</td><td style="width:20px;"></td>
+      <td> {{ family.cusps | safe }}</td><td style="width:20px;"></td>
     </tr>
     <tr>
       <td>{{ KNOWL("modcurve.genus", "Genus") }}:</td><td>{{ family.genus_formula }}</td>
     </tr>
-  {# Need to think about what should go here.  List of references?
-  <tr>
-    <td>{{ KNOWL("modcurve.gonality", "$\Q$-gonality")}}:</td>
-    <td> ${{ family.q_gonality if family.q_gonality else "%s \\le \\gamma \\le %s"%(curve.q_gonality_bounds[0],curve.q_gonality_bounds[1]) }}$ </td>
-  </tr>
-  <tr>
-    <td>{{ KNOWL("modcurve.gonality", "$\overline{\Q}$-gonality")}}:</td>
-    <td> ${{ family.qbar_gonality if family.qbar_gonality else "%s \\le \\gamma \\le %s"%(curve.qbar_gonality_bounds[0],curve.qbar_gonality_bounds[1]) }}$ </td>
-  </tr>
-  #}
 </table>
 
 

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -33,12 +33,12 @@
 </table>
 
 
-<!-- {% if family.hypell_description or family.biell_description %} -->
-<!-- <h2> Remarks </h2>
+{% if family.hypell_description or family.biell_description %} 
+<h2> Remarks </h2>
 <p>{{KNOWL('ag.hyperelliptic_curve', 'Hyperelliptic curves')}}: {{ family.hypell_description|safe }}</p>
-<p>{{KNOWL('ag.bielliptic_curve', 'Bielliptic curves')}}: {{ family.biell_description|safe }}</p> -->
-<!-- {% endif %} -->
-<p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p>
+<p>{{KNOWL('ag.bielliptic_curve', 'Bielliptic curves')}}: {{ family.biell_description|safe }}</p> 
+{% endif %}
+<!-- <p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p> -->
 
 
 {% endblock %}

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -1,7 +1,7 @@
 {% extends 'embedded_results.html' %}
 {% block embedding_content %}
 
-<p>{{ family.moduli_description | safe }}</p>
+<p>{{ KNOWL_INC(family.knowl_ID) }}</p>
 
 <h2> {{ KNOWL('modcurve.invariants', 'Invariants') }} </h2>
 <table>

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -13,7 +13,7 @@
     </tr>
     <tr>
       <td>{{ KNOWL("modcurve.psl2index", "$\PSL_2$-index") }}:</td>
-      <td>${{ family.psl2index }}$</td>
+      <td>${{ family.psl2index | safe }}$</td>
     </tr>
     <tr>
       <td>{{ KNOWL("modcurve.elliptic_points", "Elliptic points") }} of order 2:</td>
@@ -33,12 +33,8 @@
 </table>
 
 
-{% if family.hypell_description or family.biell_description %} 
-<h2> Remarks </h2>
-<p>{{KNOWL('ag.hyperelliptic_curve', 'Hyperelliptic curves')}}: {{ family.hypell_description|safe }}</p>
-<p>{{KNOWL('ag.bielliptic_curve', 'Bielliptic curves')}}: {{ family.biell_description|safe }}</p> 
-{% endif %}
-<!-- <p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p> -->
+
+ <p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p> 
 
 
 {% endblock %}

--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -33,7 +33,7 @@
     </tr>
 </table>
 
-
+<h2> Remarks </h2>
 
  <p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p> 
 

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -296,16 +296,19 @@ class ModCrvTest(LmfdbTest):
             assert url[15:] in L1.get_data(as_text=True)
 
     def test_family_page(self):
-        for family in ALL_FAMILIES.keys():
-            L = self.tc.get(f'/ModularCurve/Q/family/{family}')
-            assert ALL_FAMILIES[family].name in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].genus_formula in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].cusps in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].psl2index in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].nu2 in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].nu3 in L.get_data(as_text=True)
-
-
+           for name, family in ALL_FAMILIES.items():
+            self.check_args(
+                f"/ModularCurve/Q/family/{name}",
+                [
+                    family.name,
+                    family.genus_formula,
+                    family.cusps,
+                    family.psl2index,
+                    family.nu2,
+                    family.nu3,
+                ],
+            )
+            
     def test_family_search(self):
         family_set = [
             ('X0','2.3.0.a.1'),

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -1,5 +1,5 @@
 from lmfdb.tests import LmfdbTest
-from lmfdb.modular_curves.family import FAMILY_DATA
+from lmfdb.modular_curves.family import ALL_FAMILIES
 
 class ModCrvTest(LmfdbTest):
     def test_home(self):
@@ -296,13 +296,12 @@ class ModCrvTest(LmfdbTest):
             assert url[15:] in L1.get_data(as_text=True)
 
     def test_family_page(self):
-        for family in FAMILY_DATA.keys():
-            L = self.tc.get(f"/ModularCurve/Q/family/{family}", follow_redirects=True)
-            assert family in L.get_data(as_text=True)
-            assert FAMILY_DATA[family]['name'] in L.get_data(as_text=True)
-            assert FAMILY_DATA[family]['sl2level'] in L.get_data(as_text=True)
-            assert FAMILY_DATA[family]['index'] in L.get_data(as_text=True)
-            assert FAMILY_DATA[family]['genus'] in L.get_data(as_text=True)
+        for family in ALL_FAMILIES.keys():
+            L = self.tc.get(f'/ModularCurve/Q/family/{family}')
+            assert ALL_FAMILIES[family].name in L.get_data(as_text=True)
+            assert str(ALL_FAMILIES[family].sl2level) in L.get_data(as_text=True)
+            assert str(ALL_FAMILIES[family].index) in L.get_data(as_text=True)
+            assert str(ALL_FAMILIES[family].genus) in L.get_data(as_text=True)
 
     def test_family_search(self):
         family_set = [

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -299,8 +299,8 @@ class ModCrvTest(LmfdbTest):
         for family in ALL_FAMILIES.keys():
             L = self.tc.get(f'/ModularCurve/Q/family/{family}')
             assert ALL_FAMILIES[family].name in L.get_data(as_text=True)
-            assert str(ALL_FAMILIES[family].sl2level) in L.get_data(as_text=True)
-            assert str(ALL_FAMILIES[family].genus) in L.get_data(as_text=True)
+            assert ALL_FAMILIES[family].knowl_ID in L.get_data(as_text=True)
+            
 
     def test_family_search(self):
         family_set = [

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -1,4 +1,5 @@
 from lmfdb.tests import LmfdbTest
+from lmfdb.modular_curves.family import FAMILY_DATA
 
 class ModCrvTest(LmfdbTest):
     def test_home(self):
@@ -293,6 +294,15 @@ class ModCrvTest(LmfdbTest):
             L1 = self.tc.get(url)
             assert url[15:] in L.get_data(as_text=True)
             assert url[15:] in L1.get_data(as_text=True)
+
+    def test_family_page(self):
+        for family in FAMILY_DATA.keys():
+            L = self.tc.get(f"/ModularCurve/Q/family/{family}", follow_redirects=True)
+            assert family in L.get_data(as_text=True)
+            assert FAMILY_DATA[family]['name'] in L.get_data(as_text=True)
+            assert FAMILY_DATA[family]['sl2level'] in L.get_data(as_text=True)
+            assert FAMILY_DATA[family]['index'] in L.get_data(as_text=True)
+            assert FAMILY_DATA[family]['genus'] in L.get_data(as_text=True)
 
     def test_family_search(self):
         family_set = [

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -299,8 +299,12 @@ class ModCrvTest(LmfdbTest):
         for family in ALL_FAMILIES.keys():
             L = self.tc.get(f'/ModularCurve/Q/family/{family}')
             assert ALL_FAMILIES[family].name in L.get_data(as_text=True)
-            assert ALL_FAMILIES[family].knowl_ID in L.get_data(as_text=True)
-            
+            assert ALL_FAMILIES[family].genus_formula in L.get_data(as_text=True)
+            assert ALL_FAMILIES[family].cusps in L.get_data(as_text=True)
+            assert ALL_FAMILIES[family].psl2index in L.get_data(as_text=True)
+            assert ALL_FAMILIES[family].nu2 in L.get_data(as_text=True)
+            assert ALL_FAMILIES[family].nu3 in L.get_data(as_text=True)
+
 
     def test_family_search(self):
         family_set = [

--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -300,7 +300,6 @@ class ModCrvTest(LmfdbTest):
             L = self.tc.get(f'/ModularCurve/Q/family/{family}')
             assert ALL_FAMILIES[family].name in L.get_data(as_text=True)
             assert str(ALL_FAMILIES[family].sl2level) in L.get_data(as_text=True)
-            assert str(ALL_FAMILIES[family].index) in L.get_data(as_text=True)
             assert str(ALL_FAMILIES[family].genus) in L.get_data(as_text=True)
 
     def test_family_search(self):


### PR DESCRIPTION
Updated the modular curve family pages to have knowls for the curve description and remarks on the curve for ease of editing.
The base code has been refactored so that the families are all objects in ModCurveFamily_base.
The attributes have been pared down to the ones displayed on the page currently. 

The previous remarks on hyperelliptic and bielliptic curves have been moved into knowls. 
