### PR TITLE
Add number field picture description page

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -173,11 +173,10 @@ def nf_picture_page():
     bread = bread_prefix() + [('Number Field Picture', ' ')]
     return render_template(
         "single.html",
-        kid='portrait.nf',
+        kid='nf.picture',
         title=t,
         bread=bread,
-        learnmore=learnmore_list()
-    )
+        learnmore=learnmore_list())
 
 
 @nf_page.route("/GaloisGroups")


### PR DESCRIPTION
This adds a number field picture description page, to be filled by a knowl with the ID "nf.picture".
Similar pages exist for other objects, e.g. https://www.lmfdb.org/EllipticCurve/Q/CurvePictures

You can test it by navigating to
http://127.0.0.1:37777/NumberField/2.0.1468243.1
and clicking on the link in the "Learn more" section of the sidebar.

<img width="1582" height="1030" alt="image" src="https://github.com/user-attachments/assets/1a30b585-7f93-441c-9d6e-321c0e3f2ce4" />

