### PR TITLE
Fix ECNF regulator search box

### DIFF
--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -511,7 +511,7 @@ def elliptic_curve_search(info, query):
     parse_ints(info,query,'class_size','class_size')
     parse_ints(info,query,'class_deg','class_deg')
     parse_ints(info,query,'sha','analytic order of &#1064;')
-    parse_floats(info,query,'reg','regulator')
+    parse_floats(info,query,'regulator',name='regulator',qfield='reg')
     parse_nf_jinv(info,query,'jinv','j-invariant',field_label=query.get('field_label'))
 
     if info.get('one') == "yes":

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -100,6 +100,10 @@ class EllCurveTest(LmfdbTest):
         assert '729.1-CMb1' in t and '1024.1-a1' in t and '73.1-a1' not in t
         L = self.tc.get('/EllipticCurve/?field=2.0.11.1&jinv=~-52893159101157376/11')
         assert '11.1-a1' not in L.get_data(as_text=True)
+        # Test regulator search
+        L = self.tc.get('/EllipticCurve/?regulator=8.4-9.1')
+        t = L.get_data(as_text=True)
+        assert '14763.2-b4' in t and '73.1-a1' not in t
 
     def test_browse(self):
         r"""


### PR DESCRIPTION
This just fixes a typo in the ECNF search when parsing the regulator.  The regulator search box has name set to `regulator` while the column is `reg`; this resulted in the regulator search box having no effect.  Rather surprising this has gone unnoticed for so long!

https://beta.lmfdb.org/EllipticCurve/?regulator=8.4-9.1  (returns all elliptic curves)
http://localhost:37777/EllipticCurve/?regulator=8.4-9.1  (returns the correct search page)