### PR TITLE
fix(lfunctions): limit downloaded Dirichlet coefficients to stored Euler factors

### DIFF
--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -34,7 +34,6 @@ from sage.all import (
     is_prime,
     lazy_attribute,
     log,
-    next_prime,
     nth_prime,
     primes_first_n,
     prime_pi,
@@ -623,7 +622,10 @@ class Lfunction_from_db(Lfunction):
     def download_dirichlet_coeff(self):
         filename = self.label
         data = {}
-        data['an'] = an_from_data(self.localfactors, next_prime(nth_prime(len(self.localfactors)+1)) - 1)
+        # Only a_1..a_{q-1} are determined by the stored Euler factors, where q
+        # is the first prime without one (an unknown a_p would wrongly default to
+        # 1). Same bound as the displayed coefficients in makeLfromdata.
+        data['an'] = an_from_data(self.localfactors, nth_prime(len(self.localfactors) + 1) - 1)
         return Downloader()._wrap(
                 Json.dumps(data),
                 filename + '.dir_coeffs',

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -25,8 +25,8 @@ class LfunctionTest(LmfdbTest):
         assert response.status_code == 200
         body = response.get_data(as_text=True)
         an = json.loads(body[body.index('{'):])['an']
-        # 25 stored Euler factors (primes up to 97); the first prime without one
-        # is 101, so only a_1..a_100 are determined. a_101 must not leak in.
+        # 25 stored Euler factors (primes up to 97); to match the display bound and avoid the
+        # bogus a_101 (unknown Euler factor would default to 1), the download stops at a_100.
         assert len(an) == 100
 
     def test_LDirichlet(self):

--- a/lmfdb/lfunctions/test_lfunctions.py
+++ b/lmfdb/lfunctions/test_lfunctions.py
@@ -1,4 +1,6 @@
 
+import json
+
 from .LfunctionPlot import paintSvgFileAll
 from lmfdb.tests import LmfdbTest
 
@@ -17,6 +19,15 @@ class LfunctionTest(LmfdbTest):
         page = response.get_data(as_text=True)
         assert '81<sup>-s</sup>' in page
         assert '101<sup>-s</sup>' not in page
+
+    def test_download_dirichlet_coefficients_stop_before_unknown_euler_factor(self):
+        response = self.tc.get('/L/download_dirichlet_coeff/4-5e5-1.1-c1e2-0-0')
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        an = json.loads(body[body.index('{'):])['an']
+        # 25 stored Euler factors (primes up to 97); the first prime without one
+        # is 101, so only a_1..a_100 are determined. a_101 must not leak in.
+        assert len(an) == 100
 
     def test_LDirichlet(self):
         L = self.tc.get('/L/Character/Dirichlet/19/9/', follow_redirects=True)


### PR DESCRIPTION
## Summary

Follow-up to #7058, which limited the *displayed* Dirichlet coefficients to the stored Euler factors. The "Dirichlet coefficients to text" download still leaked one prime too far: `download_dirichlet_coeff` computed `a_n` up to `next_prime(nth_prime(N+1)) - 1`, one prime past the last stored factor, so `a_p` for the first unstored prime `p` came out as a bogus `1` (an unknown Euler factor defaults to `1` in `an_from_data`).

Signature: for [`4-5e5-1.1-c1e2-0-0`](https://www.lmfdb.org/L/4/5e5/1.1/c1e2/0/0) the download returned an `an` array of length 102 with `an[101] = 1`, which should be `29` (PARI/GP `lfunan`).

## Fix

Bound the download to `nth_prime(N+1) - 1`, the same cutoff the display path in `makeLfromdata` already uses. Every `n` below the first unstored prime has all prime factors among the stored ones, so `a_1..a_{nth_prime(N+1)-1}` are exactly the coefficients the stored Euler factors determine.

- `lmfdb/lfunctions/Lfunction.py`: use the display bound in `download_dirichlet_coeff`; drop the now-unused `next_prime` import.
- `lmfdb/lfunctions/test_lfunctions.py`: regression test that the download for `4-5e5-1.1-c1e2-0-0` returns only `a_1..a_100`.

## Verification

- Exercised the actual `download_dirichlet_coeff` on live `4-5e5-1.1-c1e2-0-0` data: the array is now length 100 and omits `a_101` (was length 102 with `a_101 = 1`).
- `pyflakes` and `git diff --check` pass.
- Note: this test and the merged display test both fail locally on Sage 10.8 for an unrelated reason. Building the Euler-product table raises `'GaloisGroup_v2_with_category' object has no attribute 'group'` in the constructor, upstream of the coefficient assertions.

Fixes #7057.
