### PR TITLE
Make the database TCP keepalive settings configurable

### DIFF
--- a/lmfdb/utils/config.py
+++ b/lmfdb/utils/config.py
@@ -220,6 +220,51 @@ class Configuration(_Configuration):
             default="lmfdb",
         )
 
+        # TCP keepalives on the database connection.  LMFDB usually talks to a
+        # remote database (see --postgresql-host), where a connection can be
+        # silently dropped by the server, a load balancer, or the network.
+        # Keepalives let libpq detect a dead connection within about a minute
+        # (with the defaults below) instead of blocking on the OS TCP timeout
+        # for several minutes; this is a recurring source of spurious CI
+        # failures that pass on a rerun.  psycodict passes these parameters
+        # straight through to psycopg2.connect, for both the initial connection
+        # and every reconnection.  They are ignored for local unix-socket
+        # connections and never interrupt a running query.  Pass
+        # --postgresql-keepalives 0 to fall back to the operating system
+        # defaults.
+        postgresqlgroup.add_argument(
+            "--postgresql-keepalives",
+            dest="postgresql_keepalives",
+            metavar="0|1",
+            type=int,
+            help="use TCP keepalives on the database connection, 0 to disable [default: %(default)s]",
+            default=1,
+        )
+        postgresqlgroup.add_argument(
+            "--postgresql-keepalives-idle",
+            dest="postgresql_keepalives_idle",
+            metavar="SECONDS",
+            type=int,
+            help="idle time before the first keepalive probe is sent [default: %(default)s]",
+            default=30,
+        )
+        postgresqlgroup.add_argument(
+            "--postgresql-keepalives-interval",
+            dest="postgresql_keepalives_interval",
+            metavar="SECONDS",
+            type=int,
+            help="time between keepalive probes [default: %(default)s]",
+            default=10,
+        )
+        postgresqlgroup.add_argument(
+            "--postgresql-keepalives-count",
+            dest="postgresql_keepalives_count",
+            metavar="N",
+            type=int,
+            help="unanswered keepalive probes before the connection is dropped [default: %(default)s]",
+            default=5,
+        )
+
         # undocumented options
         parser.add_argument(
             "--enable-profiler",
@@ -266,30 +311,6 @@ class Configuration(_Configuration):
         writeargstofile = writeargstofile or startlmfdbQ
         readargs = readargs or startlmfdbQ
         _Configuration.__init__(self, parser, writeargstofile=writeargstofile, readargs=readargs)
-
-        # Enable TCP keepalives on the PostgreSQL connection.
-        #
-        # LMFDB usually talks to a *remote* database (the default host is
-        # devmirror.lmfdb.xyz), so a connection can be silently dropped by the
-        # server, a load balancer, or the network.  Without keepalives, libpq
-        # only notices when it next uses the socket: a query issued on a dead
-        # connection then blocks on the OS TCP timeout for several minutes
-        # before raising "OperationalError: server closed the connection
-        # unexpectedly".  This is a recurring source of spurious CI failures
-        # that pass on a rerun.
-        #
-        # These libpq parameters live in options["postgresql"] and are passed
-        # straight through to psycopg2.connect by psycodict, for both the
-        # initial connection and every reset_connection().  They are ignored for
-        # local unix-socket connections and never interrupt a long-running query
-        # (keepalives are handled by the OS TCP stack), so they are safe
-        # defaults; setdefault lets an explicit config.ini or command-line value
-        # take precedence.
-        pg_options = self.options["postgresql"]
-        pg_options.setdefault("keepalives", 1)
-        pg_options.setdefault("keepalives_idle", 30)
-        pg_options.setdefault("keepalives_interval", 10)
-        pg_options.setdefault("keepalives_count", 5)
 
         opts = self.options
         extopts = self.extra_options


### PR DESCRIPTION
Follow-up to #7064.

That PR enabled TCP keepalives on the PostgreSQL connection to stop dropped
connections to the remote database from hanging for minutes (a recurring cause
of spurious CI failures), but it hardcoded the four values. As discussed there,
this change reaches every LMFDB instance — production and dev sites, not just CI
— so the settings should be tunable per site.

## What this does

Exposes the keepalive values as command-line / `config.ini` options, matching
the existing `--postgresql-*` pattern:

| Option | Default |
| --- | --- |
| `--postgresql-keepalives` (`0`/`1`) | `1` |
| `--postgresql-keepalives-idle` (seconds) | `30` |
| `--postgresql-keepalives-interval` (seconds) | `10` |
| `--postgresql-keepalives-count` | `5` |

The defaults are unchanged, so out-of-the-box behaviour is identical. A site can
now pass `--postgresql-keepalives 0` (or set it in `config.ini`) to fall back to
the OS defaults, or adjust the timings, without editing code.

## Why it's also a correctness fix

The previous approach set the values with `setdefault()` *after* the config had
already been parsed. Since psycodict only reads keys that have an argparse
option, a `keepalives` value placed in `config.ini` was silently ignored — so
the settings were not actually overridable, despite the comment claiming they
took precedence. Routing them through the normal argparse/config machinery makes
a `config.ini` or command-line value genuinely win.

## Verification

- Defaults still populate `options["postgresql"]` as `keepalives=1, idle=30,
  interval=10, count=5` (verified against an existing `config.ini` that predates
  these keys — the missing keys are filled in without error).
- `--postgresql-keepalives 0 --postgresql-keepalives-idle 99` is respected, and
  the other two keep their defaults.
- End-to-end: the `db` singleton connects to `devmirror.lmfdb.xyz` with
  `keepalives=1 keepalives_idle=30 keepalives_interval=10 keepalives_count=5` in
  the live connection DSN.
- `pyflakes` and `ruff` (the CI lint steps) pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
