### PR TITLE
Do not log create_table in ongoing operations

### DIFF
--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -27,7 +27,7 @@ class LMFDBStatsTable(PostgresStatsTable):
 
 
 # These are the operations where we don't insert records into the ongoing_operations table since they don't take noticeable space.
-_nolog_changetypes = ["delete", "resort", "add_column", "drop_column", "create_extra_table", "move_column"]
+_nolog_changetypes = ["delete", "resort", "add_column", "drop_column", "create_table", "create_extra_table", "move_column"]
 
 
 class LMFDBSearchTable(PostgresSearchTable):


### PR DESCRIPTION
We recently added functionality to check whether there was enough space on grace and devmirror when making database changes.  There are several logging functions that are excluded because they don't take noticeable space.  `create_table` was unintentionally omitted from this list, so we add it back in.  This is important, since the `log_db_change` call in `create_table` doesn't pass a `logid`, so you can't create new tables until this is addressed.