### PR TITLE
Never let a completeness check turn a search into a 500

### DIFF
--- a/lmfdb/cmdline_search.py
+++ b/lmfdb/cmdline_search.py
@@ -541,6 +541,10 @@ def run(args, parser):
                     write("No reliance on unproven conjectures\n", F)
                 else:
                     write("The completeness " + caveat + "\n", F)
+            elif caveat is not None:
+                # A verdict of "not complete" comes with no caveat, so this means the
+                # completeness check itself failed; say so rather than asserting a verdict.
+                write("The completeness " + caveat + "\n\n", F)
             else:
                 write("Not guaranteed complete\n\n", F)
         if args.format == "raw":

--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -12,14 +12,25 @@ EXAMPLES::
 """
 
 
+import logging
+import traceback
 from collections import defaultdict
 from sage.all import (
     factor, prod, factorial, is_prime, prime_range, ZZ, NN, RR,
     ceil, floor, RealSet, infinity, cached_function, RLF, log, sqrt)
 
+# We deliberately use the standard library logger rather than lmfdb.logger, since this
+# module is also used outside the website (e.g. from lmfdb-lite and lmfdb_search).
+# Records still propagate to the root logger that lmfdb.logger configures.
+logger = logging.getLogger(__name__)
+
 # This dictionary is filled in the __init__ method of CompletenessCheckers based on the table name;
 # specific CompletenessCheckers are created at the bottom of this file.
 lookup = {}
+
+# Caveat reported when the completeness machinery itself fails.  Callers display caveats
+# as "The completeness " + caveat, so this is phrased to fit that sentence.
+FAILED_CHECK_CAVEAT = "check did not finish, so the results may or may not be complete"
 
 
 def results_complete(table, query, db, search_array=None):
@@ -42,15 +53,35 @@ def results_complete(table, query, db, search_array=None):
 
       False if there may be objects missing (depending on the query, these objects may or may not exist)
 
-      None if the table has not implemented completeness guarantees
+      None if the table has not implemented completeness guarantees, or if the completeness
+      check could not be carried out (see below)
 
     - ``reason`` -- A string, giving a reason why results are complete.  Can be grammatically appended to "The LMFDB contains all".   ``None`` if not ``complete``.
 
     - ``caveat`` -- A string, giving any caveats (like dependence on GRH or unproven modularity theorems).  May be ``None``.
+
+    Completeness information is advisory: it annotates search results that have already been
+    computed.  A failure inside the checking machinery must therefore never propagate to the
+    caller and turn a working search into an error.  If the check raises, we log the traceback
+    and report ``(None, None, FAILED_CHECK_CAVEAT)``, i.e. "completeness unknown" together with
+    a caveat that callers can show to the user.  We never report ``True`` in that case.
     """
-    if table in lookup:
+    if table not in lookup:
+        return None, None, None
+    try:
         return lookup[table].check(query, db, search_array)
-    return None, None, None
+    except Exception:
+        # We intentionally catch broadly.  The check runs database queries (which can hit the
+        # statement timeout, as the null-count queries do when a column is unindexed), indexes
+        # into ``db`` (KeyError for a missing table), asserts invariants about the shape of the
+        # query (AssertionError), and does Sage arithmetic on user-supplied bounds (ValueError,
+        # TypeError, ...).  Enumerating those classes would leave the 500 we are fixing in place
+        # for whichever one we forgot, so anything short of a KeyboardInterrupt/SystemExit is
+        # downgraded to "unknown".
+        logger.warning(
+            "Completeness check failed for table %s with query %s\n%s",
+            table, query, traceback.format_exc())
+        return None, None, FAILED_CHECK_CAVEAT
 
 
 #################################

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -454,8 +454,8 @@ class SearchWrapper(Wrapper):
             info["results"] = res
             # Display warning message if user searched on column(s) with null values
             if query:
-                nulls = table.stats.null_counts()
                 try:
+                    nulls = table.stats.null_counts()
                     complete, msg, caveat = results_complete(table.search_table, query, table._db, info.get("search_array"))
                     if complete:
                         flash_success("The results below are complete, since the LMFDB contains all " + msg)
@@ -488,10 +488,15 @@ class SearchWrapper(Wrapper):
                         flash_info("The completeness " + caveat)
                 except Exception as err:
                     import traceback
-                    msg = f"There was an error in the completeness checking code, so the search results below may or may not be complete: \n{err}"
-                    flash_info(msg)
-                    msg += "\n" + traceback.format_exc()
-                    app.logger.warning(msg)
+                    # ``results_complete`` no longer raises, but the null-count display above
+                    # also queries the database, so we keep this net.  Note that the error is
+                    # passed as an argument rather than interpolated: flash_info applies %
+                    # formatting to its first argument, so a % in the error text would raise
+                    # from inside this handler and produce the very 500 we are avoiding.
+                    flash_info("There was an error in the completeness checking code, so the search results below may or may not be complete: %s", err)
+                    app.logger.warning(
+                        "There was an error in the completeness checking code: %s\n%s",
+                        err, traceback.format_exc())
             return render_template(template, info=info, title=title, **template_kwds)
 
     def _diagram_search(self, info):


### PR DESCRIPTION
This PR fixes something that isn't broken.  There was an error in how Claude interpreted one of the logfile errors a couple days ago and when it handed the problem off to a subagent, that subagent correctly noted the error in the interpretation of the logs. But the subagent still made a few small suggested changes to our code to harden some of the completeness code.  In other words, this would not fix anything broken but help avoid future issues (in particular a very similar issue to #7090 and passing in an extra %).  

I'm including it as a PR in case we want to go ahead with the proposed modification.  I've looked at the code and run tests myself (Claude notes below that it couldn't run tests since it doesn't have access to the DB.)

Here are Claude's notes:
------

Completeness information is advisory metadata: it annotates search results that have already been computed, telling the user whether they are exhaustive.  A failure inside that machinery must never take down the request it is annotating.  In production a null-count query inside the check hit the statement timeout

    SELECT "id" FROM "nf_fields" WHERE "degree" = 2 AND "class_number" IS NULL LIMIT 1
    psycopg2.errors.QueryCanceled: canceling statement due to statement timeout

and the QueryCanceled escaped results_complete, producing a 500.  (The slow query itself is a separate, DBA-side problem and is untouched here.)

The guard goes in results_complete, the single choke point every caller goes through, rather than in any one endpoint.  SearchWrapper already had a try/except around its use, but the other callers did not, and a guard in the wrapper cannot help a caller that does not go through the wrapper. Putting it in results_complete covers the HTML search path, lmfdb_search, and any API or future caller uniformly.

On failure we log the traceback and return (None, None, FAILED_CHECK_CAVEAT): "completeness unknown" plus a caveat the caller can show.  Returning None is already the documented value for "no guarantee available", so no caller can misread it; crucially we never return True, which would be a data-integrity bug far worse than the 500.  Callers surface the caveat: the search page flashes "The completeness check did not finish, so the results may or may not be complete", and lmfdb_search writes the same line instead of its bare "Not guaranteed complete" verdict.

On exception breadth: this catches Exception deliberately.  The check runs database queries (statement timeouts), indexes into db (KeyError on a missing table), asserts invariants about query shape (AssertionError), and does Sage arithmetic on user-supplied bounds (ValueError, TypeError).  A narrower tuple would leave the same 500 in place for whichever class we failed to anticipate, which is precisely the defect.  KeyboardInterrupt and SystemExit still propagate.

Two smaller hardenings in the same block, same principle:

- table.stats.null_counts() moved inside SearchWrapper's existing try.  It is another database call feeding the same advisory display, and it sat outside the net.
- That handler built its flash message with an f-string and passed it as flash_info's format string, so an error text containing a percent sign would raise from inside the handler.  The error is now passed as an argument instead.

Verified without a database: pyflakes clean; the failure was simulated by exec'ing the real source of all three call sites against a checker stubbed to raise QueryCanceled, KeyError, AssertionError, ValueError and TypeError, confirming each path degrades, reports complete=None (never True), surfaces the caveat, and logs a traceback.  The existing tests in lmfdb/tests/test_utils.py need Sage and a live database and could not be run.