### PR TITLE
Mf hecke cc

### DIFF
--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -288,22 +288,7 @@ class CMF_download(Downloader):
 #        return self._download_cc(label, lang, 'angles', '.angles', 'Satake angles')
 
     def download_embedding(self, label, lang='text'):
-        data = db.mf_hecke_cc.lucky({'label':label},
-                                    ['label',
-                                     'embedding_root_real',
-                                     'embedding_root_imag',
-                                     'an_normalized',
-                                     'angles'])
-        if data is None:
-            return abort(404, "No embedded newform found for %s" % (label))
-        root = (data.pop('embedding_root_real', None),
-                data.pop('embedding_root_imag', None))
-        if root != (None, None):
-            data['root'] = root
-        return self._wrap(Json.dumps(data),
-                          label,
-                          lang=lang,
-                          title='Coefficient data for embedded newform %s,' % label)
+        return redirect(url_for("cmf.mf_hecke_cc", label=label), 301)
 
     def download_newform(self, label, lang='text'):
         data = db.mf_newforms.lookup(label)

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -530,7 +530,7 @@ def mf_data(label):
 def mf_hecke_cc():
     info = to_dict(request.args)
     t = 'Complex Hecke eigenvalues'
-    bread = [("Datasets", url_for("datasets")), ("mf_hecke_cc", " ")]
+    bread = get_bread()
     errors = []
     if 'label' in info:
         if LABEL_RE.match(info['label']) or EMB_LABEL_RE.match(info['label']):
@@ -551,14 +551,14 @@ def mf_hecke_cc():
                 Nlist = db.mf_hecke_cc.distinct("level", {"weight": k})
                 if Nlist:
                     Nlist = [Nlist[i:i+10] for i in range(0, len(Nlist), 10)]
-                    return render_template("mf_hecke_cc.html", k=k, Nlist=Nlist)
+                    return render_template("mf_hecke_cc.html", k=k, Nlist=Nlist, title=t, bread=bread)
                 else:
                     errors.append(f"The database does not contain any newforms with weight {k}")
             elif 'k' not in info:
                 klist = db.mf_hecke_cc.distinct("weight", {"level": N})
                 if klist:
                     klist = [klist[i:i+10] for i in range(0, len(klist), 10)]
-                    return render_template("mf_hecke_cc.html", N=N, klist=klist)
+                    return render_template("mf_hecke_cc.html", N=N, klist=klist, title=t, bread=bread)
                 else:
                     errors.append(f"The database does not contain any newforms with level {N}")
             elif db.mf_hecke_cc.exists({"level":N, "weight":k}):
@@ -577,7 +577,7 @@ def mf_hecke_cc():
     if errors:
         for err in errors:
             flash_error(err)
-    return render_template("mf_hecke_cc.html")
+    return render_template("mf_hecke_cc.html", title=t, bread=bread)
 
 @cmf.route("/<level>/")
 def by_url_level(level):

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -52,7 +52,8 @@ def learnmore_list():
     return [('Source and acknowledgments', url_for(".how_computed_page")),
             ('Completeness of the data', url_for(".completeness_page")),
             ('Reliability of the data', url_for(".reliability_page")),
-            ('Classical modular form labels', url_for(".labels_page"))]
+            ('Classical modular form labels', url_for(".labels_page")),
+            ('Complex Hecke eigenvalues', url_for(".mf_hecke_cc"))]
 
 
 def learnmore_list_add(learnmore_label, learnmore_url):
@@ -426,7 +427,7 @@ def render_embedded_newform_webpage(newform_label, embedding_label):
     except ValueError as err:
         return abort(404, err.args)
     info['CC_m'] = [m]
-    info['CC_n'] = [0, 1000]
+    info['CC_n'] = [0, 100]
     # errs.extend(parse_prec(info))
     errs = parse_prec(info)
     newform.setup_cc_data(info)
@@ -531,6 +532,7 @@ def mf_hecke_cc():
     info = to_dict(request.args)
     t = 'Complex Hecke eigenvalues'
     bread = get_bread()
+    learnmore = learnmore_list_remove("Hecke")
     errors = []
     if 'label' in info:
         if LABEL_RE.match(info['label']) or EMB_LABEL_RE.match(info['label']):
@@ -551,14 +553,14 @@ def mf_hecke_cc():
                 Nlist = db.mf_hecke_cc.distinct("level", {"weight": k})
                 if Nlist:
                     Nlist = [Nlist[i:i+10] for i in range(0, len(Nlist), 10)]
-                    return render_template("mf_hecke_cc.html", k=k, Nlist=Nlist, title=t, bread=bread)
+                    return render_template("mf_hecke_cc.html", k=k, Nlist=Nlist, title=t, bread=bread, learnmore=learnmore)
                 else:
                     errors.append(f"The database does not contain any newforms with weight {k}")
             elif 'k' not in info:
                 klist = db.mf_hecke_cc.distinct("weight", {"level": N})
                 if klist:
                     klist = [klist[i:i+10] for i in range(0, len(klist), 10)]
-                    return render_template("mf_hecke_cc.html", N=N, klist=klist, title=t, bread=bread)
+                    return render_template("mf_hecke_cc.html", N=N, klist=klist, title=t, bread=bread, learnmore=learnmore)
                 else:
                     errors.append(f"The database does not contain any newforms with level {N}")
             elif db.mf_hecke_cc.exists({"level":N, "weight":k}):
@@ -577,7 +579,7 @@ def mf_hecke_cc():
     if errors:
         for err in errors:
             flash_error(err)
-    return render_template("mf_hecke_cc.html", title=t, bread=bread)
+    return render_template("mf_hecke_cc.html", title=t, bread=bread, learnmore=learnmore)
 
 @cmf.route("/<level>/")
 def by_url_level(level):

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -15,7 +15,7 @@ from lmfdb.utils import (
     flash_error, to_dict, comma, display_knowl, bigint_knowl, num2letters,
     SearchArray, TextBox, TextBoxNoEg, SelectBox, TextBoxWithSelect, YesNoBox,
     DoubleSelectBox, RowSpacer, HiddenBox, SearchButtonWithSelect,
-    SubsetBox, ParityMod, CountBox,
+    SubsetBox, ParityMod, CountBox, send_file_from_beta,
     StatsDisplay, proportioners, totaler, integer_divisors,
     redirect_no_cache)
 from psycodict.utils import range_formatter
@@ -25,7 +25,7 @@ from lmfdb.utils.search_columns import SearchColumns, LinkCol, MathCol, FloatCol
 from lmfdb.api import datapage
 from lmfdb.classical_modular_forms import cmf
 from lmfdb.classical_modular_forms.web_newform import (
-    WebNewform, convert_newformlabel_from_conrey, LABEL_RE,
+    WebNewform, convert_newformlabel_from_conrey, LABEL_RE, EMB_LABEL_RE,
     quad_field_knowl, cyc_display, field_display_gen)
 from lmfdb.classical_modular_forms.web_space import (
     WebNewformSpace, WebGamma1Space, DimGrid, convert_spacelabel_from_conrey,
@@ -531,21 +531,52 @@ def mf_hecke_cc():
     info = to_dict(request.args)
     t = 'Complex Hecke eigenvalues'
     bread = [("Datasets", url_for("datasets")), ("mf_hecke_cc", " ")]
-    if 'Fetch' in info:
-        errors = []
-        if 'N' in info and 'k' in info:
-            N, k = info["N"].strip(), info["k"].strip()
-            if N.isdigit() and k.isdigit():
-                N, k = int(N), int(k)
-                if db.mf_hecke_cc.exists({"level":N, "weight":k}):
-                    filepath = os.path.expand(f"~/data/mf_hecke_cc/{k}/{N}")
-                    return send_file_from_beta(filepath, as_attachment=True)
-                else:
-                    errors.append(f"The database does not contain any newforms with weight {k} and level {N}")
-            else:
-                errors.append(f"The weight ({k}) and level ({N}) must be positive integers")
+    errors = []
+    if 'label' in info:
+        if LABEL_RE.match(info['label']) or EMB_LABEL_RE.match(info['label']):
+            N, k, _ = info['label'].split(".", 2)
+            if 'N' in info and info['N'].strip() != N:
+                errors.append("Level does not match label")
+            if 'k' in info and info['k'].strip() != k:
+                errors.append("Weight does not match label")
+            info['N'] = N
+            info['k'] = k
         else:
-            errors.append("You must specify both weight and level")
+            errors.append("Invalid label format")
+    if ('N' in info or 'k' in info) and not errors:
+        N, k = info.get('N','0').strip(), info.get('k', '0').strip()
+        if N.isdigit() and k.isdigit():
+            N, k = int(N), int(k)
+            if 'N' not in info:
+                Nlist = db.mf_hecke_cc.distinct("level", {"weight": k})
+                if Nlist:
+                    Nlist = [Nlist[i:i+10] for i in range(0, len(Nlist), 10)]
+                    return render_template("mf_hecke_cc.html", k=k, Nlist=Nlist)
+                else:
+                    errors.append(f"The database does not contain any newforms with weight {k}")
+            elif 'k' not in info:
+                klist = db.mf_hecke_cc.distinct("weight", {"level": N})
+                if klist:
+                    klist = [klist[i:i+10] for i in range(0, len(klist), 10)]
+                    return render_template("mf_hecke_cc.html", N=N, klist=klist)
+                else:
+                    errors.append(f"The database does not contain any newforms with level {N}")
+            elif db.mf_hecke_cc.exists({"level":N, "weight":k}):
+                if 'label' in info:
+                    label = info['label']
+                    def line_matcher(i, line):
+                        return i < 2 or line.startswith(label)
+                else:
+                    line_matcher = None
+                filepath = os.path.expand(f"~/data/mf_hecke_cc/{k}/{N}")
+                return send_file_from_beta(filepath, line_matcher=line_matcher, as_attachment=True)
+            else:
+                errors.append(f"The database does not contain any newforms with weight {k} and level {N}")
+        else:
+            errors.append(f"The weight ({k}) and level ({N}) must be positive integers")
+    if errors:
+        for err in errors:
+            flash_error(err)
     return render_template("mf_hecke_cc.html")
 
 @cmf.route("/<level>/")

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -568,7 +568,7 @@ def mf_hecke_cc():
                         return i < 2 or line.startswith(label)
                 else:
                     line_matcher = None
-                filepath = os.path.expand(f"~/data/mf_hecke_cc/{k}/{N}")
+                filepath = f"/home/lmfdb/data/mf_hecke_cc/{k}/{N}"
                 return send_file_from_beta(filepath, line_matcher=line_matcher, as_attachment=True)
             else:
                 errors.append(f"The database does not contain any newforms with weight {k} and level {N}")

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -243,7 +243,7 @@ def parse_n(info, newform, primes_only):
     info['default_nrange'] = '2-%s' % maxp
     nrange = info.get('n', '2-%s' % maxp)
     try:
-        info['CC_n'] = integer_options(nrange, newform.an_cc_bound)
+        info['CC_n'] = integer_options(nrange, 6000)
     except (ValueError, TypeError) as err:
         info['CC_n'] = list(range(2, maxp + 1))
         if err.args and err.args[0] == 'Too many options':

--- a/lmfdb/classical_modular_forms/main.py
+++ b/lmfdb/classical_modular_forms/main.py
@@ -526,6 +526,27 @@ def mf_data(label):
     bread = get_bread(other=[(label, url_for_label(label)), ("Data", " ")])
     return datapage(labels, tables, title=title, bread=bread, label_cols=label_cols)
 
+@cmf.route("/mf_hecke_cc/")
+def mf_hecke_cc():
+    info = to_dict(request.args)
+    t = 'Complex Hecke eigenvalues'
+    bread = [("Datasets", url_for("datasets")), ("mf_hecke_cc", " ")]
+    if 'Fetch' in info:
+        errors = []
+        if 'N' in info and 'k' in info:
+            N, k = info["N"].strip(), info["k"].strip()
+            if N.isdigit() and k.isdigit():
+                N, k = int(N), int(k)
+                if db.mf_hecke_cc.exists({"level":N, "weight":k}):
+                    filepath = os.path.expand(f"~/data/mf_hecke_cc/{k}/{N}")
+                    return send_file_from_beta(filepath, as_attachment=True)
+                else:
+                    errors.append(f"The database does not contain any newforms with weight {k} and level {N}")
+            else:
+                errors.append(f"The weight ({k}) and level ({N}) must be positive integers")
+        else:
+            errors.append("You must specify both weight and level")
+    return render_template("mf_hecke_cc.html")
 
 @cmf.route("/<level>/")
 def by_url_level(level):

--- a/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
@@ -27,7 +27,6 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download a
   }
 </script>
 
-{% set class_n = [100] %}
 {% set subsets = [('primes', 'only \(a_p\)','\(a_p\) with \(p\)'), ('all', 'all \(a_n\)','\(a_n\) with \(n\)')]%}
 {% set default_class = [100,'primes'] %}
 {% macro render_display_options(href) %}
@@ -37,21 +36,15 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download a
     {% if s[0] == default_class[1] %}
       {% set extra = '' %}
     {% endif %}
-    {% for n in class_n %}
-      {% set extra = 'nodisplay' %}
-      {% if n == default_class[0] and s[0] == default_class[1] %}
-        {% set extra = '' %}
-      {% endif %}
 
-      {# deals with the other options #}
-      <span class="{{s[0]}} {{n|string}} {{extra}}" >
-      {% for ns in subsets %}
-       {% if ns != s %}
-       Currently showing {{s[1]}}; <a onclick="show_primes_all_n('{{n}}','{{ns[0]}}'); return true" href="{{href}}">display {{ns[1]}}</a>
-       {% endif %}
-      {% endfor %} {# for ns in subsets #}
-      </span>
-    {% endfor %} {# for n in class_n #}
+    {# deals with the other options #}
+    <span class="{{s[0]}} 100 {{extra}}" >
+    {% for ns in subsets %}
+      {% if ns != s %}
+        Currently showing {{s[1]}}; <a onclick="show_primes_all_n('100','{{ns[0]}}'); return true" href="{{href}}">display {{ns[1]}}</a>
+      {% endif %}
+    {% endfor %} {# for ns in subsets #}
+    </span>
   {% endfor %} {# for s in subsets #}
 </div>
 {% endmacro %}
@@ -114,8 +107,8 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download a
     <tbody>
       {% set m = newform.embedding_m %}
       {% set pindex = [1] %}
-      {% for n in range(2, 1000) %}
-        {% set classes = ["all"] %}
+      {% for n in range(2, 100) %}
+        {% set classes = ["all", "100"] %}
         {% if n in newform.character_values %} {# n is a prime that doesn't divide the level #}
           {% set rowspan = 2 %}
           {% do classes.append("primes") %}
@@ -139,14 +132,6 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download a
           {% set shaden = 'lightall' %}
         {% endif %}
         {% set allshades = shade + ' ' + shaden + ' ' + shadep %}
-        {% for cn in class_n %}
-          {% if n <= cn %}
-            {% do classes.append(cn|string) %}
-          {% endif %}
-        {% endfor %} {# cn in class_n #}
-        {% if n > default_class[0] %}
-          {% do classes.append("nodisplay") %}
-        {% endif %}
 
         {% set class = classes|join(" ") %}
 
@@ -195,7 +180,7 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download a
             <td colspan=4></td>
             </tr>
           {% endif %}
-    {% endfor %} {# n in range(2, 1000) #}
+    {% endfor %} {# n in range(2, 100) #}
     </tbody>
   </table>
 </div>

--- a/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_embedded_newform.html
@@ -6,7 +6,7 @@
 
 <p>For each \(n\) we display the coefficients of the \(q\)-expansion \(a_n\), the
 {{ KNOWL('cmf.satake_parameters',title='Satake parameters') }} \(\alpha_p\),
-and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).</p>
+and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).  You can download additional coefficients <a href="{{url_for('cmf.mf_hecke_cc', label=newform.label+'.'+newform.embedding_label)}}">here</a>.</p>
 
 
 <script>
@@ -27,9 +27,9 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).</p>
   }
 </script>
 
-{% set class_n = [50, 250, 1000] %}
-{% set subsets = [('primes', 'only \(a_p\)','\(a_p\) with \(p\)'), ('all', '\(a_n\) instead','\(a_n\) with \(n\)')]%}
-{% set default_class = [50,'primes'] %}
+{% set class_n = [100] %}
+{% set subsets = [('primes', 'only \(a_p\)','\(a_p\) with \(p\)'), ('all', 'all \(a_n\)','\(a_n\) with \(n\)')]%}
+{% set default_class = [100,'primes'] %}
 {% macro render_display_options(href) %}
 <div>
   {% for s in subsets %}
@@ -37,12 +37,6 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).</p>
     {% if s[0] == default_class[1] %}
       {% set extra = '' %}
     {% endif %}
-    <span class="noptions {{s[0]}} {{extra}}">
-    Display {{s[2]}} up to:
-    {% for k in class_n %}
-    <a onclick="show_primes_all_n('{{k}}','{{s[0]}}'); return true" href="{{href}}">{{k}}</a>
-    {% endfor %} {# for k in class_n #}
-    </span>
     {% for n in class_n %}
       {% set extra = 'nodisplay' %}
       {% if n == default_class[0] and s[0] == default_class[1] %}
@@ -53,7 +47,7 @@ and the Satake angles \(\theta_p = \textrm{Arg}(\alpha_p)\).</p>
       <span class="{{s[0]}} {{n|string}} {{extra}}" >
       {% for ns in subsets %}
        {% if ns != s %}
-       (<a onclick="show_primes_all_n('{{n}}','{{ns[0]}}'); return true" href="{{href}}">See {{ns[1]}}</a>)
+       Currently showing {{s[1]}}; <a onclick="show_primes_all_n('{{n}}','{{ns[0]}}'); return true" href="{{href}}">display {{ns[1]}}</a>
        {% endif %}
       {% endfor %} {# for ns in subsets #}
       </span>

--- a/lmfdb/classical_modular_forms/templates/cmf_newform.html
+++ b/lmfdb/classical_modular_forms/templates/cmf_newform.html
@@ -158,7 +158,7 @@ function get_all_embeddings(num_embeddings) {
     <tr>
       <td>\(n\): </td>
       <td><input type='text' name='n' style="width: 160px" value="{{info.n}}" placeholder="{{info.default_nrange}}"></td>
-      <td><span class="formexample"> e.g. 2-40 or 990-1000</span></td>
+      <td><span class="formexample"> e.g. 2-40 or 80-90</span></td>
     </tr>
     {% if newform.dim > 4 or (info.m) %}
     <tr>

--- a/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
+++ b/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
@@ -3,7 +3,14 @@
 {% block content %}
 
 <p>
-  This dataset contains normalized complex Hecke eigenvalues $a_n$ and {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for
+  This dataset contains normalized complex Hecke eigenvalues $a_n/n^{(k-1)/2}$ and {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for {{KNOWL('cmf.embedding', 'embedded newforms')}}.
 </p>
+
+<p>
+  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The {{KNOWL('cmf.level', 'level')}} varies by weight
+
+<h2>File and data format</h2>
+
+Each file contains data for all 
 
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
+++ b/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
@@ -3,11 +3,11 @@
 {% block content %}
 
 <p>
-  This dataset contains normalized complex Hecke eigenvalues $a_n/n^{(k-1)/2}$ and {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for {{KNOWL('cmf.embedding', 'embedded newforms')}}.
+  This dataset contains normalized complex {{KNOWL('cmf.hecke_operator', 'Hecke eigenvalues')}} $a_n/n^{(k-1)/2}$ and {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for {{KNOWL('cmf.embedding', 'embedded newforms')}}.
 </p>
 
 <p>
-  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The stored {{KNOWL('cmf.level', 'levels')}} vary by weight, and for each newform we store either 2000, 4000, or 6000 Hecke eigenvalues.
+  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The stored {{KNOWL('cmf.level', 'levels')}} vary by weight, and for each newform we store either 2000, 4000, or 6000 Hecke eigenvalues (and corresponding Satake angles).  The main difference between this dataset and the internal <tt>mf_hecke_cc</tt> table within the LMFDB is that this dataset stores more eigenvalues (the internal table only has $n$ up to 100).
 </p>
 
 <h3>File and data format</h3>

--- a/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
+++ b/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
@@ -1,0 +1,9 @@
+{% extends 'homepage.html' %}
+
+{% block content %}
+
+<p>
+  This dataset contains normalized complex Hecke eigenvalues $a_n$ and {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for
+</p>
+
+{% endblock %}

--- a/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
+++ b/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
@@ -7,10 +7,122 @@
 </p>
 
 <p>
-  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The {{KNOWL('cmf.level', 'level')}} varies by weight
+  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The stored {{KNOWL('cmf.level', 'levels')}} vary by weight, and for each newform we store either 2000, 4000, or 6000 Hecke eigenvalues.
+</p>
 
-<h2>File and data format</h2>
+<h3>File and data format</h3>
 
-Each file contains data for all 
+Each text file starts with a header line follwed by a blank line; the remainder of the file contains one line per embedded newform, and each line has the following format.
+
+<table>
+  <tr>
+    <td>
+      <tt>label</tt>
+    </td>
+    <td>
+      The {{KNOWL('cmf.label', 'label')}} of the embedded newform.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <tt>dual_label</tt>
+    </td>
+    <td>
+      The {{KNOWL('cmf.label', 'label')}} for the {{KNOWL('cmf.dualform', 'dual')}}
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <tt>embedding_root</tt>
+    </td>
+    <td>
+      A pair <tt>[a,b]</tt> giving the image $a + bi$ of the generator for the {{KNOWL('cmf.coefficient_field', 'coefficient field')}} under this embedding.  If unknown (which will occur when the degree of the coefficient field is larger than $20$), the string <tt>None</tt> is recorded instead.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <tt>an_normalized</tt>
+    </td>
+    <td>
+      A list of pairs <tt>[cn, dn]</tt> so that the {{KNOWL('cmf.hecke_operator', 'Hecke eigenvalue')}} $a_n = n^{(k-1)/2} (c_n + d_n i)$.  Here $k$ is the {{KNOWL('cmf.weight', 'weight')}} and the list starts at $n=1$.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <tt>angles</tt>
+    </td>
+    <td>
+      The list of {{KNOWL('cmf.satake_angles', 'Satake angles')}} $\theta_p$ for good primes $p$.  For $p$ dividing the {{KNOWL('cmf.level', 'level')}}, the string <tt>NULL</tt> is recorded instead.
+    </td>
+  </tr>
+</table>
+
+<h3>Download</h3>
+
+{% if klist is defined %}
+<p>
+  Select a {{KNOWL('cmf.weight', 'weight')}} $k$ to download the file containing data for the embedded newforms in $S_k^{\mathrm{new}}(\Gamma_1({{N}})).$
+</p>
+<table>
+  {% for krow in klist %}
+  <tr>
+    {% for k in krow %}
+    <td>
+      <a href="{{url_for('cmf.mf_hecke_cc', N=N, k=k)}}">{{k}}</a>
+    </td>
+    {% endfor %}
+  </tr>
+  {% endfor %}
+</table>
+{% elif Nlist is defined %}
+<p>
+  Select a {{KNOWL('cmf.level', 'level')}} $N$ to download the file containing data for the embedded newforms in $S_{ {{k}} }^{\mathrm{new}}(\Gamma_1(N)).$
+</p>
+<table>
+  {% for Nrow in Nlist %}
+  <tr>
+    {% for N in Nrow %}
+    <td>
+      <a href="{{url_for('cmf.mf_hecke_cc', N=N, k=k)}}">{{N}}</a>
+    </td>
+    {% endfor %}
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>
+  Specify both a {{KNOWL('cmf.weight', 'weight')}} $k$ and a {{KNOWL('cmf.level', 'level')}} $N$ to download the file containing data for the embedded newforms in $S_k^{\mathrm{new}}(\Gamma_1(N)),$ or provide one to get a page showing the available options for the other.  Alternatively, you may give the full label to get just the data for one embedded modular form.
+</p>
+<form>
+  <table>
+    <tr>
+      <td align="right">$k = $</td>
+      <td align="left">
+        <input type="text" name="k" size="7" placeholder="2">
+        <span class="formexample">integer from $1$ to $316$ (even if at least $182$)</span>
+      </td>
+    </tr>
+    <tr>
+      <td align="right">$N = $</td>
+      <td align="left">
+        <input type="text" name="N" size="7" placeholder="11">
+        <span class="formexample">integer from $1$ to $10000$</span>
+      </td>
+    </tr>
+    <tr>
+      <td align="right">{{KNOWL('cmf.label', 'Label')}}</td>
+      <td align="left">
+        <input type="text" name="label" size="20" placeholder="11.2.a.a.1.1">
+        <span class="formexample">Label <tt>N.k.a.x</tt> or <tt>N.k.a.x.n.i</tt></span>
+      </td>
+    </tr>
+    <tr>
+      <td align="left">
+        <button type="submit" name="Fetch" value="fetch">Fetch file</button>
+      </td>
+    </tr>
+  </table>
+</form>
+{% endif %}
 
 {% endblock %}

--- a/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
+++ b/lmfdb/classical_modular_forms/templates/mf_hecke_cc.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The dataset currently contains 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The stored {{KNOWL('cmf.level', 'levels')}} vary by weight, and for each newform we store either 2000, 4000, or 6000 Hecke eigenvalues (and corresponding Satake angles).  The main difference between this dataset and the internal <tt>mf_hecke_cc</tt> table within the LMFDB is that this dataset stores more eigenvalues (the internal table only has $n$ up to 100).
+  There are currently 14,417,694 embedded newforms (arising from 281,965 {{KNOWL('cmf.newform', 'newforms')}}), with odd {{KNOWL('cmf.weight', 'weight')}} ranging from $1$ to $181$ and even weight ranging from $2$ to $316$.  The stored {{KNOWL('cmf.level', 'levels')}} vary by weight, and for each newform we store either 2000, 4000, or 6000 Hecke eigenvalues (and corresponding Satake angles).  The main difference between this dataset and the internal <tt>mf_hecke_cc</tt> table within the LMFDB is that this dataset stores more eigenvalues (the internal table only has $n$ up to 100).
 </p>
 
 <h3>File and data format</h3>

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -482,44 +482,44 @@ class CmfTest(LmfdbTest):
             assert r'0.317472\pi' in page.get_data(as_text=True)
 
         #test large floats
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/1/']:
             page = self.tc.get(url)
             assert '213.765' in page.get_data(as_text=True)
-            assert '5.39613e49' in page.get_data(as_text=True)
-            assert '7.61562e49' in page.get_data(as_text=True)
+            assert '8.08549e33' in page.get_data(as_text=True)
+            assert '3.07391e34' in page.get_data(as_text=True)
 
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/2/']:
             page = self.tc.get(url)
             assert '3412.77' in page.get_data(as_text=True)
-            assert '1.55372e49' in page.get_data(as_text=True)
-            assert '1.00032e49' in page.get_data(as_text=True)
+            assert '2.89755e32' in page.get_data(as_text=True)
+            assert '3.65313e34' in page.get_data(as_text=True)
 
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=embed',
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/3/']:
             page = self.tc.get(url)
             assert '3626.53' in page.get_data(as_text=True)
-            assert '1.17540e49' in page.get_data(as_text=True)
-            assert '1.20001e50' in page.get_data(as_text=True)
+            assert '7.61461e34' in page.get_data(as_text=True)
+            assert '2.65998e34' in page.get_data(as_text=True)
 
         # same numbers but normalized
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/1/']:
             page = self.tc.get(url)
-            assert '0.993913' in page.get_data(as_text=True)
-            assert '1.36787' in page.get_data(as_text=True)
+            assert '0.198401' in page.get_data(as_text=True)
+            assert '0.627978' in page.get_data(as_text=True)
 
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/2/']:
             page = self.tc.get(url)
-            assert '0.286180' in page.get_data(as_text=True)
-            assert '0.179671' in page.get_data(as_text=True)
-        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=695-696&prec=6&format=analytic_embed',
+            assert '0.00710997' in page.get_data(as_text=True)
+            assert '0.746308' in page.get_data(as_text=True)
+        for url in ['/ModularForm/GL2/Q/holomorphic/1/36/a/a/?m=1-3&n=95-96&prec=6&format=analytic_embed',
                     '/ModularForm/GL2/Q/holomorphic/1/36/a/a/1/3/']:
             page = self.tc.get(url)
-            assert '0.216496' in page.get_data(as_text=True)
-            assert '2.15537' in page.get_data(as_text=True)
+            assert '1.86846' in page.get_data(as_text=True)
+            assert '0.543416' in page.get_data(as_text=True)
 
         # test some exact values
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/25/2/e/a/?n=97&m=8&prec=6&format=satake_angle')
@@ -548,28 +548,28 @@ class CmfTest(LmfdbTest):
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/13/2/e/a/?m=1-2&n=2-10000&prec=6&format=embed')
         assert "Only" in page.get_data(as_text=True)
-        assert "up to 1000 are available" in page.get_data(as_text=True)
+        assert "up to 100 are available" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/7524/2/l/b/?n=5000&m=&prec=&format=embed')
         assert "Only" in page.get_data(as_text=True)
-        assert "up to 3000 are available" in page.get_data(as_text=True)
+        assert "up to 100 are available" in page.get_data(as_text=True)
         assert "in specified range; resetting to default" in page.get_data(as_text=True)
-        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/7524/2/l/b/?n=1500-4000&m=&prec=&format=embed')
+        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/7524/2/l/b/?n=50-4000&m=&prec=&format=embed')
         assert "Only" in page.get_data(as_text=True)
-        assert "up to 3000 are available" in page.get_data(as_text=True)
+        assert "up to 100 are available" in page.get_data(as_text=True)
         assert "limiting to" in page.get_data(as_text=True)
 
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/13/2/e/a/?m=1-2&n=3.5&prec=6&format=embed')
         assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=2-10&m=1-20000&prec=6&format=embed', follow_redirects=True)
-        assert "Web interface only supports 1000 embeddings at a time.  Use download link to get more (may take some time)." in page.get_data(as_text=True)
+        assert "Web interface only supports 100 embeddings at a time.  Use download link to get more (may take some time)." in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=3.14&format=embed', follow_redirects=True)
         assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=2-10&m=1-20&prec=16&format=embed')
         assert 'must be a positive integer, at most 15 (for higher precision, use the download button)' in page.get_data(as_text=True)
-        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=999-1001&m=1-20&prec=6&format=embed')
+        page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=99-101&m=1-20&prec=6&format=embed')
         assert 'Only' in page.get_data(as_text=True)
-        assert 'up to 1000 are available' in page.get_data(as_text=True)
-        assert 'a_{1000}' in page.get_data(as_text=True)
+        assert 'up to 100 are available' in page.get_data(as_text=True)
+        assert 'a_{100}' in page.get_data(as_text=True)
 
     def test_mf_hecke_cc_dataset(self):
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/', ['14,417,694', 'N.k.a.x.n.i'])

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -575,7 +575,7 @@ class CmfTest(LmfdbTest):
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/', ['14,417,694', 'N.k.a.x.n.i'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?k=12', ['Select a', '269'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=12', ['Select a', '57'])
-        path = '/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2'
+        path = 'https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2' # explicit link to beta since check_args prohibits external redirects
         self.check_external(path, path, '11.2.a.a.1.1') # Downloads from beta
 
     def test_underlying_data(self):

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -571,6 +571,12 @@ class CmfTest(LmfdbTest):
         assert 'up to 1000 are available' in page.get_data(as_text=True)
         assert 'a_{1000}' in page.get_data(as_text=True)
 
+    def test_mf_hecke_cc_dataset(self):
+        self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/', ['14,417,694', 'N.k.a.x.n.i'])
+        self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?k=12', ['Select a', '269'])
+        self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=12', ['Select a', '57'])
+        self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2', '11.2.a.a.1.1') # Downloads from beta
+
     def test_underlying_data(self):
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)
         assert ('mf_gamma1' in data and 'newspace_dims' in data

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -575,7 +575,8 @@ class CmfTest(LmfdbTest):
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/', ['14,417,694', 'N.k.a.x.n.i'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?k=12', ['Select a', '269'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=12', ['Select a', '57'])
-        self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2', '11.2.a.a.1.1') # Downloads from beta
+        path = '/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2'
+        self.check_external(path, path, '11.2.a.a.1.1') # Downloads from beta
 
     def test_underlying_data(self):
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -561,7 +561,7 @@ class CmfTest(LmfdbTest):
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/13/2/e/a/?m=1-2&n=3.5&prec=6&format=embed')
         assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=2-10&m=1-20000&prec=6&format=embed', follow_redirects=True)
-        assert "Web interface only supports 100 embeddings at a time.  Use download link to get more (may take some time)." in page.get_data(as_text=True)
+        assert "Web interface only supports 1000 embeddings at a time.  Use download link to get more (may take some time)." in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/419/3/h/a/?n=3.14&format=embed', follow_redirects=True)
         assert "must be an integer, range of integers or comma separated list of integers" in page.get_data(as_text=True)
         page = self.tc.get('/ModularForm/GL2/Q/holomorphic/99/2/p/a/?n=2-10&m=1-20&prec=16&format=embed')

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -424,12 +424,7 @@ class WebNewform():
 
     @lazy_attribute
     def an_cc_bound(self):
-        if self.level <= 1000:
-            return 1000
-        elif self.level <= 4000:
-            return 2000
-        else:
-            return 3000
+        return 100
 
     @lazy_attribute
     def primes_cc_bound(self):

--- a/lmfdb/templates/datasets.html
+++ b/lmfdb/templates/datasets.html
@@ -23,18 +23,19 @@
   </tr>
   <tr>
     <td><a href="/zeros/zeta/">Zeros of $\zeta(s)$</a></td>
-    <td>The first $10^{11}$ zeros of the {{ KNOWL('lfunction.riemann', 'Riemann zeta function') }}.</td>
+    <td>The first $10^{11}$ zeros of the {{ KNOWL('lfunction.riemann', 'Riemann zeta function') }}</td>
     <td>1.32 TB</td>
     <td>The ZetaGrid project</td>
   </tr>
   <tr>
     <td><a href='{{url_for("cmf.mf_hecke_cc")}}'>mf_hecke_cc (large version)</a></td>
-    <td>Complex Hecke eigenvalues and Satake parameters for classical modular forms</td>
+    <td>Complex {{KNOWL('cmf.hecke_operator', 'Hecke eigenvalues')}} for {{ KNOWL('cmf.embedding', 'embedded newforms') }}</td>
+    <td>637 GB</td>
     <td>LMFDB Collaboration</td>
   </tr>
   <tr>
     <td><a href='{{url_for("ec.render_bhkssw")}}'>BHKSSW dataset</a></td>
-    <td>All {{KNOWL('ec.q', 'elliptic curves')}} of naive height up to $2.7 \cdot 10^{10}$.</td>
+    <td>All {{KNOWL('ec.q', 'elliptic curves')}} of naive height up to $2.7 \cdot 10^{10}$</td>
     <td>18.5 GB</td>
     <td><a href="https://doi.org/10.1112/S1461157016000152">Balakrishnan, Ho, Kaplan, Spicer, Stein, Weigandt</a></td>
   </tr>

--- a/lmfdb/templates/datasets.html
+++ b/lmfdb/templates/datasets.html
@@ -28,6 +28,11 @@
     <td>The ZetaGrid project</td>
   </tr>
   <tr>
+    <td><a href='{{url_for("cmf.mf_hecke_cc")}}'>mf_hecke_cc (large version)</a></td>
+    <td>Additional complex Hecke eigenvalues and Satake parameters for classical modular forms, beyond what is stored in the mf_hecke_cc table</td>
+    <td>LMFDB Collaboration</td>
+  </tr>
+  <tr>
     <td><a href='{{url_for("ec.render_bhkssw")}}'>BHKSSW dataset</a></td>
     <td>All {{KNOWL('ec.q', 'elliptic curves')}} of naive height up to $2.7 \cdot 10^{10}$.</td>
     <td>18.5 GB</td>

--- a/lmfdb/templates/datasets.html
+++ b/lmfdb/templates/datasets.html
@@ -29,7 +29,7 @@
   </tr>
   <tr>
     <td><a href='{{url_for("cmf.mf_hecke_cc")}}'>mf_hecke_cc (large version)</a></td>
-    <td>Additional complex Hecke eigenvalues and Satake parameters for classical modular forms, beyond what is stored in the mf_hecke_cc table</td>
+    <td>Complex Hecke eigenvalues and Satake parameters for classical modular forms</td>
     <td>LMFDB Collaboration</td>
   </tr>
   <tr>

--- a/lmfdb/utils/__init__.py
+++ b/lmfdb/utils/__init__.py
@@ -41,7 +41,7 @@ __all__ = ['request', 'make_response', 'flash', 'url_for', 'render_template',
            'SelectBox', 'YesNoBox', 'YesNoMaybeBox', 'ExcludeOnlyBox',
            'ParityBox', 'ParityMod', 'SubsetBox', 'SubsetNoExcludeBox', 'SelectBoxNoEg', 'CountBox',
            'SneakyTextBox', 'SneakySelectBox',
-           'Downloader', 'WebObj',
+           'Downloader', 'WebObj', 'send_file_from_beta',
            'formatters', 'proportioners', 'totaler', 'StatsDisplay',
            'Configuration', 'plural_form', 'pluralize',
            'names_and_urls', 'name_and_object_from_url',
@@ -165,7 +165,7 @@ from .search_boxes import (
     ParityBox, ParityMod, SubsetBox, SubsetNoExcludeBox, SelectBoxNoEg, CountBox,
     SneakyTextBox, SneakySelectBox,
     SearchButton, SearchButtonWithSelect, RowSpacer)
-from .downloader import Downloader
+from .downloader import Downloader, send_file_from_beta
 from .display_stats import formatters, proportioners, totaler, StatsDisplay
 from .config import Configuration
 from .names_and_urls import names_and_urls, name_and_object_from_url

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -35,7 +35,7 @@ def send_file_from_beta(filepath, line_matcher, **kwds):
     urlparts = urlparse(request.url)
     if urlparts.netloc != "beta.lmfdb.org":
         replaced = urlparts._replace(netloc="beta.lmfdb.org", scheme="https")
-        return redirect(urlunparse(replaced, code=301))
+        return redirect(urlunparse(replaced), code=301)
     if line_matcher is None:
         return send_file(filepath, **kwds)
     bIO = BytesIO()

--- a/lmfdb/utils/downloader.py
+++ b/lmfdb/utils/downloader.py
@@ -28,6 +28,24 @@ from sage.all import Integer, Rational, lazy_attribute
 from lmfdb.utils import plural_form, pluralize, flash_error
 from lmfdb.utils.datetime_utils import utc_now_naive
 
+def send_file_from_beta(filepath, line_matcher, **kwds):
+    """
+    If running on beta.lmfdb.org, return the file as an attachment (potentially filtering lines).  Otherwise, return a redirect to the current URL on beta.
+    """
+    urlparts = urlparse(request.url)
+    if urlparts.netloc != "beta.lmfdb.org":
+        replaced = urlparts._replace(netloc="beta.lmfdb.org", scheme="https")
+        return redirect(urlunparse(replaced, code=301))
+    if line_matcher is None:
+        return send_file(filepath, **kwds)
+    bIO = BytesIO()
+    with open(filepath) as F:
+        for i, line in enumerate(F):
+            if line_matcher(i, line):
+                bIO.write(line.encode('utf-8'))
+    bIO.seek(0)
+    return send_file(bIO, **kwds)
+
 class DownloadLanguage():
     # We choose the most common values; override these if needed in each subclass
     comment_prefix = '#'


### PR DESCRIPTION
Switch from using `mf_hecke_cc` to files on beta for getting Hecke coefficients beyond $n=100$.  Always display 100 coefficients on embedded newform pages, and limit the displayed coefficients on non-embedded newform pages (changing the previous limit of 1000 to 100).

Here we set up a mechanism for redirecting file requests to beta.lmfdb.org.  This can't be tested yet, since this code is not yet running on beta.  I propose merging this to main and dev, then testing that code before merging to web.  I've added tests; the one checking that we can download the file from beta will fail for the moment.

Once this is merged, we can reload `mf_hecke_cc` with a smaller version.