### PR TITLE
Add space between brackets in p-adic field slopes

### DIFF
--- a/lmfdb/local_fields/family.py
+++ b/lmfdb/local_fields/family.py
@@ -15,10 +15,12 @@ def str_to_QQlist(s):
         return []
     return [QQ(x) for x in s[1:-1].split(", ")]
 
-def latex_content(s):
+def latex_content(s, add_space=False):
     # Input should be a content string, [s1, s2, ..., sm]^t_u.  This converts the s_i (which might be rational numbers) to their latex form
     if s is None or s == "":
         return "not computed"
+    elif s==[] and add_space:
+        return r'$[\ ]$'
     elif isinstance(s, list):
         return '$[' + ','.join(latex(x) for x in s) + ']$'
     else:

--- a/lmfdb/local_fields/family.py
+++ b/lmfdb/local_fields/family.py
@@ -15,11 +15,11 @@ def str_to_QQlist(s):
         return []
     return [QQ(x) for x in s[1:-1].split(", ")]
 
-def latex_content(s, add_space=False):
+def latex_content(s):
     # Input should be a content string, [s1, s2, ..., sm]^t_u.  This converts the s_i (which might be rational numbers) to their latex form
     if s is None or s == "":
         return "not computed"
-    elif s==[] and add_space:
+    elif s==[]:
         return r'$[\ ]$'
     elif isinstance(s, list):
         return '$[' + ','.join(latex(x) for x in s) + ']$'

--- a/lmfdb/local_fields/templates/lf-family.html
+++ b/lmfdb/local_fields/templates/lf-family.html
@@ -18,8 +18,8 @@
   <tr><td>{{ KNOWL('lf.ramification_index', 'Ramification index') }} $e$:</td><td> ${{family.e}}$ </td></tr>
   <tr><td>{{ KNOWL('lf.residue_field_degree', 'Residue field degree') }} $f$:</td><td> ${{family.f}}$ </td></tr>
   <tr><td>{{ KNOWL('lf.discriminant_exponent', 'Discriminant exponent') }} $c$:</td><td> ${{family.c}}$ </td></tr>
-  <tr><td>{{ KNOWL('lf.slopes', 'Absolute Artin slopes' if family.n0 > 1 else 'Artin slopes') }}:</td><td> {{info.latex_content(family.artin_slopes)}} </td></tr>
-  <tr><td>{{ KNOWL('lf.slopes', 'Swan slopes') }}:</td><td> {{info.latex_content(family.slopes)}}</td></tr>
+  <tr><td>{{ KNOWL('lf.slopes', 'Absolute Artin slopes' if family.n0 > 1 else 'Artin slopes') }}:</td><td> {{info.latex_content(family.artin_slopes, add_space=True)}} </td></tr>
+  <tr><td>{{ KNOWL('lf.slopes', 'Swan slopes') }}:</td><td> {{info.latex_content(family.slopes, add_space=True)}}</td></tr>
   <tr><td>{{ KNOWL('lf.means', 'Means') }}:</td><td> {{family.means_display}} </td></tr>
   <tr><td>{{ KNOWL('lf.rams', 'Rams') }}:</td><td> {{family.rams_display}} </td></tr>
   <tr><td>{{ KNOWL('lf.family_field_count', 'Field count') }}:</td><td> ${{family.field_count}}$ {% if family.all_stored %} (complete) {% else %} (incomplete) {% endif %}</td></tr>

--- a/lmfdb/local_fields/templates/lf-family.html
+++ b/lmfdb/local_fields/templates/lf-family.html
@@ -18,8 +18,8 @@
   <tr><td>{{ KNOWL('lf.ramification_index', 'Ramification index') }} $e$:</td><td> ${{family.e}}$ </td></tr>
   <tr><td>{{ KNOWL('lf.residue_field_degree', 'Residue field degree') }} $f$:</td><td> ${{family.f}}$ </td></tr>
   <tr><td>{{ KNOWL('lf.discriminant_exponent', 'Discriminant exponent') }} $c$:</td><td> ${{family.c}}$ </td></tr>
-  <tr><td>{{ KNOWL('lf.slopes', 'Absolute Artin slopes' if family.n0 > 1 else 'Artin slopes') }}:</td><td> {{info.latex_content(family.artin_slopes, add_space=True)}} </td></tr>
-  <tr><td>{{ KNOWL('lf.slopes', 'Swan slopes') }}:</td><td> {{info.latex_content(family.slopes, add_space=True)}}</td></tr>
+  <tr><td>{{ KNOWL('lf.slopes', 'Absolute Artin slopes' if family.n0 > 1 else 'Artin slopes') }}:</td><td> {{info.latex_content(family.artin_slopes)}} </td></tr>
+  <tr><td>{{ KNOWL('lf.slopes', 'Swan slopes') }}:</td><td> {{info.latex_content(family.slopes)}}</td></tr>
   <tr><td>{{ KNOWL('lf.means', 'Means') }}:</td><td> {{family.means_display}} </td></tr>
   <tr><td>{{ KNOWL('lf.rams', 'Rams') }}:</td><td> {{family.rams_display}} </td></tr>
   <tr><td>{{ KNOWL('lf.family_field_count', 'Field count') }}:</td><td> ${{family.field_count}}$ {% if family.all_stored %} (complete) {% else %} (incomplete) {% endif %}</td></tr>


### PR DESCRIPTION
Background: when displaying slopes for p-adic fields, if there are none, the result is [].  Usually we stick as space between the brackets since they kind of run together.  This adds that space on the family homepages for Artin and Swan slopes.

http://127.0.0.1:37777/padicField/family/2.4.1.0a
https://beta.lmfdb.org/padicField/family/2.4.1.0a
