### PR TITLE
Check subgroups for whether they are p-groups

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -3159,6 +3159,17 @@ class WebAbstractSubgroup(WebObj):
         )  # should maybe project and just retrieve needed cols
 
     @lazy_attribute
+    def pgroup(self):
+        if self.subgroup_order is not None:
+            p, k = ZZ(self.subgroup_order).is_prime_power(get_data=True)
+            if p == 1:
+                return p
+            if k == 0:
+                return k
+            return p
+
+
+    @lazy_attribute
     def sub(self):
         S = self._lookup(self.subgroup, self._full, WebAbstractGroup)
         # We set various properties from S for create_boolean_subgroup_string


### PR DESCRIPTION
This PR adds a check to always determine if a subgroup is a p-group.

Compare the beta sites below, where we claim we don't know if it's a p-group, to the local version:

beta.lmfdb.org/Groups/Abstract/sub/49152.wo.24.OD
localhost:37771/Groups/Abstract/sub/49152.wo.24.OD

beta.lmfdb.org/Groups/Abstract/sub/17915904.bd.12.HN
localhost:37771/Groups/Abstract/sub/17915904.bd.12.HN


beta.lmfdb.org/Groups/Abstract/sub/1290482565120000.h.2352._.DB
localhost:37771/Groups/Abstract/sub/1290482565120000.h.2352._.DB