### PR TITLE
Fix spacing when displaying Galois groups for p-adic fields

### DIFF
--- a/lmfdb/local_fields/templates/lf-show-field.html
+++ b/lmfdb/local_fields/templates/lf-show-field.html
@@ -26,7 +26,7 @@
       :
       {% else %}
       $=$
-      {%- set ktitle = '$\Gal(K/\Q_{' ~ info.p ~ '})$' -%}
+      {% set ktitle = '$\Gal(K/\Q_{' ~ info.p ~ '})$' %}
       {{ KNOWL('nf.galois_group', title=ktitle) }}:
       {% endif %}
       </td> 


### PR DESCRIPTION
This is just a small PR to fix the spacing between the equals sign and the Galois group knowl link, when displaying pages for Galois p-adic fields.  This now makes the formatting consistent with the number field pages.

Example:
https://beta.lmfdb.org/padicField/2.1.2.2a1.1
http://localhost:37777/padicField/2.1.2.2a1.1

Before:
<img width="371" height="70" alt="image" src="https://github.com/user-attachments/assets/6b768c5a-4409-47e5-a47c-8bef4cb02d5e" />


After:
<img width="376" height="71" alt="image" src="https://github.com/user-attachments/assets/a95790e4-da74-4e7b-b1bd-4cf8f37f5eb7" />
