### PR TITLE
Fix #6900 - restructure layout of knowl boxes (more idiomatic CSS?)

### DIFF
--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -254,7 +254,7 @@ function knowl_click_handler($el) {
           knowl_cache[knowl_id] = $output.html();
           $output.hide();
 
-          // if it is the outermost knowl, limit its height of the content to 600px
+          // if it is the outermost knowl, limit its height of the content to 500px
           if ($output.parents('.knowl-output').length == 0) {
             $(output_id + " div.knowl-content").first().parent().addClass("limit-height");
           }

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -301,7 +301,7 @@ body.knowl #header {
 #main {
   margin:  0px 0px 0px 184px;
   padding: 0px 0px 0px 10px;
-  min-height:600px;
+  min-height: 600px;
 }
 
 .debug {
@@ -1166,7 +1166,8 @@ table.statgrid td.cnt {
 }
 
 .knowl-content {
-  padding: 0 10px;
+    padding: 15px 10px;
+    background-color: {{ color.knowl_background }};
 }
 .knowl-content h1 {
   margin: 0px 0px 10px 0px;
@@ -1267,15 +1268,17 @@ h2 > .knowl-qm {
 }
 */
 .knowl-output {
-  background: {{ color.knowl_background }};
-  border: 10px solid {{ color.knowl_border }};
+  position: relative;
+  background: {{ color.knowl_border }};
+  border: 1px solid {{ color.knowl_border }};
   {{ BORDER_RADIUS(10) }}
-  padding: 0px;
+  padding: 12px 10px;
   display: none;
   margin-top: 10px;
   margin-bottom: 15px;
   margin-right: 10px;
   text-align: left;
+  overflow: hidden;
 }
 
 .knowl-output .knowl-output,
@@ -1304,24 +1307,26 @@ div.limit-height {
 .knowl-output a { display: inline; }
 
 .knowl-footer {
-  position: relative;
-  bottom: -10px;
+  position: absolute;
+  bottom: 0;
+  width: 100%;			/* This makes the knowl open prettily*/
   font-size: x-small;
   line-height: 100%;
   background: {{ color.knowl_border }};
   color: {{ color.knowl_border_text }};
   padding: 1px 0 1px 10px;
-  margin:  0 0 0 0;
+  margin: 0;
 }
 .knowl-header {
-  position: relative;
-  top: -10px;
+  position: absolute;
+  top: 0px;
+  width: 100%;			/* This makes the knowl open prettily*/
   font-size: x-small;
   line-height: 100%;
   background: {{ color.knowl_border }};
   color: {{color.grey}};
   padding: 1px 0 1px 10px;
-  margin:  0 0 0 0;
+  margin: 0;
 }
 .knowl-header a,
 .knowl-footer a {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1166,8 +1166,10 @@ table.statgrid td.cnt {
 }
 
 .knowl-content {
-    padding: 15px 10px;
+    padding: 12px 10px;
     background-color: {{ color.knowl_background }};
+    max-width: 100%;
+    overflow: auto;
 }
 .knowl-content h1 {
   margin: 0px 0px 10px 0px;


### PR DESCRIPTION
This fixes the layout problem from #6900 on all pages.
TLDR: 
### Before
<img width="1582" height="1030" alt="Screenshot 2026-05-22 at 17 21 29" src="https://github.com/user-attachments/assets/7731d6a4-97e8-4343-9f98-d90695a384ff" />

### After
<img width="1582" height="1030" alt="image" src="https://github.com/user-attachments/assets/fa0c245c-b13b-4fb7-8987-fc2de5850f85" />

 Actually, this is not as simple as tacking on `overflow: hidden;` to the knowl div, since currently the footer and header (e.g. "permalink" at the bottom) were placed inside the border of the knowl div by specifying the number of pixels to push by. This made setting `overflow: hidden` create a weird scroll bar. 

The fix is to treat the dark gray area as a part of the knowl box itself, not as a border. So I set the border width to 0, colored the existing container div the same color as the border, and then gave the text div the brighter background color (and suitable margins). That way all the elements inside the div box are positioned in a reasonable way, and setting `overflow: hidden` works as intended.