### PR TITLE
Stop referring to psycodict extras tables

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -356,12 +356,9 @@ def api_query(table, id=None):
             title += " (%s)" % description
         search_schema = [(col, coll.col_type[col])
                          for col in sorted(coll.search_cols)]
-        extra_schema = [(col, coll.col_type[col])
-                        for col in sorted(coll.extra_cols)]
         return render_template("collection.html",
                                title=title,
                                search_schema={table: search_schema},
-                               extra_schema={table: extra_schema},
                                single_object=single_object,
                                query_unquote=query_unquote,
                                url_args=url_args,
@@ -411,7 +408,6 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None, limit=10
     data = []
     totals = []
     search_schema = {}
-    extra_schema = {}
     for label, table, col, sort in zip(labels, tables, label_cols, sorts):
         if isinstance(col, list):  # Needed for gps_conj_classes, which effectively has a pair of columns for a label
             q = dict(zip(col, label))
@@ -436,8 +432,6 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None, limit=10
             return apierror(str(err), table=table)
         search_schema[table] = [(col, coll.col_type[col])
                                 for col in sorted(coll.search_cols)]
-        extra_schema[table] = [(col, coll.col_type[col])
-                               for col in sorted(coll.extra_cols)]
     data = Json.prep(data)
 
     # the collected result
@@ -462,7 +456,6 @@ def datapage(labels, tables, title, bread, label_cols=None, sorts=None, limit=10
         return render_template("apidata.html",
                                title=title,
                                search_schema=search_schema,
-                               extra_schema=extra_schema,
                                bread=bread,
                                pretty=pretty_document,
                                **data)

--- a/lmfdb/api/templates/apischema.html
+++ b/lmfdb/api/templates/apischema.html
@@ -12,13 +12,5 @@
           <td>{{typ}}</td>
         </tr>
       {% endfor %}
-      {% if extra_schema %}
-        {% for col, typ in extra_schema[table] %}
-          <tr{% if loop.index == 1 %} class="toplined"{% endif %}>
-            <td>{{KNOWL('columns.'+table+'.'+col, col)}}</td>
-            <td>{{typ}}</td>
-          </tr>
-        {% endfor %}
-      {% endif %}
     </table>
   </div>

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -589,14 +589,14 @@ def columns():
                 knowls[pieces[1]][pieces[2]] = k['content']
         else:
             bad_cat.append(k)
-    missing_tables = {tbl: sorted(db[tbl].search_cols) + sorted(db[tbl].extra_cols) for tbl in db.tablenames if tbl not in knowls}
+    missing_tables = {tbl: sorted(db[tbl].search_cols) for tbl in db.tablenames if tbl not in knowls}
     bad_tables = {tbl: klist for tbl, klist in knowls.items() if tbl not in db.tablenames}
     for tbl in bad_tables:
         del knowls[tbl]
     missing_knowls = defaultdict(list)
     for tbl in knowls:
         table = db[tbl]
-        for col in sorted(table.search_cols) + sorted(table.extra_cols):
+        for col in sorted(table.search_cols):
             if col not in knowls[tbl]:
                 missing_knowls[tbl].append(col)
     b = get_bread([("Missing columns", " ")])

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -28,7 +28,7 @@ class LMFDBStatsTable(PostgresStatsTable):
 
 
 # These are the operations where we don't insert records into the ongoing_operations table since they don't take noticeable space.
-_nolog_changetypes = ["delete", "resort", "add_column", "drop_column", "create_table", "create_extra_table", "move_column"]
+_nolog_changetypes = ["delete", "resort", "add_column", "drop_column", "create_table"]
 
 
 class LMFDBSearchTable(PostgresSearchTable):
@@ -57,7 +57,7 @@ class LMFDBSearchTable(PostgresSearchTable):
         We use knowls to implement the column description API.
         """
         from lmfdb.knowledge.knowl import knowldb
-        allcols = self.search_cols + self.extra_cols
+        allcols = self.search_cols
         current = knowldb.get_column_descriptions(self.search_table)
         current = {col: kwl.content for col, kwl in current.items()}
         if not drop and description is None:
@@ -643,7 +643,7 @@ class LMFDBDatabase(PostgresDatabase):
 
     @overrides(PostgresDatabase)
     def drop_table(self, name, *args, **kwargs):
-        cols = self[name].search_cols + self[name].extra_cols
+        cols = self[name].search_cols
         super().drop_table(name, *args, **kwargs)
         from lmfdb.knowledge.knowl import knowldb
         knowldb.drop_table(name)


### PR DESCRIPTION
psycodict is removing the search/extras table split before its 1.0 release ([roed314/psycodict#59](https://github.com/roed314/psycodict/pull/59)), and the last LMFDB tables that used it (`maass_newforms`, `maass_rigor`) have had their extras columns merged back into the search table. This drops the remaining references so the LMFDB doesn't depend on the mechanism.

## Changes

- **`lmfdb_database.py`** — `column_description` and `drop_table` no longer append `self.extra_cols`; `create_extra_table` and `move_column` leave `_nolog_changetypes`, since neither psycodict operation exists any more (`create_extra_table` had in fact been broken on postgres 10+ for years).
- **`knowledge/main.py`** — the missing-column-knowls report no longer walks `extra_cols`.
- **`api/api.py`** — stop building `extra_schema` for the collection and data pages and stop passing it to the templates.
- **`api/templates/apischema.html`** — drop the now-unreachable extra-columns rows.

## Merge ordering

**No coupling to the psycodict PR — this can merge before or after it.** Every change removes a read of `.extra_cols`, which is `[]` for every table today, so behavior is identical under the current psycodict; under the new one the attribute is gone and these removals are required. There is no use of `extra_columns=`, `extrafile=`, or any psycodict private API anywhere in the LMFDB, so this is the whole surface.

## Verification

Confirmed against devmirror that no table has `has_extras` set and no `_extras` tables remain, so the code paths being deleted are already dead. Lint clean (ruff); `apischema.html` re-verified to parse and render correctly with only `search_schema` in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)