### PR TITLE
Add more latex names for number fields

### DIFF
--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -77,13 +77,14 @@ class NumberFieldTest(LmfdbTest):
         # Test "prettified" latex labels for number fields
         self.check_args('/NumberField/1.1.1.1', r'\Q')
         self.check_args('/NumberField/2.0.4.1', r'\Q(\sqrt{-1})')
-        self.check_args('/NumberField/4.4.2304.1', r'\Q(\sqrt{2}, \sqrt{3})')
+        self.check_args('/NumberField/4.4.1600.1', r'\Q(\sqrt{2}, \sqrt{5})')
         self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_{7})')
         self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_{7})^+')
         self.check_args('/NumberField/3.1.300.1', r'\Q(\sqrt[3]{10})')
         self.check_args('/NumberField/4.2.2048.1', r'\Q(\sqrt[4]{2})')
-        self.check_args('/NumberField/4.4.2048.1', r'\Q(\sqrt{2 + \sqrt{2}})')
         self.check_args('/NumberField/4.0.512.1', r'\Q(\sqrt{1 + i})')
+        self.check_args('/NumberField/4.2.1024.1', r'\Q(\sqrt{1 + \sqrt{2}})')
+        self.check_args('/NumberField/4.0.2048.2', r'\Q(\sqrt{-2 + \sqrt{2}})')
         self.check_args('/NumberField/8.8.3317760000.1', r'\Q(\sqrt{2}, \sqrt{3}, \sqrt{5})')
         self.check_args('/NumberField/16.0.11007531417600000000.1', r'\Q(i, \sqrt{2}, \sqrt{3}, \sqrt{5})')
 

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -81,6 +81,8 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_{7})')
         self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_{7})^+')
         self.check_args('/NumberField/4.2.2048.1', r'\Q(\sqrt[4]{2})')
+        self.check_args('/NumberField/8.8.3317760000.1', r'\Q(\sqrt{2}, \sqrt{3}, \sqrt{5})')
+        self.check_args('/NumberField/16.0.11007531417600000000.1', r'\Q(i, \sqrt{2}, \sqrt{3}, \sqrt{5})')
 
     def test_signature_search(self):
         # Square brackets

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -78,8 +78,9 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/1.1.1.1', r'\Q')
         self.check_args('/NumberField/2.0.4.1', r'\Q(\sqrt{-1})')
         self.check_args('/NumberField/4.4.2304.1', r'\Q(\sqrt{2}, \sqrt{3})')
-        self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_7)')
-        self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_7^+)')
+        self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_{7})')
+        self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_{7})^+')
+        self.check_args('/NumberField/4.2.2048.1', r'\Q(\sqrt[4]{2})')
 
     def test_signature_search(self):
         # Square brackets

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -82,6 +82,8 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_{7})^+')
         self.check_args('/NumberField/3.1.300.1', r'\Q(\sqrt[3]{10})')
         self.check_args('/NumberField/4.2.2048.1', r'\Q(\sqrt[4]{2})')
+        self.check_args('/NumberField/4.4.2048.1', r'\Q(\sqrt{2 + \sqrt{2}})')
+        self.check_args('/NumberField/4.0.512.1', r'\Q(\sqrt{1 + i})')
         self.check_args('/NumberField/8.8.3317760000.1', r'\Q(\sqrt{2}, \sqrt{3}, \sqrt{5})')
         self.check_args('/NumberField/16.0.11007531417600000000.1', r'\Q(i, \sqrt{2}, \sqrt{3}, \sqrt{5})')
 

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -73,6 +73,14 @@ class NumberFieldTest(LmfdbTest):
     def test_statistics(self):
         self.check_args('/NumberField/stats', 'Class number')
 
+    def test_pretty_labels(self):
+        # Test "prettified" latex labels for number fields
+        self.check_args('/NumberField/1.1.1.1', r'\Q')
+        self.check_args('/NumberField/2.0.4.1', r'\Q(\sqrt{-1})')
+        self.check_args('/NumberField/4.4.2304.1', r'\Q(\sqrt{2}, \sqrt{3})')
+        self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_7)')
+        self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_7^+)')
+
     def test_signature_search(self):
         # Square brackets
         self.check_args('/NumberField/?start=0&degree=6&signature=%5B0%2C3%5D&count=100', '6.0.61131.1')

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -80,6 +80,7 @@ class NumberFieldTest(LmfdbTest):
         self.check_args('/NumberField/4.4.2304.1', r'\Q(\sqrt{2}, \sqrt{3})')
         self.check_args('/NumberField/6.0.16807.1', r'\Q(\zeta_{7})')
         self.check_args('/NumberField/3.3.49.1', r'\Q(\zeta_{7})^+')
+        self.check_args('/NumberField/3.1.300.1', r'\Q(\sqrt[3]{10})')
         self.check_args('/NumberField/4.2.2048.1', r'\Q(\sqrt[4]{2})')
         self.check_args('/NumberField/8.8.3317760000.1', r'\Q(\sqrt{2}, \sqrt{3}, \sqrt{5})')
         self.check_args('/NumberField/16.0.11007531417600000000.1', r'\Q(i, \sqrt{2}, \sqrt{3}, \sqrt{5})')

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -261,16 +261,21 @@ def field_pretty(label):
             
         # Case 4b: Imprimitive quartic fields of type Q(sqrt(A + Bsqrt(D)))
         if len(subs) == 1:
-            # Factorise defining polynomial for K over Q(sqrt(D))
-            D = subs[0]
-            Ksub = QuadraticField(D)
-            relative_poly = poly.factor()[0]
-            rel_ceoffs = relative_poly.coefficients(sparse=False)
-            ans = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
+            quad_sub = wnf.from_coeffs(string2list(str(subs[0][0])))
+            if not quad_sub._data is None:
+                # Factorise defining polynomial for K over Q(sqrt(D))
+                quad_label = str(quad_sub.get_label())
+                D = quad_label.split('.')[2]
+                Ksub = NumberField(quad_sub.poly(), 'b')
+                Rsub = PolynomialRing(Ksub, 'x')
+                relative_poly = Rsub(wnf.poly())
+                factors = relative_poly.factor()
 
-            return r'\(\Q(\sqrt{%s}\)' % ans
+                # Can extract the first quadratic factor
+                rel_coeffs = factors.coefficients(sparse=False)
+                ans = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
+                return r'\(\Q(\sqrt{%s})\)' % latex(ans)
 
-            
     # Case 5: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
     if label in rcycloinfo:
         return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -212,10 +212,21 @@ def is_fundamental_discriminant(d):
 
 @cached_function
 def field_pretty(label):
+    """
+    Given an LMFDB number field label, returns a "pretty" latexed representation of this field (if this exists)
+    Otherwise, simply returns back the label itself if unable to find a latex represntation
+
+    Cases implemented:  Quadratic fields, Pure cubic fields, Impritive quartic fields, (real) cyclotomic fields, and multi-quadratic fields
+    """
+
     d, r, D, _ = label.split('.')
+
+    # Case 1: The rationals Q
     if d == '1':  # Q
         return r'\(\Q\)'
-    if d == '2':  # quadratic field
+    
+    # Case 2: Quadratic fields Q(\sqrt{D})
+    if d == '2':
         D = ZZ(int(D))
         if r == '0':
             D = -D
@@ -223,11 +234,17 @@ def field_pretty(label):
         if not is_fundamental_discriminant(D):
             return label
         return r'\(\Q(\sqrt{' + str(D if D % 4 else D/4) + r'}) \)'
+    
+    # Case 3: Cyclotomic fields Q(\zeta_N)
     if label in cycloinfo:
         return r'\(\Q(\zeta_{%d})\)' % cycloinfo[label]
+    
+    # Case 4: Imprimitive quartic fields
     if d == '4':
         wnf = WebNumberField(label)
         subs = wnf.subfields()
+
+        # Case 4a: Biquadratic fields Q(\sqrt{A}, \sqrt{B})
         if len(subs) == 3:  # only for V_4 fields
             subs = [wnf.from_coeffs(string2list(str(z[0]))) for z in subs]
             # Abort if we don't know one of these fields
@@ -241,8 +258,69 @@ def field_pretty(label):
                 labels_str = ['i' if z == -1 else r'\sqrt{%d}' % z
                               for z in labels_values]
                 return r'\(\Q(%s, %s)\)' % (labels_str[0], labels_str[1])
+            
+        # Case 4b: Imprimitive quartic fields of type Q(sqrt(A + Bsqrt(D)))
+        if len(subs) == 1:
+            # Factorise defining polynomial for K over Q(sqrt(D))
+            D = subs[0]
+            Ksub = QuadraticField(D)
+            relative_poly = poly.factor()[0]
+            rel_ceoffs = relative_poly.coefficients(sparse=False)
+            ans = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
+
+            return r'\(\Q(\sqrt{%s}\)' % ans
+
+            
+    # Case 5: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
     if label in rcycloinfo:
         return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
+    
+    # Case 6: Pure cubic fields Q(\sqrt[3]{N})
+    if d == 3:
+        wnf = WebNumberField(label)
+        # Check that discriminant is negative
+        if wnf.disc() < 0:
+            # Try to solve for a real root of defining polynomial:
+            poly = wnf.poly()
+            p = (3*a*c - b**2)/(3*a**2)
+            q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
+            r = (q**2)/4 + (p**3)/27
+
+            if r.is_square():
+                rs = sqrt(r)
+                # Check if they generate the same cubic field
+                if gen_same(-q/2 + rs, -q/2 - rs):
+                    return r'\(\Q(\sqrt[3]{%d})\)' % -q/2 + rs
+
+    # Case 7: Arbitrary multi-quadratic fields
+    if is_power_of_2(d):
+        wnf = WebNumberField(label)
+        subs = wnf.subfields()
+        num_quad_subs = sum(s.count('.')==2 for s in subs)
+        if num_quad_subs == d-1:
+            all_Ds = sorted(int(D) for D in Ds)
+            final_Ds = []
+            # Compute set of all primes dividing the Ds
+            primes = sorted({int(p) for d in ds for p in ZZ(abs(d)).prime_divisors()})
+
+            # Keep track of prime exponents used so far
+            all_prime_exponents = []
+
+            for D in Ds:
+                prime_exp = [D.valuation(p)%2 for p in primes]
+                tmp = matrix(GF(2), all_prime_exponents)
+
+                if prime_exp not in tmp.column_space():
+                    all_prime_exponents.append(prime_exp)
+                    final_Ds.append(D)
+
+                    # Break out once rank is full
+                    if len(final_Ds) == d:
+                        break
+            return r'\(\Q('+', '.join([str(D) for D in Ds])+')\)'
+
+
+    # Otherwise, return label
     return label
 
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -296,10 +296,9 @@ def field_pretty(label):
                 A, B = ZZ(A//g), ZZ(B//g)
 
                 # Return final pretty latex
-                print("****DEBUG****", label, "A,B=", A, B)
                 if A == 0:
                     # Case: Pure quartic field
-                    return r'\(\Q(\sqrt[4]{%s})\)' % D*ZZ(B)**2
+                    return r'\(\Q(\sqrt[4]{%d})\)' % (D*B**2)
                 else:
                     B_str = "+" if B == 1 else "-" if B == -1 else f"{B:+d}"
                     return r'\(\Q(\sqrt{%d %s %s})\)' % (A, B_str, _sqrt_symbol(D))
@@ -317,22 +316,18 @@ def field_pretty(label):
             d, c, b, a = wnf.poly().coefficients(sparse=False)
             p = (3*a*c - b**2)/(3*a**2)
             q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
-            r = (q**2)/4 + (p**3)/27
-            print("***** DEBUG PQR:", p, q, r)
+            r = (q**2)/4 + (p**3)/27   # r is positive if disc negative
 
-            # A real root is (-q/2 +/- sqrt(r))^{1/3}
+            # A real root is (-q/2 + sqrt(r))^{1/3} + (-q/2 - sqrt(r))^{1/3}
             if r.is_square():
-                rs = sqrt(r)
-                
-                r1, r2 = -q/2 + rs, -q/2 - rs
+                # Construct r1, r2 such that r1 <= r2
+                r1, r2 = abs(27*(-q/2 + r.sqrt())), abs(27*(-q/2 - r.sqrt()))
+                r1, r2 = min(r1,r2), max(r1,r2)
 
-                print("*** CUBIC DEBUG  ***:", -q/2 + rs, -q/2 - rs)
                 # Check if (-q/2+sqrt(r))^{1/3} and (-q/2-sqrt(r))^{1/3} generate the same cubic field
-                #if gen_same(-q/2 + rs, -q/2 - rs):
-                if r1.is_zero() or r2.is_zero():
-                    D = r1+r2
-                    # Get cubefree part of D
-                    D = ZZ(prod([pp[0]**(pp[1]%3) for pp in D.factor()]))
+                if r1.is_zero() or (all([(pp[1]%3==0) for pp in (r1*r2).factor()])):
+                    D = r1 if r1 > 0 else r2
+                    D = ZZ(prod([pp[0]**(pp[1]%3) for pp in D.factor()]))  # Get cubefree part
                     # If square, can take square root
                     if D.is_square():
                         D = D.sqrt()
@@ -343,35 +338,26 @@ def field_pretty(label):
         k = ZZ(d).valuation(2)
         wnf = WebNumberField(label)
         all_subs = wnf.subfields()
-        print("all_subs:", all_subs)
         quad_subs = [s[0] for s in all_subs if s[0].count(',') == 2]
         num_quad_subs = len(quad_subs)
-        print("********test", num_quad_subs)
         if num_quad_subs == int(d) - 1:
-            print("*******TEST****")
             quad_labels = [str(wnf.from_coeffs(string2list(str(z))).get_label()) for z in quad_subs]
-            print("quad labels:", quad_labels)
             all_Ds = [_quad_label_to_D(qlabel) for qlabel in quad_labels]
-            print("all Ds", all_Ds)
 
             # Sort the Ds by absolute value (in case of tie, put positive Ds first)
             sorted_Ds = sorted(all_Ds, key = lambda x: (abs(x), -x))
-            print("sorted Ds:", sorted_Ds)
             final_Ds = []
 
-            # Compute set of all primes dividing the Ds (include -1)
+            # Compute set of all primes dividing the Ds
             primes = sorted({int(p) for D in all_Ds for p in ZZ(abs(D)).prime_divisors()})
 
             # Keep track of prime exponents used so far
             all_prime_exponents = []
 
             for D in sorted_Ds:
-                print("Checking D=", D)
                 # Convert D to a vector of prime exponents mod 2 (including sign)
                 prime_exp = [int(D < 0)]+[D.valuation(p)%2 for p in primes]
-                print("prime exp:", prime_exp)
                 if vector(prime_exp) not in matrix(GF(2), all_prime_exponents).row_space():
-                    print("Adding the D=", D, "to the gens :)")
                     all_prime_exponents.append(prime_exp)
                     final_Ds.append(D)
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -293,7 +293,7 @@ def field_pretty(label):
                 # Divide out common square factors
                 g = gcd(A,B)
                 g //= g.squarefree_part()
-                A, B = A//g, B//g
+                A, B = ZZ(A//g), ZZ(B//g)
 
                 # Return final pretty latex
                 print("****DEBUG****", label, "A,B=", A, B)

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -4,7 +4,7 @@ import yaml
 
 from flask import url_for
 from sage.all import (
-    Set, ZZ, RR, pi, euler_phi, CyclotomicField, gap, RealField, sqrt, prod, matrix, GF,
+    Set, ZZ, RR, pi, gcd, euler_phi, CyclotomicField, gap, RealField, sqrt, prod, matrix, GF,
     QQ, NumberField, QuadraticField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
@@ -217,7 +217,7 @@ def field_pretty(label):
     Otherwise, simply returns back the label itself if unable to find a latex representation.
 
     Cases implemented:
-     - Rational field, Quadratic fields, Pure cubic fields, Imprimitive quartic fields,
+     - Rational field, quadratic fields, pure cubic fields, imprimitive quartic fields,
      - cyclotomic fields and their maximal real subfields, and general multi-quadratic fields.
     """
 
@@ -230,13 +230,13 @@ def field_pretty(label):
     # Converts LMFDB label for quadratic field K to the D in K = Q(sqrt(D))
     def _quad_label_to_D(quad_label):
         parts = str(quad_label).split('.')
-        DD = integer_squarefree_part(ZZ(parts[2]))  # Get squarefree part
-        DD *= (-1) ** (1 + int(parts[1]) // 2)      # Get correct sign
-        return ZZ(DD)
+        z = integer_squarefree_part(ZZ(parts[2]))  # Get squarefree part
+        z *= (-1) ** (1 + int(parts[1]) // 2)      # Get correct sign
+        return ZZ(z)
 
     # Converts D to the latexed form of sqrt(D)
-    def _sqrt_symbol(DD):
-        return 'i' if DD == -1 else r'\sqrt{%d}' % DD
+    def _sqrt_symbol(z):
+        return 'i' if z == -1 else r'\sqrt{%d}' % z
 
     # Case 2: Quadratic fields Q(\sqrt{D})
     if d == '2':
@@ -275,17 +275,39 @@ def field_pretty(label):
         if len(subs) == 1:
             quad_sub = wnf.from_coeffs(string2list(str(subs[0][0])))
             if not quad_sub._data is None:
-                # Factorise defining polynomial for K over Q(sqrt(D))
+                # Get unique quadratic subfield Q(sqrt(D))
                 quad_label = str(quad_sub.get_label())
                 D = _quad_label_to_D(quad_label)
-                Ksub = QuadraticField(D, 'b')
+                Ksub = QuadraticField(D, 'sqrtD')
+                sqrtD = Ksub._first_ngens(1)[0]
+                
+                # Factorise defining polynomial for K over Q(sqrt(D))
                 Rsub = PolynomialRing(Ksub, 'x')
                 relative_poly = Rsub(wnf.poly()).factor()[0][0]
 
                 # Can extract the first quadratic factor
                 rel_coeffs = relative_poly.coefficients(sparse=False)
-                ans = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
-                return r'\(\Q(\sqrt{%s})\)' % latex(ans)
+                alpha = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
+                A, B = sqrtD.coordinates_in_terms_of_powers()(alpha)
+
+                # Divide out common square factors
+                g = gcd(A,B)
+                g //= g.squarefree_part()
+                A, B = A//g, B//g
+                # Return final pretty latex
+                if A == 0:
+                    # Pure quartic field
+                    return r'\(\Q(\sqrt[4]{%d})\)' % D*ZZ(B)**2
+                else:
+                    if B == 1:
+                        B = ""
+                    elif B == -1:
+                        B = "-"
+                    elif B > 0:
+                        B = "+"+str(B)
+                    else:
+                        B = str(B)
+                return r'\(\Q(\sqrt{%d %s %s})\)' % (A, B, _sqrt_symbol(D))
 
     # Case 5: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
     if label in rcycloinfo:

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -4,7 +4,7 @@ import yaml
 
 from flask import url_for
 from sage.all import (
-    Set, ZZ, RR, pi, gcd, euler_phi, CyclotomicField, gap, RealField, sqrt, prod, matrix, GF,
+    Set, ZZ, RR, pi, gcd, euler_phi, CyclotomicField, gap, RealField, sqrt, prod, matrix, vector, GF,
     QQ, NumberField, QuadraticField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
@@ -294,20 +294,15 @@ def field_pretty(label):
                 g = gcd(A,B)
                 g //= g.squarefree_part()
                 A, B = A//g, B//g
+
                 # Return final pretty latex
+                print("****DEBUG****", label, "A,B=", A, B)
                 if A == 0:
-                    # Pure quartic field
-                    return r'\(\Q(\sqrt[4]{%d})\)' % D*ZZ(B)**2
+                    # Case: Pure quartic field
+                    return r'\(\Q(\sqrt[4]{%s})\)' % D*ZZ(B)**2
                 else:
-                    if B == 1:
-                        B = ""
-                    elif B == -1:
-                        B = "-"
-                    elif B > 0:
-                        B = "+"+str(B)
-                    else:
-                        B = str(B)
-                return r'\(\Q(\sqrt{%d %s %s})\)' % (A, B, _sqrt_symbol(D))
+                    B_str = "+" if B == 1 else "-" if B == -1 else f"{B:+d}"
+                    return r'\(\Q(\sqrt{%d %s %s})\)' % (A, B_str, _sqrt_symbol(D))
 
     # Case 5: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
     if label in rcycloinfo:
@@ -338,28 +333,35 @@ def field_pretty(label):
         k = ZZ(d).valuation(2)
         wnf = WebNumberField(label)
         all_subs = wnf.subfields()
-        quad_subs = [s[0] for s in all_subs if s[0].count('.') == 2]
+        print("all_subs:", all_subs)
+        quad_subs = [s[0] for s in all_subs if s[0].count(',') == 2]
         num_quad_subs = len(quad_subs)
-        #print("********test")
+        print("********test", num_quad_subs)
         if num_quad_subs == int(d) - 1:
-            #print("*******TEST****")
-            quad_labels = [str(wnf.from_coeffs(string2list(str(z[0]))).get_label()) for z in quad_subs]
+            print("*******TEST****")
+            quad_labels = [str(wnf.from_coeffs(string2list(str(z))).get_label()) for z in quad_subs]
+            print("quad labels:", quad_labels)
             all_Ds = [_quad_label_to_D(qlabel) for qlabel in quad_labels]
+            print("all Ds", all_Ds)
 
-            # Sort the Ds by absolute value (in case of tie, put positives first)
+            # Sort the Ds by absolute value (in case of tie, put positive Ds first)
             sorted_Ds = sorted(all_Ds, key = lambda x: (abs(x), -x))
+            print("sorted Ds:", sorted_Ds)
             final_Ds = []
 
             # Compute set of all primes dividing the Ds (include -1)
-            primes = sorted({int(p) for D in Ds for p in ZZ(abs(D)).prime_divisors()})
+            primes = sorted({int(p) for D in all_Ds for p in ZZ(abs(D)).prime_divisors()})
 
             # Keep track of prime exponents used so far
             all_prime_exponents = []
 
             for D in sorted_Ds:
+                print("Checking D=", D)
                 # Convert D to a vector of prime exponents mod 2 (including sign)
                 prime_exp = [int(D < 0)]+[D.valuation(p)%2 for p in primes]
-                if prime_exp not in matrix(GF(2), all_prime_exponents).row_space():
+                print("prime exp:", prime_exp)
+                if vector(prime_exp) not in matrix(GF(2), all_prime_exponents).row_space():
+                    print("Adding the D=", D, "to the gens :)")
                     all_prime_exponents.append(prime_exp)
                     final_Ds.append(D)
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -5,7 +5,7 @@ import yaml
 from flask import url_for
 from sage.all import (
     Set, ZZ, RR, pi, euler_phi, CyclotomicField, gap, RealField, sqrt, prod,
-    QQ, NumberField, PolynomialRing, latex, pari, cached_function, Permutation)
+    QQ, NumberField, QuadraticField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
 from lmfdb.utils import (web_latex, coeff_to_poly,
@@ -225,6 +225,17 @@ def field_pretty(label):
     if d == '1':  # Q
         return r'\(\Q\)'
     
+    # Converts LMFDB label for quadratic field K to the D in K = Q(sqrt(D))
+    def _quad_label_to_D(quad_label):
+        parts = str(quad_label).split('.')
+        DD = integer_squarefree_part(ZZ(parts[2]))  # Get squarefree part
+        DD *= (-1) ** (1 + int(parts[1]) // 2)      # Get correct sign
+        return ZZ(DD)
+
+    # Converts D to the latexed form of sqrt(D)
+    def _sqrt_symbol(DD):
+        return 'i' if DD == -1 else r'\sqrt{%d}' % DD
+
     # Case 2: Quadratic fields Q(\sqrt{D})
     if d == '2':
         D = ZZ(int(D))
@@ -255,8 +266,7 @@ def field_pretty(label):
                 labels = sorted([[integer_squarefree_part(ZZ(z[2])), - int(z[1])] for z in labels_split])
                 # put in +/- sign
                 labels_values = [z[0] * (-1)**(1 + z[1] / 2) for z in labels]
-                labels_str = ['i' if z == -1 else r'\sqrt{%d}' % z
-                              for z in labels_values]
+                labels_str = [_sqrt_symbol(z) for z in labels_values]
                 return r'\(\Q(%s, %s)\)' % (labels_str[0], labels_str[1])
             
         # Case 4b: Imprimitive quartic fields of type Q(sqrt(A + Bsqrt(D)))
@@ -265,14 +275,13 @@ def field_pretty(label):
             if not quad_sub._data is None:
                 # Factorise defining polynomial for K over Q(sqrt(D))
                 quad_label = str(quad_sub.get_label())
-                D = quad_label.split('.')[2]
-                Ksub = NumberField(quad_sub.poly(), 'b')
+                D = _quad_label_to_D(quad_label)
+                Ksub = QuadraticField(D, 'b')
                 Rsub = PolynomialRing(Ksub, 'x')
-                relative_poly = Rsub(wnf.poly())
-                factors = relative_poly.factor()
+                relative_poly = Rsub(wnf.poly()).factor()[0][0]
 
                 # Can extract the first quadratic factor
-                rel_coeffs = factors.coefficients(sparse=False)
+                rel_coeffs = relative_poly.coefficients(sparse=False)
                 ans = rel_coeffs[1]**2 - 4*rel_coeffs[0]*rel_coeffs[2]
                 return r'\(\Q(\sqrt{%s})\)' % latex(ans)
 
@@ -281,7 +290,7 @@ def field_pretty(label):
         return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
     
     # Case 6: Pure cubic fields Q(\sqrt[3]{N})
-    if d == 3:
+    if d == '3':
         wnf = WebNumberField(label)
         # Check that discriminant is negative
         if wnf.disc() < 0:
@@ -298,21 +307,27 @@ def field_pretty(label):
                     return r'\(\Q(\sqrt[3]{%d})\)' % -q/2 + rs
 
     # Case 7: Arbitrary multi-quadratic fields
-    if is_power_of_2(d):
+    if ZZ(d).is_power_of(2):
         wnf = WebNumberField(label)
         subs = wnf.subfields()
-        num_quad_subs = sum(s.count('.')==2 for s in subs)
-        if num_quad_subs == d-1:
-            all_Ds = sorted(int(D) for D in Ds)
+        quad_labels = [s[0] for s in subs if s[0].count('.') == 2]
+        num_quad_subs = len(quad_labels)
+        #print("********test")
+        if num_quad_subs == int(d) - 1:
+            #print("*******TEST****")
+            all_Ds = [_quad_label_to_D(qlabel) for qlabel in quad_labels]
+            # Sort the Ds by absolute value (in case of tie, put positives first)
+            sorted_Ds = sorted(all_Ds, key = lambda x: (abs(x), -x))
             final_Ds = []
-            # Compute set of all primes dividing the Ds
-            primes = sorted({int(p) for d in ds for p in ZZ(abs(d)).prime_divisors()})
+            # Compute set of all primes dividing the Ds (include -1)
+            primes = sorted({int(p) for D in Ds for p in ZZ(abs(D)).prime_divisors()})
 
             # Keep track of prime exponents used so far
             all_prime_exponents = []
 
-            for D in Ds:
-                prime_exp = [D.valuation(p)%2 for p in primes]
+            for D in sorted_Ds:
+                # Convert D to a vector of prime exponents mod 2 (including sign)
+                prime_exp = [int(D < 0)]+[D.valuation(p) % 2 for p in primes]
                 tmp = matrix(GF(2), all_prime_exponents)
 
                 if prime_exp not in tmp.column_space():
@@ -320,9 +335,9 @@ def field_pretty(label):
                     final_Ds.append(D)
 
                     # Break out once rank is full
-                    if len(final_Ds) == d:
+                    if len(final_Ds) == int(d):
                         break
-            return r'\(\Q('+', '.join([str(D) for D in Ds])+')\)'
+            return r'\(\Q('+', '.join([_sqrt_symbol(D) for D in final_Ds])+r')\)'
 
 
     # Otherwise, return label

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -251,13 +251,17 @@ def field_pretty(label):
     # Case 3: Cyclotomic fields Q(\zeta_N)
     if label in cycloinfo:
         return r'\(\Q(\zeta_{%d})\)' % cycloinfo[label]
+
+    # Case 4: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
+    if label in rcycloinfo:
+        return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
     
-    # Case 4: Imprimitive quartic fields
+    # Case 5: Imprimitive quartic fields
     if d == '4':
         wnf = WebNumberField(label)
         subs = wnf.subfields()
 
-        # Case 4a: Biquadratic fields Q(\sqrt{A}, \sqrt{B})
+        # Case 5a: Biquadratic fields Q(\sqrt{A}, \sqrt{B})
         if len(subs) == 3:  # only for V_4 fields
             subs = [wnf.from_coeffs(string2list(str(z[0]))) for z in subs]
             # Abort if we don't know one of these fields
@@ -271,7 +275,7 @@ def field_pretty(label):
                 labels_str = [_sqrt_symbol(z) for z in labels_values]
                 return r'\(\Q(%s, %s)\)' % (labels_str[0], labels_str[1])
             
-        # Case 4b: Imprimitive quartic fields of type Q(\sqrt(A + B*\sqrt(D)))
+        # Case 5b: Imprimitive quartic fields of type Q(\sqrt(A + B*\sqrt(D)))
         if len(subs) == 1:
             quad_sub = wnf.from_coeffs(string2list(str(subs[0][0])))
             if not quad_sub._data is None:
@@ -279,7 +283,7 @@ def field_pretty(label):
                 quad_label = str(quad_sub.get_label())
                 D = _quad_label_to_D(quad_label)
                 Ksub = QuadraticField(D, 'sqrtD')
-                sqrtD = Ksub._first_ngens(1)[0]
+                sqrtD = Ksub.gen(0)
                 
                 # Factorise defining polynomial for K over Q(sqrt(D))
                 Rsub = PolynomialRing(Ksub, 'x')
@@ -303,10 +307,6 @@ def field_pretty(label):
                     B_str = "+" if B == 1 else "-" if B == -1 else f"{B:+d}"
                     return r'\(\Q(\sqrt{%d %s %s})\)' % (A, B_str, _sqrt_symbol(D))
 
-    # Case 5: Maximal real subfields of cyclotomic fields Q(\zeta_N)^+
-    if label in rcycloinfo:
-        return r'\(\Q(\zeta_{%d})^+\)' % rcycloinfo[label]
-    
     # Case 6: Pure cubic fields Q(\sqrt[3]{N})
     if d == '3':
         wnf = WebNumberField(label)
@@ -351,19 +351,24 @@ def field_pretty(label):
             # Compute set of all primes dividing the Ds
             primes = sorted({int(p) for D in all_Ds for p in ZZ(abs(D)).prime_divisors()})
 
-            # Keep track of prime exponents used so far
+            # Keep track of prime exponents and row space used so far
             all_prime_exponents = []
+            row_space = matrix(GF(2), all_prime_exponents).row_space()
 
             for D in sorted_Ds:
                 # Convert D to a vector of prime exponents mod 2 (including sign)
                 prime_exp = [int(D < 0)]+[D.valuation(p)%2 for p in primes]
-                if vector(prime_exp) not in matrix(GF(2), all_prime_exponents).row_space():
-                    all_prime_exponents.append(prime_exp)
+                if vector(prime_exp) not in row_space:
                     final_Ds.append(D)
 
                     # Break out once rank is full
                     if len(final_Ds) == k:
                         break
+
+                    # Recompute row space
+                    all_prime_exponents.append(prime_exp)
+                    row_space = matrix(GF(2), all_prime_exponents).row_space()
+            
             return r'\(\Q('+', '.join([_sqrt_symbol(D) for D in final_Ds])+r')\)'
 
     # Otherwise, if no latex form found, just return the LMFDB label

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -4,7 +4,7 @@ import yaml
 
 from flask import url_for
 from sage.all import (
-    Set, ZZ, RR, pi, euler_phi, CyclotomicField, gap, RealField, sqrt, prod,
+    Set, ZZ, RR, pi, euler_phi, CyclotomicField, gap, RealField, sqrt, prod, matrix, GF,
     QQ, NumberField, QuadraticField, PolynomialRing, latex, pari, cached_function, Permutation)
 
 from lmfdb import db
@@ -213,10 +213,12 @@ def is_fundamental_discriminant(d):
 @cached_function
 def field_pretty(label):
     """
-    Given an LMFDB number field label, returns a "pretty" latexed representation of this field (if this exists)
-    Otherwise, simply returns back the label itself if unable to find a latex represntation
+    Given an LMFDB number field label, returns a "pretty" latexed representation of this field (if it exists)
+    Otherwise, simply returns back the label itself if unable to find a latex representation.
 
-    Cases implemented:  Quadratic fields, Pure cubic fields, Impritive quartic fields, (real) cyclotomic fields, and multi-quadratic fields
+    Cases implemented:
+     - Rational field, Quadratic fields, Pure cubic fields, Imprimitive quartic fields,
+     - cyclotomic fields and their maximal real subfields, and general multi-quadratic fields.
     """
 
     d, r, D, _ = label.split('.')
@@ -269,7 +271,7 @@ def field_pretty(label):
                 labels_str = [_sqrt_symbol(z) for z in labels_values]
                 return r'\(\Q(%s, %s)\)' % (labels_str[0], labels_str[1])
             
-        # Case 4b: Imprimitive quartic fields of type Q(sqrt(A + Bsqrt(D)))
+        # Case 4b: Imprimitive quartic fields of type Q(\sqrt(A + B*\sqrt(D)))
         if len(subs) == 1:
             quad_sub = wnf.from_coeffs(string2list(str(subs[0][0])))
             if not quad_sub._data is None:
@@ -295,30 +297,37 @@ def field_pretty(label):
         # Check that discriminant is negative
         if wnf.disc() < 0:
             # Try to solve for a real root of defining polynomial:
-            poly = wnf.poly()
+            a, b, c, d = wnf.poly().coefficients(sparse=False)
             p = (3*a*c - b**2)/(3*a**2)
             q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
             r = (q**2)/4 + (p**3)/27
 
+            # A real root is (-q/2 +/- sqrt(r))^{1/3}
             if r.is_square():
                 rs = sqrt(r)
-                # Check if they generate the same cubic field
+
+                print("*** CUBIC DEBUG  ***:", -q/2 + rs, -q/2 - rs)
+                # Check if (-q/2+sqrt(r))^{1/3} and (-q/2-sqrt(r))^{1/3} generate the same cubic field
                 if gen_same(-q/2 + rs, -q/2 - rs):
                     return r'\(\Q(\sqrt[3]{%d})\)' % -q/2 + rs
 
-    # Case 7: Arbitrary multi-quadratic fields
+    # Case 7: General multi-quadratic fields: Q(\sqrt{D_1}, ..., \sqrt{D_k})
     if ZZ(d).is_power_of(2):
+        k = ZZ(d).valuation(2)
         wnf = WebNumberField(label)
-        subs = wnf.subfields()
-        quad_labels = [s[0] for s in subs if s[0].count('.') == 2]
-        num_quad_subs = len(quad_labels)
+        all_subs = wnf.subfields()
+        quad_subs = [s[0] for s in all_subs if s[0].count('.') == 2]
+        num_quad_subs = len(quad_subs)
         #print("********test")
         if num_quad_subs == int(d) - 1:
             #print("*******TEST****")
+            quad_labels = [str(wnf.from_coeffs(string2list(str(z[0]))).get_label()) for z in quad_subs]
             all_Ds = [_quad_label_to_D(qlabel) for qlabel in quad_labels]
+
             # Sort the Ds by absolute value (in case of tie, put positives first)
             sorted_Ds = sorted(all_Ds, key = lambda x: (abs(x), -x))
             final_Ds = []
+
             # Compute set of all primes dividing the Ds (include -1)
             primes = sorted({int(p) for D in Ds for p in ZZ(abs(D)).prime_divisors()})
 
@@ -327,20 +336,17 @@ def field_pretty(label):
 
             for D in sorted_Ds:
                 # Convert D to a vector of prime exponents mod 2 (including sign)
-                prime_exp = [int(D < 0)]+[D.valuation(p) % 2 for p in primes]
-                tmp = matrix(GF(2), all_prime_exponents)
-
-                if prime_exp not in tmp.column_space():
+                prime_exp = [int(D < 0)]+[D.valuation(p)%2 for p in primes]
+                if prime_exp not in matrix(GF(2), all_prime_exponents).row_space():
                     all_prime_exponents.append(prime_exp)
                     final_Ds.append(D)
 
                     # Break out once rank is full
-                    if len(final_Ds) == int(d):
+                    if len(final_Ds) == k:
                         break
             return r'\(\Q('+', '.join([_sqrt_symbol(D) for D in final_Ds])+r')\)'
 
-
-    # Otherwise, return label
+    # Otherwise, if no latex form found, just return the LMFDB label
     return label
 
 

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -313,8 +313,8 @@ def field_pretty(label):
         wnf = WebNumberField(label)
         # Check that discriminant is negative
         if wnf.disc() < 0:
-            # Try to solve for a real root of defining polynomial:
-            a, b, c, d = wnf.poly().coefficients(sparse=False)
+            # Explicitly solve for a real root of defining polynomial (using Cardano's formula):
+            d, c, b, a = wnf.poly().coefficients(sparse=False)
             p = (3*a*c - b**2)/(3*a**2)
             q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
             r = (q**2)/4 + (p**3)/27

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -318,15 +318,25 @@ def field_pretty(label):
             p = (3*a*c - b**2)/(3*a**2)
             q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
             r = (q**2)/4 + (p**3)/27
+            print("***** DEBUG PQR:", p, q, r)
 
             # A real root is (-q/2 +/- sqrt(r))^{1/3}
             if r.is_square():
                 rs = sqrt(r)
+                
+                r1, r2 = -q/2 + rs, -q/2 - rs
 
                 print("*** CUBIC DEBUG  ***:", -q/2 + rs, -q/2 - rs)
                 # Check if (-q/2+sqrt(r))^{1/3} and (-q/2-sqrt(r))^{1/3} generate the same cubic field
-                if gen_same(-q/2 + rs, -q/2 - rs):
-                    return r'\(\Q(\sqrt[3]{%d})\)' % -q/2 + rs
+                #if gen_same(-q/2 + rs, -q/2 - rs):
+                if r1.is_zero() or r2.is_zero():
+                    D = r1+r2
+                    # Get cubefree part of D
+                    D = ZZ(prod([pp[0]**(pp[1]%3) for pp in D.factor()]))
+                    # If square, can take square root
+                    if D.is_square():
+                        D = D.sqrt()
+                    return r'\(\Q(\sqrt[3]{%d})\)' % D
 
     # Case 7: General multi-quadratic fields: Q(\sqrt{D_1}, ..., \sqrt{D_k})
     if ZZ(d).is_power_of(2):


### PR DESCRIPTION
For some families of number fields $K$, we give a "pretty" latexed name for $K$ at the top of the field homepage, currently implemented for quadratic fields $\mathbb{Q}(\sqrt{D})$, biquadratic fields $\mathbb{Q}(\sqrt{A}, \sqrt{B})$, and cyclotomic fields $\mathbb{Q}(\zeta_n)$.  This PR extends the `field_pretty` function to give latexed names for some additional families of number fields. :)

The following three cases have been added:

 - **General multi-quadratic fields** $\mathbb{Q}(\sqrt{D_1}, \sqrt{D_2}, \dots, \sqrt{D_k})$ :  For fields $K$ of degree $2^k$ with $2^k - 1$ quadratic subfields, this now selects the $k$ smallest quadratic subfields $Q(\sqrt{D_1}), \dots, Q(\sqrt{D_k})$ which generate $K$.
  
   http://localhost:37777/NumberField/8.0.12960000.1
   http://localhost:37777/NumberField/16.0.63456228123711897600000000.10
   http://localhost:37777/NumberField/32.0.4026692887688564776141139207792885760000000000000000.1

 - **Imprimitive (non-biquadratic) quartic fields** $\mathbb{Q}(√ (A + B \sqrt{D}))$:  This checks if a quartic field $K$ has exactly one quadratic subfield $\mathbb{Q}(\sqrt{D})$, and then computes a generator for $K$ of the form $√(A + B \sqrt{D})$ by factoring the defining polynomial for $K$ over $\mathbb{Q}(\sqrt{D})$.  If $A = 0$, then returns the latexed form as a pure quartic field $\mathbb{Q}(\sqrt[4]{n})$.

   http://localhost:37777/NumberField/4.0.512.1
   http://localhost:37777/NumberField/4.2.2048.1
   http://localhost:37777/NumberField/4.4.2048.1

 - **Pure cubic fields**: $\mathbb{Q}(\sqrt[3]{n})$: Detects if a cubic field K is of the form $\mathbb{Q}(\sqrt[3]{n})$, by computing a real root of the defining polynomial for $K$.

   http://localhost:37777/NumberField/3.1.108.1
   http://localhost:37777/NumberField/3.1.243.1
   http://localhost:37777/NumberField/3.1.300.1
   

As always, any comments/feedback very welcome! 🙂 