### PR TITLE
Fix issue with conjugacy classes of Galois groups

### DIFF
--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -236,8 +236,9 @@ class WebGaloisGroup:
             ccn = [x.Size() for x in cc]
             cclabels = ['' for z in cc]
             cc = [x.Representative() for x in cc]
-            for j in range(len(self.conjugacy_classes)):
-                self.conjugacy_classes[j].force_repr(' ')
+            if self.conjugacy_classes:
+                for j in range(len(self.conjugacy_classes)):
+                    self.conjugacy_classes[j].force_repr(' ')
         cc2 = [libgap.CycleLengths(x, list(range(1,n+1))) for x in cc]
         inds = [n-len(z) for z in cc2]
         cc2 = [compress_cycle_type(z) for z in cc2]


### PR DESCRIPTION
Fix issue #6657 

In this case, the number of classes was above our limit for the number we are willing to display

http://127.0.0.1:37777/GaloisGroup/38T14
http://beta.lmfdb.org/GaloisGroup/38T14