### PR TITLE
Integrate maximum ramified prime into completeness tests for number fields

### DIFF
--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -1987,7 +1987,7 @@ class NFBound(ColTest):
         if n < len(self._rdgrd) and max(galt) <= len(self._rdgrd[n]):
             return max(1 / self._rdgrd[n][t - 1] for t in galt)
 
-    def get_S(self, ramps, radical):
+    def get_S(self, ramps, radical, maxp):
         S = None
         if radical is not None:
             if isinstance(radical, dict):
@@ -1997,6 +1997,14 @@ class NFBound(ColTest):
                 # Now we can just fall back on ramps parsing below
             else:
                 S = set(p for p,e in factor(radical))
+                # Next three conditions would be incompatible
+                if maxp is not None:
+                    if '$lte' in maxp and max(S)> maxp['$lte']:
+                        return []
+                    if '$gte' in maxp and max(S)< maxp['$lte']:
+                        return []
+                    if not isinstance(maxp, dict) and max(S)!= maxp:
+                        return []
         if ramps is not None:
             if isinstance(ramps, dict):
                 if "$containedin" in ramps:
@@ -2006,6 +2014,12 @@ class NFBound(ColTest):
                             return []
                     else:
                         S = ramps["$containedin"]
+                        if maxp is not None:
+                            if not isinstance(maxp, dict):
+                                S = [p for p in S if p<=maxp]
+                            elif '$lte' in maxp:
+                                S = [p for p in S if p<=maxp['$lte']]
+
                 else:
                     # $notcontains and $contains do not yield finite S
                     return
@@ -2016,6 +2030,11 @@ class NFBound(ColTest):
                         return []
                 else:
                     S = ramps
+                    if maxp is not None:
+                        if not isinstance(maxp, dict):
+                            S = [p for p in S if p<=maxp]
+                        elif '$lte' in maxp:
+                            S = [p for p in S if p<=maxp['$lte']]
         if S is not None:
             return tuple(sorted(S))
 
@@ -2134,7 +2153,7 @@ class NFBound(ColTest):
 
         ## Completeness 4: degree, ramified primes, and Galois group (optional)
         # Can fill rams from discriminant range, or from radical
-        ramps, radical, nram = query.get("ramps"), query.get("disc_rad"), query.get("num_ram")
+        ramps, radical, nram, maxp = query.get("ramps"), query.get("disc_rad"), query.get("num_ram"), query.get("maxp")
         if isinstance(nram, dict):
             if "$lte" in nram:
                 nram = nram["$lte"]
@@ -2142,10 +2161,12 @@ class NFBound(ColTest):
                 # nram is complicated, so we give up on using it
                 nram = None
         if ramps or radical:
-            S = self.get_S(ramps, radical)
+            S = self.get_S(ramps, radical, maxp)
             if S == []: # incompatible
-                reasons.add("incompatible conditions: ramps and radical")
+                reasons.add("incompatible conditions on ramifying primes")
                 return True, None
+            if S is not None:
+                nram = min([len(S), nram])
             if S is not None and self.clear_S(n, S, nram, galt, reasons):
                 return True, caveat
 

--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -1999,11 +1999,12 @@ class NFBound(ColTest):
                 S = set(p for p,e in factor(radical))
                 # Next three conditions would be incompatible
                 if maxp is not None:
-                    if '$lte' in maxp and max(S)> maxp['$lte']:
-                        return []
-                    if '$gte' in maxp and max(S)< maxp['$lte']:
-                        return []
-                    if not isinstance(maxp, dict) and max(S)!= maxp:
+                    if isinstance(maxp, dict):
+                        if '$lte' in maxp and max(S)> maxp['$lte']:
+                            return []
+                        if '$gte' in maxp and max(S)< maxp['$lte']:
+                            return []
+                    elif max(S)!= maxp:
                         return []
         if ramps is not None:
             if isinstance(ramps, dict):
@@ -2016,7 +2017,12 @@ class NFBound(ColTest):
                         S = ramps["$containedin"]
                         if maxp is not None:
                             if not isinstance(maxp, dict):
-                                S = [p for p in S if p<=maxp]
+                                if maxp in S:
+                                    S = [p for p in S if p<=maxp]
+                                else:
+                                    return []
+                            elif '$gte' in maxp and maxp['$gte']>max(S):
+                                return []
                             elif '$lte' in maxp:
                                 S = [p for p in S if p<=maxp['$lte']]
 

--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -2035,6 +2035,11 @@ class NFBound(ColTest):
                             S = [p for p in S if p<=maxp]
                         elif '$lte' in maxp:
                             S = [p for p in S if p<=maxp['$lte']]
+        if ramps is None and radical is None:
+            if not isinstance(maxp, dict):
+                S = prime_range(maxp+1)
+            elif '$lte' in maxp:
+                S = prime_range(maxp['$lte']+1)
         if S is not None:
             return tuple(sorted(S))
 
@@ -2160,12 +2165,12 @@ class NFBound(ColTest):
             else:
                 # nram is complicated, so we give up on using it
                 nram = None
-        if ramps or radical:
+        if ramps or radical or maxp:
             S = self.get_S(ramps, radical, maxp)
             if S == []: # incompatible
                 reasons.add("incompatible conditions on ramifying primes")
                 return True, None
-            if S is not None:
+            if S is not None and nram is not None:
                 nram = min([len(S), nram])
             if S is not None and self.clear_S(n, S, nram, galt, reasons):
                 return True, caveat


### PR DESCRIPTION
Cases where the ramifying set is specified, and maxp is not compatible

http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=exactly&ram_primes=3%2C5%2C7%2C11%2C13&maxp=23-29
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=exactly&ram_primes=3%2C5%2C7%2C11%2C13&maxp=11
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=exactly&ram_primes=3%2C5%2C7%2C11%2C13&maxp=5-11

Ramifying set is a subset and is incompatible with maxp
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=subset&ram_primes=3%2C5%2C7%2C11%2C13&maxp=17-23
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=subset&ram_primes=3%2C5%2C7%2C13&maxp=11

Ramifying primes are a subset and maxp reduces the set
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=subset&ram_primes=3%2C5%2C7%2C13%2C23&maxp=2-7
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=subset&ram_primes=3%2C5%2C7%2C13%2C23&maxp=7

Number of ramifying primes is set with maxp 
http://127.0.0.1:37777/NumberField/?degree=5&ram_quantifier=subset&num_ram=1&maxp=2%2C5-23

Note, the last case has the same wrong completeness message as reported in issue #7020