### PR TITLE
Fix download for p-adic families search results (#6829)

### DIFF
--- a/lmfdb/local_fields/main.py
+++ b/lmfdb/local_fields/main.py
@@ -424,6 +424,10 @@ class LF_download(Downloader):
         ),
     }
 
+class LF_families_download(Downloader):
+    table = db.lf_families
+    title = '$p$-adic families'
+
 def galcolresponse(n,t,cache):
     if t is None:
         return 'not computed'
@@ -612,7 +616,9 @@ families_columns = SearchColumns([
     MathCol("c_absolute", "lf.discriminant_exponent", r"$c_{\mathrm{abs}}$", short_title="abs. disc. exponent", default=False, contingent=lambda info: "relative" in info),
     MultiProcessedCol("base_field", "lf.family_base", "Base",
                       ["base", "p", "n0", "rf0"],
-                      pretty_link, contingent=lambda info: "relative" in info),
+                      pretty_link,
+                      apply_download=lambda base, p, n0, rf0: base,
+                      contingent=lambda info: "relative" in info),
     RationalListCol("visible", "lf.slopes", "Abs. Artin slopes",
                     show_slopes2, default=False, short_title="abs. Artin slopes"),
     RationalListCol("slopes", "lf.slopes", "Swan slopes", short_title="Swan slopes"),
@@ -1442,6 +1448,7 @@ def common_family_parse(info, query):
     titletag=lambda:'p-adic families search results',
     err_title='p-adic families search input error',
     learnmore=learnmore_list,
+    shortcuts={'download': LF_families_download()},
     bread=lambda:get_bread([("Families", "")]),
     postprocess=families_postprocess,
     url_for_label=url_for_family,

--- a/lmfdb/local_fields/test_localfields.py
+++ b/lmfdb/local_fields/test_localfields.py
@@ -59,3 +59,16 @@ create_record(row) =
     field = Polrev(mapget(out, "coeffs"));
     mapput(~out, "field", field);
     return(out);''' in page
+
+    def test_families_search_download(self):
+        # Absolute families: download should produce a file (not just refresh the page).  Issue #6829.
+        r = self.tc.get('/padicField/?Submit=sage&download=1&query=%7B%27n0%27%3A+1%2C+%27p%27%3A+2%2C+%27n%27%3A+2%7D&p=2&n=2&search_type=Families')
+        assert 'attachment' in r.headers.get('Content-Disposition', '')
+        page = r.get_data(as_text=True)
+        assert '"2.2.1.0a"' in page
+        assert '"2.1.2.2a"' in page
+        # Relative families: download should also work and include the base field label.
+        r = self.tc.get('/padicField/?Submit=sage&download=1&query=%7B%27base%27%3A+%272.2.1.0a1.1%27%2C+%27n%27%3A+2%7D&n=2&base=2.2.1.0a1.1&relative=1&search_type=Families')
+        assert 'attachment' in r.headers.get('Content-Disposition', '')
+        page = r.get_data(as_text=True)
+        assert '"2.2.1.0a1.1"' in page


### PR DESCRIPTION
The families search had no `download` shortcut on its `search_wrap`, so clicking Download just re-ran the search and refreshed the page. Add an `LF_families_download` Downloader and register it as the download shortcut. Also set `apply_download` on the `base_field` column so the relative-families download doesn't crash on the virtual `rf0` field (only populated by the wrapper's postprocess, not the downloader's row stream).