### PR TITLE
Only show Remarks section when needed for modular curve families

### DIFF
--- a/lmfdb/modular_curves/templates/modcurve_family.html
+++ b/lmfdb/modular_curves/templates/modcurve_family.html
@@ -33,9 +33,10 @@
     </tr>
 </table>
 
+{% if Knowl(family.knowl_ID_remarks).content  %}
 <h2> Remarks </h2>
 
  <p>{{ KNOWL_INC(family.knowl_ID_remarks) }}</p> 
-
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
On modular curve families page, there is a section for remarks which is sometimes empty.  This does not display the Remarks section when there is no content.

There is no actual remarks:
https://beta.lmfdb.org/ModularCurve/Q/family/Xarithpm1
http://127.0.0.1:37777/ModularCurve/Q/family/Xarithpm1

There are remarks:
https://beta.lmfdb.org/ModularCurve/Q/family/X1
http://127.0.0.1:37777/ModularCurve/Q/family/X1