### PR TITLE
Fix example span for nf completions

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1277,8 +1277,8 @@ class NFSearchArray(SearchArray):
             name="completions",
             label="$p$-adic completions",
             knowl="nf.padic_completion.search",
-            example_span="2.4.10.7 or 2.4.10.7,3.2.1.2",
-            example="2.4.10.7")
+            example_span="2.1.4.10a1.5 or 2.1.4.10a1.5,3.1.2.1a1.1",
+            example="2.1.4.10a1.5")
         monogenic = YesNoMaybeBox(
             name="monogenic",
             label="Monogenic",


### PR DESCRIPTION
Look at the p-adic completions search box on https://beta.lmfdb.org/NumberField/ vs http://localhost:37777/NumberField/.  Fixes #6704.