### PR TITLE
#6696 lmfdb/abvar/fq/test_av.py

### DIFF
--- a/lmfdb/abvar/fq/test_av.py
+++ b/lmfdb/abvar/fq/test_av.py
@@ -157,3 +157,11 @@ class AVTest(LmfdbTest):
 
         page = self.tc.get('Variety/Abelian/Fq/download_curves/5.3.ac_e_ai_v_abl', follow_redirects=True)
         assert 'No curves for abelian variety isogeny class 5.3.ac_e_ai_v_abl' in page.get_data(as_text=True)
+
+    def test_cyclic_group_of_points_display(self):
+        r"""
+        Check that the cyclic group of points information is displayed
+        on the isogeny-class page.
+        """
+        page = self.tc.get("/Variety/Abelian/Fq/2/9/aj_bl").get_data(as_text=True)
+        assert "Cyclic" in page


### PR DESCRIPTION
* Update / add test_cyclic_group_of_points_display to reflect the new terminology used on the isogeny-class page.
    * Ensure the test checks for the presence of the new cyclicity label (e.g. "Cyclic" and/or "Noncyclic primes") on /Variety/Abelian/Fq/2/9/aj_bl.
    * Keep the rest of the test suite unchanged; all 19 tests pass under the new UI text.