### PR TITLE
Fix bug in DEFINES

### DIFF
--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -804,7 +804,7 @@ def external_definition_link(site, xid):
         return f"https://doi.org/{xid}", xid, fragment
     if site == "groupprops":
         # example xid="Alternating_group"
-        return f"https://groupprops.subwiki.org/wiki/{xid}", xid, fragment
+        return f"https://groupprops.subwiki.org/wiki/{xid}", "groupprops:" + xid, fragment
     if site == "href":
         # href contains both the link and text for displaying
         if not xid or xid[0] != "{" or xid[-1] != "}" or xid.count("}{") != 1:


### PR DESCRIPTION
The new DEFINES macro is broken when there is only one keyword (the output format of `external_definition_link` changed and a usage of it didn't get updated).