### PR TITLE
Fix flash_error/flash_warning/flash_info to avoid 500s on second % pass

### DIFF
--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -778,15 +778,24 @@ def debug():
 
 def flash_error(errmsg, *args):
     """ flash errmsg in red with args in black; errmsg may contain markup, including latex math mode"""
-    flash(Markup("Error: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args))), "error")
+    errmsg = str(errmsg)
+    if args:
+        errmsg = errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)
+    flash(Markup("Error: " + errmsg), "error")
 
 def flash_warning(errmsg, *args):
     """ flash warning in grey with args in red; warning may contain markup, including latex math mode"""
-    flash(Markup("Warning: " + (errmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args))), "warning")
+    errmsg = str(errmsg)
+    if args:
+        errmsg = errmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args)
+    flash(Markup("Warning: " + errmsg), "warning")
 
 def flash_info(errmsg, *args):
     """ flash information in grey with args in black; warning may contain markup, including latex math mode"""
-    flash(Markup("Note: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args))), "info")
+    errmsg = str(errmsg)
+    if args:
+        errmsg = errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)
+    flash(Markup("Note: " + errmsg), "info")
 
 def flash_success(msg, *args):
     """ flash information in green with args in black; msg may contain markup, including latex math mode"""


### PR DESCRIPTION
In my continuing experimentation, I  asked Claude to analyze the flasklog and recent production errors to see if there were some errors it could help fix.  

One set of errors it notices were issues with flash error messaging.   Here's the proposed fix. 


----------

flash_error applied Python's % formatting to errmsg unconditionally, even when called with no args. This caused three classes of 500 errors:

- Double % formatting: query_cancelled_error() in search_wrapper.py pre-formats its message (interpolating a percent-encoded beta_link URL) and passes the already-substituted string with no args. flash_error then re-applied % with an empty tuple, and leftover %3D/%2B sequences from the URL's query string were read as format specifiers, raising "TypeError: not enough arguments for format string" (3 prod hits on /L/rational).

- Non-string errmsg: siegel_modular_form.py calls flash_error(err) with a caught NotImplementedError instance. % on a non-str object raised "TypeError: unsupported operand type(s) for %: 'NotImplementedError' and 'tuple'" (2 beta hits on /ModularForm/GSp/Q/Gamma_2/).

- Latent: any of the ~231 flash_error call sites that pass a single pre-built string (str(err), f-strings with user input, etc.) containing a literal % would hit the same TypeError as soon as that text appeared.

Fix: coerce errmsg to str() up front, and only apply % substitution when args are actually supplied. Applied identically to flash_warning and flash_info, which had the same defect. Call sites are unchanged -- passing beta_link as a flash_error arg instead would get HTML-escaped and wrapped in a <span>, corrupting the href.

Verified the fixed logic directly (flash() needs a Flask request context) by extracting the three function bodies from utilities.py and exercising them under a real flask.test_request_context(): the C1 (percent-encoded URL, no args), C2 (exception object), and C3 (literal % in a pre-built string) inputs above all now flash successfully instead of raising, and normal usage with args still substitutes and escapes correctly. No existing tests under lmfdb/tests/ reference these functions, and none were added since importing the module chain requires Sage, which is unavailable in this environment.