### PR TITLE
Add cookie for beta access

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -576,9 +576,9 @@ class CmfTest(LmfdbTest):
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?k=12', ['Select a', '269'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=12', ['Select a', '57'])
         path = 'https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2' # explicit link to beta since check_args prohibits external redirects
-        self.check_external(path, path, '11.2.a.a.1.1') # Downloads from beta
+        self.check_external(path, path, '11.2.a.a.1.1', cookie="human=1") # Downloads from beta
         path = 'https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?label=21.2.e.a' # explicit link to beta since check_args prohibits external redirects
-        self.check_external(path, path, '21.2.e.a.4.1')
+        self.check_external(path, path, '21.2.e.a.4.1', cookie="human=1")
 
     def test_underlying_data(self):
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)

--- a/lmfdb/tests/__init__.py
+++ b/lmfdb/tests/__init__.py
@@ -73,10 +73,12 @@ class LmfdbTest(unittest.TestCase):
         for t in text:
             assert t not in page, "%s in the %s" % (t, path)
 
-    def check_external(self, homepage, path, text):
+    def check_external(self, homepage, path, text, cookie=None):
         headers = {"User-Agent": "Mozilla/5.0"}
         context = ssl._create_unverified_context()
         request = Request(path, headers=headers)
+        if cookie:
+            request.add_header("Cookie", cookie)
         assert path in homepage, f"Path {path} not found in homepage"
         try:
             # Create opener that follows redirects for both HTTP and HTTPS, including 308


### PR DESCRIPTION
This change makes links like `https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?label=21.2.e.a` succeed from CI (they already worked for a browser with javascript enabled).