### PR TITLE
Fix error with narrow class group search

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1237,7 +1237,7 @@ class NFSearchArray(SearchArray):
             knowl="nf.narrow_class_number",
             example="5")
         narrow_class_group = TextBox(
-            name="class_group",
+            name="narrow_class_group",
             label="Narrow class group structure",
             short_label='Narrow class group',
             knowl="nf.narrow_class_group",


### PR DESCRIPTION
Corrected a typo in number_field.py.  This fixes #6629 - an error with searching on the (narrow) class group structure for number fields.  