### PR TITLE
Resolves #6691

### DIFF
--- a/lmfdb/sato_tate_groups/main.py
+++ b/lmfdb/sato_tate_groups/main.py
@@ -754,7 +754,7 @@ def su2_mu_data(w, n):
     if rec['component_group'] is None:
         rec['component_group'] = 'ab/%s' % n
     else:
-        rec['component_group_number'] = int(rec['component_group'].split('.')[1])
+        rec['component_group_number'] = rec['component_group'].split('.')[1] # not necessarily an integer (e.g. for cyclic groups outside GAP ID range)
     rec['st0_label'] = '%d.2.A' % w
     rec['identity_component'] = 'SU(2)'
     rec['trace_zero_density'] = '0'
@@ -808,7 +808,7 @@ def nu1_mu_data(w,n):
     rec['component_group'] = '4.2' if n == 2 else db.gps_special_names.lucky({'family':'D','parameters':{'n':n}},projection='label')
     if rec['component_group'] is None:
         return None
-    rec['component_group_number'] = int(rec['component_group'].split('.')[1])
+    rec['component_group_number'] = rec['component_group'].split('.')[1] # not necessarily an integer (e.g. for groups outside GAP ID range)
     rec['st0_label'] = '%d.2.B' % w
     rec['identity_component'] = 'U(1)'
     rec['trace_zero_density'] = '1/2'


### PR DESCRIPTION
The problem was caused by the presence of additional records in gps_special_names with identifiers N.n where n is not necessarily an integer (e.g. for cyclic groups whose order is outside the GAP id range).