### PR TITLE
Typo fix in elliptic curve isogeny snippet tests

### DIFF
--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -277,6 +277,7 @@ snippet_test:
     url: EllipticCurve/Q/11/a/3/download/{lang}?label=11.a3
   test37a: 
     label: 37.a
+    langs:
       - sage
       - magma
       - gp


### PR DESCRIPTION
This PR just fixes a small silly typo I made in the elliptic curve isogeny class snippet tests!