### PR TITLE
Elliptic Curve landing page

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -473,6 +473,14 @@ def modular_forms():
     return render_template('single.html', title=t, kid='mf.about', bread=b)
 
 
+@app.route('/EllipticCurves')
+@app.route('/EllipticCurves/')
+def elliptic_curves():
+    t = 'Elliptic curves'
+    b = [(t, url_for('elliptic_curves'))]
+    return render_template('single.html', title=t, kid='ec.about', bread=b)
+
+
 @app.route('/Variety')
 @app.route('/Variety/')
 def varieties():

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -39,7 +39,8 @@ from lmfdb.ecnf.WebEllipticCurve import (ECNF, web_ainvs, LABEL_RE,
 from lmfdb.ecnf.isog_class import ECNF_isoclass
 
 def get_bread(*breads):
-    bc = [("Elliptic curves", url_for(".index"))]
+#    bc = [("Elliptic curves", url_for(".index"))]
+    bc = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q(\alpha)$', url_for(".index"))]
     for x in breads:
         if not isinstance(x, tuple):
             x = (x, " ")
@@ -64,7 +65,8 @@ def learnmore_list_remove(matchstring):
 @ecnf_page.route("/Completeness")
 def completeness_page():
     t = 'Completeness of elliptic curve data over number fields'
-    bread = [('Elliptic curves', url_for("ecnf.index")),
+#    bread = [('Elliptic curves', url_for("ecnf.index")),
+    bread = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q(\alpha)$', url_for(".index")),
              ('Completeness', '')]
     return render_template("single.html", kid='rcs.cande.ec',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Completeness'))
@@ -73,7 +75,8 @@ def completeness_page():
 @ecnf_page.route("/Source")
 def how_computed_page():
     t = 'Source of elliptic curve data over number fields'
-    bread = [('Elliptic curves', url_for("ecnf.index")),
+#    bread = [('Elliptic curves', url_for("ecnf.index")),
+    bread = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q(\alpha)$', url_for(".index")),
              ('Source', '')]
     return render_template("multi.html", kids=['rcs.source.ec',
                                                'rcs.ack.ec',
@@ -83,7 +86,8 @@ def how_computed_page():
 @ecnf_page.route("/Reliability")
 def reliability_page():
     t = 'Reliability of elliptic curve data over number fields'
-    bread = [('Elliptic curves', url_for("ecnf.index")),
+#    bread = [('Elliptic curves', url_for("ecnf.index")),
+    bread = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q(\alpha)$', url_for(".index")),
              ('Source', '')]
     return render_template("single.html", kid='rcs.rigor.ec',
                            title=t, bread=bread, learnmore=learnmore_list_remove('Reliability'))
@@ -91,7 +95,8 @@ def reliability_page():
 @ecnf_page.route("/Labels")
 def labels_page():
     t = 'Labels for elliptic curves over number fields'
-    bread = [('Elliptic curves', url_for("ecnf.index")),
+#    bread = [('Elliptic curves', url_for("ecnf.index")),
+    bread = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q(\alpha)$', url_for(".index")),
              ('Labels', '')]
     return render_template("single.html", kid='ec.curve_label',
                            title=t, bread=bread, learnmore=learnmore_list_remove('labels'))

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -48,7 +48,7 @@ def sorting_label(lab1):
     return (int(a), class_to_int(b), int(c))
 
 def get_bread(tail=[]):
-    base = [('Elliptic curves', url_for("ecnf.index")), (r'$\Q$', url_for(".rational_elliptic_curves"))]
+    base = [('Elliptic curves', url_for("elliptic_curves")), (r'$\Q$', url_for(".rational_elliptic_curves"))]
     if not isinstance(tail, list):
         tail = [(tail, " ")]
     return base + tail


### PR DESCRIPTION
This PR adds a landing page for elliptic curves (similar to the landing page for modular forms) and finishes fixing issue #2479 

http://localhost:37777/EllipticCurves/

It could use some feedback before it is merged.

For EC/Q things work pretty smoothly.  The "Elliptic curves" bread goes to the page above (click on "Elliptic curves" in the bread on any EC page).

For ECNF, this does change the behavior of the bread a bit.  It adds a Q(\alpha) bread at the top of the main page and the RCS (RSC? CRS?) knowls:
http://localhost:37777/EllipticCurve/

But then for individual pages, it does not currently add a Q(\alpha) bread as there is already a Q(blah) bread added for that particular \alpha.  I could add Q(\alpha) also, but I wasn't sure if that made the bread too long.

I can easily change this behavior, just wanted to get feedback before doing so.


Also, I have commented out some lines of code that I will remove once this is ready to be merged, but I wanted to keep them in to easily undo parts as needed (adding this note as much to remind myself later as for anyone else).