### PR TITLE
fix: show exponent one for cusp orbit sizes

### DIFF
--- a/lmfdb/modular_curves/test_modular_curves.py
+++ b/lmfdb/modular_curves/test_modular_curves.py
@@ -135,6 +135,9 @@ class ModCrvTest(LmfdbTest):
         assert "Cusp orbits" in L.get_data(as_text=True)
         assert r"$8^{6}\cdot16^{3}$" in L.get_data(as_text=True)
 
+        L = self.tc.get("/ModularCurve/Q/17.136.6.a.1", follow_redirects=True)
+        assert r"$8^{1}$" in L.get_data(as_text=True)
+
     def test_modcrv_label(self):
         L = self.tc.get("/ModularCurve/Q/48.576.21-48.bqz.1.2",follow_redirects=True)
         assert "Cummins and Pauli (CP) label" in L.get_data(as_text=True)

--- a/lmfdb/modular_curves/web_curve.py
+++ b/lmfdb/modular_curves/web_curve.py
@@ -39,8 +39,8 @@ def get_bread(tail=[]):
         tail = [(tail, " ")]
     return base + tail
 
-def showexp(c, wrap=True):
-    if c == 1:
+def showexp(c, wrap=True, include_one=False):
+    if c == 1 and not include_one:
         return ""
     elif wrap:
         return f"$^{{{c}}}$"
@@ -543,7 +543,7 @@ class WebModCurve(WebObj):
     def cusp_orbits_display(self):
         if not self.cusp_orbits:
             return ""
-        return "$" + r"\cdot".join(f"{w}{showexp(n, wrap=False)}" for w, n in self.cusp_orbits) + "$"
+        return "$" + r"\cdot".join(f"{w}{showexp(n, wrap=False, include_one=True)}" for w, n in self.cusp_orbits) + "$"
 
     @lazy_attribute
     def cm_discriminant_list(self):


### PR DESCRIPTION
## Summary

- display cusp orbit sizes with an explicit exponent of 1
- keep the existing compact notation for multiplicities greater than 1
- add a regression assertion for the example from #7038

The issue's maintainer confirmed this focused change was useful. I kept the rendering change local to cusp orbits and left cusp widths and other exponent displays unchanged.

## Validation

- `python -m py_compile lmfdb/modular_curves/web_curve.py lmfdb/modular_curves/test_modular_curves.py`
- `git diff --check`
- static assertions for the updated formatter and rendering call

The Sage integration test suite could not run in this checkout because Sage is not installed locally.

Closes #7038