### PR TITLE
Workaround for not yet using small group labels

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -23,7 +23,7 @@ from sage.all import (
     lcm,
     is_prime,
     cartesian_product_iterator,
-    exists,
+    #exists,
     euler_phi,
 )
 from sage.libs.gap.libgap import libgap


### PR DESCRIPTION
This change fixes #6814.  Compare

* https://beta.lmfdb.org/Groups/Abstract/?group=12550.a&order=50&search_type=ConjugacyClasses
* http://localhost:37777/Groups/Abstract/?group=12550.a&order=50&search_type=ConjugacyClasses