### PR TITLE
Fix flaky CI: tolerate unreachable external servers, remove beta download checks

### DIFF
--- a/lmfdb/classical_modular_forms/test_cmf.py
+++ b/lmfdb/classical_modular_forms/test_cmf.py
@@ -575,10 +575,10 @@ class CmfTest(LmfdbTest):
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/', ['14,417,694', 'N.k.a.x.n.i'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?k=12', ['Select a', '269'])
         self.check_args('/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=12', ['Select a', '57'])
-        path = 'https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?N=11&k=2' # explicit link to beta since check_args prohibits external redirects
-        self.check_external(path, path, '11.2.a.a.1.1', cookie="human=1") # Downloads from beta
-        path = 'https://beta.lmfdb.org/ModularForm/GL2/Q/holomorphic/mf_hecke_cc/?label=21.2.e.a' # explicit link to beta since check_args prohibits external redirects
-        self.check_external(path, path, '21.2.e.a.4.1', cookie="human=1")
+        # Download checks against the live beta server were removed here
+        # because they tested the deployed site rather than this codebase and
+        # regularly timed out from CI runners; see issue #6225 for tracking
+        # external link checking outside of CI.
 
     def test_underlying_data(self):
         data = self.tc.get('/ModularForm/GL2/Q/holomorphic/data/13.2').get_data(as_text=True)

--- a/lmfdb/tests/__init__.py
+++ b/lmfdb/tests/__init__.py
@@ -86,7 +86,7 @@ class LmfdbTest(unittest.TestCase):
             http_handler = HTTPHandler()
             https_handler = HTTPSHandler(context=context)
             opener = build_opener(redirect_handler, http_handler, https_handler)
-            response = opener.open(request)
+            response = opener.open(request, timeout=30)
 
             # Check if we were redirected
             final_url = response.geturl()
@@ -96,14 +96,20 @@ class LmfdbTest(unittest.TestCase):
             response_text = response.read().decode("utf-8")
 
             assert text in response_text, f"Text '{text}' not found in response from {path} (final URL: {final_url})"
-        except URLError as e:
-            if e.errno in [errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN]:
-                pass
-            elif "Connection refused" in str(e):  # not every error comes with a errno
-                pass
+        except (URLError, TimeoutError, ConnectionError) as e:
+            # An unreachable external server is not an LMFDB bug, so skip
+            # rather than fail.  urllib wraps the underlying socket error,
+            # so the errno lives on e.reason, not on the URLError itself
+            # (URLError.errno is always None).
+            reason = getattr(e, "reason", e)
+            errnum = getattr(reason, "errno", None)
+            if (isinstance(reason, (TimeoutError, ConnectionError))
+                    or errnum in [errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN,
+                                  errno.EHOSTUNREACH, errno.ENETUNREACH, errno.ECONNRESET]
+                    or "timed out" in str(e)
+                    or "Connection refused" in str(e)):
+                self.skipTest(f"External server unreachable for {path}: {e}")
             else:
-                print(e)
-                print(e.errno)
                 raise
 
     def assert_if_magma(self, expected, magma_code, mode='equal'):


### PR DESCRIPTION
## Summary

Over the last ~2.5 months, roughly half of the Tests-workflow runs on `main` failed (27 of 53 completed runs). Classifying all 40 failed jobs: 22 were `CmfTest::test_mf_hecke_cc_dataset` timing out downloading from `beta.lmfdb.org`, 16 were dropped database connections (addressed by the TCP keepalives in #7064/#7066 — no recurrences since), and 2 were unrelated data-dependent assertions. This PR eliminates the remaining big cause.

**Why the beta downloads failed:** the TCP connect from GitHub's runners to beta times out (`[Errno 110]`), while beta answers the same request in ~0.16s from other networks — consistent with MIT-side filtering/rate-limiting of datacenter IP ranges, so it will keep recurring no matter how healthy beta is.

**Why `check_external`'s tolerance didn't help:** it was written to tolerate exactly this (`if e.errno in [errno.ETIMEDOUT, ...]`), but urllib wraps the socket error, so `URLError.errno` is always `None` — the real errno lives on `e.reason.errno`. The handler's own debug output in the CI logs shows it: `<urlopen error [Errno 110] Connection timed out>` followed by `None`. Refused connections were rescued by a string fallback; timeouts fell through to `raise`.

## Changes

- **`lmfdb/tests/__init__.py`** — `check_external` now classifies unreachability via `e.reason` (plus errno list and string fallbacks), also catches bare `TimeoutError`/`ConnectionError` (a *read* timeout is not wrapped in `URLError`), calls `self.skipTest(...)` instead of silently passing so skips are visible in test output, and passes `timeout=30` so a dead server costs 30s rather than the ~130s kernel connect timeout. HTTP errors (404 etc.), malformed URLs, and DNS failures still fail the test as before.
- **`lmfdb/classical_modular_forms/test_cmf.py`** — removed the two `check_external` downloads from `beta.lmfdb.org` in `test_mf_hecke_cc_dataset`. They fetched pages from the *deployed* beta site, so they could never catch a regression in the code under test, while being the single largest source of CI failures. The three local `check_args` assertions remain. Live external-link checking is tracked in #6225.

## Verification

- The exception classification was exercised against the exact exception shapes urllib produces (wrapped connect timeout, wrapped refused, bare read timeout, reset-by-peer, EHOSTUNREACH → skip; HTTP 404, `no host given`, DNS failure → still raise), with the condition extracted from the committed source via AST so the test can't drift from the code.
- `test_mf_hecke_cc_dataset` passes end-to-end against devmirror (36.7s).
- `lmfdb/tests/test_workshoplinks.py` passes live (5 real external fetches through the new code path, confirming the success path and the `timeout=` addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)