### PR TITLE
Disable automatic hashtag links in knowls

### DIFF
--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -15,7 +15,6 @@ import string
 import re
 import json
 import time
-from xml.etree import ElementTree
 from collections import Counter, defaultdict
 from lmfdb.app import app, is_beta
 from flask import (abort, flash, jsonify, make_response,


### PR DESCRIPTION
If you try to add a cite command with a hashtag (which will be common for citations to mathlib), the knowl processing code currently raises an error.  For example, try adding

```
\cite{mathlib:Algebra/Group/Defs.html#inv_mul_cancel_comm}
```

to the end of any knowl text while editing and look at the preview.  After this PR, it works.

However, in order to fix it, we break the links created by using a hash keyword (like `#Maass`)