### PR TITLE
Fix char table 500 error for unreduced Q(zeta_4) values

### DIFF
--- a/lmfdb/utils/web_display.py
+++ b/lmfdb/utils/web_display.py
@@ -829,8 +829,13 @@ def sparse_cyclotomic_to_mathml(n, dat):
         if k == 0:
             return "<mn>1</mn>"
         elif n == 4:
-            assert k == 1
-            return zeta
+            # zeta = i has no subscript index, so higher powers (which can occur
+            # when the input is not reduced to a basis) are shown as superscripts.
+            if k == 1:
+                return zeta
+            if k < 0:
+                return f"<msup>{zeta}<mrow>{minus}<mn>{-k}</mn></mrow></msup>"
+            return f"<msup>{zeta}<mn>{k}</mn></msup>"
         if k == 1:
             return f"<msub>{zeta}</msub>"
         if 1 < k < 10:


### PR DESCRIPTION
There was an error with some of the char_tables in the flasklog.  (issue in utils/web_display).

Eg: https://www.lmfdb.org/Groups/Abstract/char_table/160000.wj
https://www.lmfdb.org/Groups/Abstract/char_table/49152.zt


I set Claude on it and they note:

> sparse_cyclotomic_to_mathml's zetapow helper asserted k == 1 for n == 4, but the input data is not reduced to a basis, so zeta_4 terms can carry exponents 0, 2, or 3 (i^2 = -1, i^3 = -i). Render any n == 4 exponent as a superscript on i instead of asserting.


You can see the two char_tables above load fine on this branch.



