### PR TITLE
Bug fix for computing latex names for certain cubic fields

### DIFF
--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -313,9 +313,9 @@ def field_pretty(label):
         # Check that discriminant is negative
         if wnf.disc() < 0:
             # Explicitly solve for a real root of defining polynomial (using Cardano's formula):
-            d, c, b, a = wnf.poly().coefficients(sparse=False)
+            e, c, b, a = wnf.poly().coefficients(sparse=False)
             p = (3*a*c - b**2)/(3*a**2)
-            q = (2*b**3 - 9*a*b*c + 27*a**2*d)/(27*a**3)
+            q = (2*b**3 - 9*a*b*c + 27*a**2*e)/(27*a**3)
             r = (q**2)/4 + (p**3)/27   # r is positive if disc negative
 
             # A real root is (-q/2 + sqrt(r))^{1/3} + (-q/2 - sqrt(r))^{1/3}


### PR DESCRIPTION
This just fixes a small bug when generating latex names for certain cubic fields, e.g. for [3.1.23.1](https://beta.lmfdb.org/NumberField/3.1.23.1).  In `field_pretty` in `web_number_field.py`, in Case 6, the code originally redefined the variable $d$, which overwrote the degree $d$, thus causing a bug when checking the later Case 7.

(my sincere apologies for only noticing this after `dev` and `web` had already been updated!)

https://beta.lmfdb.org/NumberField/3.1.23.1
http://localhost:37777/NumberField/3.1.23.1
