### PR TITLE
Remove some unnecessary code from the code.yaml files

### DIFF
--- a/lmfdb/characters/code.yaml
+++ b/lmfdb/characters/code.yaml
@@ -3,27 +3,6 @@ prompt:
   pari: 'gp'
   magma: 'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-comment:
-  sage: |
-    #
-  pari: |
-    \\
-  magma: |
-    //
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with Dirichlet character {label}

--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -8,6 +8,13 @@ prompt:
   pari:   'gp'
   magma:  'magma'
 
+comment:
+  sage: |
+    #
+  pari: |
+    \\
+  magma: |
+    //
 
 header:
   pari: |

--- a/lmfdb/classical_modular_forms/code-form.yaml
+++ b/lmfdb/classical_modular_forms/code-form.yaml
@@ -8,26 +8,6 @@ prompt:
   pari:   'gp'
   magma:  'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-comment:
-  sage: |
-    #
-  pari: |
-    \\
-  magma: |
-    //
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
 
 header:
   pari: |

--- a/lmfdb/classical_modular_forms/code-space.yaml
+++ b/lmfdb/classical_modular_forms/code-space.yaml
@@ -3,27 +3,6 @@ prompt:
   pari:   'gp'
   magma:  'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-comment:
-  sage: |
-    #
-  pari: |
-    \\
-  magma: |
-    //
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-
 dimension-full-space:
   comment: dimension of the space M_{k}(Gamma_1({N}))
   pari: |

--- a/lmfdb/classical_modular_forms/code.yaml
+++ b/lmfdb/classical_modular_forms/code.yaml
@@ -3,27 +3,6 @@ prompt:
   pari:   'gp'
   magma:  'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-comment:
-  sage: |
-    #
-  pari: |
-    \\
-  magma: |
-    //
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-
 newforms-nontriv-char:
   sage: |
     D = DirichletGroup({N})

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -888,10 +888,6 @@ sorted_code_names = ['field', 'curve', 'is_min', 'cond', 'cond_norm',
                      'disc', 'disc_norm', 'jinv', 'cm', 'rank',
                      'gens', 'heights', 'reg', 'tors', 'ntors', 'torgens', 'localdata']
 
-
-Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP', 'pari': 'Pari/GP', 'oscar': 'Oscar'}
-Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\', 'oscar': '#'}
-
 def make_code(label, lang=None):
     """Return a dict of code snippets for one curve in either one
     language (if lang is 'pari' or 'gp', 'sage', 'magma', or 'oscar') or all

--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -4,22 +4,6 @@ prompt:
   magma: 'magma'
   oscar: 'oscar'
 
-logo:
-  sage:  <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari:  <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-  oscar: <img src = "https://oscar-system.github.io/Oscar.jl/stable/assets/logo.png" width="50px">
-
-not-implemented:
-  sage:  |
-    # (not yet implemented)
-  pari:  |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-  oscar: |
-    # (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with elliptic curve {label}

--- a/lmfdb/elliptic_curves/code.yaml
+++ b/lmfdb/elliptic_curves/code.yaml
@@ -4,32 +4,6 @@ prompt:
   magma:  'magma'
   oscar:  'oscar'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-  oscar: <img src = "https://oscar-system.github.io/Oscar.jl/stable/assets/logo.png" width="50px">
-
-comment:
-  sage: |
-    #
-  pari: |
-    \\
-  magma: |
-    //
-  oscar: |
-    #
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-  oscar: |
-    # (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with elliptic curve {label}

--- a/lmfdb/galois_groups/code.yaml
+++ b/lmfdb/galois_groups/code.yaml
@@ -4,33 +4,6 @@ prompt:
   oscar: 'oscar'
   gap:   'gap'
 
-logo:
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  oscar: <img src = "https://oscar-system.github.io/Oscar.jl/stable/assets/logo.png" width="50px">
-  gap: <img src = "https://gap.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_GAP-GP_Couleurs_L150px.png" width="50px">
-
-comment:
-  sage: |
-    #
-  magma: |
-    //
-  oscar: |
-    #
-  gap: |
-    #
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  magma: |
-    // (not yet implemented)
-  oscar: |
-    # (not yet implemented)
-  gap: |
-    # (not yet implemented)
-
-
 frontmatter:
   all: |
     {lang} code for working with transitive group {label}

--- a/lmfdb/genus2_curves/code.yaml
+++ b/lmfdb/genus2_curves/code.yaml
@@ -3,19 +3,6 @@ prompt:
   pari:   'gp'
   magma:  'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with genus 2 curve {label}.

--- a/lmfdb/groups/abstract/code.yaml
+++ b/lmfdb/groups/abstract/code.yaml
@@ -5,37 +5,6 @@ prompt:
   sage_gap: 'sage'   # For implementing groups in SageMath, but using the GAP interface
   oscar: 'oscar'
 
-logo:
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-  gap: <img src = "https://gap.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_GAP-GP_Couleurs_L150px.png" width="50px">
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  sage_gap: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  oscar: <img src = "https://oscar-system.github.io/Oscar.jl/stable/assets/logo.png" width="50px">
-
-comment:
-  magma: |
-    //
-  gap: |
-    #
-  sage: |
-    #
-  sage_gap: |
-    #
-  oscar: |
-    #
-
-not-implemented:
-  magma: |
-    // (not yet implemented)
-  gap: |
-    # (not yet implemented)
-  sage: |
-    # (not yet implemented)
-  sage_gap: |
-    # (not yet implemented)
-  oscar: |
-    # (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with abstract group {label}.

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -3976,9 +3976,3 @@ def order_stats_list_to_string(o_list):
         if o_list.index(pair) != len(o_list) - 1:
             s += ","
     return s
-
-
-#sorted_code_names = ['presentation', 'permutation', 'matrix', 'transitive']
-
-Fullname = {'magma': 'Magma', 'gap': 'Gap'}
-Comment = {'magma': '//', 'gap': '#'}

--- a/lmfdb/higher_genus_w_automorphisms/code.yaml
+++ b/lmfdb/higher_genus_w_automorphisms/code.yaml
@@ -2,19 +2,9 @@ prompt:
   gap:   'gap'
   magma:  'magma'
 
-logo:
-  gap: <img src = "https://gap.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_GAP-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-not-implemented:
-  gap: |
-    \\\\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
 top_matter:
   gap:  "# WARNING: The conjugacy class numbers may not be the same as those listed in lmfdb.org, as numberings in Magma and GAP may differ. If you need to connect this data to that posted on lmfdb.org, compare the variables 'passport_label' and 'gen_vector_labels'."
   magma:  RecFormat:=recformat<group,gp_id, signature,gen_vectors,conj_classes,genus,dimension,r,g0, passport_label,gen_vect_label, is_hyperelliptic, hyp_involution, is_cyclic_trigonal,cyc_auto,full_auto, full_sign,topological_class,braid_class>;
-
 
 
 gp_comment:

--- a/lmfdb/local_fields/code.yaml
+++ b/lmfdb/local_fields/code.yaml
@@ -2,16 +2,6 @@ prompt:
   sage:   'sage'
   magma:  'magma'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  magma: |
-    // (not yet implemented)
-
 frontmatter:
   all: |
     {lang} code for working with p-adic field {label}.

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -4,22 +4,6 @@ prompt:
   magma:  'magma'
   oscar:  'oscar'
 
-logo:
-  sage: <img src ="https://www.sagemath.org/pix/sage_logo_new.png" width = "50px">
-  pari: <img src = "https://pari.math.u-bordeaux.fr/logo/Logo%20Couleurs/Logo_PARI-GP_Couleurs_L150px.png" width="50px">
-  magma: <img src = "https://i.stack.imgur.com/0468s.png" width="50px">
-  oscar: <img src = "https://oscar-system.github.io/Oscar.jl/stable/assets/logo.png" width="50px">
-
-not-implemented:
-  sage: |
-    # (not yet implemented)
-  pari: |
-    \\ (not yet implemented)
-  magma: |
-    // (not yet implemented)
-  oscar: |
-    # (not yet implemented)
-
 # Valid keys are: 'all' any key appearing in prompt, and 'rest'
 frontmatter:
   all: |

--- a/lmfdb/number_fields/number_field.py
+++ b/lmfdb/number_fields/number_field.py
@@ -1176,11 +1176,6 @@ sorted_code_names = ['field', 'poly', 'degree', 'signature',
                      'fundamental_units', 'regulator', 'class_number_formula',
                      'intermediate_fields', 'galois_group', 'prime_cycle_types']
 
-
-Fullname = {'magma': 'Magma', 'sage': 'SageMath', 'gp': 'Pari/GP', 'oscar': 'Oscar'}
-Comment = {'magma': '//', 'sage': '#', 'gp': '\\\\', 'pari': '\\\\', 'oscar': '#'}
-
-
 def nf_code(**args):
     label = args['nf']
     if not FIELD_LABEL_RE.fullmatch(label):


### PR DESCRIPTION
This PR just removes some old unused code from the `code.yaml` files.

The full names and comment characters for all languages (Sage/Magma/Pari etc.) are now provided globally in `lmfdb/utils/place_code.py`, so there's no need to separately define these in each section anymore.  The logos for each language are also not used anywhere (and anyway should be done globally if they are used in the future).  I haven't touched any sections which still handle code snippets the old way.

As always, comments/feedback welcome! :)
