### PR TITLE
Fix JSON error in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   "postCreateCommand": "/bin/bash .devcontainer/setup.sh",
   "postAttachCommand": {
-    "server": "sage -python start-lmfdb.py --debug",
+    "server": "sage -python start-lmfdb.py --debug"
   },
   "forwardPorts": [37777],
   "customizations": {


### PR DESCRIPTION
The JSON parser used to read this is lenient enough that this doesn't break things, but proper JSON lacks (frustratingly) trailing commas.