### PR TITLE
Update code-81.1-CMa1-gp.log

### DIFF
--- a/lmfdb/tests/snippet_tests/ecnf/code-81.1-CMa1-gp.log
+++ b/lmfdb/tests/snippet_tests/ecnf/code-81.1-CMa1-gp.log
@@ -7,9 +7,8 @@ gp> ellglobalred(E)[1]
 
 [0 9]
 
-gp> idealnorm(ellglobalred(E)[1])
-  ***   too few arguments: ...alnorm(ellglobalred(E)[1])
-  ***                                                  ^-
+gp> idealnorm(K, ellglobalred(E)[1])
+81
 gp> E.disc
 Mod(-27, x^2 - x + 1)
 gp> norm(E.disc)
@@ -23,3 +22,5 @@ gp> T[1]
 gp> T[3]
 [[Mod(-1, x^2 - x + 1), Mod(-x, x^2 - x + 1)], [Mod(0, x^2 - x + 1), Mod(-1, x^2 - x + 1)]]
 gp> 
+gp> idealnorm(K, ellglobalred(E)[1])
+81


### PR DESCRIPTION
Fixed 

 gp> idealnorm(ellglobalred(E)[1])
   ***   too few arguments: ...alnorm(ellglobalred(E)[1])
   ***