### PR TITLE
Enable number field diagram search via computed discriminant axes (#6985)

### DIFF
--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1210,7 +1210,6 @@ class NFSearchArray(SearchArray):
     jump_egspan = r"e.g. 2.2.5.1, Qsqrt5, x^2-5, or x^2-x-1 for \(\Q(\sqrt{5})\)"
     jump_knowl = "nf.search_input"
     jump_prompt = "Label, name, polynomial, or comma-separated list"
-    has_diagram = True
 
     def __init__(self):
         degree = TextBox(

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -930,7 +930,23 @@ class NFDownloader(Downloader):
                            ('Diagram search results', '.')],
                  "x_axis_default": "disc",
                  "y_axis_default": "regulator",
-                 "color_default": "num_ram"})
+                 "color_default": "num_ram",
+                 # Axes computed from database columns rather than stored directly:
+                 # the database keeps the sign and absolute value of the discriminant
+                 # in separate columns, so neither the signed nor the absolute
+                 # discriminant is a plain column that can be selected as an axis.
+                 "computed_cols": {
+                     "disc": {
+                         "label": "Discriminant",
+                         "cols": ["disc_sign", "disc_abs"],
+                         "func": lambda r: r["disc_sign"] * r["disc_abs"],
+                     },
+                     "disc_abs": {
+                         "label": "Absolute discriminant",
+                         "cols": ["disc_abs"],
+                         "func": lambda r: r["disc_abs"],
+                     },
+                 }})
 def number_field_search(info, query):
     parse_posints(info,query,'degree')
     parse_galgrp(info,query, qfield=('galois_label', 'degree'))
@@ -1194,7 +1210,7 @@ class NFSearchArray(SearchArray):
     jump_egspan = r"e.g. 2.2.5.1, Qsqrt5, x^2-5, or x^2-x-1 for \(\Q(\sqrt{5})\)"
     jump_knowl = "nf.search_input"
     jump_prompt = "Label, name, polynomial, or comma-separated list"
-    has_diagram = False
+    has_diagram = True
 
     def __init__(self):
         degree = TextBox(

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -937,12 +937,12 @@ class NFDownloader(Downloader):
                  # discriminant is a plain column that can be selected as an axis.
                  "computed_cols": {
                      "disc": {
-                         "label": "Discriminant",
+                         "label": "discriminant",
                          "cols": ["disc_sign", "disc_abs"],
                          "func": lambda r: r["disc_sign"] * r["disc_abs"],
                      },
                      "disc_abs": {
-                         "label": "Absolute discriminant",
+                         "label": "absolute discriminant",
                          "cols": ["disc_abs"],
                          "func": lambda r: r["disc_abs"],
                      },

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -143,6 +143,21 @@ class NumberFieldTest(LmfdbTest):
     def test_underlying_data(self):
         self.check_args('NumberField/2.2.10069.1', ['Underlying data', 'data/2.2.10069.1'])
 
+    def test_diagram_search(self):
+        # The Diagram button should be offered on the search page
+        self.check_args('/NumberField/?degree=2', 'Diagram search')
+        # Default axes use the computed signed discriminant (disc = disc_sign * disc_abs),
+        # which is not a stored column; this used to 500 with KeyError: 'disc'.
+        page = self.tc.get('/NumberField/?search_type=Diagram&degree=2&count=100').get_data(as_text=True)
+        assert 'my_dataviz' in page
+        assert 'Discriminant' in page
+        # 2.0.3.1 is the field of discriminant -3, so its x-coordinate is -3
+        assert '"label": "2.0.3.1"' in page and '"x": "-3"' in page
+        # The computed absolute-discriminant axis also works
+        page2 = self.tc.get('/NumberField/?hst=Diagram&x-axis=disc_abs&y-axis=rd&degree=3&count=50').get_data(as_text=True)
+        assert 'my_dataviz' in page2
+        assert 'Absolute discriminant' in page2
+
     def test_errors(self):
         self.check_args('NumberField/18.0.10490638424...4432.1/download/sage', 'Invalid label')
         self.check_args('NumberField/4.3.2.1/download/sage', 'There is no number field with label 4.3.2.1')

--- a/lmfdb/number_fields/test_numberfield.py
+++ b/lmfdb/number_fields/test_numberfield.py
@@ -150,13 +150,13 @@ class NumberFieldTest(LmfdbTest):
         # which is not a stored column; this used to 500 with KeyError: 'disc'.
         page = self.tc.get('/NumberField/?search_type=Diagram&degree=2&count=100').get_data(as_text=True)
         assert 'my_dataviz' in page
-        assert 'Discriminant' in page
+        assert 'discriminant' in page
         # 2.0.3.1 is the field of discriminant -3, so its x-coordinate is -3
         assert '"label": "2.0.3.1"' in page and '"x": "-3"' in page
         # The computed absolute-discriminant axis also works
         page2 = self.tc.get('/NumberField/?hst=Diagram&x-axis=disc_abs&y-axis=rd&degree=3&count=50').get_data(as_text=True)
         assert 'my_dataviz' in page2
-        assert 'Absolute discriminant' in page2
+        assert 'absolute discriminant' in page2
 
     def test_errors(self):
         self.check_args('NumberField/18.0.10490638424...4432.1/download/sage', 'Invalid label')

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -504,6 +504,15 @@ class SearchWrapper(Wrapper):
         Additionally, one should pass 'diagram_opts = {}' as keyword argument to the @search_wrap macro,
         with options specifying the title, breadcrumbs, and default x/y-axes and color keys, matching numerical
         (or in the case of 'color_default', boolean) columns in the database.
+
+        The 'computed_cols' option registers axes whose values are derived from one or more
+        database columns via a function, rather than stored directly in a single column (e.g.
+        the signed discriminant of a number field, whose sign and absolute value live in
+        separate columns).  It maps an axis key to a spec dict with keys:
+            'label': the display name shown in the dropdown and on the axis,
+            'cols':  the list of database columns to project so 'func' can be evaluated,
+            'func':  a callable taking a result row (dict) and returning the numeric value,
+            'type':  optional, "number" (default) or "boolean" for a color-only option.
         """
         # Get diagram options with defaults
         opts = self.diagram_opts or {}
@@ -538,6 +547,16 @@ class SearchWrapper(Wrapper):
         table = self.table
         col_types = table.col_type
 
+        # Computed axes derived from database columns via a function (see docstring).
+        computed_cols = opts.get("computed_cols", {})
+
+        def clean_title(title):
+            # clean up short titles - get rid of latex
+            return title.replace("$", "") \
+                        .replace(r"\(", "") \
+                        .replace(r"\)", "") \
+                        .replace("\\", "")
+
         columns = self.columns
         if columns is not None:
             # Build from SearchColumns - uses actual database column names
@@ -547,11 +566,10 @@ class SearchWrapper(Wrapper):
                 db_col = col.name if col.name else col.orig[0]
                 # db_col = col.name
                 if db_col in col_types:
-                    # clean up short titles - get rid of latex
-                    diagram_fields[db_col] = col.short_title.replace("$", "") \
-                                                             .replace(r"\(", "") \
-                                                             .replace(r"\)", "") \
-                                                             .replace("\\", "")
+                    diagram_fields[db_col] = clean_title(col.short_title)
+                elif db_col in computed_cols:
+                    # A displayed column whose value is computed from other columns
+                    diagram_fields[db_col] = computed_cols[db_col].get("label") or clean_title(col.short_title)
 
         else:
             # Fall back to search array boxes if no columns defined
@@ -559,11 +577,25 @@ class SearchWrapper(Wrapper):
                              flatten(SA.browse_array) + flatten(SA.refine_array)
                              if hasattr(box, 'name') and hasattr(box, 'short_title')}
 
+        # Register any computed axes not already tied to a displayed column
+        for cname, spec in computed_cols.items():
+            diagram_fields.setdefault(cname, spec.get("label", cname))
+
+        def axis_is_numeric(name):
+            if name in computed_cols:
+                return computed_cols[name].get("type", "number") == "number"
+            return col_types.get(name) in number_types
+
+        def axis_is_boolean(name):
+            if name in computed_cols:
+                return computed_cols[name].get("type", "number") == "boolean"
+            return col_types.get(name) == "boolean"
+
         # Filter to numerical and binary fields based on database column types
         numerical_fields = [(name, label) for (name, label) in diagram_fields.items()
-                           if col_types.get(name) in number_types]
+                           if axis_is_numeric(name)]
         binary_fields = [(name, label) for (name, label) in diagram_fields.items()
-                        if col_types.get(name) == "boolean"]
+                        if axis_is_boolean(name)]
         color_fields = numerical_fields + binary_fields
 
         # Create SearchBox objects for diagram-specific controls
@@ -588,6 +620,9 @@ class SearchWrapper(Wrapper):
         # Get projection
         proj = query.pop("__projection__", self.projection)
         if isinstance(proj, list):
+            # Make sure columns needed to compute derived axes are fetched
+            deps = [dep for spec in computed_cols.values() for dep in spec.get("cols", [])]
+            proj = proj + [dep for dep in deps if dep not in proj]
             proj = [col for col in proj if col in table.search_cols]
 
         count = parse_count(info, result_count_default)
@@ -626,6 +661,9 @@ class SearchWrapper(Wrapper):
                 )
 
             if not res:
+                # Empty result set: hand the template an empty list rather than None
+                # so the d3 script renders an empty diagram instead of erroring.
+                info["d3_data"] = []
                 return render_template(
                     template, info=info, title=title, **template_kwds
                 )
@@ -650,6 +688,19 @@ class SearchWrapper(Wrapper):
             # Get label_builder from diagram_opts if provided (for nonstandard labeling)
             label_builder = opts.get("label_builder")
 
+            # Extract a value for one axis from a result row, applying the
+            # computed-column function when the key names a computed axis.
+            def axis_value(r, key):
+                if key in computed_cols:
+                    func = computed_cols[key].get("func")
+                    if func is None:
+                        return None
+                    try:
+                        return func(r)
+                    except (KeyError, TypeError, ValueError, ZeroDivisionError):
+                        return None
+                return r.get(key)
+
             # Build d3 data
             info["d3_data"] = []
             for r in res:
@@ -664,15 +715,15 @@ class SearchWrapper(Wrapper):
                     # break
 
                 info["d3_data"].append({
-                    "x": str(r.get(x_key)),
-                    "y": str(r.get(y_key)),
-                    "color": str(r.get(col_key)),
+                    "x": str(axis_value(r, x_key)),
+                    "y": str(axis_value(r, y_key)),
+                    "color": str(axis_value(r, col_key)),
                     "path": self.url_for_label(label),
                     "label": label,
                 })
-            # Set axis labels for display
-            info["x-axis-label"] = diagram_fields[x_key]
-            info["y-axis-label"] = diagram_fields[y_key]
+            # Set axis labels for display (fall back to the raw key for unknown axes)
+            info["x-axis-label"] = diagram_fields.get(x_key, x_key)
+            info["y-axis-label"] = diagram_fields.get(y_key, y_key)
 
             return render_template(template, info=info, title=title, **template_kwds)
 


### PR DESCRIPTION
The number field diagram search was disabled because choosing discriminant as an axis did
not work: the database stores the sign and absolute value of the discriminant in separate
columns, so the signed discriminant is not a plain column and could not be selected — and
the configured default even made the page 500 with `KeyError: 'disc'`. This adds a reusable
`computed_cols` option to `diagram_opts` (handled in `SearchWrapper._diagram_search`) that
registers axes whose values are derived from one or more database columns via a function,
adds those columns to the projection, and evaluates the function when building the diagram
data. Number fields use it for the signed discriminant (`disc_sign * disc_abs`) and the
absolute discriminant, and the diagram page is re-enabled. Empty result sets and unknown
axis keys now degrade cleanly instead of erroring, and pages that do not set `computed_cols`
are unaffected. Verified with the flask test client (default/signed/absolute discriminant
axes render correct plots, existing axes and the elliptic-curve/groups diagrams unchanged,
degenerate cases return 200); added `test_diagram_search`; number_fields tests and pyflakes
pass. Addresses LMFDB/lmfdb#6985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)