### PR TITLE
#6696 lmfdb/abvar/fq/isog_class.py

### DIFF
--- a/lmfdb/abvar/fq/isog_class.py
+++ b/lmfdb/abvar/fq/isog_class.py
@@ -237,15 +237,19 @@ class AbvarFq_isoclass():
             ("Primitive", "yes" if self.is_primitive else "no"),
         ]
         # Cyclicity information (new)
-        if getattr(self, "is_cyclic", None) is not None:
-            props.append(("Cyclic", "yes" if self.is_cyclic else "no"))
-            primes = getattr(self, "noncyclic_primes", None)
-            if primes is not None:
-                if primes:
-                    primes_str = "{" + ", ".join(str(p) for p in primes) + "}"
-                else:
-                    primes_str = "{}"
-                props.append(("Noncyclic primes", primes_str))
+        ic = getattr(self, "is_cyclic", None)
+        if ic is True:
+            cyclic_val = "yes"
+        elif ic is False:
+            cyclic_val = "no"
+        else:
+            cyclic_val = "unknown"
+        props.append(("Cyclic group of points", cyclic_val))
+
+        primes = getattr(self, "noncyclic_primes", None)
+        if primes:
+            primes_str = "{" + ", ".join(str(p) for p in primes) + "}"
+            props.append(("Noncyclic primes", primes_str))
         if self.has_principal_polarization != 0:
             props += [("Principally polarizable", "yes" if self.has_principal_polarization == 1 else "no")]
         if self.has_jacobian != 0:


### PR DESCRIPTION
Extend AbvarFq_isoclass.__init__ to handle new invariants:

Default is_cyclic to None if missing.

Default noncyclic_primes to [] if missing.

In AbvarFq_isoclass.properties:

Append a row "Cyclic" with value "yes" / "no" when is_cyclic is present.

Append a row "Noncyclic primes" showing the stored list (rendered as {p1, p2, …} or {} if empty).