### PR TITLE
#6696 lmfdb/abvar/fq/main.py

### DIFF
--- a/lmfdb/abvar/fq/main.py
+++ b/lmfdb/abvar/fq/main.py
@@ -893,12 +893,3 @@ def split_label(lab):
 
 def abvar_label(g, q, iso):
     return "%s.%s.%s" % (g, q, iso)
-
-
-lmfdb_label_regex = re.compile(r"(\d+)\.(\d+)\.([a-z_]+)")
-
-def split_label(lab):
-    return lmfdb_label_regex.match(lab).groups()
-
-def abvar_label(g, q, iso):
-    return "%s.%s.%s" % (g, q, iso)


### PR DESCRIPTION
Import parse_primes from lmfdb.utils.search_parsing.

In AbvarSearchArray.__init__:

Add a YesNoBox named cyclic (“Cyclic isotypic factors”) to the browse UI.

Add a TextBox named noncyclic_primes (“Non-cyclic primes”) to the refine UI, with example input like 2 or 2,3,5.

Wire cyclic and noncyclic_primes into self.browse_array / self.refine_array.