### PR TITLE
Add some aim squares to activities

### DIFF
--- a/lmfdb/templates/workshops.html
+++ b/lmfdb/templates/workshops.html
@@ -201,8 +201,7 @@ Sponsored by <a href="https://icerm.brown.edu">ICERM</a> and <a href="https://ww
 <li>
 Improved tabulation of local fields 1, <br>
 May 18-22, 2020, 
-<a href="https://aimath.org/">American Institute of
-Mathematics</a>, San Jose, CA, USA <br>
+online <br>
 Sponsored by <a href="https://aimath.org/">American Institute of
 Mathematics</a>
 </li>


### PR DESCRIPTION
I tried to get all of the meetings of the AIM squares on mod-ell representations and expanding p-adic fields.  I think there was at least mod-ell meeting of the square before I joined the group, so I don't have details on that.  I also moved the K3 workshop based on its page at ICERM.

The only page to check is activies:

https://beta.lmfdb.org/acknowledgment/activities
http://127.0.0.1:37777/acknowledgment/activities
