### PR TITLE
partial fix for Issue #6190

### DIFF
--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -466,6 +466,7 @@ The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {
   <th>prime $\ell$</th>
   <th>{{KNOWL('ec.galois_rep_modell_image', title='mod-$\ell$ image')}}</th>
   <th>{{KNOWL('ec.galois_rep_elladic_image', title='$\ell$-adic image')}}</th>
+  <th>{{KNOWL('gl2.label', title='$\ell$-adic index')}}</th>
   </tr>
   </thead><tbody>
   {% for pr in data.data.galois_data %}
@@ -473,6 +474,7 @@ The {{KNOWL('ec.galois_rep', title=' $\ell$-adic Galois representation')}} has {
     <td align=center>${{pr.prime}}$</td>
     <td align=center>{{data.display_modell_image(pr.modell_image) | safe}}</td>
     <td align=center>{{data.display_elladic_image(pr.elladic_image) | safe}}</td>
+    <td align=center>${{pr.elladic_index}}$</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -395,6 +395,14 @@ class WebEC():
         # remove adelic image record (prime set to 0) from ell-adic data if present
         galois_data = list(db.ec_galrep.search({'lmfdb_label': lmfdb_label}))
         data['galois_data'] = [r for r in galois_data if r["prime"] > 0]
+        for gd in data['galois_data']:
+            if self.cm:
+                if self.cm in [-3,-4]:
+                    gd['elladic_index'] = '?'
+                else:
+                    gd['elladic_index'] = 2
+            else:
+                gd['elladic_index'] = gd['elladic_image'].split('.')[1]
         adelic_data = [r for r in galois_data if r["prime"] == 0]
         if adelic_data:
             assert len(adelic_data) == 1


### PR DESCRIPTION
This adds a new column \ell-adic index to the Galois Representations section of the home page of an elliptic curve over Q, as requested in #6190 .

For non-CM curves it takes the index from the 2nd part of the image label. For CM curves with CM discriminant not -3, -4 it sets the index to be 2 (as stated in #6190).  For discriminants -3, -4 it currently sets it to '?' since I have not worked out or looked up what it should be.  Hopefully the reviewer will know and will give the recipe here.

For the knowl for "\ell-adic index" I just used gl2.label.  It might be better to use ec.galois_rep_elladic_image (as for the ell-adic image column) *provided that* (1) that knowl actually defines the term "ell-adic image" explicitly as I think it should -- not just implicitly -- and also in that same knowl define the ell-adic index to be the index of the ell-adic image in GL(2,Zhat).