### PR TITLE
An alternative to 6941

### DIFF
--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 
-{{ tabs(("Q", "ec.rational_elliptic_curves", false), ("Number Fields", ".index", true)) }}
+{{ tabs(("over $\Q$", "ec.rational_elliptic_curves", false), ("over Number Fields", ".index", true)) }}
 
 
 

--- a/lmfdb/ecnf/templates/ecnf-index.html
+++ b/lmfdb/ecnf/templates/ecnf-index.html
@@ -2,6 +2,11 @@
 
 {% block content %}
 
+
+{{ tabs(("Q", "ec.rational_elliptic_curves", false), ("Number Fields", ".index", true)) }}
+
+
+
 <div>
   {{ info.stats.short_summary | safe}}
 </div>

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-{{ tabs(("Q", ".index", true), ("Number Fields", "ecnf.index", false)) }}
+{{ tabs(("over $\Q$", ".index", true), ("over Number Fields", "ecnf.index", false)) }}
 
 
 

--- a/lmfdb/elliptic_curves/templates/ec-index.html
+++ b/lmfdb/elliptic_curves/templates/ec-index.html
@@ -2,6 +2,11 @@
 
 {% block content %}
 
+{{ tabs(("Q", ".index", true), ("Number Fields", "ecnf.index", false)) }}
+
+
+
+
 <div>
   {{info.stats.short_summary| safe}}
 </div>

--- a/lmfdb/homepage/sidebar.yaml
+++ b/lmfdb/homepage/sidebar.yaml
@@ -64,11 +64,8 @@
     title: Varieties
     url_for: "varieties"
   parts:
-    - title: Elliptic curves over $\Q$
+    - title: Elliptic curves
       url_for: "ec.rational_elliptic_curves"
-      colspan: onecolumn
-    - title: Elliptic curves over $\Q(\alpha)$
-      url_for: "ecnf.index"
       colspan: onecolumn
     - title: Elliptic curves over $\F_{q}(t)$
       status: future

--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -6,6 +6,20 @@
 {% endif %}
 {% endmacro %}
 
+
+{% macro tabs() %}
+  <div class="tab-container">
+    {% for arg in varargs %}
+      {% if arg[2] %}
+        <span class="tab-active">{{arg[0]}}</span>
+      {% else %}
+        <span class="tab-inactive"><a href="{{url_for(arg[1])}}">{{arg[0]}}</a></span>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endmacro %}
+
+
 {% block body -%}
 <div id="header">
     <div id="logo"><a href="{{ url_for('index') }}">

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -2335,3 +2335,25 @@ button.search_stale, button.search_stale:hover {
 button.search_fresh {
   background: {{color.button_background}};
 }
+
+
+div.tab-container {
+  display: inline-block;
+  border-radius: 5px;
+  overflow: hidden;
+  font-weight: bold;
+}
+
+span.tab-active {
+  padding: 10px;
+  background: #0D47A1;
+  color: white;
+}
+span.tab-inactive {
+  padding: 10px;
+  background: #90CAF9;
+}
+span.tab-inactive a, span.tab-inactive a:hover {
+  background: #90CAF9;
+  color: #0D47A1;
+}

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -425,7 +425,7 @@ body > .debug {
 #content {
   margin-top: 10px;
   font-size: 95%;
-  line-height: 135%;
+  line-height: 1.4;
   padding-right: 10px;
 }
 
@@ -2336,24 +2336,29 @@ button.search_fresh {
   background: {{color.button_background}};
 }
 
-
+/* Tabs for elliptic curves & lattice pages */
 div.tab-container {
   display: inline-block;
   border-radius: 5px;
   overflow: hidden;
   font-weight: bold;
+  line-height: 1.4;
 }
 
-span.tab-active {
-  padding: 10px;
-  background: #0D47A1;
-  color: white;
+/* ">" selector is needed because a's are already styled above */
+span.tab-inactive > a {
+    color: inherit;
+    background: inherit;
 }
+
+span.tab-active, span.tab-inactive:hover {
+  padding: 10px;
+  background: {{ color.sidebar_background_h2_hover }};
+  color: {{ color.sidebar_h2_hover }};
+}
+
 span.tab-inactive {
   padding: 10px;
-  background: #90CAF9;
-}
-span.tab-inactive a, span.tab-inactive a:hover {
-  background: #90CAF9;
-  color: #0D47A1;
+  background: {{ color.sidebar_background_h2 }};
+  color: {{ color.col_sidebar_header_links }};
 }


### PR DESCRIPTION
Here's a possible alternative if we don't want a landing page for elliptic curves as is proposed in #6941.

This is NOT ready to merge yet, and maybe worth putting on a color server so folks can look at.

It uses two tabs (like on alpha lattices) on the EC and ECNF index pages that people can toggle between to get to these two sections.  The proposal is also to reduce the sidebar entries to only have one link saying "Elliptic curves" which goes to the rational EC page.  This would require one extra click if you want ECNF.

Easy to change the names of the tabs too!

Feedback welcome!
