### PR TITLE
Add /CodeCoverage page showing code snippet coverage per module and CAS

### DIFF
--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -30,12 +30,12 @@
         "server": "devmirror"
     },
     {
-        "files": "lmfdb/tests/test_dynamic_knowls.py lmfdb/tests/test_root.py lmfdb/hecke_algebras/test_hecke_algebras.py lmfdb/tests/test_homepage.py lmfdb/tests/test_random_redirects.py lmfdb/elliptic_curves/test_ell_curves.py lmfdb/elliptic_curves/test_browse_page.py",
+        "files": "lmfdb/tests/test_dynamic_knowls.py lmfdb/tests/test_root.py lmfdb/tests/test_code_coverage.py lmfdb/hecke_algebras/test_hecke_algebras.py lmfdb/tests/test_homepage.py lmfdb/tests/test_random_redirects.py lmfdb/elliptic_curves/test_ell_curves.py lmfdb/elliptic_curves/test_browse_page.py",
         "folders": "elliptic_curves hecke_algebras tests",
         "server": "proddb"
     },
     {
-        "files": "lmfdb/tests/test_dynamic_knowls.py lmfdb/tests/test_root.py lmfdb/hecke_algebras/test_hecke_algebras.py lmfdb/tests/test_homepage.py lmfdb/tests/test_random_redirects.py lmfdb/elliptic_curves/test_ell_curves.py lmfdb/elliptic_curves/test_browse_page.py",
+        "files": "lmfdb/tests/test_dynamic_knowls.py lmfdb/tests/test_root.py lmfdb/tests/test_code_coverage.py lmfdb/hecke_algebras/test_hecke_algebras.py lmfdb/tests/test_homepage.py lmfdb/tests/test_random_redirects.py lmfdb/elliptic_curves/test_ell_curves.py lmfdb/elliptic_curves/test_browse_page.py",
         "folders": "elliptic_curves hecke_algebras tests",
         "server": "devmirror"
     },

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -90,7 +90,7 @@ jobs:
     - name: checking that we didn't miss any test files
       shell: bash -l {0}
       # If this fails you need to update the file list above and file count
-      run: test $(find lmfdb -name 'test_*.py' -or -name '*_test.py' | wc -l) -eq 41
+      run: test $(find lmfdb -name 'test_*.py' -or -name '*_test.py' | wc -l) -eq 42
 
     - name: Config LMFDB to run tests against proddb
       if: matrix.files != 'lint' && matrix.server == 'proddb'

--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -628,6 +628,54 @@ def not_yet_implemented():
     return render_template("not_yet_implemented.html", title="Not Yet Implemented")
 
 
+@app.route("/CodeCoverage")
+def code_coverage():
+    import glob
+    import yaml
+    lmfdb_dir = os.path.dirname(os.path.abspath(__file__))
+    yaml_files = sorted(glob.glob(os.path.join(lmfdb_dir, "**/code*.yaml"), recursive=True))
+    metadata_keys = {'prompt', 'logo', 'comment', 'not-implemented', 'frontmatter', 'snippet_test', 'top_matter'}
+    cas_display = {"pari": "Pari/GP", "sage": "SageMath", "magma": "Magma", "oscar": "Oscar", "gap": "Gap"}
+    all_cas = set()
+    modules = []
+    for yf in yaml_files:
+        with open(yf) as f:
+            data = yaml.safe_load(f)
+        if not data:
+            continue
+        cas_list = list(data.get('prompt', {}).keys())
+        all_cas.update(cas_list)
+        sections = {k: v for k, v in data.items() if k not in metadata_keys and isinstance(v, dict)}
+        total = len(sections)
+        per_cas = {}
+        for cas in cas_list:
+            per_cas[cas] = sum(1 for s in sections.values() if cas in s)
+        rel = os.path.relpath(yf, lmfdb_dir)
+        module_name = rel.split(os.sep)[0].replace('_', ' ').capitalize()
+        basename = os.path.basename(yf)
+        if basename != 'code.yaml':
+            suffix = basename.replace('code-', '').replace('code', '').replace('.yaml', '')
+            module_name += f' ({suffix})'
+        modules.append({'name': module_name, 'file': rel, 'total': total, 'per_cas': per_cas, 'cas_list': cas_list})
+    cas_order = [c for c in ['sage', 'pari', 'magma', 'oscar', 'gap'] if c in all_cas]
+    totals = {}
+    grand_total = 0
+    for cas in cas_order:
+        count = sum(m['per_cas'].get(cas, 0) for m in modules if cas in m['cas_list'])
+        applicable = sum(m['total'] for m in modules if cas in m['cas_list'])
+        totals[cas] = (count, applicable)
+    grand_total = sum(m['total'] for m in modules)
+    bread = [("Code Coverage", '')]
+    return render_template("code_coverage.html",
+                           title="Code Snippet Coverage",
+                           bread=bread,
+                           modules=modules,
+                           cas_order=cas_order,
+                           cas_display=cas_display,
+                           totals=totals,
+                           grand_total=grand_total)
+
+
 ##############################
 #         Intro pages        #
 ##############################

--- a/lmfdb/templates/code_coverage.html
+++ b/lmfdb/templates/code_coverage.html
@@ -1,0 +1,83 @@
+{% extends 'homepage.html' %}
+
+{% block content %}
+<h2>Code snippet coverage by module and CAS</h2>
+
+<p>Each code.yaml file defines code snippets for various computer algebra systems.
+The table below shows how many of the available code sections have a snippet for each CAS.</p>
+
+<style>
+  .cov-table { border-collapse: collapse; margin: 1em 0; }
+  .cov-table th, .cov-table td { border: 1px solid #ccc; padding: 4px 10px; text-align: center; }
+  .cov-table th { background: #f0f0f0; }
+  .cov-full { background: #c6efce; }
+  .cov-partial { background: #ffeb9c; }
+  .cov-low { background: #ffc7ce; }
+  .cov-none { background: #eee; color: #999; }
+</style>
+
+<table class="cov-table">
+<thead>
+<tr>
+  <th style="text-align:left">Module</th>
+  {% for cas in cas_order %}
+  <th>{{ cas_display.get(cas, cas) }}</th>
+  {% endfor %}
+  <th>Total sections</th>
+</tr>
+</thead>
+<tbody>
+{% for mod in modules %}
+<tr>
+  <td style="text-align:left" title="{{ mod.file }}">{{ mod.name }}</td>
+  {% for cas in cas_order %}
+    {% if cas in mod.cas_list %}
+      {% set count = mod.per_cas.get(cas, 0) %}
+      {% set total = mod.total %}
+      {% if total > 0 %}
+        {% set pct = (100 * count / total)|int %}
+      {% else %}
+        {% set pct = 0 %}
+      {% endif %}
+      {% if pct == 100 %}
+        {% set cls = "cov-full" %}
+      {% elif pct >= 50 %}
+        {% set cls = "cov-partial" %}
+      {% else %}
+        {% set cls = "cov-low" %}
+      {% endif %}
+      <td class="{{ cls }}">{{ count }}/{{ total }}</td>
+    {% else %}
+      <td class="cov-none">&mdash;</td>
+    {% endif %}
+  {% endfor %}
+  <td>{{ mod.total }}</td>
+</tr>
+{% endfor %}
+</tbody>
+<tfoot>
+<tr style="font-weight:bold">
+  <td style="text-align:left">Total</td>
+  {% for cas in cas_order %}
+    {% set count = totals[cas][0] %}
+    {% set total = totals[cas][1] %}
+    {% if total > 0 %}
+      {% set pct = (100 * count / total)|int %}
+    {% else %}
+      {% set pct = 0 %}
+    {% endif %}
+    {% if pct == 100 %}
+      {% set cls = "cov-full" %}
+    {% elif pct >= 50 %}
+      {% set cls = "cov-partial" %}
+    {% else %}
+      {% set cls = "cov-low" %}
+    {% endif %}
+    <td class="{{ cls }}">{{ count }}/{{ total }}</td>
+  {% endfor %}
+  <td>{{ grand_total }}</td>
+</tr>
+</tfoot>
+</table>
+
+{% endblock %}

--- a/lmfdb/tests/test_code_coverage.py
+++ b/lmfdb/tests/test_code_coverage.py
@@ -1,0 +1,50 @@
+from lmfdb.tests import LmfdbTest
+
+
+class CodeCoverageTest(LmfdbTest):
+
+    def test_page_loads(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "Code snippet coverage" in page
+
+    def test_table_header(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        for cas in ["SageMath", "Pari/GP", "Magma"]:
+            assert cas in page, f"{cas} not in code coverage page"
+
+    def test_modules_present(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "Elliptic curves" in page
+        assert "Number fields" in page
+        assert "Genus2 curves" in page
+
+    def test_classical_modular_forms_variants(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "Classical modular forms (form)" in page
+        assert "Classical modular forms (space)" in page
+
+    def test_coverage_cells(self):
+        """Check that coverage cells contain X/Y patterns"""
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        import re
+        matches = re.findall(r'\d+/\d+', page)
+        assert len(matches) > 10, "Expected many X/Y coverage cells"
+
+    def test_total_row(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "<td style=\"text-align:left\">Total</td>" in page
+
+    def test_color_classes(self):
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "cov-full" in page or "cov-partial" in page or "cov-low" in page
+
+    def test_oscar_and_gap(self):
+        """Oscar and Gap should appear since some yaml files define them"""
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "Oscar" in page
+        assert "Gap" in page
+
+    def test_dash_for_missing_cas(self):
+        """Modules without a CAS should show a dash"""
+        page = self.tc.get("/CodeCoverage").get_data(as_text=True)
+        assert "cov-none" in page


### PR DESCRIPTION
Parses all code*.yaml files and renders a table showing how many code sections have snippets for each CAS (SageMath, Pari/GP, Magma, Oscar, Gap), with color-coded cells and a summary row. Includes tests.


Live on https://olive.lmfdb.xyz/CodeCoverage