### PR TITLE
Verify that search result download button works for magma and sage #4810

### DIFF
--- a/lmfdb/genus2_curves/main.py
+++ b/lmfdb/genus2_curves/main.py
@@ -579,7 +579,7 @@ class G2C_download(Downloader):
             ["eqn"],
             {
                 "magma": 'QQx<x> := PolynomialRing(Rationals());\n    curve := HyperellipticCurve(QQx!(out`eqn[1]), QQx!(out`eqn[2]));',
-                "sage": 'QQx.<x> := QQ[]\n    curve = HyperellipticCurve(QQx(out["eqn"][0]), QQx(out["eqn"][1]))',
+                "sage": 'QQx.<x> = QQ[]\n    curve = HyperellipticCurve(QQx(out["eqn"][0]), QQx(out["eqn"][1]))',
                 "gp": 'curve = apply(Polrev, mapget(out, "eqn"));',
             }
         ),


### PR DESCRIPTION
This pull request is for issue #4810.

I verified the following download buttons on the search page by downloading and running 2 files per grid below:

|    -     | Text file | Magma file | Sage file | 
|---|---|---|---|
| Genus 2 curve  |Works| Works | Works after fixing a tiny syntax error (see PR)|
| EC/Q  | Works | Works |Works |
| EC/NF  | Works | Works |Works |