### PR TITLE
Fixed typo in Sage code snippet for ECQ isogeny class pages

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -183,7 +183,7 @@ class ECisog_class():
                       ('%s' % self.iso_label, ' ')]
         self.code = {}
         self.code['show'] = {'sage':''} # use default show names
-        self.code['class'] = {'sage':'E = EllipticCurve("%s1")\n' % (self.iso_label) + 'E.isogeny_class()\n'}
+        self.code['class'] = {'sage':'E = EllipticCurve(%s)\n' % (self.ainvs) + 'E.isogeny_class()\n'}
         self.code['curves'] = {'sage':'E.isogeny_class().curves'}
         self.code['rank'] = {'sage':'E.rank()'}
         self.code['q_eigenform'] = {'sage':'E.q_eigenform(10)'}


### PR DESCRIPTION
This PR just fixes a minor typo in the top Sage code snippet on the ECQ isogeny class pages.  I've just copied what's done on the usual ECQ pages, where we use the a-invariants of the first listed elliptic curve to define E, instead of the label (since the conductor might be too large to be in the Cremona database).

E.g. Isogeny class 11.a:
https://beta.lmfdb.org/EllipticCurve/Q/11/a/
http://localhost:37777/EllipticCurve/Q/11/a/

E.g. Isogeny class 500393.a
https://beta.lmfdb.org/EllipticCurve/Q/500393/a/
http://localhost:37777/EllipticCurve/Q/500393/a/