### PR TITLE
Bsd formula formating

### DIFF
--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -680,6 +680,7 @@ class ECNF():
             eq_query = '\\overset{?}{=}'
             frac = '\\frac'
             Sha = '\\# &#1064;(E/K)'
+            Sha = '\\# Ш(E/K)'
             Om = '\\Omega(E/K)'
             Reg = '\\mathrm{Reg}_{\\mathrm{NT}}(E/K)'
             prodcp = '\\prod_{\\mathfrak{p}} c_{\\mathfrak{p}}'
@@ -695,7 +696,7 @@ class ECNF():
                 rhs_num    = rf'{BSDsha} {dot} {BSDomega:0.6f} {dot} {BSDReg:0.6f} {dot} {BSDprodcp}'
             rhs_den    = rf'{{{BSDntors}^2 {dot} {BSDrootdisc:0.6f}}}'
             rhs        = rf'{frac}{{ {rhs_num} }} {{ {rhs_den} }}'
-            self.bsd_formula = rf'{BSDLvalue:0.9f} {approx} {lder_name} {eq_query} {lhs} {approx} {rhs} {approx} {BSDLvalue_from_formula:0.9f}'
+            self.bsd_formula = rf'\begin{{aligned}}{BSDLvalue:0.9f} {approx} {lder_name} & {eq_query} {lhs} \\ & {approx} {rhs} \\ & {approx} {BSDLvalue_from_formula:0.9f} \end{{aligned}}'
 
         else:
             self.BSDsha = "not available"

--- a/lmfdb/ecnf/templates/ecnf-curve.html
+++ b/lmfdb/ecnf/templates/ecnf-curve.html
@@ -399,8 +399,8 @@ cellpadding="5";
 
 <h2> {{ KNOWL('ec.bsdconjecture', title='BSD formula') }}</h2>
 <div>
-<p style="margin:10px 280px;">
-$\displaystyle {{ ec.bsd_formula|safe }}$
+<p>
+$${{ ec.bsd_formula }}$$
 </p>
 <center>
 {{ place_code('bsd_formula') }}

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -330,8 +330,8 @@ white-space: pre in order to keep line breaks! #}
         </table>
 
 <h2> {{ KNOWL('ec.bsdconjecture', title='BSD formula') }}</h2>
-<p style="margin:10px 280px;">
-$\displaystyle {{ data.mwbsd.formula|safe }}$
+<p>
+$${{ data.mwbsd.formula }}$$
 </p>
 <center>
 {{ place_code('bsd_formula') }}

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -689,7 +689,7 @@ class WebEC():
 
         mwbsd['equal'] = r'=' if mwbsd['analytic_rank'] < 2 else r'\overset{?}{=}'
         mwbsd['rhs'] = '?' if mwbsd['sha'] == '?' else mwbsd['sha'] * mwbsd['real_period'] * mwbsd['reg'] * mwbsd['tamagawa_product'] / mwbsd['torsion']**2
-        mwbsd['formula'] = r'%0.9f \approx %s %s \frac{\# &#1064;(E/\Q)\cdot \Omega_E \cdot \mathrm{Reg}(E/\Q) \cdot \prod_p c_p}{\#E(\Q)_{\rm tor}^2} \approx \frac{%s \cdot %0.6f \cdot %0.6f \cdot %s}{%s^2} \approx %0.9f' % tuple([mwbsd[k] for k in ['special_value', 'lder_name', 'equal','sha', 'real_period', 'reg', 'tamagawa_product', 'torsion', 'rhs']])
+        mwbsd['formula'] = r'\begin{aligned} %0.9f \approx %s & %s \frac{\# Ш(E/\Q)\cdot \Omega_E \cdot \mathrm{Reg}(E/\Q) \cdot \prod_p c_p}{\#E(\Q)_{\rm tor}^2} \\ & \approx \frac{%s \cdot %0.6f \cdot %0.6f \cdot %s}{%s^2} \\ & \approx %0.9f\end{aligned}' % tuple([mwbsd[k] for k in ['special_value', 'lder_name', 'equal','sha', 'real_period', 'reg', 'tamagawa_product', 'torsion', 'rhs']])
 
     def display_modell_image(self,label):
         return display_knowl('gl2.subgroup_data', title=label, kwargs={'label':label})


### PR DESCRIPTION
Fix #5572

For elliptic curves, both over Q and over number fields, the BSD formula is being reformatted using the aligned environment.

Over Q:
http://127.0.0.1:37777/EllipticCurve/Q/20888/a/1
https://beta.lmfdb.org/EllipticCurve/Q/20888/a/1

Over Q(a):
http://127.0.0.1:37777/EllipticCurve/2.0.3.1/73.1/a/4
https://beta.lmfdb.org/EllipticCurve/2.0.3.1/73.1/a/4
