### PR TITLE
Fix TypeError in pAdicSlopeFamily.galois_groups on records with gal=None

### DIFF
--- a/lmfdb/local_fields/family.py
+++ b/lmfdb/local_fields/family.py
@@ -394,7 +394,7 @@ class pAdicSlopeFamily:
     @lazy_attribute
     def galois_groups(self):
         fields, cache = self.fields
-        opts = sorted(Counter((rec["gal"], rec["galois_label"]) for rec in fields if "gal" in rec and "galois_label" in rec).items())
+        opts = sorted(Counter((rec["gal"], rec["galois_label"]) for rec in fields if rec.get("gal") is not None and rec.get("galois_label") is not None).items())
         if not opts:
             return "No Galois groups in this family have been computed"
 

--- a/lmfdb/local_fields/family.py
+++ b/lmfdb/local_fields/family.py
@@ -395,16 +395,22 @@ class pAdicSlopeFamily:
     def galois_groups(self):
         fields, cache = self.fields
         opts = sorted(Counter((rec["gal"], rec["galois_label"]) for rec in fields if rec.get("gal") is not None and rec.get("galois_label") is not None).items())
+        unknown_cnt = sum(1 for rec in fields if rec.get("gal") is None or rec.get("galois_label") is None)
         if not opts:
             return "No Galois groups in this family have been computed"
 
         def show_gal(label, cnt):
             kwl = transitive_group_display_knowl(label, cache=cache)
-            if len(opts) == 1:
+            if len(opts) == 1 and not unknown_cnt:
                 return kwl
             url = url_for(".family_page", label=self.label, gal=label)
             return f'{kwl} (<a href="{url}#fields">show {cnt}</a>)'
-        s = ", ".join(show_gal(label, cnt) for ((t, label), cnt) in opts)
+        parts = [show_gal(label, cnt) for ((t, label), cnt) in opts]
+        if unknown_cnt:
+            # No gal= value exists to filter on missing/null Galois groups, so this
+            # bucket is plain text rather than a link (unlike the entries above).
+            parts.append(f"unknown ({unknown_cnt})")
+        s = ", ".join(parts)
         if not self.all_hidden_data_available:
             s += " (incomplete)"
         return s


### PR DESCRIPTION
The second issue Claude identified was an issue with a "None" value for padic Fields.   The fix notes are below. I want to emphasize here this particular warning:

> This fix silently drops fields whose Galois group hasn't been computed from the summary line. It's possible the intended behavior is instead to surface them as "unknown" in the listing. That's a display/math decision for a domain expert, not made here.

I *think* this is the behavior we want but I don't know these pages as well as others, so if we want the unknowns listed, just let me know.


-----

Production traceback on /padicField/family/... pages: sorted() raised "'<' not supported between instances of 'NoneType' and 'int'".

The filter guarding the Counter comprehension checked only for *key presence* ("gal" in rec and "galois_label" in rec), not for a non-None *value*. Records where "gal" is present but null (Galois group not yet computed) passed the filter, so None values reached sorted() alongside ints and comparison failed.

Switched to rec.get(col) is not None checks, matching the idiom already used a few lines above in some_hidden_data_available (rec.get(col) for col in [...]).
