### PR TITLE
Fix TypeError on live group pages referenced from gps_transitive

### DIFF
--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -2351,7 +2351,10 @@ class WebAbstractGroup(WebObj):
             desc = "Groups of " + display_knowl("group.lie_type", "Lie type")
             reps = ", ".join(fr"$\{rep['family']}({rep['d']},{rep['q']})$" for rep in rdata)
             code_cmd = " ".join([self.create_short_snippet((rep['family'], rep['d'], rep['q'])) for rep in rdata])
-            return f'<tr><td>{desc}:</td><td colspan="5">{reps}</td></tr><tr><td colspan="6">{code_cmd}</td></tr>'
+            head = f'<tr><td>{desc}:</td><td colspan="5">{reps}</td></tr>'
+            if not code_cmd.strip():
+                return head
+            return head + f'<tr><td colspan="6">{code_cmd}</td></tr>'
         elif rep_type == "PC":
             pres = self.presentation()
             if not skip_head:  #add copy button in certain cases
@@ -2511,6 +2514,8 @@ class WebAbstractGroup(WebObj):
 
                 # Display code snippets for transitive group representations
                 code_cmd = " ".join([self.create_short_snippet(trans) for trans in self.transitive_friends])
+                if not code_cmd.strip():
+                    return rep_content
                 return rep_content + f'<tr><td colspan="6">{code_cmd}</td></tr>'
 
             elif rtype == "semidirect":
@@ -2857,8 +2862,11 @@ class WebAbstractGroup(WebObj):
 
     # Used for displaying code snippets across multiple columns in a table
     def create_long_snippet(self,item):
+        code = self.code_snippets()
+        if not code or not code.get(item):
+            return ""
         col_span_val = '"6"'
-        snippet = CodeSnippet(self.code_snippets(), item,
+        snippet = CodeSnippet(code, item,
                               pre=f"<tr> <td colspan={col_span_val}>",
                               post="</td></tr>")
         return snippet.place_code()
@@ -2866,7 +2874,10 @@ class WebAbstractGroup(WebObj):
     # Used for displaying (short) code snippets in the constructions table
     # e.g. for Lie type representations or transitive groups
     def create_short_snippet(self,item):
-        snippet = CodeSnippet(self.code_snippets(), item)
+        code = self.code_snippets()
+        if not code or not code.get(item):
+            return ""
+        snippet = CodeSnippet(code, item)
         return snippet.place_code()
 
     @lazy_attribute


### PR DESCRIPTION
This will fix #7075

As Claude describes below, the issue was *only* for groups that were not in the gps_groups DB but were in gps_transitive and where we could pull info from Gap.  The issue was in some code_snippet commands.   Note that #7089 suggests we add those groups anyway, and so this error could go away by adding those groups, but I still propose  we fix this issue just in case more data gets added to transitive groups without updating Galois groups.

Claude also proposed changing CodeSnippet in utils to allow for None but I thought that could cause some issues with blank spaces where code should be.   

---

For a live group (not stored in gps_groups), WebAbstractGroup.code_snippets() returns None early. If that same label is nonetheless referenced from gps_transitive (e.g. 2166.11 via the 38T13 record's abstract_label), the transitive-representations branch of representation_line() still runs and calls create_short_snippet() for each transitive friend, which built CodeSnippet(None, item) unguarded. CodeSnippet.__init__ then evaluated 'prompt' in code with code=None, raising
"TypeError: argument of type 'NoneType' is not iterable" and 500ing the page.

This guard already existed at every other consumer of code_snippets() (homepage.html's `{% if code and code[item] %}` and main.py's `if code and len(code['prompt']) == 0: code = None`), but was missing from create_short_snippet and create_long_snippet themselves. Add the same "code and code.get(item)" guard to both helpers so they return "" instead of raising. Also update both call sites (the transitive-friends branch and the Lie-representation branch, which has the identical pattern) to skip emitting the now-empty `<tr><td colspan="6"></td></tr>` row when there's no code to show, rather than rendering a blank table row.

lmfdb/utils/place_code.py is intentionally left untouched; making CodeSnippet tolerate code=None was considered and declined upstream.