### PR TITLE
Cap /data/ pages at 100 rows per table (fix #6939)

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -370,7 +370,7 @@ def api_query(table, id=None):
 
 
 # This function is used to show the data associated to a given homepage, which could possibly be from multiple tables.
-def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
+def datapage(labels, tables, title, bread, label_cols=None, sorts=None, limit=100):
     """
     INPUT:
 
@@ -380,8 +380,15 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
     - ``bread`` -- bread for the page
     - ``label_cols`` -- a list of column names of the same length; defaults to using ``label`` everywhere
     - ``sorts`` -- lists for sorting each table; defaults to None
+    - ``limit`` -- maximum number of rows displayed from each table; if more rows match, the total count is reported instead of listing them all
     """
     format = request.args.get("_format", "html")
+    try:
+        limit_arg = request.args.get("_limit")
+        if limit_arg is not None:
+            limit = max(0, min(10000, int(limit_arg)))
+    except (TypeError, ValueError):
+        pass
     if not isinstance(tables, list):
         tables = [tables]
     if not isinstance(labels, list):
@@ -402,6 +409,7 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
         else:
             return abort(code, msg % tuple(flash_extras))
     data = []
+    totals = []
     search_schema = {}
     extra_schema = {}
     for label, table, col, sort in zip(labels, tables, label_cols, sorts):
@@ -411,7 +419,15 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
             q = {col: label}
         coll = db[table]
         try:
-            data.append(list(coll.search(q, projection=3, sort=sort)))
+            # Fetch limit+1 rows to cheaply detect truncation; only call count() if we actually exceeded the limit.
+            rows = list(coll.search(q, projection=3, sort=sort, limit=limit + 1))
+            if len(rows) > limit:
+                total = coll.count(q)
+                rows = rows[:limit]
+            else:
+                total = len(rows)
+            data.append(rows)
+            totals.append(total)
         except QueryCanceledError:
             return apierror("Query %s exceeded time limit.", [q], code=500, table=table)
         except KeyError as err:
@@ -431,6 +447,8 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None):
         "label_cols": label_cols,
         "timestamp": utc_now_naive().isoformat(),
         "data": data,
+        "totals": totals,
+        "limit": limit,
     }
     if format.lower() == "json":
         return current_app.response_class(json.dumps(data, indent=2), mimetype='application/json')

--- a/lmfdb/api/templates/apidata.html
+++ b/lmfdb/api/templates/apidata.html
@@ -23,15 +23,18 @@ Formats:
 </div>
 
 <ul class="api-entries">
-  {% for table, recs, label, label_col in zip(tables, data, labels, label_cols) %}
+  {% for table, recs, label, label_col, total in zip(tables, data, labels, label_cols, totals) %}
     <li>
-      {% if (recs|length) == 0 %}
+      {% if total == 0 %}
         {{ label_col }} {{ label }} does not appear in <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a>
-      {% elif (recs|length) == 1 %}
+      {% elif total == 1 %}
         <a href="{{ url_for('API.api_query_id', table=table, id=recs[0].get('id')) }}">{{ table }}</a> &bull; {% include "apischema.html" %} </br/>
         <code>{{ pretty(recs[0], id=False) }}</code>
       {% else %}
         <a href="{{ url_for('API.api_query', table=table) }}">{{ table }}</a> &bull; {% include "apischema.html" %} </br/>
+        {% if (recs|length) < total %}
+          Showing the first {{ recs|length }} of {{ total }} matching records in this table.
+        {% endif %}
         <ul>
           {% for entry in recs %}
             <li>


### PR DESCRIPTION
## Summary
- `datapage()` (the helper behind every "Underlying data" page) used to dump every matching row from each related table. For labels like `/ModularCurve/data/2.6.0.a.1`, that meant rendering ~190K `modcurve_points` records and locking up the browser (#6939).
- It now caps each per-table result at `limit=100` and reports the total count when truncated. The truncation check is cheap — it fetches `limit+1` rows and only calls `count()` when the cap is actually hit.
- A `?_limit=N` query arg (clamped to 10000) lets users opt into a bigger page.
- The JSON/YAML output gains `totals` and `limit` fields so API consumers can detect truncation too.

The cap follows @AndrewVSutherland's suggestion in the issue thread; @roed314 asked for the total-count display when the cap is reached.

## Test plan
- [x] Visit `/ModularCurve/data/2.6.0.a.1` and confirm it renders quickly with a "Showing the first 100 of N matching records" notice on the `modcurve_points` section.
- [x] Visit a `/data/<label>` page where no table is over the cap and confirm no truncation notice appears.
- [x] Visit `/ModularCurve/data/2.6.0.a.1?_format=json` and confirm `totals`/`limit` keys are present and `data` is truncated.
- [x] Visit `/ModularCurve/data/2.6.0.a.1?_limit=500` and confirm the cap is raised.
- [x] Spot-check a few other `/data/` pages (elliptic curves, modular forms, groups, etc.) to confirm nothing regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)