### PR TITLE
Limit displayed Dirichlet coefficients to stored Euler factors

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -262,7 +262,8 @@ def makeLfromdata(L):
         L.dirichlet_coefficients_arithmetic = data['dirichlet_coefficients']
     elif data.get('euler_factors', None) is not None:
         # ask for more, in case many are zero
-        L.dirichlet_coefficients_arithmetic = an_from_data(L.localfactors, 2*L.degree*L.numcoeff)
+        upperbound = min(2*L.degree*L.numcoeff, nth_prime(len(L.localfactors) + 1) - 1)
+        L.dirichlet_coefficients_arithmetic = an_from_data(L.localfactors, upperbound)
 
         # get rid of extra coeff
         count = 0

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -11,6 +11,13 @@ class LfunctionTest(LmfdbTest):
     # Testing at least one example of each type of L-function page
     #------------------------------------------------------
 
+    def test_dirichlet_coefficients_stop_before_unknown_euler_factor(self):
+        response = self.tc.get('/L/4/5e5/1.1/c1e2/0/0')
+        assert response.status_code == 200
+        page = response.get_data(as_text=True)
+        assert '81<sup>-s</sup>' in page
+        assert '101<sup>-s</sup>' not in page
+
     def test_LDirichlet(self):
         L = self.tc.get('/L/Character/Dirichlet/19/9/', follow_redirects=True)
         assert '0.4813597783' in L.get_data(as_text=True)


### PR DESCRIPTION
# Limit displayed Dirichlet coefficients to stored Euler factors

Fixes #7057.

## Description

L-function pages could display Dirichlet coefficients beyond the range determined by the stored Euler factors. These unknown coefficients were initialized to `1`, making them appear authoritative.

For example, the page for [`4-5e5-1.1-c1e2-0-0`](https://www.lmfdb.org/L/4/5e5/1.1/c1e2/0/0) stores Euler factors through \(p=97\), but displayed incorrect coefficients at \(n=101,103,\ldots\).

This change limits generated display coefficients to indices before the first prime without a stored Euler factor. Explicitly stored coefficient arrays and coefficient downloads are unchanged.

## Testing

- Added a regression test that requests the rendered page for `4-5e5-1.1-c1e2-0-0`.
- Confirmed that the page renders a known coefficient within the stored range.
- Confirmed that the rendered page does not include \(101^{-s}\).
- Scoped `pyflakes` and `git diff --check` pass.

The full L-function test module had 15 passing tests and 6 unrelated failures caused by the Sage 10.8 Galois-group API.
