### PR TITLE
Add _lmfdb_label attribute to elliptic curve Sage downloads (over Q)

### DIFF
--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -487,7 +487,7 @@ class ECDownloader(Downloader):
         "curve": (
             ["ainvs"],
             {
-                "sage": 'curve = EllipticCurve(out["ainvs"])',
+                "sage": 'curve = EllipticCurve(out["ainvs"]){attach_lmfdb_label}',
                 "magma": 'curve := EllipticCurve(out`ainvs);',
                 "gp": 'curve = ellinit(mapget(out, "ainvs"));',
                 "oscar": 'curve = EllipticCurve(out["ainvs"])',
@@ -504,6 +504,15 @@ class ECDownloader(Downloader):
                 gens = [(ZZ(a) / c, ZZ(b) / c) for a, b, c in gens]
             row["mwgens"] = gens
         return row
+
+    def createrecord_code(self, lang, column_names):
+        # We override the createrecord_code subclass to attach the lmfdb label
+        # to the elliptic curve, if lang is Sage and "lmfdb_label" is in column_name
+        code = super().createrecord_code(lang, column_names)
+        attach_lmfdb_label = '\n    curve._lmfdb_label = out["lmfdb_label"]' if "lmfdb_label" in column_names else ""
+        code = code.replace("{attach_lmfdb_label}", attach_lmfdb_label)
+        return code
+
 
 @search_wrap(table=db.ec_curvedata,
              title='Elliptic curve search results',


### PR DESCRIPTION
This PR adds the internal `_lmfdb_label` attribute to the constructed elliptic curves in the ECQ search download file, thereby implementing one of @JohnCremona's suggestions in issue #4810 . 

In particular, the line of code `curve._lmfdb_label = out["lmfdb_label"]` is added to the `create_record()` function in the Sage downloads, if both the `ainvs` and `lmfdb_label` columns are present.  This allows the user to call `curve.lmfdb_page()` to see the relevant LMFDB homepage, and so is particularly useful for the large conductor elliptic curves which are not by default included in `CremonaDatabase()` in Sage.

Comments or feedback very welcome! :)

E.g. Download file for rank 5 elliptic curves over Q:
https://beta.lmfdb.org/EllipticCurve/Q/?download=1&query=%7B%27rank%27%3A+5%7D&rank=5&Submit=sage
http://localhost:37777/EllipticCurve/Q/?download=1&query=%7B%27rank%27%3A+5%7D&rank=5&Submit=sage
