### PR TITLE
added visuals for the dessin d'enfants

### DIFF
--- a/lmfdb/belyi/templates/belyi_galmap.html
+++ b/lmfdb/belyi/templates/belyi_galmap.html
@@ -5,6 +5,7 @@
   .toggle {margin-top:5px; margin-left:20px;}
   div.properties-body table tr td.label { vertical-align: top    ; }
   #content > h2.subhead { color:{{color.black}};}
+  #dessin-box svg { width: 100%; height: auto; display: block; }
 </style>
 
 <script>
@@ -14,6 +15,22 @@ function show_eqns(eqnstyle) {
     $('.plane_eqn').css("display", "none");
     $('.'+eqnstyle).css("display", "inline");
   }
+
+var _activeDessinRow = null;
+function viewEmbedding(idx) {
+  var $box = $('#dessin-box');
+  if (_activeDessinRow === idx) {
+    $box.hide();
+    _activeDessinRow = null;
+    return false;
+  }
+  $('.dessin-svg-item').hide();
+  $('#dessin-svg-' + idx).show();
+  $box.show();
+  $box[0].scrollIntoView({behavior: 'smooth', block: 'nearest'});
+  _activeDessinRow = idx;
+  return false;
+}
 </script>
 
 <h2>{{ KNOWL('belyi.base_field', title='Base field')}}</h2>
@@ -107,20 +124,34 @@ function show_eqns(eqnstyle) {
       <tr>
         <td>Embedding $\nu \mapsto \nu_i \in \mathbb{C}$</td>
         <td>{{ KNOWL('belyi.permutation_triple', title="Permutation triple") }}</td>
+        {% if data.dessin_svgs %}<td>Dessin</td>{% endif %}
       </tr>
     </thead>
     <tbody>
       {% for g in data.embeddings_and_triples %}
-       <td>${{g['embedding']}}$</td>
-       <td>${{g['triple']}}$</td>
-       </tr>
-      <!-- TODO: uncomment this when embedded map pages are reactivated
-         <td><a href="{{g['triple_link']}}">${{g['embedding']}}$</a></td>
-         <td><a href="{{g['triple_link']}}">${{g['triple']}}$</a></td>
-         </tr>
-      -->
+      <tr>
+        <td>${{g['embedding']}}$</td>
+        <td>${{g['triple']}}$</td>
+        {% if data.dessin_svgs %}
+        <td><a href="#" onclick="return viewEmbedding({{ loop.index0 }});">View Embedding</a></td>
+        {% endif %}
+      </tr>
       {% endfor %}
     </tbody>
-    </table>
+  </table>
+
+{% if data.dessin_svgs %}
+  <div id="dessin-box" class="knowl-output" style="display:none; max-width:440px;">
+    <div class="knowl"><div><div class="knowl-content">
+      <strong>Dessin d&rsquo;enfant</strong>
+      {% for g in data.embeddings_and_triples %}
+        {% set svg_idx = loop.index0 if loop.index0 < data.dessin_svgs|length else 0 %}
+        <div id="dessin-svg-{{ loop.index0 }}" class="dessin-svg-item" style="display:none;">
+          {{ data.dessin_svgs[svg_idx]|safe }}
+        </div>
+      {% endfor %}
+    </div></div></div>
+  </div>
+{% endif %}
 
 {% endblock %}

--- a/lmfdb/belyi/templates/belyi_galmap.html
+++ b/lmfdb/belyi/templates/belyi_galmap.html
@@ -150,6 +150,11 @@ function viewEmbedding(idx) {
           {{ data.dessin_svgs[svg_idx]|safe }}
         </div>
       {% endfor %}
+      <p style="font-size:0.85em; margin-top:0.75em;">
+        The drawing routine is based on a C program by Gunnar Brinkmann, described in:<br>
+        G. Brinkmann, <em>Drawing maps on oriented surfaces</em>, 2025.
+        Preprint: <a href="https://arxiv.org/abs/2505.01480">arXiv:2505.01480</a>.
+      </p>
     </div></div></div>
   </div>
 {% endif %}

--- a/lmfdb/belyi/web_belyi.py
+++ b/lmfdb/belyi/web_belyi.py
@@ -15,7 +15,7 @@ from lmfdb import db
 # Belyi dessin images from belyi_images.txt
 ###############################################################################
 
-_belyi_images = None  # loaded lazily
+_belyi_images = None  
 
 def _load_belyi_images():
     global _belyi_images

--- a/lmfdb/belyi/web_belyi.py
+++ b/lmfdb/belyi/web_belyi.py
@@ -6,8 +6,90 @@ from lmfdb.utils import (names_and_urls, prop_int_pretty, raw_typeset,
         web_latex, compress_expression)
 from flask import url_for
 import re
+import os
 
 from lmfdb import db
+
+
+###############################################################################
+# Belyi dessin images from belyi_images.txt
+###############################################################################
+
+_belyi_images = None  # loaded lazily
+
+def _load_belyi_images():
+    global _belyi_images
+    if _belyi_images is not None:
+        return _belyi_images
+    _belyi_images = {}
+    txt_path = os.path.join(os.path.dirname(__file__), '..', 'static', 'images', 'belyi_images.txt')
+    txt_path = os.path.abspath(txt_path)
+    if not os.path.exists(txt_path):
+        return _belyi_images
+    with open(txt_path, encoding='utf-8') as f:
+        for i, line in enumerate(f):
+            if i < 2:  # skip header rows
+                continue
+            line = line.rstrip('\n')
+            parts = line.split('|', 2)
+            if len(parts) != 3:
+                continue
+            belyidb_label = parts[1]
+            svg_field = parts[2]
+            lmfdb_plabel = _belyidb_to_lmfdb_plabel(belyidb_label)
+            if lmfdb_plabel is None:
+                continue
+            # svg_field is a PostgreSQL text[] like {svg1,svg2,...}; split into list
+            svg_field = svg_field.strip()
+            if svg_field.startswith('{') and svg_field.endswith('}'):
+                svg_field = svg_field[1:-1]
+            # Each element is a complete <svg>...</svg>; split on the boundary between them
+            raw_svgs = re.split(r'(?<=</svg>),', svg_field)
+            svgs = [_crop_svg_bottom(s.replace('\\"', '"').strip()) for s in raw_svgs if s.strip()]
+            _belyi_images[lmfdb_plabel] = svgs
+    return _belyi_images
+
+
+def _crop_svg_bottom(svg, crop_height=660):
+    # The page number sits at y≈702 in a 792-unit-tall viewBox.
+    # Fix: shrink the viewBox height AND the SVG height attribute proportionally,
+    # and set overflow="hidden" so nothing outside the viewBox leaks through.
+    # 1. Update viewBox height
+    svg = re.sub(
+        r'(viewBox=")(\S+\s+\S+\s+\S+\s+)\S+(")',
+        lambda m: m.group(1) + m.group(2) + str(crop_height) + m.group(3),
+        svg
+    )
+    # 2. Update the SVG height attribute proportionally (original viewBox height = 792)
+    def _new_height(m):
+        try:
+            orig = float(m.group(1))
+            new_h = round(orig * crop_height / 792)
+            return 'height="{}"'.format(new_h)
+        except ValueError:
+            return m.group(0)
+    svg = re.sub(r'height="([\d.]+)"', _new_height, svg, count=1)
+    # 3. Ensure the outermost <svg> tag has overflow="hidden" to clip below the viewBox
+    svg = re.sub(r'(<svg\b)(?![^>]*overflow)', r'\1 overflow="hidden"', svg, count=1)
+    return svg
+
+
+def _belyidb_to_lmfdb_plabel(belyidb_label):
+    # "4T2-[2,2,2]-22-22-22-g0" -> "4T2-2.2_2.2_2.2"
+    parts = belyidb_label.split('-')
+    if len(parts) < 5:
+        return None
+    group = parts[0]
+    # parts[1] is abc like [2,2,2] — skip it; parts[2-4] are cycle types
+    sigma0 = '.'.join(list(parts[2]))
+    sigma1 = '.'.join(list(parts[3]))
+    sigmaoo = '.'.join(list(parts[4]))
+    return '{}-{}_{}_{}'.format(group, sigma0, sigma1, sigmaoo)
+
+
+def get_belyi_images(plabel):
+    """Return list of SVG strings for the given LMFDB passport label, or []."""
+    return _load_belyi_images().get(plabel, [])
 
 
 ###############################################################################
@@ -299,6 +381,9 @@ class WebBelyiGalmap():
 
         if galmap.get('plane_map_constant_factored'):
             data['plane_map_constant_factored'] = galmap['plane_map_constant_factored']
+
+        # Dessin images (one per embedding, or a single shared one)
+        data['dessin_svgs'] = get_belyi_images(galmap['plabel'])
 
         # Properties
         self.plot = db.belyi_galmap_portraits.lucky({"label": galmap['label']},


### PR DESCRIPTION
Add interactive dessin d'enfant display on Belyi galmap pages

 Load SVG images from belyi_images.txt and display them in the embeddings table on each Belyi galmap page. Each row gets a "View Embedding" link that opens a styled popup box (matching the existing style) showing the corresponding dessin d'enfant SVG. Clicking a different row swaps the image; clicking the same row closes the box.
