### PR TITLE
Follow psycodict's API narrowing (psycodict#92)

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -383,7 +383,7 @@ def alive():
     a basic health check
     """
     from . import db
-    if db.is_alive():
+    if (getattr(db, "_is_alive", None) or db.is_alive)():
         return "LMFDB!"
     else:
         abort(503)
@@ -395,7 +395,7 @@ def statshealth():
     a health check on the stats pages
     """
     from . import db
-    if db.is_alive():
+    if (getattr(db, "_is_alive", None) or db.is_alive)():
         tc = app.test_client()
         for url in ['/NumberField/stats',
                     '/ModularForm/GL2/Q/holomorphic/stats',
@@ -425,7 +425,7 @@ def info():
     output += "HOSTNAME = %s\n\n" % gethostname()
     output += "# PostgreSQL info\n"
     from . import db
-    if not db.is_alive():
+    if not (getattr(db, "_is_alive", None) or db.is_alive)():
         output += "db is offline\n"
     else:
         conn_str = "%s" % db.conn

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -142,7 +142,7 @@ class KnowlBackend(PostgresBase):
 
     def __init__(self):
         PostgresBase.__init__(self, 'db_knowl', db)
-        self._rw_knowldb = db.can_read_write_knowls()
+        self._rw_knowldb = (getattr(db, "_can_read_write_knowls", None) or db.can_read_write_knowls)()
         # we cache knowl titles for 10s
         self.caching_time = 10
         self.cached_titles_timestamp = 0

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -501,7 +501,7 @@ class LMFDBDatabase(PostgresDatabase):
             self.__editor = uid
         return self.__editor
 
-    def log_db_change(self, operation, tablename=None, logid=None, aborted=False, **data):
+    def _log_db_change(self, operation, tablename=None, logid=None, aborted=False, **data):
         """
         Log a change to the database.
 
@@ -531,6 +531,11 @@ class LMFDBDatabase(PostgresDatabase):
                     "VALUES (%s, %s, %s, %s, %s, %s)"
                 )
                 self._execute(inserter, [logid, True, utc_now_naive(), tablename, operation, uid])
+
+    # psycodict renamed this hook to _log_db_change (roed314/psycodict#92);
+    # keep the old name bound too so the override works whichever psycodict is
+    # installed.  Delete this alias once psycodict is pinned past that PR.
+    log_db_change = _log_db_change
 
     def verify(
         self,

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -23,7 +23,7 @@ class PostgresUserTable(PostgresBase):
         PostgresBase.__init__(self, 'db_users', db)
         # never narrow down the rmin-rmax range, only increase it!
         self.rmin, self.rmax = -10000, 10000
-        self._rw_userdb = db.can_read_write_userdb()
+        self._rw_userdb = (getattr(db, "_can_read_write_userdb", None) or db.can_read_write_userdb)()
         #TODO use this instead of hardcoded columns names
         #with identifiers
         self._username_full_name = ["username", "full_name"]


### PR DESCRIPTION
Companion to [roed314/psycodict#92](https://github.com/roed314/psycodict/pull/92) (underscore-prefixing psycodict methods that are not public API). Written version-tolerantly, so it is safe to merge **before or after** the psycodict PR; lmfdb installs psycodict from git master, so merging this first avoids any window where main is broken.

lmfdb's real exposure to the renames (surveyed on main):

- `lmfdb/lmfdb_database.py`: the `log_db_change` **override** becomes `_log_db_change`, with the old name kept bound to the same function so the hook fires whichever psycodict is installed. This is the dangerous one — a missed rename would silently stop recording database operations in `userdb.dbrecord`.
- `lmfdb/app.py` (×3, health checks) and `lmfdb/knowledge/knowl.py` / `lmfdb/users/pwdmanager.py` (×1 each): `is_alive` / `can_read_write_knowls` / `can_read_write_userdb` called through `(getattr(db, "_name", None) or db.name)()` fallbacks.

Not touched: the `db.cursor()` calls in `riemann/stieltjes` and `zeros/zeta` — those are **sqlite3** connections named `db`, not psycodict. `fetch_userpassword` and `is_verifying` (from the original LMFDB/lmfdb#3262 list) are lmfdb-side attributes and out of scope here.

Simplify the fallbacks (and drop the alias) once requirements pin psycodict past the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
