### PR TITLE
Make sage code able to run for weight 1 classical modular forms

### DIFF
--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -53,7 +53,8 @@ initialize-newspace:
     from sage.modular.dirichlet import DirichletCharacter
     H = DirichletGroup({N}, base_ring=CyclotomicField({sage_zeta_order}))
     chi = DirichletCharacter(H, H._module({sage_genvalues}))
-    N = Newforms(chi, {k}, names="a")
+    N = Newforms(chi, {k}, names="a") if {k} != 1 \
+    else ModularForms(chi, 1).cuspidal_submodule().basis()[0].qexp(100)
   magma: |
     //Please install CHIMP (https://github.com/edgarcosta/CHIMP) if you want to run this code
     chi := DirichletCharacter("{N}.{conrey_index}");

--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -53,8 +53,11 @@ initialize-newspace:
     from sage.modular.dirichlet import DirichletCharacter
     H = DirichletGroup({N}, base_ring=CyclotomicField({sage_zeta_order}))
     chi = DirichletCharacter(H, H._module({sage_genvalues}))
-    N = Newforms(chi, {k}, names="a") if {k} != 1 \
-    else ModularForms(chi, 1).cuspidal_submodule().basis()[0].qexp(100)
+    if {k} != 1:
+      N = Newforms(chi, {k}, names="a") 
+    else:
+      B = ModularForms(chi, 1).cuspidal_submodule().basis()
+      N = [B[i].qexp(100) for i in range(len(B))]
   magma: |
     //Please install CHIMP (https://github.com/edgarcosta/CHIMP) if you want to run this code
     chi := DirichletCharacter("{N}.{conrey_index}");

--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -43,26 +43,34 @@ dimensions-spaces:
     mfdim([N,k,chi],1) \\ Cusps
     mfdim([N,k,chi],0) \\ New
 
-initialize-newspace:
+initialize-newspace-common: &initialize-newspace-common
   comment: Compute space of new eigenforms
   pari: |
     [N,k,chi] = [{N},{k},Mod({conrey_index},{N})]
     mf = mfinit([N,k,chi],0)
     lf = mfeigenbasis(mf)
-  sage: |
-    from sage.modular.dirichlet import DirichletCharacter
-    H = DirichletGroup({N}, base_ring=CyclotomicField({sage_zeta_order}))
-    chi = DirichletCharacter(H, H._module({sage_genvalues}))
-    if {k} != 1:
-      N = Newforms(chi, {k}, names="a") 
-    else:
-      B = ModularForms(chi, 1).cuspidal_submodule().basis()
-      N = [B[i].qexp(100) for i in range(len(B))]
   magma: |
     //Please install CHIMP (https://github.com/edgarcosta/CHIMP) if you want to run this code
     chi := DirichletCharacter("{N}.{conrey_index}");
     S:= CuspForms(chi, {k});
     N := Newforms(S);
+
+initialize-newspace-weight-1:
+  <<: *initialize-newspace-common
+  sage: |
+    from sage.modular.dirichlet import DirichletCharacter
+    H = DirichletGroup({N}, base_ring=CyclotomicField({sage_zeta_order}))
+    chi = DirichletCharacter(H, H._module({sage_genvalues}))
+    B = ModularForms(chi, 1).cuspidal_submodule().basis()
+    N = [B[i] for i in range(len(B))]
+
+initialize-newspace-weight-not-1:
+  <<: *initialize-newspace-common
+  sage: |
+    from sage.modular.dirichlet import DirichletCharacter
+    H = DirichletGroup({N}, base_ring=CyclotomicField({sage_zeta_order}))
+    chi = DirichletCharacter(H, H._module({sage_genvalues}))
+    N = Newforms(chi, {k}, names="a") 
 
 coeff-field:
   comment: Coefficient field, relative polynomial

--- a/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform_common.html
@@ -7,7 +7,11 @@
 
 <h2> {{KNOWL('cmf.newspace',title='Newspace')}} parameters </h2>
 
-{{ place_code('initialize-newspace')}}
+{% if newform.weight == 1 %}
+{{ place_code('initialize-newspace-weight-1')}}
+{% else %}
+{{ place_code('initialize-newspace-weight-not-1')}}
+{% endif %}
 
 <table>
   <tr>


### PR DESCRIPTION
Resolves issue #6369

If the weight is not 1, display the original sage code. Otherwise, display the following sage code to get modular forms of weight 1.

```
B = ModularForms(chi, 1).cuspidal_submodule().basis()
N = [B[i] for i in range(len(B))]
```