### PR TITLE
Add irreducible Coxeter groups to group families

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -223,7 +223,7 @@ def parse_family(inp, query, qfield):
     # Case of CoxI2 (return all dihedral groups D_n)
     elif inp == 'CoxI2':
         query["dihedral"] = True
-    # Case to check if family if one of the individual irreducible Coxeter families
+    # Case to check if family is one of the individual irreducible Coxeter families
     elif inp[:3] == 'Cox' and len(inp) == 4:
         query[qfield] = {'$in':list(db.gps_special_names.search({'family':"Cox", 'parameters.fam':inp[3]}, projection='label'))}
 

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -127,7 +127,7 @@ def group_families(deTeX=False):
         L.insert(cox_index, ("Cox"+f[0], "$W("+f+"_{{n}})$"))
         cox_index += 1
     L.insert(cox_index, ("CoxH", "$H_{{n}}$"))
-    L.insert(cox_index+1, ("CoxI", "$I_2({n})$"))
+    L.insert(cox_index+1, ("CoxI2", "$I_2({n})$"))
 
     if deTeX:
         # Used for constructing the dropdown
@@ -220,8 +220,8 @@ def parse_family(inp, query, qfield):
         labels = list(db.gps_special_names.search({'family':'S'}, projection='label'))
         labels.remove('1.1')
         query[qfield] = {'$in':labels}
-    # Case of CoxI (return all dihedral groups D_n)
-    elif inp == 'CoxI':
+    # Case of CoxI2 (return all dihedral groups D_n)
+    elif inp == 'CoxI2':
         query["dihedral"] = True
     # Case to check if family if one of the individual irreducible Coxeter families
     elif inp[:3] == 'Cox' and len(inp) == 4:


### PR DESCRIPTION
This adds the irreducible Coxeter groups ($W(A_n)$, $W(B_n)$, $W(D_n)$, $W(E_n)$, $W(F_4)$, $H_n$, $I_2(n)$ ) to the search options for group families (and dropdown menu).

Main groups page:
https://beta.lmfdb.org/Groups/Abstract/
http://localhost:37777/Groups/Abstract/

Before clicking "more..."

<img width="1056" height="57" alt="image" src="https://github.com/user-attachments/assets/ebedff24-d2d9-4c06-a5fd-d34b040420f1" />

After clicking "more..."

<img width="1664" height="147" alt="image" src="https://github.com/user-attachments/assets/3817c413-cff7-4625-8dc0-bb288021bb26" />


Searching for all irreducible Coxeter groups:
https://beta.lmfdb.org/Groups/Abstract/?family=Cox
http://localhost:37777/Groups/Abstract/?family=Cox

Many thanks to @roed314, @edgarcosta, and @havarddj for helping with this!