### PR TITLE
Update code.yaml

### DIFF
--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -65,10 +65,13 @@ discriminant:
   oscar: OK = ring_of_integers(K); discriminant(OK)
 
 rd:
+  comment: Root discriminant
   sage: (K.disc().abs())^(1./K.degree())
   pari: abs(K.disc)^(1/poldegree(K.pol))
   magma: Abs(Discriminant(OK))^(1/Degree(K));
-  oscar: (1.0 * dK)^(1/degree(K))
+  oscar: |
+    OK = ring_of_integers(K);
+    (1.0 * abs(discriminant(OK)))^(1/degree(K))
 
 automorphisms:
   comment: Autmorphisms
@@ -81,7 +84,7 @@ ramified_primes:
   sage:  K.disc().support()
   pari:  factor(abs(K.disc))[,1]~
   magma: PrimeDivisors(Discriminant(OK));
-  oscar: prime_divisors(discriminant((OK)))
+  oscar: prime_divisors(discriminant(OK))
 
 integral_basis:
   comment: Integral basis
@@ -161,7 +164,7 @@ class_number_formula:
     2^r1 * (2*Pi(RR))^r2 * RK * hK / (wK * Sqrt(RR!Abs(DK)));
   oscar: |
     # self-contained Oscar code snippet to compute the analytic class number formula
-    Qx, x = PolynomialRing(QQ); K, a = NumberField(%s);
+    Qx, x = polynomial_ring(QQ); K, a = number_field(%s);
     OK = ring_of_integers(K); DK = discriminant(OK);
     UK, fUK = unit_group(OK); clK, fclK = class_group(OK);
     r1,r2 = signature(K); RK = regulator(K); RR = parent(RK);
@@ -173,12 +176,15 @@ galois_group:
   sage:  K.galois_group(type='pari')
   pari:  polgalois(K.pol)
   magma: G = GaloisGroup(K);
-  oscar: G, Gtx = galois_group(K); G, transitive_group_identification(G)
+  oscar: |
+    G, Gtx = galois_group(K);
+    degree(K) > 1 ? (G, transitive_group_identification(G)) : (G, nothing)
+
 
 intermediate_fields:
   comment: Intermediate fields
   sage: K.subfields()[1:-1]
-  pari: L = nfsubfields(K); L[2..length(b)]
+  pari: L = nfsubfields(K); L[2..length(L)]
   magma: L := Subfields(K); L[2..#L];
   oscar: subfields(K)[2:end-1]
 


### PR DESCRIPTION
GP: nfsubfields slice fixed (L[2..length(L)], not length(b)).

Oscar: Avoid non-portable API:

Replaced uppercase PolynomialRing/NumberField with lowercase polynomial_ring/number_field.

automorphisms(K) now uses a fallback: isdefined(Main,:automorphisms) ? automorphisms(K) : Hecke.hom(K,K).

Guarded transitive_group_identification(G) with degree(K) > 1.

Fixed root discriminant to compute from discriminant(ring_of_integers(K)) (no stray dK).

Class number formula block uses the lowercase API consistently.