### PR TITLE
Various improvements to the Downloader utility class

### DIFF
--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -812,7 +812,7 @@ class Downloader():
                 all_knowls = {rec["id"]: (rec["title"], rec["content"]) for rec in knowldb.get_all_knowls(fields=["id", "title", "content"])}
                 knowl_re = re.compile(r"""\{\{\s*KNOWL\(\s*["'](?:[^"']+)["'],\s*(?:title\s*=\s*)?['"]([^"']+)['"]\s*\)\s*\}\}""")
                 defines_re = re.compile(r"""\{\{\s*DEFINES\(\s*"([^"]+)"[^)]*\)\s*\}\}""")
-                jinja_comment_re = re.compile(r"""\{#.*#\}""")
+                jinja_comment_re = re.compile(r"""\{#.*?#\}""")
 
                 def knowl_subber(match):
                     return match.group(1)


### PR DESCRIPTION
This PR adds a few improvements and bug fixes to the `lmfdb/utils/downloader.py` file, thereby resolving various issues mentioned in #4810, #6821, and #6824 (many thanks to @JohnCremona and @jenpaulhus for flagging these issues!).

 - Fixed a bug where the CSV downloads didn't work if one of the search columns didn't have a linked knowl.  E.g. this error can occur for subgroup searches, classical modular forms, and hypergeometric motives over Q.

 - Added a semicolon after `make_data()` for gp downloads, as suggested in [#4810](https://github.com/LMFDB/lmfdb/issues/4810) by @JohnCremona .

 - Now removes Jinja comments (i.e. `{# ... #}`) from the knowl output at the bottom of the download files. (e.g. such comments can be found in [nf.signature](https://beta.lmfdb.org/knowledge/show/nf.signature), [nf.degree](https://beta.lmfdb.org/knowledge/show/nf.degree), [nf.class_number](https://beta.lmfdb.org/knowledge/show/nf.class_number), etc.), resolving issue [#6824](https://github.com/LMFDB/lmfdb/issues/6824).

 - Now also replaces the recently added `{{DEFINES("name", ...)}}` macro in the downloaded knowl text with just `**name**`  (i.e. as would originally be seen if the text were just highlighted in bold in the knowl).

As always, any comments or feedback very welcome! :)

E.g. CSV download for subgroups:
https://beta.lmfdb.org/Groups/Abstract/?download=1&query=%7B%27ambient_order%27%3A+%7B%27%24gte%27%3A+1%2C+%27%24lte%27%3A+3%7D%7D&ambient_order=1-3&search_type=Subgroups&Submit=csv
http://localhost:37777/Groups/Abstract/?download=1&query=%7B%27ambient_order%27%3A+%7B%27%24gte%27%3A+1%2C+%27%24lte%27%3A+3%7D%7D&ambient_order=1-3&search_type=Subgroups&Submit=csv

E.g. CSV download for hypergeometric over Q:
https://beta.lmfdb.org/Motive/Hypergeometric/Q/?download=1&query=%7B%7D&search_type=Motive&Submit=csv
http://localhost:37777/Motive/Hypergeometric/Q/?download=1&query=%7B%7D&search_type=Motive&Submit=csv

E.g. A number field text download with all columns selected (where knowls contain `DEFINES` macros and Jinja comments):
https://beta.lmfdb.org/NumberField/?download=1&query=%7B%27disc_abs%27%3A+%7B%27%24lte%27%3A+100%2C+%27%24gte%27%3A+1%7D%2C+%27disc_sign%27%3A+1%7D&discriminant=1-100&showcol=degree.signature.num_ram.rd.grd.cm.is_galois.monogenic.narrow_class_group_desc.torsion_order.unit_rank.regulator&Submit=text
http://localhost:37777/NumberField/?download=1&query=%7B%27disc_abs%27%3A+%7B%27%24lte%27%3A+100%2C+%27%24gte%27%3A+1%7D%2C+%27disc_sign%27%3A+1%7D&discriminant=1-100&showcol=degree.signature.num_ram.rd.grd.cm.is_galois.monogenic.narrow_class_group_desc.torsion_order.unit_rank.regulator&Submit=text