### PR TITLE
Don't build a default psycodict config for the devmirror connection

### DIFF
--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -424,8 +424,19 @@ class LMFDBSearchTable(PostgresSearchTable):
         check_space(grace_space_claimed[None], grace_default, "grace.mit.edu /var/lib/postgresql", ts_filter(grace_ops, None))
         check_space(grace_space_claimed["scratch"], grace_scratch, "grace.mit.edu /scratch", ts_filter(grace_ops, "scratch"))
 
-        # Get a connection to devmirror so that we can see which operations have been mirrored there
-        devmirror = PostgresDatabase(host="devmirror.lmfdb.xyz", user="lmfdb", password="lmfdb", port="5432")
+        # Get a connection to devmirror so that we can see which operations have been mirrored there.
+        # Every connection parameter is given explicitly, but we still pass along our own
+        # configuration: without it psycodict builds a default Configuration, which reads (and
+        # creates) a config.ini in the current directory, and in some versions parses sys.argv,
+        # so that an unrelated argument to the calling script aborts the upload.
+        devmirror = PostgresDatabase(
+            config=self._db.config,
+            host="devmirror.lmfdb.xyz",
+            user="lmfdb",
+            password="lmfdb",
+            port="5432",
+            dbname="lmfdb",
+        )
         dm_ops = list(devmirror._execute(op_cmd))
         # dm_finished is a set with logids that have finished mirroring; dm_space_claimed is a dictionary (by tablespace) of how much space the in-progress operations might need
         dm_finished, dm_space_claimed = get_space_needed(dm_ops)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,11 @@ flask-login
 flask-markdown
 markupsafe
 itsdangerous
-# the pgbinary extra installs the driver psycodict itself is built on
-psycodict[pgbinary] @ git+https://github.com/roed314/psycodict.git
+# the pgbinary extra installs the driver psycodict itself is built on.  We track
+# released versions rather than a git branch, so that what an install gets doesn't
+# depend on the day it was run; the upper bound is psycodict's next major version,
+# where its versioning policy allows breaking changes.
+psycodict[pgbinary]>=1.0.0rc1,<2
 pyflakes
 pytest
 pytest-cov


### PR DESCRIPTION
Number field uploads on lovelace have been dying inside `insert_many` with an argparse usage message for options the upload script doesn't have:

```
import_nf_data-new.py: error: unrecognized arguments: ED-prims.prep.out
usage: import_nf_data-new.py [-h] [-c FILE] [-s SECRETS] [--slowcutoff SLOWCUTOFF]
                             [--slowlogfile FILE] [--postgresql-host HOST] ...
```

Those options belong to psycodict's own argument parser, not to the script.

## What happens

`LMFDBSearchTable._check_locks` (the disk space audit that runs before `insert_many`, `upsert`, `copy_from`, ...) opens a second connection so it can see which operations have already been mirrored:

```python
devmirror = PostgresDatabase(host="devmirror.lmfdb.xyz", user="lmfdb", password="lmfdb", port="5432")
```

With no `config` argument, psycodict builds a default `Configuration`, which

* reads a `config.ini` from the *current directory*, creating one with psycodict's defaults (localhost/postgres) if there isn't one, and
* in psycodict before the 1.0 release candidate, parses `sys.argv` with psycodict's own parser, because it defaulted `readargs` to "am I running inside a script?"

The second one is fatal: the data file being imported isn't an option psycodict knows, so argparse prints its usage and exits — halfway through the upload, right after the `table_sizes()` query that the audit runs just before this line. It only bites non-interactive runs (a REPL has no `__main__.__file__`), and only when the script takes arguments, which is why hard-coding the filename "fixed" it.

psycodict [#119](https://github.com/roed314/psycodict/pull/119) turned the argv parsing off and stopped writing config files into the working directory, so current psycodict is not affected. This PR keeps LMFDB from depending on that.

## The change

**Pass our own configuration to the devmirror connection.** `PostgresDatabase` only builds a `Configuration` when it isn't given one, on every psycodict version, so this removes the failure mode rather than waiting for everyone's psycodict to be new enough. `dbname` is now given explicitly as well, so all five connection parameters come from this call and not from whichever configuration the caller happens to have; connection kwargs override the config's postgresql options, so the target is unchanged.

**Pin psycodict to a released version** instead of `git+https://github.com/roed314/psycodict.git` with no ref. The unpinned git URL meant the same install command produced different code depending on the day it was run — that is how an unreleased intermediate state (psycopg3 already in, #119 not yet) reached lovelace. `>=1.0.0rc1,<2` installs the published wheel, picks up 1.0.0 when it is released, and stops at the next major version, where psycodict's versioning policy allows breaking changes. psycodict's current default branch and the published 1.0.0rc1 are byte-identical in code, so this is not a downgrade for CI.

## Verification

Against the real devmirror server, running as a script with a stray argument, from a directory with no `config.ini`:

* the new call form connects (`host=devmirror.lmfdb.xyz dbname=lmfdb user=lmfdb`) and returns the 28 current `userdb.ongoing_operations` rows;
* no `config.ini` is created in the working directory;
* feeding it a config that points at a different host/port/user/dbname still connects to devmirror, confirming the explicit arguments win;
* the original failure reproduces exactly under the affected psycodict and does not under the fixed one.

`pyflakes` clean.

## Not addressed here

`_check_locks` runs for `upsert` too, so a loop of single-record upserts opens one devmirror connection per record. That is slow but correct, and predates this issue; caching the connection would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
