### PR TITLE
Improve error handling in g2c

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -539,26 +539,30 @@ def genus2_jump(info):
             errmsg = f"unable to find equation {eqn_str} (interpreted from %s) in the genus 2 curve database"
     elif jump.count('=') == 1:
         lhs_str, rhs_str = jump.split('=')
+        errmsg = "Unable to parse input %s into a polynomial"
         try:
             rhs_poly = coeff_to_poly_multi(rhs_str)
-            main_poly_str = lhs_str + "+" + str(-rhs_poly)
-            main_poly = coeff_to_poly_multi(main_poly_str)
         except Exception:
-            errmsg = "Unable to parse input %s into a polynomial"
-            flash_error(errmsg, main_poly_str)
-            return redirect(url_for(".index"))
-        try:
-            f,h = unpack_hyperelliptic_polys(main_poly)
-        except ValueError as e:
-            flash_error(str(e), main_poly)
-            return redirect(url_for(".index"))
-        new_input = str(f) + "," + str(h)
-        label, eqn_str = genus2_lookup_equation(new_input)
-        if label:
-            return redirect(url_for_curve_label(label), 301)
-        elif label is None:
-            # the input was parsed
-            errmsg = f"unable to find equation {eqn_str} (interpreted from %s) in the genus 2 curve database"
+            jump = rhs_str
+        else:
+            try:
+                main_poly_str = lhs_str + "+" + str(-rhs_poly)
+                main_poly = coeff_to_poly_multi(main_poly_str)
+            except Exception:
+                jump = main_poly_str
+            else:
+                try:
+                    f,h = unpack_hyperelliptic_polys(main_poly)
+                except ValueError as e:
+                    err_msg, jump = str(e), main_poly)
+                else:
+                    new_input = str(f) + "," + str(h)
+                    label, eqn_str = genus2_lookup_equation(new_input)
+                    if label:
+                        return redirect(url_for_curve_label(label), 301)
+                    elif label is None:
+                        # the input was parsed
+                        errmsg = f"unable to find equation {eqn_str} (interpreted from %s) in the genus 2 curve database"
     else:
         errmsg = "%s is not valid input. Expected a label, e.g., 169.a.169.1"
         errmsg += ", or a univariate polynomial, e.g., x^5 + 1"


### PR DESCRIPTION
Should resolve this error from the flasklog:

```
Exception on /Genus2Curve/Q/coeffs=[1,4,6,2,1,2,1] [GET]
Traceback (most recent call last):
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 543, in genus2_jump
    rhs_poly = coeff_to_poly_multi(rhs_str)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/utilities.py", line 269, in coeff_to_poly_multi
    return PolynomialRing(QQ, list(varposs))(c)
  File "/home/sage/sage-10.4/src/sage/rings/polynomial/multi_polynomial_ring.py", line 511, in __call__
    return self(x)
  File "/home/sage/sage-10.4/src/sage/rings/polynomial/multi_polynomial_ring.py", line 542, in __call__
    c = self.base_ring()(x)
  File "sage/structure/parent.pyx", line 908, in sage.structure.parent.Parent.__call__
    return mor._call_(x)
  File "sage/structure/coerce_maps.pyx", line 164, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_
    raise
  File "sage/structure/coerce_maps.pyx", line 159, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_
    return C._element_constructor(x)
  File "sage/rings/rational.pyx", line 555, in sage.rings.rational.Rational.__init__
    self.__set_value(x, base)
  File "sage/rings/rational.pyx", line 700, in sage.rings.rational.Rational._Rational__set_value
    raise TypeError("unable to convert {!r} to a rational".format(x))
TypeError: unable to convert [1, 4, 6, 2, 1, 2, 1] to a rational

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/search_wrapper.py", line 165, in __call__
    return func(info)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 548, in genus2_jump
    flash_error(errmsg, main_poly_str)
UnboundLocalError: local variable 'main_poly_str' referenced before assignment

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 324, in by_label
    return genus2_curve_search({"jump": label})
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/search_wrapper.py", line 177, in __call__
    return render_template(
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/templating.py", line 154, in render_template
    return _render(
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/templating.py", line 128, in _render
    rv = template.render(context)
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/search_results.html", line 1, in top-level template code
    {% extends 'homepage.html' %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/homepage.html", line 5, in top-level template code
    {{CodeSnippet(code, item).place_code()}}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/base.html", line 186, in top-level template code
    {% block body -%}{%- endblock body %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/homepage.html", line 207, in block 'body'
    {% block content -%}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/search_results.html", line 4, in block 'content'
    {% include 'refine_search_form.html' %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/refine_search_form.html", line 20, in top-level template code
    {% if info.search_array.has_advanced_inputs(info) %}
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 487, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'search_array'
[2025-07-28 07:09:28 UTC] 500 error on URL https://www.lmfdb.org/Genus2Curve/Q/coeffs%3D%5B1,4,6,2,1,2,1%5D ()
Exception on /Genus2Curve/Q/coeffs=[1,4,6,2,1,2,1] [GET]
Traceback (most recent call last):
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 543, in genus2_jump
    rhs_poly = coeff_to_poly_multi(rhs_str)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/utilities.py", line 269, in coeff_to_poly_multi
    return PolynomialRing(QQ, list(varposs))(c)
  File "/home/sage/sage-10.4/src/sage/rings/polynomial/multi_polynomial_ring.py", line 511, in __call__
    return self(x)
  File "/home/sage/sage-10.4/src/sage/rings/polynomial/multi_polynomial_ring.py", line 542, in __call__
    c = self.base_ring()(x)
  File "sage/structure/parent.pyx", line 908, in sage.structure.parent.Parent.__call__
    return mor._call_(x)
  File "sage/structure/coerce_maps.pyx", line 164, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_
    raise
  File "sage/structure/coerce_maps.pyx", line 159, in sage.structure.coerce_maps.DefaultConvertMap_unique._call_
    return C._element_constructor(x)
  File "sage/rings/rational.pyx", line 555, in sage.rings.rational.Rational.__init__
    self.__set_value(x, base)
  File "sage/rings/rational.pyx", line 700, in sage.rings.rational.Rational._Rational__set_value
    raise TypeError("unable to convert {!r} to a rational".format(x))
TypeError: unable to convert [1, 4, 6, 2, 1, 2, 1] to a rational

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/search_wrapper.py", line 165, in __call__
    return func(info)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 548, in genus2_jump
    flash_error(errmsg, main_poly_str)
UnboundLocalError: local variable 'main_poly_str' referenced before assignment

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/genus2_curves/main.py", line 324, in by_label
    return genus2_curve_search({"jump": label})
  File "/home/lmfdb/lmfdb-git-web/lmfdb/utils/search_wrapper.py", line 177, in __call__
    return render_template(
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/templating.py", line 154, in render_template
    return _render(
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/flask/templating.py", line 128, in _render
    rv = template.render(context)
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/search_results.html", line 1, in top-level template code
    {% extends 'homepage.html' %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/homepage.html", line 5, in top-level template code
    {{CodeSnippet(code, item).place_code()}}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/base.html", line 186, in top-level template code
    {% block body -%}{%- endblock body %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/homepage.html", line 207, in block 'body'
    {% block content -%}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/search_results.html", line 4, in block 'content'
    {% include 'refine_search_form.html' %}
  File "/home/lmfdb/lmfdb-git-web/lmfdb/templates/refine_search_form.html", line 20, in top-level template code
    {% if info.search_array.has_advanced_inputs(info) %}
  File "/home/sage/sage-10.4/local/var/lib/sage/venv-python3.10/lib/python3.10/site-packages/jinja2/environment.py", line 487, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'search_array'
[2025-07-28 07:09:29 UTC] 500 error on URL https://www.lmfdb.org/Genus2Curve/Q/coeffs%3D%5B1,4,6,2,1,2,1%5D ()
```