### PR TITLE
Add commas on api/stats, make comma mathmode by default

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from psycopg2.extensions import QueryCanceledError
 from lmfdb import db
 from psycodict.encoding import Json
-from lmfdb.utils import flash_error
+from lmfdb.utils import flash_error, comma
 from lmfdb.utils.datetime_utils import utc_now_naive
 from flask import (render_template, request, url_for, current_app,
                    abort, redirect, Response)
@@ -137,11 +137,11 @@ def stats():
                 'tablespace': tablespaces.get(tablename, ""),
             }
     dataSize = size - indexSize
-    info['ntables'] = len(table_sizes)
-    info['nobjects'] = nobjects
-    info['size'] = mb(size)
-    info['dataSize'] = mb(dataSize)
-    info['indexSize'] = mb(indexSize)
+    info['ntables'] = comma(len(table_sizes))
+    info['nobjects'] = comma(nobjects)
+    info['size'] = comma(mb(size))
+    info['dataSize'] = comma(mb(dataSize))
+    info['indexSize'] = comma(mb(indexSize))
     if info['sortby'] == 'name':
         sortedkeys = sorted(stats)
     elif info['sortby'] == 'objects' and info['groupby'] == 'db':

--- a/lmfdb/tests/test_utils.py
+++ b/lmfdb/tests/test_utils.py
@@ -105,8 +105,10 @@ class UtilsTest(unittest.TestCase):
         r"""
         Checking utility: comma
         """
-        self.assertEqual(comma(123), "123")
-        self.assertEqual(comma(123456789), "123,456,789")
+        self.assertEqual(comma(123), "$123$")
+        self.assertEqual(comma(123456789), "$123{,}456{,}789$")
+        self.assertEqual(comma(123, mathmode=False), "123")
+        self.assertEqual(comma(123456789, mathmode=False), "123,456,789")
 
     def test_format_percentage(self):
         r"""

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -573,7 +573,7 @@ def splitcoeff(coeff):
 #  display and formatting utilities
 ################################################################################
 
-def comma(x, sep=","):
+def comma(x, sep=None, mathmode=True):
     """
     Input is an integer. Output is a string of that integer with commas.
     CAUTION: this misbehaves if the input is not an integer.
@@ -584,7 +584,15 @@ def comma(x, sep=","):
     >>> comma("12345")
     '12,345'
     """
-    return x < 1000 and str(x) or ('%s%s%03d' % (comma(x // 1000, sep), sep, (x % 1000)))
+    if sep is None:
+        sep = "{,}" if mathmode else ","
+    if x < 1000:
+        x = str(x)
+    else:
+        x = '%s%s%03d' % (comma(x // 1000, sep, False), sep, (x % 1000))
+    if mathmode:
+        x = f"${x}$"
+    return x
 
 def latex_comma(x):
     """


### PR DESCRIPTION
Compare the top of https://beta.lmfdb.org/api/stats with http://localhost:37777/api/stats, and the top of https://beta.lmfdb.org/EllipticCurve/Q/ with http://localhost:37777/EllipticCurve/Q/.