### PR TITLE
Fix comment type for Sage download of Hilbert cusp form eigenvalues

### DIFF
--- a/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
+++ b/lmfdb/hilbert_modular_forms/hilbert_modular_form.py
@@ -340,10 +340,10 @@ def download_hmf_sage(**args):
     F = WebNumberField(f['field_label'])
     F_hmf = get_hmf_field(f['field_label'])
 
-    outstr = '/*\n  This code can be loaded, or copied and paste using cpaste, into Sage.\n'
+    outstr = '"""\n  This code can be loaded, or copied and paste using cpaste, into Sage.\n'
     outstr += '  It will load the data associated to the HMF, including\n'
     outstr += '  the field, level, and Hecke and Atkin-Lehner eigenvalue data.\n'
-    outstr += '*/\n\n'
+    outstr += '"""\n\n'
 
     outstr += 'P.<x> = PolynomialRing(QQ)\n'
     outstr += 'g = P(' + str(F.coeffs()) + ')\n'


### PR DESCRIPTION
This fixes issue #6986 - replaced the incorrect Magma comment delineation `/*`, `*/` with the Sage comment delineation `"""`  (e.g. as is correctly done in the BMF eigenvalues downloads).

http://localhost:37777/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-61.1-a/download/sage
https://beta.lmfdb.org/ModularForm/GL2/TotallyReal/2.2.5.1/holomorphic/2.2.5.1-61.1-a/download/sage
