### PR TITLE
Track psycodict's driver instead of importing psycopg2 directly

### DIFF
--- a/lmfdb/api/api.py
+++ b/lmfdb/api/api.py
@@ -3,7 +3,7 @@ import re
 import yaml
 import json
 from collections import defaultdict
-from psycopg2.extensions import QueryCanceledError
+from lmfdb.utils.psycopg_compat import QueryCanceledError
 from lmfdb import db
 from psycodict.encoding import Json
 from lmfdb.utils import flash_error, comma

--- a/lmfdb/ecnf/ecnf_stats.py
+++ b/lmfdb/ecnf/ecnf_stats.py
@@ -3,7 +3,7 @@ from lmfdb.utils import comma, StatsDisplay, proportioners, totaler
 from lmfdb.number_fields.number_field import field_pretty
 from lmfdb import db
 from flask import url_for
-from psycopg2.sql import SQL
+from lmfdb.utils.psycopg_compat import SQL
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.cachefunc import cached_method
 from collections import defaultdict

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -5,7 +5,7 @@ import yaml
 from lmfdb import db
 from flask import url_for
 from urllib.parse import quote_plus
-from psycopg2.sql import SQL, Identifier
+from lmfdb.utils.psycopg_compat import SQL, Identifier
 
 from sage.all import (
     Permutations,

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -14,7 +14,7 @@ from lmfdb.app import is_beta
 from lmfdb.utils import code_snippet_knowl
 from lmfdb.utils.config import Configuration
 from lmfdb.users.pwdmanager import userdb
-from psycopg2.sql import SQL, Identifier, Placeholder
+from lmfdb.utils.psycopg_compat import SQL, Identifier, Placeholder
 from sage.all import cached_function
 from lmfdb.logger import logger
 

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -297,7 +297,7 @@ def test():
 @knowledge_page.route("/edit/<ID>")
 @login_required
 def edit(ID):
-    from psycopg2 import DatabaseError
+    from lmfdb.utils.psycopg_compat import DatabaseError
     if not allowed_id(ID):
         return redirect(url_for(".index"))
     knowl = Knowl(ID, editing=True)
@@ -838,7 +838,7 @@ def render_knowl(ID, footer=None, kwargs=None,
 
 @knowledge_page.route("/", methods=['GET', 'POST'])
 def index():
-    from psycopg2 import DataError
+    from lmfdb.utils.psycopg_compat import DataError
     cur_cat = request.args.get("category", "")
 
     from .knowl import knowl_status_code, knowl_type_code

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -5,7 +5,7 @@ import signal
 import socket
 import subprocess
 from collections import Counter
-from psycopg2.sql import SQL
+from lmfdb.utils.psycopg_compat import SQL
 from lmfdb.utils.config import Configuration, ConfigWrapper
 from psycodict.utils import DelayCommit
 from psycodict.database import PostgresDatabase

--- a/lmfdb/tests/test_dynamic_knowls.py
+++ b/lmfdb/tests/test_dynamic_knowls.py
@@ -49,7 +49,7 @@ class DynamicKnowlTest(LmfdbTest):
         if db.config.postgresql_options["host"] == "proddb.lmfdb.xyz":
             # Create a different connection to devmirror to compare timestamps
             from lmfdb.utils.config import Configuration
-            from psycopg2.sql import SQL
+            from lmfdb.utils.psycopg_compat import SQL
             from datetime import timedelta
             dev_config = Configuration()
             # Modify configuration to connect to devmirror

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -10,7 +10,7 @@ fixed_salt = '=tU\xfcn|\xab\x0b!\x08\xe3\x1d\xd8\xe8d\xb9\xcc\xc3fM\xe9O\xfb\x02
 from lmfdb import db
 from psycodict.base import PostgresBase
 from psycodict.encoding import Array
-from psycopg2.sql import SQL, Identifier, Placeholder
+from lmfdb.utils.psycopg_compat import SQL, Identifier, Placeholder
 from datetime import timedelta
 from lmfdb.utils.datetime_utils import utc_now_naive
 from lmfdb.logger import logger

--- a/lmfdb/utils/psycopg_compat.py
+++ b/lmfdb/utils/psycopg_compat.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+SQL composition classes and exception types that track the driver psycodict
+is built on.
+
+psycodict is switching from psycopg2 to psycopg3 (roed314/psycodict#88).
+Query fragments composed here are executed by psycodict's ``_execute``, so
+they must come from the *same* driver psycodict uses -- and both drivers may
+be installed at once, so trying imports is not a valid probe.  Instead we key
+off psycodict's own re-exported ``SQL``.
+
+Once the psycodict requirement is pinned to a psycopg3-based release, the sql
+classes can be imported from psycodict itself (which re-exports them) and the
+exceptions from ``psycopg``/``psycopg.errors``, and this module can be
+deleted.
+"""
+
+import psycodict
+
+if psycodict.SQL.__module__.startswith("psycopg2"):
+    from psycopg2 import DatabaseError, DataError
+    from psycopg2.errors import NumericValueOutOfRange
+    from psycopg2.extensions import QueryCanceledError
+    from psycopg2.sql import SQL, Composable, Composed, Identifier, Literal, Placeholder
+else:
+    from psycopg import DatabaseError, DataError
+    from psycopg.errors import NumericValueOutOfRange
+    from psycopg.errors import QueryCanceled as QueryCanceledError
+    from psycopg.sql import SQL, Composable, Composed, Identifier, Literal, Placeholder
+
+__all__ = [
+    "SQL",
+    "Composable",
+    "Composed",
+    "Identifier",
+    "Literal",
+    "Placeholder",
+    "DatabaseError",
+    "DataError",
+    "NumericValueOutOfRange",
+    "QueryCanceledError",
+]

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -2,8 +2,7 @@ import time
 from random import randrange
 from flask import render_template, jsonify, redirect, request, url_for
 from urllib.parse import urlparse
-from psycopg2.extensions import QueryCanceledError
-from psycopg2.errors import NumericValueOutOfRange
+from lmfdb.utils.psycopg_compat import QueryCanceledError, NumericValueOutOfRange
 from sage.misc.decorators import decorator_keywords
 from sage.misc.cachefunc import cached_function
 

--- a/lmfdb/verify/mf/mf.py
+++ b/lmfdb/verify/mf/mf.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from sage.all import cached_function, psi, RR, Integer, prod
 
-from psycopg2.sql import SQL, Identifier
+from lmfdb.utils.psycopg_compat import SQL, Identifier
 from ..verification import TableChecker, overall
 
 

--- a/lmfdb/verify/mf/mf_hecke_cc.py
+++ b/lmfdb/verify/mf/mf_hecke_cc.py
@@ -4,7 +4,7 @@ from sage.all import prime_range, CC, gcd, ZZ
 
 from lmfdb.lmfdb_database import db
 from psycodict.utils import IdentifierWrapper as Identifier
-from psycopg2.sql import SQL, Literal
+from lmfdb.utils.psycopg_compat import SQL, Literal
 from .mf import MfChecker
 from ..verification import overall, overall_long, slow
 

--- a/lmfdb/verify/mf/mf_newforms.py
+++ b/lmfdb/verify/mf/mf_newforms.py
@@ -3,7 +3,7 @@ from sage.all import prime_range, Integer, kronecker_symbol, PolynomialRing, Com
 
 from lmfdb.lmfdb_database import db
 from psycodict.utils import IdentifierWrapper as Identifier
-from psycopg2.sql import SQL, Literal
+from lmfdb.utils.psycopg_compat import SQL, Literal
 from lmfdb.utils import names_and_urls
 from .mf import MfChecker
 from ..verification import overall, overall_long, slow, fast, accumulate_failures

--- a/lmfdb/verify/verification.py
+++ b/lmfdb/verify/verification.py
@@ -10,7 +10,7 @@ from timeout_decorator import timeout, TimeoutError
 from sage.all import Integer, vector, ZZ
 
 from lmfdb.lmfdb_database import db
-from psycopg2.sql import SQL, Composable, Literal
+from lmfdb.utils.psycopg_compat import SQL, Composable, Literal
 from lmfdb.utils import pluralize
 from psycodict.utils import IdentifierWrapper as Identifier
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ flask-login
 flask-markdown
 markupsafe
 itsdangerous
-psycopg2-binary
-git+https://github.com/roed314/psycodict.git
+# the pgbinary extra installs the driver psycodict itself is built on
+psycodict[pgbinary] @ git+https://github.com/roed314/psycodict.git
 pyflakes
 pytest
 pytest-cov

--- a/scripts/belyi/old/make_test_tables.py
+++ b/scripts/belyi/old/make_test_tables.py
@@ -7,7 +7,7 @@ db.create_table_like('belyi_galmaps_test', db.belyi_galmaps) # create empty tabl
 db.create_table_like('belyi_passports_test', db.belyi_passports) # create empty table with same format as db.belyi_passports
 db.create_table_like('belyi_galmap_portraits_test', db.belyi_galmap_portraits)
 # insert data
-from psycopg2.sql import SQL # to import SQL functions
+from lmfdb.utils.psycopg_compat import SQL # to import SQL functions
 db._execute(SQL('INSERT INTO belyi_galmaps_test SELECT * FROM belyi_galmaps')) # insert data from belyi_galmaps into test table
 db._execute(SQL('INSERT INTO belyi_passports_test SELECT * FROM belyi_passports')) # insert data from belyi_passports into test table
 db._execute(SQL('INSERT INTO belyi_galmap_portraits_test SELECT * FROM belyi_galmap_portraits')) # insert data from belyi_galmaps into test table


### PR DESCRIPTION
psycodict is switching from psycopg2 to psycopg3 ([roed314/psycodict#88](https://github.com/roed314/psycodict/pull/88)). Query fragments the LMFDB composes are executed by psycodict's `_execute`, so they must come from whichever driver psycodict is built on — and since both drivers can be installed simultaneously, try/except imports are not a valid probe.

## Deployable in either order

**This PR works on both sides of the transition**: the new `lmfdb/utils/psycopg_compat.py` keys off psycodict's re-exported `SQL` (`psycodict.SQL.__module__`) and provides `SQL`, `Identifier`, `Placeholder`, `Literal`, `Composable`, `Composed`, `DatabaseError`, `DataError`, `NumericValueOutOfRange`, and `QueryCanceledError` from the matching driver. It can merge and deploy now, before psycodict's port lands — and it is what lets the psycodict PR's downstream CI go green.

All sixteen direct psycopg2 imports move to the compat module: `lmfdb_database.py`, `utils/search_wrapper.py`, `api/api.py`, `knowledge/{knowl,main}.py`, `users/pwdmanager.py`, `verify/verification.py` + the three `verify/mf` modules, `groups/abstract/web_groups.py`, `ecnf/ecnf_stats.py`, the dynamic-knowls test, and the old belyi script. `requirements.txt` now installs `psycodict[pgbinary]`, whose extra resolves to the driver psycodict itself needs (psycopg2-binary today, psycopg[binary] after the port), instead of naming psycopg2 directly.

Once the psycodict requirement is pinned past the transition, the module body shrinks to plain `psycopg` imports (or direct `from psycodict import SQL, ...`, which the port re-exports).

## Verification

Loaded the compat module against **both** psycodict versions (current master on psycopg2, the port branch on psycopg 3.3.4) over a live server: every exported name resolves from the matching driver, composed statements execute through `_execute`, and — the semantic that must not regress — a `statement_timeout` raises the exported `QueryCanceledError` under both drivers, which is what turns long searches into the "search took too long" page rather than a 500. pyflakes clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)