### PR TITLE
Fix minor typos in the documentation

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -60,7 +60,7 @@ mathematician, or the wikipedia article of someone famous.
 
 An object's home page should provide a wide variety of information about the
 object. Basic information, of interest to both experts and non-experts,
-should appear ear the top. More specialized information should appear
+should appear near the top. More specialized information should appear
 near the bottom.
 
 In the upper right corner of each home page should be the "properties" box,
@@ -209,7 +209,7 @@ Here are some conventions the LMFDB uses:
 
 1. If X is the URL of an object, then L/X is the URL of its standard
    L-function. According to the Langlands program, other L-functions
-   associated to X may be written on the the form L(s, X, rho). Examples include
+   associated to X may be written in the form L(s, X, rho). Examples include
 
    - L(s, f, sym^2)
    - L(s, f, spin)
@@ -246,7 +246,7 @@ Here are some conventions the LMFDB uses:
    Qsqrt5 as a search parameter for the coefficient field.
 
    Note that number fields like Qsqrt5 has an "official name" as well as a
-   nickname. Many discussions have occurred for what appropriate labels for
+   nickname. Many discussions have occurred about what appropriate labels for
    objects should be. Examine the structure of existing objects in the
    LMFDB very closely to maintain correct labels and relationships.
 
@@ -269,9 +269,9 @@ Here are some conventions the LMFDB uses:
    - `/Motive/Hypergeometric/Q/\<label>`
    - `/NumberField/\<label>`
 
-In practice, prior to deciding on a labelling scheme for new objects, one
+In practice, prior to deciding on a labeling scheme for new objects, one
 should talk to the current LMFDB developers (who now have a lot of experience
-in considering labelling schemes).
+in considering labeling schemes).
 
 
 Templates
@@ -347,7 +347,7 @@ Testing
   ```
   It takes a few minutes. If sage or some additional parts are missing it may fail,
   consider updating
-  (see [Getting Started](https://github.com/LMFDB/lmfdb/wiki/GettingStarted) )
+  (see [Getting Started](https://github.com/LMFDB/lmfdb/wiki/GettingStarted))
 
 - New blueprints and features should include a `test_<name>.py` file
   which runs tests on all functions.
@@ -430,7 +430,7 @@ this puts you inside an interactive python debugger, where you can:
 - continue executing code using the `n` command.
 
 If you get lost, the command `bt` shows you exactly where you
-are, and `up` helps you to get on step up on the stack.
+are, and `up` helps you to get one step up on the stack.
 Of course, `help <command>` will tell you more.
 
 Git Tips
@@ -438,7 +438,7 @@ Git Tips
 
 Contributing to the LMFDB requires some familiarity with git, a popular version control system which LMFDB uses. The LMFDB code base is hosted on Github, which is a common hosting service owned by Microsoft.
 - [Official git tutorial](https://git-scm.com/docs/gittutorial) and [Github's git guide](https://github.com/git-guides)
-- Use a global .gitignore file to exclude temporary files like `.DS_store` or `main.py~`; [copy-paste ready instructions on github](https://help.github.com/articles/ignoring-files#global-gitignore).
+- Use a global .gitignore file to exclude temporary files like `.DS_Store` or `main.py~`; [copy-paste ready instructions on github](https://help.github.com/articles/ignoring-files#global-gitignore).
 - Configure your global .gitconfig for shortcuts or global configuration options; for example:
   ```
 [alias]

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -46,7 +46,7 @@ Installation
  * Install dependencies.  This requires you to have write access to the
    Sage installation directory, so should be no problem on a personal
    machine, but if you are using a system-wide Sage install on a shared
-   machine, you will need ask a system administrator to do this step.
+   machine, you will need to ask a system administrator to do this step.
 
    ```
    sage -i gap_packages
@@ -76,13 +76,13 @@ Installation
      that). This problem does seem to be resolved for Sage 9.3beta, and it is currently
      unclear if the problem exists for Sage 9.0 or 9.1.
 
-   - In case the last step fails by is Mac OSX with the error
+   - In case the last step fails on Mac OSX with the error
 
      ```
      Error: pg_config executable not found.
      ```
 
-     we recommend to installing PostgreSQL by doing
+     we recommend installing PostgreSQL by doing
 
      ```
      brew install postgresql
@@ -104,9 +104,9 @@ Installation
    - [optional] Memcache.  *This step is not at all necessary and can
      safely be ignored!* Memcache speeds up recompilation of python
      modules during development.  Using it requires both installing the
-     appropriate package for your Operating System and installing an
+     appropriate package for your operating system and installing an
      additional python module.  The first line below needs to be run in
-     a Sage shell, and the for second you need to be a super-user to
+     a Sage shell, and for the second you need to be a super-user to
      install memcached if your machine does not have it.
 
      * `easy_install -U python-memcached`
@@ -141,7 +141,7 @@ Running
  * When running with `--debug`, whenever a python (*.py) file changes
    the server will reload automatically.  If you save while editing
    at a point where such a file is not syntactically correct, the
-   server will crash and you will need to `start_lmfdb` again.   Any
+   server will crash and you will need to `start-lmfdb` again.   Any
    changes to html files will not cause the server to restart, so
    you will need to reload the pages in your browser.  Changes in
    the yaml files which are read only once at startup will require
@@ -167,8 +167,8 @@ Running
 CoCalc
 ======
 
- * You can run the LMFDB inside a [CoCalc](https://www.cocalc.com) project by doing
-   following the above installation instructions on a terminal in your project (you may want to
+ * You can run the LMFDB inside a [CoCalc](https://www.cocalc.com) project by following
+   the above installation instructions on a terminal in your project (you may want to
    install the requirements using the `--user` flag).
    Explicitly,
 
@@ -194,7 +194,7 @@ Troubleshooting
 ===============
 
 [warning] Recently on some linux machines, users have had to install the
-contents of requirements.txt by manually.  If the above instructions do not
+contents of requirements.txt manually.  If the above instructions do not
 work, un-install the above packages and re-install them one at a time,
 including those in requirements.txt.
 
@@ -259,10 +259,10 @@ Code development and sharing your work
    branches upstream to be aware of: `web`, `dev` and `main`:
 
    - `web` is changed rarely and contains the code currently running at
-     [www.lmfdb.org](www.lmfdb.org)
+     [www.lmfdb.org](https://www.lmfdb.org)
 
    - `dev` is changed more often and contains the code currently running at
-     [beta.lmfdb.org](beta.lmfdb.org)
+     [beta.lmfdb.org](https://beta.lmfdb.org)
 
    - `main` is the development branch.
 
@@ -323,5 +323,5 @@ For anyone who would like to attempt it, the following steps should theoreticall
  * Now you need to run ssh-keygen within the Sage appliance and e-mail the result to Harald Schilly, Jonathan Bober or John Cremona (see above).
    Since copy-and-paste can be tricky from inside the virtual image, we suggest writing to a file shared by the host OS.
 
- * The instructions for Linux/OS X should now work.  You should be able to forward the mongo database and run `sage -python start-lmfdb.py` within the Sage appliance,
+ * The instructions for Linux/OS X should now work.  You should be able to run `sage -python start-lmfdb.py` within the Sage appliance,
    and access the resulting website from your host OS' web browser.

--- a/Postgres_FAQ.md
+++ b/Postgres_FAQ.md
@@ -153,7 +153,7 @@ Database Interface
    run commands from a `psql` prompt, or use the `pgAdmin4` interface
    (not yet supported).
 
-   If use `db._execute`, make sure to wrap your statements in the SQL
+   If you use `db._execute`, make sure to wrap your statements in the SQL
    class from `psycopg2.sql` (you can also import it from
    `psycodict`). You can see lots of examples of this
    paradigm in https://github.com/roed314/psycodict/
@@ -209,7 +209,7 @@ Developer configuration
    `password` field to the editor password, and the `host` to
    `localhost`.  Instead, if you prefer to work from your own machine,
    you may use the `ssh` connection to forward a local port to `5432`,
-   and use that port on your `config.ini` file.
+   and use that port in your `config.ini` file.
 
 Adding and modifying data
 -------------------------
@@ -234,7 +234,7 @@ Note that you need editor privileges to add, delete or modify data.
    descriptions of each of its columns which will be shown when users
    view the schema for the table in the database section (these will
    be used to populate knowls that can then be edited by you or anyone
-   with an LMFDB account can edit, they don't need to be perfect).
+   with an LMFDB account; they don't need to be perfect).
 
    You can also give columns for an extra table (see the question "What is an
    `extra_table`?" later in this document), using the same format as the second
@@ -291,7 +291,7 @@ Note that you need editor privileges to add, delete or modify data.
    the search columns.
 
    Once this table exists, you can access it via the object
-    `db.perfect_numers`, which is of type `PostgresTable`.
+    `db.perfect_numbers`, which is of type `PostgresTable`.
 
    Conversely, to remove a table from the LMFDB you can use `drop_table`.
 
@@ -318,7 +318,7 @@ Note that you need editor privileges to add, delete or modify data.
 
 1. How do I delete a column?
 
-   If you want to delete a column to an existing table, use the
+   If you want to delete a column from an existing table, use the
    `drop_column` method.
 
    ```python
@@ -342,7 +342,7 @@ Note that you need editor privileges to add, delete or modify data.
    large numbers of rows, this method will be faster.
 
    ```python
-   sage: db.test_table.copy_from('test.txt', sep='|'])
+   sage: db.test_table.copy_from('test.txt', sep='|')
    ```
 
    Example contents of `test.txt`:
@@ -487,7 +487,7 @@ Note that you need editor privileges to add, delete or modify data.
    (also stored in the `meta_tables` table), the `id` column serves
    this purpose.  As a consequence, indexes can contain this column,
    rather than all of the columns that define the sort order.  The
-   `id` column is added as a primary key, and because its used for
+   `id` column is added as a primary key, and because it's used for
    sorting, many queries will actually use this primary key in
    searches (see the next section on `analyze`).
 
@@ -632,7 +632,7 @@ Statistics
 
    If you added stats for column `A`, it would record that there are
    four instances of 2, three of 1, two of 5 and one each of 3, 4,
-   and 8.  It would also record the minimum value (1), the maximum value (6),
+   and 8.  It would also record the minimum value (1), the maximum value (8),
    the average (3), and the total (12 rows).
 
    If you specified a threshold of 3, it would only record that there
@@ -714,7 +714,7 @@ Data Validation
    `not null`, which checks that a specified column is filled in for
    every row in the table.  The second is `unique`, which checks that
    a column or set of columns is unique across all rows of a table.
-   The final options is `check`, which runs an arbitrary SQL function
+   The final option is `check`, which runs an arbitrary SQL function
    on a set of rows.
 
    Note that constraints are checked whenever a row is added or

--- a/StyleGuide.md
+++ b/StyleGuide.md
@@ -2,7 +2,7 @@
 
 Below, we describe several styling conventions for the LMFDB. See also the
 [Developer's Guide](https://github.com/LMFDB/lmfdb/blob/main/Development.md)
-contains other conventions and information for the development process.
+which contains other conventions and information for the development process.
 
 ## General style conventions
 
@@ -22,11 +22,11 @@ contains other conventions and information for the development process.
 
 ## Browse and search
 
-- Each browse page should have a short summary at the top followed by sections labelled "Browse", "Search", "Find", in that order.
+- Each browse page should have a short summary at the top followed by sections labeled "Browse", "Search", "Find", in that order.
 - Colons should not follow captions on browse/search pages.
 - Captions should have knowls attached to them.
 - Abbreviated column headings should omit the period.
-- Input boxes should have standard widths (very long boxes, e.g. geometric invariants, may span the entire width),
+- Input boxes should have standard widths (very long boxes, e.g. geometric invariants, may span the entire width).
 - Option boxes should use standard captions in lower case (e.g. include/exclude/exactly or yes/no).
 - If an option imposes no restrictions on the search it should be blank, and except where there is a good reason to do otherwise, this should be the default.
 - All search pages should have "List of blahs" and "Random blah" buttons (and possibly others).
@@ -38,18 +38,18 @@ contains other conventions and information for the development process.
 - Search result values that are words (e.g. even/odd, not computed, trivial, etc...) should be lower case in the default html font (not \mathrm).
 - Boolean values in search results that indicate the presence of a property (e.g. IsSolvable) should generally use a checkmark &#x2713; for yes, blank for no, with the checkmark centered.
 - Labels and lists (e.g. Weierstrass coefficients) in search results should be left-aligned.
-- Alignment of numbers in search results may vary: fixed precision decimal numbers should be right aligned, as should integers whose values vary over a wide range (e.g. orders of Galois groups).  Small integers (e.g < 100) should generally be centered, factored signed integers (e.g discriminants) should be left aligned.
+- Alignment of numbers in search results may vary: fixed precision decimal numbers should be right aligned, as should integers whose values vary over a wide range (e.g. orders of Galois groups).  Small integers (e.g. < 100) should generally be centered, factored signed integers (e.g. discriminants) should be left aligned.
 - Factored polynomials and factored positive integers in search results should be centered.
 
 ## Object pages
 
 - Object page templates should extend homepage.html and include a content block.
 - Every object page should have a properties box, and when relevant/available, a related objects box, and a downloads box.
-- Content should be organized into sections (with`<h2>` headings).  The first section should contain the information that defines the object, the second section should contain standard invariants associated to the object, and from there they should be ordered from least to most technical/obscure.
+- Content should be organized into sections (with `<h2>` headings).  The first section should contain the information that defines the object, the second section should contain standard invariants associated to the object, and from there they should be ordered from least to most technical/obscure.
 - Content tables that are lists (each row is the same type of thing, e.g. local data at a prime) should use row striping (ntdata table).
 - Content captions should be knowls (or contain a knowl) and be followed by colons.
 - Any invariant listed in the properties box should also appear in the body (or header) of the page -- all information should be visible even with the property box closed.
-- Values that are words (e.g yes/no, even/odd, Trivial) should be in lower case using the default (sans serif) font
+- Values that are words (e.g. yes/no, even/odd, Trivial) should be in lower case using the default (sans serif) font
 - Mathematical values including integers should be displayed in math mode, with the exception of tables whose entries are integers or percentages.
 - Factorizations of negative numbers should include only the sign, not -1 (use web_latex_factored_integer in utilities.py).
 - Mathematical values, including integers, should be in math mode.
@@ -60,9 +60,9 @@ contains other conventions and information for the development process.
 
 - Captions in the property box should be sentence case (like all captions) with no colon.
 - The first line of the properties box should be the label (if one exists) followed by a portrait (if available), followed by up to 8 standard invariants or properties of the object that can be displayed in a compact form (the properties box should never scroll).
-- Property values that are words (e.g yes/no, even/odd, Trivial) should be in lower case using the default (sans serif) font
+- Property values that are words (e.g. yes/no, even/odd, Trivial) should be in lower case using the default (sans serif) font
 - Mathematical values including integers should be in math mode.
-- Integers in properties box should not be shown in factored form (the relevant the factorization should be in the body of the page) and should be shown in scientific notation if they are too large to fit (use prop_int_pretty).
+- Integers in properties box should not be shown in factored form (the relevant factorization should be in the body of the page) and should be shown in scientific notation if they are too large to fit (use prop_int_pretty).
 - Properties that are words (e.g. yes/no, even/odd, not computed, trivial, etc...) should be lower case in the default html font (not \mathrm).
 
 ## Related objects box


### PR DESCRIPTION
This PR just fixes a few small spelling and grammar typos in the `GettingStarted.md`, `Development.md`, `StyleGuide.md`, and `Postgres_FAQ.md` documentation files.