### PR TITLE
Fix typo on CMF browse page

### DIFF
--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -1595,7 +1595,7 @@ class CMFSearchArray(SearchArray):
             knowl='cmf.coefficient_field',
             label='Coefficient field',
             example='1.1.1.1',
-            example_span='2.0.5.1, Qsqrt5')
+            example_span='2.2.5.1, Qsqrt5')
 
         analytic_conductor = TextBox(
             name='analytic_conductor',


### PR DESCRIPTION
On the bugreport someone noted that we list "2.0.5.1" as a possible value to enter in the coefficient field box on the main CMF page: https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/

Yet there is no number field with that entry.  So this PR just changes the 0 to a 2. 

