### PR TITLE
Reorganized isogeny classes page 

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-isoclass.html
+++ b/lmfdb/ecnf/templates/ecnf-isoclass.html
@@ -41,30 +41,6 @@ function show_code(system) {
     {{ place_code('field', is_top_snippet=True) }}
 </div>
 
-<h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.field_knowl|safe }}</h2>
-<p>
-Isogeny class {{cl.short_class_label}} contains
-{% if cl.class_size==1 %}
-only one elliptic curve.
-{% else %}
-{{cl.class_size}} curves linked by isogenies of
-{% if cl.one_deg %}degree {% else %}degrees dividing {% endif %}
-{{cl.class_deg}}.
-{% endif %}
-</p>
-<table>
-<tr>
-<th>{{ KNOWL('ec.curve_label',title = "Curve label") }}</th>
-<th>{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass Coefficients') }}</th>
-</tr>
-{% for c in cl.curves %}
-<tr>
-<td> <a href={{c[1]}}>{{c[0]}}</a>
-<td> <a href={{c[1]}}>{{c[2]}}</a>
-</tr>
-{% endfor %}
-</table>
-
 <h2>{{ KNOWL('ec.rank',title='Rank') }}</h2>
 
 {% if cl.rk == "?" %}
@@ -96,6 +72,30 @@ Rank not yet determined.
 {% else %}
 <p>Not available.</p>
 {% endif %}
+
+<h2>Elliptic curves in class {{cl.short_class_label}} over   {{ cl.field_knowl|safe }}</h2>
+<p>
+Isogeny class {{cl.short_class_label}} contains
+{% if cl.class_size==1 %}
+only one elliptic curve.
+{% else %}
+{{cl.class_size}} curves linked by isogenies of
+{% if cl.one_deg %}degree {% else %}degrees dividing {% endif %}
+{{cl.class_deg}}.
+{% endif %}
+</p>
+<table>
+<tr>
+<th>{{ KNOWL('ec.curve_label',title = "Curve label") }}</th>
+<th>{{ KNOWL('ec.weierstrass_coeffs',  title='Weierstrass Coefficients') }}</th>
+</tr>
+{% for c in cl.curves %}
+<tr>
+<td> <a href={{c[1]}}>{{c[0]}}</a>
+<td> <a href={{c[1]}}>{{c[2]}}</a>
+</tr>
+{% endfor %}
+</table>
 
 {% if DEBUG %}
 <hr>

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -91,6 +91,22 @@ Each elliptic curve in class {{info.class_label}} has complex multiplication by 
     </form>
 </div>
 
+<script type="text/javascript">
+  var number_of_coefficients = 20;
+  function more_handler(evt) {
+      number_of_coefficients += number_of_coefficients;
+      evt.preventDefault();
+      $("#modform_output").load("{{info.modform_display}}"+number_of_coefficients,
+          function() {
+              {# render the output #}
+              renderMathInElement($("#modform_output").get(0), katexOpts);
+          });
+  }
+  $(function() {
+      $("#morebutton").click(function(e) {more_handler(e)});
+  });
+  </script>
+  
 {% if info.class_size>1 %}
 
 <h2>{{ KNOWL('ec.isogeny_matrix',title='Isogeny matrix') }}</h2>
@@ -199,23 +215,5 @@ curve {{info.optimal_label}}.{% endif %}
 {% if info.class_size>1 %}<sup>**</sup>conjecturally; proved in some cases.{% endif %}
 #}
 
-
-<script type="text/javascript">
-var number_of_coefficients = 20;
-function more_handler(evt) {
-    number_of_coefficients += number_of_coefficients;
-    evt.preventDefault();
-    $("#modform_output").load("{{info.modform_display}}"+number_of_coefficients,
-        function() {
-            {# render the output #}
-            renderMathInElement($("#modform_output").get(0), katexOpts);
-        });
-}
-$(function() {
-    $("#morebutton").click(function(e) {more_handler(e)});
-});
-</script>
-
 {% endblock %}
-
 

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -10,94 +10,6 @@ text-align: center;
 }
 </style>
 
-<h2>Elliptic curves in class {{info.class_label}}</h2>
-{{ place_code('curves') }}
-<table id = "isogeny_class_table">
-<tr>
-<th>{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
-{% if info.conductor < info.cremona_bound %}
-<th>{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
-{% endif %}
-<th>{{ KNOWL('ec.q.minimal_weierstrass_equation', title='Weierstrass coefficients') }}</th>
-<th>{{ KNOWL('ec.j_invariant', title='j-invariant') }}</th>
-<th>{{ KNOWL('ec.discriminant',  title='Discriminant') }}</th>
-<th>{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</th>
-<th>{{ KNOWL('ec.q.modular_degree', title='Modular degree') }}</th>
-<th>{{ KNOWL('ec.q.faltings_height', title='Faltings height') }}</th>
-{% if info.conductor < info.cremona_bound %}
-<th>{{ KNOWL('ec.q.optimal', title='Optimality') }}</th>
-{% endif %}
-{#
-<th>{{ KNOWL('ec.q.faltings_ratio', title='Faltings ratio') }}</th>
-#}
-{% if info.cm %}
-<th>{{ KNOWL('ec.complex_multiplication', title='CM discriminant') }}</th>
-{% endif %}
-</tr>
-{% for c in info.curves %}
-{% if c.optimal %}
-<tr bgcolor="{{color.ec_background}}">
-{% else %}
-<tr>
-{% endif %}
-<td class="center"><a href="{{c.curve_url_lmfdb}}">{{c.lmfdb_label}}</a></td>
-{% if info.conductor < info.cremona_bound %}
-<td class="center"><a href="{{c.curve_url_cremona}}">{{c.Clabel}}</a></td>
-{% endif %}
-<td class="center">\({{c.ai}}\)</td>
-<td class="center">\({{c.j_inv}}\)</td>
-<td class="center">\({{c.disc}}\)</td>
-<td align="center">\({{c.torsion_structure}}\)</td>
-<td align="center">
-{% if c.degree==0 %}Not available{% else %}\({{c.degree}}\){% endif %}
-</td>
-<td align="center">
-\({{c.FH}}\)
-</td>
-{% if info.conductor < info.cremona_bound %}
-<td>
-  {% if c.optimal %}
-\(\Gamma_0(N)\)-optimal{% if not info.optimality_known %}<sup>*</sup>{% endif %}
-{#
-  {% if c.faltings_index==0 %}
-, \(\Gamma_1(N)\)-optimal{% if info.class_size>1 %}<sup>**</sup>{% endif %}
-  {% endif %}
-#}
-{% else %}
-{#
-{% if c.faltings_index==0 %}
-\(\Gamma_1(N)\)-optimal{% if info.class_size>1 %}<sup>**</sup>{% endif %}
-{% else %}
-#}
-&nbsp;
-{#
-{% endif %}
-#}
-{% endif %}
-</td>
-{% endif %}
-{#
-<td>\({{c.faltings_ratio}}\)</td>
-#}
-{% if info.cm %}
-<td>\({{c.cm}}\)</td>
-{% endif %}
-</tr>
-{% endfor %}
-</table>
-
-{% if info.conductor < info.cremona_bound %}
-{% if not info.optimality_known %}<sup>*</sup>optimality has not been
-determined rigorously for conductors over {{ info.optimality_bound }}.  In
-this case the optimal curve is certainly one of the {{
-info.curves[0].optimality }} curves highlighted, and conditionally
-curve {{info.optimal_label}}.{% endif %}
-{% endif %}
-
-{#
-{% if info.class_size>1 %}<sup>**</sup>conjecturally; proved in some cases.{% endif %}
-#}
-
 <h2>{{KNOWL('ec.rank', title='Rank')}}</h2>
 {{ place_code('rank') }}
 <p>
@@ -198,6 +110,95 @@ Each elliptic curve in class {{info.class_label}} has complex multiplication by 
 </center>
 
 {% endif %}
+
+<h2>Elliptic curves in class {{info.class_label}}</h2>
+{{ place_code('curves') }}
+<table id = "isogeny_class_table">
+<tr>
+<th>{{ KNOWL('ec.q.lmfdb_label', title='LMFDB label')}}</th>
+{% if info.conductor < info.cremona_bound %}
+<th>{{ KNOWL('ec.q.cremona_label', title='Cremona label')}}</th>
+{% endif %}
+<th>{{ KNOWL('ec.q.minimal_weierstrass_equation', title='Weierstrass coefficients') }}</th>
+<th>{{ KNOWL('ec.j_invariant', title='j-invariant') }}</th>
+<th>{{ KNOWL('ec.discriminant',  title='Discriminant') }}</th>
+<th>{{ KNOWL('ec.torsion_subgroup', title='Torsion structure') }}</th>
+<th>{{ KNOWL('ec.q.modular_degree', title='Modular degree') }}</th>
+<th>{{ KNOWL('ec.q.faltings_height', title='Faltings height') }}</th>
+{% if info.conductor < info.cremona_bound %}
+<th>{{ KNOWL('ec.q.optimal', title='Optimality') }}</th>
+{% endif %}
+{#
+<th>{{ KNOWL('ec.q.faltings_ratio', title='Faltings ratio') }}</th>
+#}
+{% if info.cm %}
+<th>{{ KNOWL('ec.complex_multiplication', title='CM discriminant') }}</th>
+{% endif %}
+</tr>
+{% for c in info.curves %}
+{% if c.optimal %}
+<tr bgcolor="{{color.ec_background}}">
+{% else %}
+<tr>
+{% endif %}
+<td class="center"><a href="{{c.curve_url_lmfdb}}">{{c.lmfdb_label}}</a></td>
+{% if info.conductor < info.cremona_bound %}
+<td class="center"><a href="{{c.curve_url_cremona}}">{{c.Clabel}}</a></td>
+{% endif %}
+<td class="center">\({{c.ai}}\)</td>
+<td class="center">\({{c.j_inv}}\)</td>
+<td class="center">\({{c.disc}}\)</td>
+<td align="center">\({{c.torsion_structure}}\)</td>
+<td align="center">
+{% if c.degree==0 %}Not available{% else %}\({{c.degree}}\){% endif %}
+</td>
+<td align="center">
+\({{c.FH}}\)
+</td>
+{% if info.conductor < info.cremona_bound %}
+<td>
+  {% if c.optimal %}
+\(\Gamma_0(N)\)-optimal{% if not info.optimality_known %}<sup>*</sup>{% endif %}
+{#
+  {% if c.faltings_index==0 %}
+, \(\Gamma_1(N)\)-optimal{% if info.class_size>1 %}<sup>**</sup>{% endif %}
+  {% endif %}
+#}
+{% else %}
+{#
+{% if c.faltings_index==0 %}
+\(\Gamma_1(N)\)-optimal{% if info.class_size>1 %}<sup>**</sup>{% endif %}
+{% else %}
+#}
+&nbsp;
+{#
+{% endif %}
+#}
+{% endif %}
+</td>
+{% endif %}
+{#
+<td>\({{c.faltings_ratio}}\)</td>
+#}
+{% if info.cm %}
+<td>\({{c.cm}}\)</td>
+{% endif %}
+</tr>
+{% endfor %}
+</table>
+
+{% if info.conductor < info.cremona_bound %}
+{% if not info.optimality_known %}<sup>*</sup>optimality has not been
+determined rigorously for conductors over {{ info.optimality_bound }}.  In
+this case the optimal curve is certainly one of the {{
+info.curves[0].optimality }} curves highlighted, and conditionally
+curve {{info.optimal_label}}.{% endif %}
+{% endif %}
+
+{#
+{% if info.class_size>1 %}<sup>**</sup>conjecturally; proved in some cases.{% endif %}
+#}
+
 
 <script type="text/javascript">
 var number_of_coefficients = 20;

--- a/lmfdb/genus2_curves/templates/g2c_isogeny_class.html
+++ b/lmfdb/genus2_curves/templates/g2c_isogeny_class.html
@@ -5,26 +5,6 @@
 p {padding-left: 1ch;}
 </style>
 
-<style type="text/css">
-#isogeny_class_table th, #isogeny_class_table td {
-padding : 4px;
-text-align: center;
-}
-</style>
-
-<h2>Genus 2 curves in {{KNOWL("g2c.isogeny_class", title="isogeny class" )}} {{data.label}}</h2>
-<table id = "isogeny_class_table">
-<tr>
-<th>{{ KNOWL('g2c.label', title='Label')}}</th>
-<th>{{ KNOWL('g2c.minimal_equation', title='Equation') }}</th>
-</tr>
-{% for c in data.curves %}
-<tr>
-<td class="center"><a href="{{c.url}}">{{c.label}}</a></td>
-<td align="center">\({{c.equation_formatted}}\)</td>
-{% endfor %}
-</table>
-
 <h2>{{KNOWL('g2c.lfunction', title='L-function')}} data</h2>
 
 <p>
@@ -112,5 +92,25 @@ text-align: center;
 <p>More complete information on endomorphism algebras and rings can be found on the pages of the individual curves in the isogeny class.</p>
 
 <!-- <h2>{{ KNOWL('av.isogeny', title='Isogenies') }}</h2> -->
+
+<style type="text/css">
+  #isogeny_class_table th, #isogeny_class_table td {
+  padding : 4px;
+  text-align: center;
+  }
+  </style>
+  
+  <h2>Genus 2 curves in {{KNOWL("g2c.isogeny_class", title="isogeny class" )}} {{data.label}}</h2>
+  <table id = "isogeny_class_table">
+  <tr>
+  <th>{{ KNOWL('g2c.label', title='Label')}}</th>
+  <th>{{ KNOWL('g2c.minimal_equation', title='Equation') }}</th>
+  </tr>
+  {% for c in data.curves %}
+  <tr>
+  <td class="center"><a href="{{c.url}}">{{c.label}}</a></td>
+  <td align="center">\({{c.equation_formatted}}\)</td>
+  {% endfor %}
+  </table>
 
 {% endblock %}


### PR DESCRIPTION
Resolves #6511 

Reorganized the isogeny class pages (for EC, for EC/number fields, also for genus 2 curve) so that the list of curves appear at the bottom of the page instead of the top of the page. 

Inside the file ec-isoclass.html, I also moved the code associated to the button for q-expansion to right after the code for q-expansion, which is before the isogeny graph code. Before we had the code associated to the button appear after the isogeny graph code.