### PR TITLE
First pass at removing extras

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -400,7 +400,7 @@ class WebNumberField:
             f = db.nf_fields.lucky({'coeffs': coeffs})
             if f is None:
                 return cls('a')  # will initialize data to None
-            f.update(db.nf_fields.extra.lookup(f['label']))
+            f.update(db.nf_fields_extra.lookup(f['label']))
             return cls(f['label'], f)
         else:
             raise Exception('wrong type')
@@ -453,7 +453,10 @@ class WebNumberField:
         return cls.from_coeffs(coeffs)
 
     def _get_dbdata(self):
-        return db.nf_fields.lookup(self.label).update(db.nf_fields_extra.lookup(self.label))
+        data1 = db.nf_fields.lookup(self.label)
+        if data1 is not None:
+            data1.update(db.nf_fields_extra.lookup(self.label))
+        return data1
 
     def is_in_db(self):
         return self._data is not None


### PR DESCRIPTION
This makes changes corresponding to the change from an extras table and its replacement as a regular table.  To properly test this, we need to delete the old extras table (or we will be getting its data when we pull data for a number field).  I think the steps should be:

 1. copy nf_fields and nf_fields_extra to the cloud version of the database
 2. merge this pull request
 3. delete the extras table for number fields for beta
 4. test this


