### PR TITLE
Bug fix for ECNF downloader

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -454,7 +454,7 @@ class ECNFDownloader(Downloader):
         row["field_coeffs"] = poly
 
         # Convert Weierstrass coefficients from string to a list of list of integers
-        row['ainvs'] = [[ZZ(aj) for aj in ai.split(",")] for ai in row['ainvs'].split(";")]
+        row['ainvs'] = [[QQ(aj) for aj in ai.split(",")] for ai in row['ainvs'].split(";")]
 
         return row
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -453,7 +453,7 @@ class ECNFDownloader(Downloader):
         poly = coeff_to_poly(db.nf_fields.lookup(row['field_label'], projection='coeffs'))
         row["field_coeffs"] = poly
 
-        # Convert Weierstrass coefficients from string to a list of list of integers
+        # Convert Weierstrass coefficients from string to a list of list of rationals
         row['ainvs'] = [[QQ(aj) for aj in ai.split(",")] for ai in row['ainvs'].split(";")]
 
         return row


### PR DESCRIPTION
This fixes issue #7004 - the ECNF downloader now parses the coefficients of elliptic curves as rational linear combinations of $a^i$, where previously it wrongly assumed it was integer linear combinations of $a^i$  (this is only true if the base field $K$ is monogenic where $O_K = \mathbb{Z}[a]$).

https://beta.lmfdb.org/EllipticCurve/?download=1&query=%7B%27conductor_norm%27%3A+1%7D&conductor_norm=1&Submit=text
http://localhost:37777/EllipticCurve/?download=1&query=%7B%27conductor_norm%27%3A+1%7D&conductor_norm=1&Submit=text