### PR TITLE
Fix error when downloading fields without slopes known

### DIFF
--- a/lmfdb/utils/search_columns.py
+++ b/lmfdb/utils/search_columns.py
@@ -573,6 +573,8 @@ def eval_rational_list(s):
     - once-nested lists like "[[1,2],[3,4]]" or "1,2;3,4"
     - single quotes wrapping the integers/rationals, like "['1','2','3']"
     """
+    if s is None:
+        return
     def split(x):
         if not x:
             return []


### PR DESCRIPTION
Fixes #6784.  To test, download degree 18 3-adic fields with

http://localhost:37777/padicField/?download=1&query={'p'%3A+3%2C+'n'%3A+18%2C+'e'%3A+18}&n=18&p=3&e=18&search_type=List&Submit=text