### PR TITLE
Enable TCP keepalives on the PostgreSQL connection

### DIFF
--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -267,6 +267,30 @@ class Configuration(_Configuration):
         readargs = readargs or startlmfdbQ
         _Configuration.__init__(self, parser, writeargstofile=writeargstofile, readargs=readargs)
 
+        # Enable TCP keepalives on the PostgreSQL connection.
+        #
+        # LMFDB usually talks to a *remote* database (the default host is
+        # devmirror.lmfdb.xyz), so a connection can be silently dropped by the
+        # server, a load balancer, or the network.  Without keepalives, libpq
+        # only notices when it next uses the socket: a query issued on a dead
+        # connection then blocks on the OS TCP timeout for several minutes
+        # before raising "OperationalError: server closed the connection
+        # unexpectedly".  This is a recurring source of spurious CI failures
+        # that pass on a rerun.
+        #
+        # These libpq parameters live in options["postgresql"] and are passed
+        # straight through to psycopg2.connect by psycodict, for both the
+        # initial connection and every reset_connection().  They are ignored for
+        # local unix-socket connections and never interrupt a long-running query
+        # (keepalives are handled by the OS TCP stack), so they are safe
+        # defaults; setdefault lets an explicit config.ini or command-line value
+        # take precedence.
+        pg_options = self.options["postgresql"]
+        pg_options.setdefault("keepalives", 1)
+        pg_options.setdefault("keepalives_idle", 30)
+        pg_options.setdefault("keepalives_interval", 10)
+        pg_options.setdefault("keepalives_count", 5)
+
         opts = self.options
         extopts = self.extra_options
         self.flask_options = {


### PR DESCRIPTION
## Problem

We regularly get spurious CI failures that pass on a rerun. A representative
example ([run 29557842626](https://github.com/LMFDB/lmfdb/actions/runs/29557842626/job/87922252742))
failed with:

```
FAILED lmfdb/characters/test_characters.py::DirichletSearchTest::test_search
  - psycopg2.OperationalError: server closed the connection unexpectedly
 happens while executing SELECT ... FROM "char_dirichlet" WHERE "conductor" >= 25 ...
1 failed, 24 passed in 797.24s
```

This is not a bug in the test or query — it's a **dropped database connection**.
The tests run against a shared *remote* database (`devmirror.lmfdb.xyz` /
`proddb.lmfdb.xyz`), and that connection is occasionally torn down by the server,
a load balancer, or the network. Contributing factors: every branch push runs
the full ~20-job matrix, each job runs 6 test files in parallel (GNU `parallel`),
and all jobs hit the same server at once; devmirror is also periodically
reloaded with fresh data.

The tell-tale sign it's environmental: `test_search` took **534s** in the failing
run (vs. 25–40s for its siblings). The captured log shows a query finishing, then
a **4.5-minute gap** before psycodict logs `Connection broken (status 2);
resetting...`. The client sat blocked in `recv()` on a connection the server had
already killed, until the OS TCP timeout finally fired.

## Fix

Enable TCP keepalives on the PostgreSQL connection by adding the four libpq
keepalive parameters to `options["postgresql"]`. psycodict passes these straight
through to `psycopg2.connect`, for both the initial connection **and** every
`reset_connection()` (it re-reads `config.options["postgresql"]` each time), so
a reconnect after a drop also gets keepalives.

With these, a dead connection is detected in ~80s instead of stalling for
minutes, and psycodict's existing reconnect-and-retry logic gets a real chance
to recover instead of the whole job going red.

Keepalives operate in the OS TCP stack, so they **never interrupt a legitimately
long-running query**, and they are ignored for local unix-socket connections.
`setdefault` lets an explicit `config.ini` / command-line value override them.

## Verification

Confirmed end-to-end against `devmirror.lmfdb.xyz` that the parameters reach the
connection and are applied to the real socket:

```
connection dsn: '... host=devmirror.lmfdb.xyz port=5432 keepalives=1 \
    keepalives_idle=30 keepalives_interval=10 keepalives_count=5'
dsn_parameters: {'keepalives': '1', 'keepalives_idle': '30',
                 'keepalives_interval': '10', 'keepalives_count': '5'}
live socket SO_KEEPALIVE: enabled;  TCP_KEEPINTVL: 10;  TCP_KEEPCNT: 5
```

`pyflakes` and `ruff` (the CI lint steps) pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
