### PR TITLE
Fix Sage downloads for p-adic fields

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -546,7 +546,7 @@ lf_columns = SearchColumns([
     hidden_col(default=False),
     hiddenswan_col(),
     aut_col(lambda info:info.get("aut")),
-    # want apply_download for download conversion
+    # Want apply_download for download conversion.  Sage requires both 'unram' and 'eisen' in the download files to construct p-adic fields.
     PolynomialCol("unram", "lf.unramified_subfield", "Unram. Ext.", default=lambda info:info.get("visible") or info.get("Submit") == "sage"),
     ProcessedCol("eisen", "lf.eisenstein_polynomial", "Eisen. Poly.", default=lambda info:info.get("visible") or info.get("Submit") == "sage", mathmode=True, func=format_eisen),
     insep_col(default=lambda info: info.get("ind_of_insep")),


### PR DESCRIPTION
This resolves issue #6846.  Currently the Sage downloads for p-adic fields are not working, as Sage doesn't support directly constructing arbitrary extensions of p-adic fields.

This fix is to separate out the p-adic field construction by first constructing the maximal unramified sub-extension (using the `unram` column), and then constructing the totally ramified part (using the `eisen` column).   In order to construct the fields, I've set both of these columns to always be included in the Sage downloaded files.

As always, any comments or feedback are very welcome! 🙂 

E.g. Sage download for 2-adic degree 4 fields:
https://beta.lmfdb.org/padicField/?download=1&query=%7B%27p%27%3A+2%2C+%27n%27%3A+4%7D&p=2&n=4&Submit=sage
http://localhost:37777/padicField/?download=1&query=%7B%27p%27%3A+2%2C+%27n%27%3A+4%7D&p=2&n=4&Submit=sage