### PR TITLE
Use multi-label search when clicking d3diagram dots w/ multiplicity

### DIFF
--- a/lmfdb/templates/d3_diagram.html
+++ b/lmfdb/templates/d3_diagram.html
@@ -193,9 +193,8 @@
 	      // remove diagram specific parameters
 	      var diagramParams = ["x-axis", "y-axis", "color", "count"];
 	      diagramParams.map(p => searchParams.delete(p));
-	      // set search parameters based on dot
-	      searchParams.set(xAxisKey, d.x);
-	      searchParams.set(yAxisKey, d.y);
+	      // set search parameters based on labels in dot
+	      searchParams.set("labels", d.labels.join(","));
 	      // perform search
 	      window.location.search = searchParams.toString();
 	  }


### PR DESCRIPTION
This fixes a known (but unreported) bug where clicking dots corresponding to multiple search results ("dots with multiplicity") in the d3 diagram searches would take the user to a results page with too few results. This was because of a rounding error coming from passing numerical parameters from python to javascript (and back to the search). With @rvisser7's multi-label search functionality, we can now simply do a search for the labels corresponding to the dot with multiplicity, so we don't have to worry about rounding errors.
