### PR TITLE
ECNF: add curve and class picture descriptions

### DIFF
--- a/lmfdb/ecnf/isog_class.py
+++ b/lmfdb/ecnf/isog_class.py
@@ -152,10 +152,11 @@ class ECNF_isoclass():
             self.friends += [('L-function not available', "")]
 
         self.properties = [('Base field', self.field_name),
-                           ('Label', self.class_label),
-                           (None, self.graph_link),
-                           ('Conductor', '%s' % self.conductor_label)
-                       ]
+                           ('Label', self.class_label)]
+        if self.class_size>1:
+            self.properties.append((None, self.graph_link))
+        self.properties.append(('Conductor', '%s' % self.conductor_label))
+
         if self.rk != '?':
             self.properties += [('Rank', '%s' % self.rk)]
         else:

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -52,6 +52,9 @@ def learnmore_list():
             ('Reliability of the data', url_for(".reliability_page")),
             ('Elliptic curve labels', url_for(".labels_page"))]
 
+def learnmore_list_add(learnmore_label, learnmore_url):
+    return learnmore_list() + [(learnmore_label, learnmore_url)]
+
 # Return the learnmore list with the matchstring entry removed
 def learnmore_list_remove(matchstring):
     return [t for t in learnmore_list() if t[0].find(matchstring) < 0]
@@ -91,6 +94,24 @@ def labels_page():
              ('Labels', '')]
     return render_template("single.html", kid='ec.curve_label',
                            title=t, bread=bread, learnmore=learnmore_list_remove('labels'))
+
+@ecnf_page.route("/CurvePictures")
+def curve_picture_page():
+    t = r'Pictures for elliptic curves over number fields'
+    bread = get_bread('Curve Pictures')
+    return render_template(
+        "single.html", kid='portrait.ec.nf',
+        title=t, bread=bread, learnmore=learnmore_list(),
+    )
+
+@ecnf_page.route("/IsogenyPictures")
+def isog_picture_page():
+    t = r'Pictures of isogeny graphs of elliptic curves over number fields'
+    bread = get_bread('Isogeny Pictures')
+    return render_template(
+        "single.html", kid='ec.isogeny_graph',
+        title=t, bread=bread, learnmore=learnmore_list(),
+    )
 
 
 @ecnf_page.route("/")
@@ -255,13 +276,14 @@ def show_ecnf_isoclass(nf, conductor_label, class_label):
     bread.append((nf_pretty, url_for(".show_ecnf1", nf=nf)))
     bread.append((conductor_label, url_for(".show_ecnf_conductor", nf=nf_label, conductor_label=conductor_label)))
     bread.append((class_label, url_for(".show_ecnf_isoclass", nf=nf_label, conductor_label=quote(conductor_label), class_label=class_label)))
+    learnmore_isog_picture = ('Picture description', url_for(".isog_picture_page"))
     return render_template("ecnf-isoclass.html",
                            title=title,
                            bread=bread,
                            cl=cl,
                            properties=cl.properties,
                            friends=cl.friends,
-                           learnmore=learnmore_list())
+                           learnmore=learnmore_list_add(*learnmore_isog_picture) if cl.class_size>1 else learnmore_list())
 
 
 @ecnf_page.route("/<nf>/<conductor_label>/<class_label>/<int:number>")
@@ -291,6 +313,8 @@ def show_ecnf(nf, conductor_label, class_label, number):
     bread.append((ec.number, ec.urls['curve']))
     code = ec.code()
     code['show'] = {'magma':'','pari':'','sage':''} # use default show names
+    learnmore_curve_picture = ('Picture description', url_for(".curve_picture_page"))
+    IQF = ec.signature == [0,1]
     info = {}
     return render_template("ecnf-curve.html",
                            title=title,
@@ -302,7 +326,7 @@ def show_ecnf(nf, conductor_label, class_label, number):
                            downloads=ec.downloads,
                            info=info,
                            KNOWL_ID="ec.%s" % label,
-                           learnmore=learnmore_list())
+                           learnmore = learnmore_list() if IQF else learnmore_list_add(*learnmore_curve_picture))
 
 @ecnf_page.route("/data/<label>")
 def ecnf_data(label):


### PR DESCRIPTION
See #6389.  This addes picture descriptions for ECNF similar to ECQ.   The isogeny picture description uses the same knowl as for ECQ, but the curve picture knowl is new (portraits.ec.nf) as it has to explain that the picture show the union of the graphs for all real embeddings only, so there is no picture or picture description for imagainary quadratic fields (currently these are the only fields with no real embeddings for which we have any elliptic curves).

At the same time I stopped showing the trivial isogeny class picture in the Properties box when the class size is 1 since it is redundant, but reviewers are welcome to revert that change for consistency.  If we were able to solve the problem of all the extra whilte space around all out isogeny graphs this would be less of an issue.