### PR TITLE
Fix issue #6988

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -782,7 +782,7 @@ class WebAbstractGroup(WebObj):
             return r'Mathieu group $M_{24}$'
         if self.label == '17556.a':
             return r'Janko group $J_1$'
-        if self.label == '60480.a':
+        if self.label == '604800.a':
             return r'Janko group $J_2$'
         if self.label == '50232960.a':
             return r'Janko group $J_3$'


### PR DESCRIPTION
The label of the group J2 was wrong in the file.

https://beta.lmfdb.org/Groups/Abstract/60480.a
http://127.0.0.1:37777/Groups/Abstract/60480.a

The correct page for this group is

https://beta.lmfdb.org/Groups/Abstract/604800.a
http://127.0.0.1:37777/Groups/Abstract/604800.a
