### PR TITLE
fix(layout): push #footer to viewport bottom on content-short pages

### DIFF
--- a/lmfdb/templates/homepage.html
+++ b/lmfdb/templates/homepage.html
@@ -7,6 +7,8 @@
 {% endmacro %}
 
 {% block body -%}
+<div id="layout">
+<div id="page-wrapper">
 <div id="header">
     <div id="logo"><a href="{{ url_for('index') }}">
 {% if ALPHA %}
@@ -230,6 +232,8 @@ The function which was called for this page is: {{calling_function}}
 </div>
 {% endif %}
 
+</div>{# /#page-wrapper #}
+
 <div id="footer">
     {% if credit -%}
       Data computed by {{ credit|safe }}.<br />
@@ -260,6 +264,7 @@ The function which was called for this page is: {{calling_function}}
       {{ version|safe }}
     </div>
 </div>
+</div>{# /#layout #}
 
 
 

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -15,6 +15,20 @@ body {
     color: {{color.body_text}};
     background-color: {{color.body_background}};
 }
+
+/* Sticky-footer scaffold: viewport-tall flex column wrapping the page
+   content + footer. Lives on a dedicated wrapper (not body) so that
+   third-party scripts that append to body (e.g. reCAPTCHA) do not
+   become extra flex items that can push the footer off the viewport. */
+#layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#page-wrapper {
+    flex: 1 0 auto;
+}
 td.title {
     color: {{color.box_tab_text}};
 }
@@ -301,7 +315,6 @@ body.knowl #header {
 #main {
   margin:  0px 0px 0px 184px;
   padding: 0px 0px 0px 10px;
-  min-height:600px;
 }
 
 .debug {


### PR DESCRIPTION
Previously #footer floated wherever #main's content (with a fixed 600px min-height) ended, leaving large gaps mid-viewport on short pages such as /, /about, and /contact when viewed on tall windows.

Switch to the standard flex sticky-footer pattern: a new #layout wrapper around the page content and footer is a flex column with min-height: 100vh, and an inner #page-wrapper grows to fill any remaining space, so #footer naturally lands at the bottom of the viewport on short pages and continues to flow after content on long pages. No magic numbers, no per-page tuning.

The flex container is a dedicated wrapper rather than body itself because third-party scripts (reCAPTCHA) append elements to body, and those should not become flex items that displace the footer.

Verified with playwright across /, /about, /contact at viewport heights 1080, 1440, 2000: footer's bottom edge is at the viewport bottom on every page.

See it on olive.lmfdb.xyz