### PR TITLE
changed example matrix to 3 x 3, for disambiguation

### DIFF
--- a/lmfdb/lattice/main.py
+++ b/lmfdb/lattice/main.py
@@ -496,7 +496,7 @@ class LatSearchArray(SearchArray):
             label="Gram matrix",
             knowl="lattice.gram",
             example="[5,1,23]",
-            example_span=r"$[5,1,23]$ for the matrix $\begin{pmatrix}5 & 1\\ 1& 23\end{pmatrix}$")
+            example_span=r"$[2,1,0,6,3,10]$ for the matrix $\begin{pmatrix}2 & 1& 0\\ 1 & 6 & 3 \\ 0 & 3 & 10\end{pmatrix}$")
         minimum = TextBox(
             name="minimum",
             label="Minimal vector length",


### PR DESCRIPTION
The sample Gram matrix is not sufficient to make the conventions clear in rank greater than 2; a user might not be certain whether to enter the top half of the matrix (how most people would speak a symmetric matrix, I think) or the bottom half (the convention used in Magma's `SymmetricMatrix` command).  Verified that the code expects the top half and changed to a $3 \times 3$ matrix to make this clearer.  Maybe this should be an option.