### PR TITLE
fix(cmf): use weight-appropriate newform code in download

### DIFF
--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -50,7 +50,7 @@ initialize-newspace-common: &initialize-newspace-common
     mf = mfinit([N,k,chi],0)
     lf = mfeigenbasis(mf)
   magma: |
-    //Please install CHIMP (https://github.com/edgarcosta/CHIMP) if you want to run this code
+    // Please install CHIMP (https://github.com/edgarcosta/CHIMP) if you want to run this code
     chi := DirichletCharacter("{N}.{conrey_index}");
     S:= CuspForms(chi, {k});
     N := Newforms(S);

--- a/lmfdb/classical_modular_forms/download.py
+++ b/lmfdb/classical_modular_forms/download.py
@@ -314,6 +314,13 @@ class CMF_download(Downloader):
             return abort(404, "Label not found: %s" % label)
         form = WebNewform(data)
         code = form.code
+        # 'initialize-newspace-common' is only a YAML merge anchor base (see
+        # code-form.yaml): its snippet is inlined into both weight-specific
+        # keys, so emitting it on its own would duplicate that snippet. Only
+        # the weight-appropriate initialization applies to a given form.
+        code.pop('initialize-newspace-common', None)
+        code.pop('initialize-newspace-weight-not-1' if form.weight == 1
+                 else 'initialize-newspace-weight-1', None)
         comment = code.pop('comment').get(lang).strip()
         script = "%s %s code for working with modular form %s\n\n" % (comment,Fullname[lang],label)
         for k in code:

--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -687,3 +687,29 @@ class CmfTest(LmfdbTest):
         data = page.get_data(as_text=True)
         assert "Valid formats are:" not in data
         assert "Invalid format parameter" not in data
+
+    def test_code_download_no_duplicates(self):
+        """Regression test for #7003: the newspace-initialization commands must
+        appear exactly once in each language's downloaded code, using the
+        weight-appropriate variant. download_code previously emitted the shared
+        initialize-newspace-common anchor base plus both weight variants."""
+        base = '/ModularForm/GL2/Q/holomorphic/download_code_newform'
+
+        def get(label, lang):
+            return self.tc.get('%s/%s/%s' % (base, label, lang)).get_data(as_text=True)
+
+        # weight 2 form: the init commands must each appear once...
+        assert get('417.2.d.a', 'magma').count('CuspForms(chi, 2)') == 1
+        pari = get('417.2.d.a', 'pari')
+        assert pari.count('mf = mfinit(') == 1 and pari.count('mfeigenbasis(') == 1, pari
+        sage = get('417.2.d.a', 'sage')
+        assert sage.count('Newforms(chi, 2, names="a")') == 1, sage
+        assert 'cuspidal_submodule' not in sage  # ...and the weight 1 sage variant must not leak in
+
+        # weight 1 form: the cuspidal-submodule sage variant is used instead
+        assert get('23.1.b.a', 'magma').count('CuspForms(chi, 1)') == 1
+        pari = get('23.1.b.a', 'pari')
+        assert pari.count('mf = mfinit(') == 1 and pari.count('mfeigenbasis(') == 1, pari
+        sage = get('23.1.b.a', 'sage')
+        assert sage.count('cuspidal_submodule().basis()') == 1, sage
+        assert 'Newforms(chi' not in sage


### PR DESCRIPTION
Follow-up to #7011.

The CMF code download iterated every `code-form.yaml` key, emitting the `initialize-newspace-common` anchor base and *both* weight variants — repeating the "Compute space of new eigenforms" block and shipping a wrong-weight Sage snippet (e.g. weight-1 init for a weight-2 form).

Fix: drop the anchor base and the inapplicable weight variant in `download_code`. Adds a regression test (weight 2 + weight 1).

Fixes #7003.
