### PR TITLE
Add intrinsic subgroup order to elliptic curve data and search options

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -466,6 +466,7 @@ ec_columns = SearchColumns([
                   short_title="j-invariant", align="center", default=False),
     FloatCol("abc_quality", "ec.q.abc_quality", "$abc$ quality", short_title="abc quality", prec=5, default=False),
     FloatCol("szpiro_ratio", "ec.q.szpiro_ratio", "Szpiro ratio", prec=5, default=False),
+    MathCol("intrinsic_torsion", "ec.intrinsic_torsion", "Intrinsic torsion order", align="center", default=False),
     MathCol("ainvs", "ec.weierstrass_coeffs", "Weierstrass coefficients", short_title="Weierstrass coeffs", align="left", default=False),
     ProcessedCol("equation", "ec.q.minimal_weierstrass_equation", "Weierstrass equation", latex_equation, short_title="Weierstrass equation", align="left", orig="ainvs", download_col="ainvs"),
     ProcessedCol("modm_images", "ec.galois_rep", r"mod-$m$ images", lambda v: "<span>" + ", ".join([make_modcurve_link(s) for s in v[:5]] + ([r"$\ldots$"] if len(v) > 5 else [])) + "</span>",
@@ -554,6 +555,7 @@ def elliptic_curve_search(info, query):
     parse_floats(info,query,'faltings_height','faltings_height')
     parse_floats(info,query,'abc_quality')
     parse_floats(info,query,'szpiro_ratio')
+    parse_ints(info,query,'intrinsic_torsion')
     if info.get('reduction'):
         if info['reduction'] == 'semistable':
             query['semistable'] = True
@@ -1233,7 +1235,8 @@ class ECSearchArray(SearchArray):
              ("adelic_genus", "adelic genus", ["adelic_genus", "adelic_level", "adelic_index"]),
              ("faltings_height", "Faltings height", ["faltings_height", "conductor", "iso_nlabel", "lmfdb_number"]),
              ("abc_quality", "$abc$ quality", ["abc_quality", "conductor", "iso_nlabel", "lmfdb_number"]),
-             ("szpiro_ratio", "Szpiro ratio", ["szpiro_ratio", "conductor", "iso_nlabel", "lmfdb_number"])]
+             ("szpiro_ratio", "Szpiro ratio", ["szpiro_ratio", "conductor", "iso_nlabel", "lmfdb_number"]),
+             ("intrinsic torsion", "Intrinsic torsion order", ["intrinsic_torsion", "conductor", "iso_nlabel", "lmfdb_number"])]
     jump_example = "11.a2"
     jump_egspan = "e.g. 11.a2 or 389.a or 11a1 or 389a or [0,1,1,-2,0] or [-3024, 46224] or y^2 = x^3 + 1"
     jump_prompt = "Label or coefficients"
@@ -1427,6 +1430,12 @@ class ECSearchArray(SearchArray):
             knowl="ec.q.szpiro_ratio",
             example="8-",
             advanced=True)
+        intrinsic_torsion = TextBox(
+            name="intrinsic_torsion",
+            label="Intrinsic torsion order",
+            knowl="ec.intrinsic_torsion",
+            example="3",
+            advanced=True)
 
         manin_constant = TextBox(
             name="manin_constant",
@@ -1450,7 +1459,8 @@ class ECSearchArray(SearchArray):
             [adelic_level, adelic_index],
             [adelic_genus, faltings_height],
             [abc_quality, szpiro_ratio],
-            [count, manin_constant]
+            [intrinsic_torsion, manin_constant],
+            [count]
             ]
 
         self.refine_array = [
@@ -1460,4 +1470,5 @@ class ECSearchArray(SearchArray):
             [sha, sha_primes, regulator, reduction, faltings_height],
             [galois_image, adelic_level, adelic_index, adelic_genus],
             [nonmax_primes, abc_quality, szpiro_ratio, manin_constant],
+            [intrinsic_torsion]
             ]

--- a/lmfdb/elliptic_curves/templates/ec-curve.html
+++ b/lmfdb/elliptic_curves/templates/ec-curve.html
@@ -245,6 +245,12 @@ white-space: pre in order to keep line breaks! #}
         <td>{{ place_code('szpiro_ratio') }}</td>
         </tr>
 
+        <tr>
+        <td>{{ KNOWL('ec.intrinsic_torsion', title='Intrinsic torsion order') }}:</td>
+        <td>$\#E(\mathbb Q)_\text{tors}^\text{is}$</td><td>&nbsp;=&nbsp;</td><td colspan=3>${{ data.intrinsic_torsion }}$</td>
+        <td>{{ place_code('intrinsic_torsion') }}</td>
+        </tr>
+
        </table>
 
     <h2> {{ KNOWL('ec.q.bsdconjecture', title='BSD invariants') }}</h2>


### PR DESCRIPTION
The intrinsic subgroup is defined in [arXiv:2512.00787](https://arxiv.org/pdf/2512.00787). Adding computed values of the order of the intrinsic subgroup for elliptic curves over Q.