### PR TITLE
Fix powers of conjugacy classes and divisions in character tables

### DIFF
--- a/lmfdb/groups/abstract/templates/character_table.html
+++ b/lmfdb/groups/abstract/templates/character_table.html
@@ -43,9 +43,9 @@
       <td></td><td class="right">{{KNOWL('group.conjugacy_class.power_classes',"{} P".format(p))}}</td>
       {% for c in ccs %}
        {% if loop.index ==  highlight_i %}
-      <td class="highlighted">{{ ccs[c['powers'][ploop.index-1]-1].label }}</td>
+      <td class="highlighted">{{ ccs[c.prime_powers()[ploop.index-1]-1].label }}</td>
       {% else %}
-<td class="right">{{ ccs[c['powers'][ploop.index-1]-1].label }}</td>
+<td class="right">{{ ccs[c.prime_powers()[ploop.index-1]-1].label }}</td>
       {% endif %}
       {% endfor %}
     </tr>

--- a/lmfdb/groups/abstract/templates/rational_character_table.html
+++ b/lmfdb/groups/abstract/templates/rational_character_table.html
@@ -24,7 +24,7 @@
     <tr>
       <td></td><td>{{KNOWL('group.conjugacy_class.power_classes',"{} P".format(p))}}</td>
       {% for c in gp.conjugacy_class_divisions %}
-        <td>{{ gp.conjugacy_classes[c.classes.0.powers[ploop.index0]-1].division.label }}</td>
+        <td>{{ gp.conjugacy_classes[c.classes.0.prime_powers()[ploop.index0]-1].division.label }}</td>
       {% endfor %}
     </tr>
   {% endfor %}

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -24,6 +24,7 @@ from sage.all import (
     is_prime,
     cartesian_product_iterator,
     exists,
+    euler_phi,
 )
 from sage.libs.gap.libgap import libgap
 from sage.libs.gap.element import GapElement
@@ -3755,6 +3756,14 @@ class WebAbstractConjClass(WebObj):
         newrep = newrep.replace(' ','')
         self.representative = newrep
         self.force_repr_elt = True
+
+    # extract from powers list the ones corresponding to ones dividing the order
+    def prime_powers(self):
+        plist=[z[0] for z in ZZ(self.group_order).factor()]
+        Nphi = self.group_order*euler_phi(self.group_order)
+        plist_long = [z[0] for z in ZZ(Nphi).factor()]
+        assert len(plist_long) == len(self.powers)
+        return [self.powers[plist_long.index(p)] for p in plist]
 
     def display_knowl(self, name=None):
         if not name:


### PR DESCRIPTION
This fixes part of issue #6864.  The powers of conjugacy classes and divisions were often incorrect in character tables.  It was caused by a mismatch between the way the data was stored and the code.

The rational character table:

http://beta.lmfdb.org/Groups/Abstract/27.2
http://127.0.0.1:37777/Groups/Abstract/27.2

3 times each class is itself when it has to at least be of smaller order.

Similar problem appears in the complex character table:

http://127.0.0.1:37777/Groups/Abstract/15.1
http://beta.lmfdb.org/Groups/Abstract/15.1