### PR TITLE
small issues with properties lists

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -659,6 +659,8 @@ def create_boolean_string(gp, type="normal"):
     unknown = [prop for prop in overall_order if getattr(gp, prop, None) is None]
     if {'ab_simple', 'nab_simple'} <= set(unknown):
         unknown.remove('ab_simple')
+    if gp.abelian and gp.monomial is None:  #if abelian then monomial
+        unknown.remove('monomial')
 
     unknown = [overall_display[prop] for prop in unknown]
     if unknown and type != "knowl":
@@ -716,6 +718,11 @@ def create_boolean_aut_string(gp, prefix="aut_", type="normal", name="automorphi
         unknown.remove('nonabelian')
     if {'solvable', 'nonsolvable'} <= set(unknown):
         unknown.remove('nonsolvable')
+    prop = 'pgroup'  # if p-group, we know it is nilpotent, solvable, and supersolvable
+    if getattr(gp,prefix+prop,None) > 1:
+        unknown.remove('nilpotent')
+        unknown.remove('solvable')
+        unknown.remove('supersolvable')
 
     unknown = [overall_display[prop] for prop in unknown]
     if unknown and type != "knowl":


### PR DESCRIPTION
A couple places where our boolean properties list claimed it did and didn't know something:

1. Abelian groups are all monomial. 
https://beta.lmfdb.org/Groups/Abstract/ab/2.2.1993134
above we claim the group is monomial and also that we don't know.  But here:
http://localhost:37777/Groups/Abstract/ab/2.2.1993134
we only say we know it is monomial


2.  p-groups are all monomial, solvable, and supersolvable
See the outer automorphism string here:
https://beta.lmfdb.org/Groups/Abstract/auto/1265625000.w
versus here:
http://localhost:37777/Groups/Abstract/auto/1265625000.w 