### PR TITLE
Improve Oscar downloads of search results

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -458,6 +458,7 @@ class ECNFDownloader(Downloader):
                 "sage": 'field.<a> = NumberField(ZZx(out["field_coeffs"]))\n    curve = EllipticCurve([field(ai) for ai in out["ainvs"]])',
                 "magma": 'field<a> := NumberField(ZZx!(out`field_coeffs));\n    curve := EllipticCurve([field!ai : ai in out`ainvs]);',
                 "gp": 'field = nfinit(Polrev(mapget(out, "field_coeffs")));\n    curve = ellinit(apply(Polrev, mapget(out, "ainvs")), field);',
+                "oscar": 'field,a = number_field(ZZx(out["field_coeffs"]))\n    curve = elliptic_curve([field(ai) for ai in out["ainvs"]])',
             }
         ),
     }

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -490,7 +490,7 @@ class ECDownloader(Downloader):
                 "sage": 'curve = EllipticCurve(out["ainvs"]){attach_lmfdb_label}',
                 "magma": 'curve := EllipticCurve(out`ainvs);',
                 "gp": 'curve = ellinit(mapget(out, "ainvs"));',
-                "oscar": 'curve = EllipticCurve(out["ainvs"])',
+                "oscar": 'curve = elliptic_curve(out["ainvs"])',
             }
         )
     }

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -888,6 +888,7 @@ class NFDownloader(Downloader):
                 "sage": 'poly = ZZx(out["coeffs"])',
                 "magma": 'poly := ZZx!(out`coeffs);',
                 "gp": 'poly = Polrev(mapget(out, "coeffs"));',
+                "oscar": 'poly = ZZx(out["coeffs"])',
             }
         ),
         "field": (
@@ -896,6 +897,7 @@ class NFDownloader(Downloader):
                 "sage": 'field.<a> = NumberField(poly)',
                 "magma": 'field<a> := NumberField(poly);',
                 "gp": 'field = nfinit(poly);',
+                "oscar": 'field,a = number_field(poly)',
             }
         ),
     }

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -305,7 +305,7 @@ class OscarLanguage(DownloadLanguage):
     def initialize(self, cols, downloader):
         from lmfdb.number_fields.number_field import PolynomialCol
         if any(isinstance(c, PolynomialCol) for c in cols):
-            return '\nRx,x = PolynomialRing(QQ)\n\n'
+            return '\nZZx,x = polynomial_ring(QQ)\n\n'
         else:
             return '\n'
 


### PR DESCRIPTION
This PR adds some improvements and small fixes to the search result downloads for Oscar.

For number field downloads, now constructs the defining polynomial and field (as already done for Sage/Magma/Pari).  Similarly for ECNF, now explicitly constructs the elliptic curve (i.e. extending PR #6821 to Oscar), and for elliptic curves over Q, corrected a small typo in construction of elliptic curve.

Comments/feedback very welcome :)

E.g. Sample Oscar download for number field search
https://beta.lmfdb.org/NumberField/?download=1&query=%7B%27disc_abs%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27disc_sign%27%3A+1%7D&discriminant=1..10&Submit=oscar
http://localhost:37777/NumberField/?download=1&query=%7B%27disc_abs%27%3A+%7B%27%24lte%27%3A+10%2C+%27%24gte%27%3A+1%7D%2C+%27disc_sign%27%3A+1%7D&discriminant=1..10&Submit=oscar

E.g. Sample Oscar download for ECQ search
https://beta.lmfdb.org/EllipticCurve/Q/?download=1&query=%7B%27conductor%27%3A+%7B%27%24gte%27%3A+1%2C+%27%24lte%27%3A+20%7D%7D&conductor=1..20&Submit=oscar
http://localhost:37777/EllipticCurve/Q/?download=1&query=%7B%27conductor%27%3A+%7B%27%24gte%27%3A+1%2C+%27%24lte%27%3A+20%7D%7D&conductor=1..20&Submit=oscar

E.g. Sample Oscar download for ECNF search
https://beta.lmfdb.org/EllipticCurve/?download=1&query=%7B%27conductor_norm%27%3A+1%2C+%27rank%27%3A+2%7D&conductor_norm=1&rank=2&Submit=oscar
http://localhost:37777/EllipticCurve/?download=1&query=%7B%27conductor_norm%27%3A+1%2C+%27rank%27%3A+2%7D&conductor_norm=1&rank=2&Submit=oscar