### PR TITLE
Say what the website needs from psycodict, rather than assuming it

### DIFF
--- a/.github/workflows/generate-matrix.py
+++ b/.github/workflows/generate-matrix.py
@@ -5,7 +5,7 @@ files = [
 "lmfdb/tests/test_dynamic_knowls.py lmfdb/tests/test_root.py lmfdb/hecke_algebras/test_hecke_algebras.py lmfdb/tests/test_homepage.py lmfdb/elliptic_curves/test_ell_curves.py lmfdb/elliptic_curves/test_browse_page.py",
 "lmfdb/sato_tate_groups/test_st.py lmfdb/hilbert_modular_forms/test_hmf.py lmfdb/tests/test_spelling.py lmfdb/tests/test_template_namespace.py lmfdb/tests/test_acknowlegments.py lmfdb/tests/test_tensor_products.py",
 "lmfdb/cluster_pictures/test_clusterpicture.py lmfdb/local_fields/test_localfields.py lmfdb/ecnf/test_ecnf.py lmfdb/ecnf/test_isog_class.py lmfdb/api/test_api.py lmfdb/characters/test_characters.py",
-"lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py",
+"lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py lmfdb/tests/test_connection_reset.py",
 "lmfdb/artin_representations/test_artin_representation.py lmfdb/genus2_curves/test_genus2_curves.py",
 "lmfdb/classical_modular_forms/test_cmf.py lmfdb/classical_modular_forms/test_cmf2.py",
     "lmfdb/lfunctions/test_lfunctions.py",

--- a/.github/workflows/matrix_includes.json
+++ b/.github/workflows/matrix_includes.json
@@ -60,12 +60,12 @@
         "server": "devmirror"
     },
     {
-        "files": "lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py",
+        "files": "lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py lmfdb/tests/test_connection_reset.py",
         "folders": "belyi higher_genus_w_automorphisms hypergm lattice maass_forms tests users",
         "server": "proddb"
     },
     {
-        "files": "lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py",
+        "files": "lmfdb/users/test_users.py lmfdb/lattice/test_lattice.py lmfdb/maass_forms/test_maass.py lmfdb/higher_genus_w_automorphisms/test_hgcwa.py lmfdb/belyi/test_belyi.py lmfdb/hypergm/test_hgm.py lmfdb/tests/test_utils.py lmfdb/tests/test_connection_reset.py",
         "folders": "belyi higher_genus_w_automorphisms hypergm lattice maass_forms tests users",
         "server": "devmirror"
     },

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -90,7 +90,7 @@ jobs:
     - name: checking that we didn't miss any test files
       shell: bash -l {0}
       # If this fails you need to update the file list above and file count
-      run: test $(find lmfdb -name 'test_*.py' -or -name '*_test.py' | wc -l) -eq 43
+      run: test $(find lmfdb -name 'test_*.py' -or -name '*_test.py' | wc -l) -eq 44
 
     - name: Config LMFDB to run tests against proddb
       if: matrix.files != 'lint' && matrix.server == 'proddb'

--- a/lmfdb/knowledge/knowl.py
+++ b/lmfdb/knowledge/knowl.py
@@ -142,12 +142,34 @@ class KnowlBackend(PostgresBase):
 
     def __init__(self):
         PostgresBase.__init__(self, 'db_knowl', db)
-        self._rw_knowldb = (getattr(db, "_can_read_write_knowls", None) or db.can_read_write_knowls)()
+        self._refresh_connection_capabilities()
         # we cache knowl titles for 10s
         self.caching_time = 10
         self.cached_titles_timestamp = 0
         self.cached_defines_timestamp = 0
         self.cached_titles = {}
+
+    def _refresh_connection_capabilities(self):
+        """
+        Ask the database what the current session may do with the knowls.
+
+        Fails closed: nothing is editable until the session has said so.
+        """
+        self._rw_knowldb = False
+        checker = getattr(db, "_can_read_write_knowls", None) or db.can_read_write_knowls
+        self._rw_knowldb = checker()
+
+    def _connection_reset(self):
+        """
+        Called by psycodict once it has replaced the connection this object
+        uses (roed314/psycodict#135); a no-op in psycodict without that hook.
+
+        Whether knowls may be edited describes the session rather than this
+        object, and a replacement connection can reach a standby, or a role
+        whose privileges have changed, so the cached answer has to be asked
+        again rather than carried over.
+        """
+        self._refresh_connection_capabilities()
 
     def _safe_execute(self, query, values=None):
         # Every 20 minutes we reload the knowl database on production

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -12,6 +12,15 @@ from psycodict.database import PostgresDatabase
 from psycodict.searchtable import PostgresSearchTable
 from psycodict.statstable import PostgresStatsTable
 
+try:
+    from psycodict.grants import LMFDBGrantPolicy
+except ImportError:
+    # psycodict before roed314/psycodict#137, which granted these privileges
+    # unconditionally and so has nothing to be told about them.  Delete this
+    # fallback once the psycodict requirement is pinned past that PR.
+    LMFDBGrantPolicy = None
+
+
 def overrides(super_class):
     def overrider(method):
         super_method = getattr(super_class, method.__name__)
@@ -483,6 +492,15 @@ class LMFDBDatabase(PostgresDatabase):
             config = ConfigWrapper(config)
         # else: config is already a Configuration object, use it as-is
 
+        if LMFDBGrantPolicy is not None:
+            # psycodict's default policy grants nothing, so a table it creates
+            # -- or swaps in during a reload -- would be readable only by its
+            # owner.  This policy is what psycodict used to do: SELECT to lmfdb
+            # and webserver, INSERT to webserver on counts and stats.  It warns
+            # rather than raises when a role is missing, since a development
+            # database usually has neither; a deployment that must have both
+            # can pass LMFDBGrantPolicy(missing_role="error") instead.
+            kwargs.setdefault("grant_policy", LMFDBGrantPolicy())
         PostgresDatabase.__init__(self, config, **kwargs)
         self.is_verifying = False  # set to true when importing lmfdb.verify
         self.__editor = config.logging_options.get("editor", "")

--- a/lmfdb/tests/test_connection_reset.py
+++ b/lmfdb/tests/test_connection_reset.py
@@ -1,0 +1,67 @@
+# Tests for the state the knowl and user backends derive from the database
+# session, which psycodict asks them to refresh when it replaces a connection.
+#
+# A real failover is not something a test suite can arrange, so these tests
+# stand in for one: they change what the database reports about the session and
+# call the hook psycodict would call, which is the part of the mechanism that
+# lives in the LMFDB.
+
+import unittest
+
+from lmfdb import db
+from lmfdb.knowledge.knowl import knowldb
+from lmfdb.users.pwdmanager import userdb
+
+
+class ConnectionResetTest(unittest.TestCase):
+    def _set_capability(self, attr, value):
+        """
+        Make the database report ``value`` for one of its capability flags,
+        returning what it reported before.
+        """
+        old = getattr(db, attr)
+        setattr(db, attr, value)
+        return old
+
+    def test_knowl_backend_follows_the_session(self):
+        old = self._set_capability("_read_and_write_knowls", False)
+        try:
+            knowldb._connection_reset()
+            assert not knowldb.can_read_write_knowls(), \
+                "knowl editing stayed enabled after the session lost the privilege"
+
+            self._set_capability("_read_and_write_knowls", True)
+            knowldb._connection_reset()
+            assert knowldb.can_read_write_knowls(), \
+                "knowl editing stayed disabled after the session regained the privilege"
+        finally:
+            self._set_capability("_read_and_write_knowls", old)
+            knowldb._connection_reset()
+
+    def test_user_backend_follows_the_session(self):
+        old = self._set_capability("_read_and_write_userdb", False)
+        try:
+            userdb._connection_reset()
+            assert not userdb.can_read_write_userdb(), \
+                "userdb stayed writable after the session lost the privilege"
+            # Failing closed means the columns the session could not confirm
+            # are not left behind either.
+            assert userdb._cols == userdb._username_full_name
+
+            self._set_capability("_read_and_write_userdb", True)
+            userdb._connection_reset()
+            assert userdb.can_read_write_userdb(), \
+                "userdb stayed read-only after the session regained the privilege"
+        finally:
+            self._set_capability("_read_and_write_userdb", old)
+            userdb._connection_reset()
+
+    def test_grant_policy_is_the_lmfdb_one(self):
+        # Only meaningful once psycodict has policies at all; before that it
+        # grants these same privileges on its own.
+        try:
+            from psycodict.grants import LMFDBGrantPolicy
+        except ImportError:
+            self.skipTest("this psycodict has no grant policies")
+        assert db.grant_policy == LMFDBGrantPolicy(), \
+            "the database is not granting what the website needs on the tables it creates"

--- a/lmfdb/users/pwdmanager.py
+++ b/lmfdb/users/pwdmanager.py
@@ -23,15 +23,52 @@ class PostgresUserTable(PostgresBase):
         PostgresBase.__init__(self, 'db_users', db)
         # never narrow down the rmin-rmax range, only increase it!
         self.rmin, self.rmax = -10000, 10000
-        self._rw_userdb = (getattr(db, "_can_read_write_userdb", None) or db.can_read_write_userdb)()
         #TODO use this instead of hardcoded columns names
         #with identifiers
         self._username_full_name = ["username", "full_name"]
-        if self._rw_userdb:
-            cur = self._execute(SQL("SELECT column_name FROM information_schema.columns WHERE table_schema = %s AND table_name = %s"), ['userdb', 'users'])
-            self._cols = [rec[0] for rec in cur]
-        else:
-            self._cols = self._username_full_name
+        self._refresh_connection_capabilities()
+
+    def _refresh_connection_capabilities(self):
+        """
+        Ask the database what the current session may do with userdb.users,
+        and which columns it has.
+
+        This fails closed: the restricted answers are installed first and are
+        only widened once the session has been found able to read and write.
+        The query is issued on ``self.conn`` rather than through ``_execute``
+        because this also runs while psycodict is recovering from a failure
+        inside ``_execute``, which it would otherwise re-enter.
+        """
+        self._rw_userdb = False
+        self._cols = self._username_full_name
+
+        checker = getattr(db, "_can_read_write_userdb", None) or db.can_read_write_userdb
+        if not checker():
+            return
+        cur = self.conn.cursor()
+        try:
+            cur.execute(SQL("SELECT column_name FROM information_schema.columns WHERE table_schema = %s AND table_name = %s"), ['userdb', 'users'])
+            cols = [rec[0] for rec in cur.fetchall()]
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+        finally:
+            cur.close()
+        self._cols = cols
+        self._rw_userdb = True
+
+    def _connection_reset(self):
+        """
+        Called by psycodict once it has replaced the connection this object
+        uses (roed314/psycodict#135); a no-op in psycodict without that hook.
+
+        Whether userdb may be written to describes the session rather than this
+        object, and a replacement connection can reach a standby, or a role
+        whose privileges have changed, so the cached answers have to be asked
+        again rather than carried over.
+        """
+        self._refresh_connection_capabilities()
 
     def can_read_write_userdb(self):
         return self._rw_userdb


### PR DESCRIPTION
Preparation for psycodict's security release (roed314/psycodict#133–#137). **Everything here is inert under the psycodict we currently install**, so it can merge now; the dependency bump then becomes a one-line change with no coupled behaviour change.

### 1. Ask for the grants the website needs (roed314/psycodict#137)

Until now psycodict granted `SELECT` to `lmfdb` and `webserver` on every relation it created, plus `INSERT` to `webserver` on counts and stats — the LMFDB's deployment hard-coded in a general-purpose library. After the release its default policy grants nothing, so a table we create, **or one a reload swaps in**, would come back readable only by its owner: the website would lose access to a reloaded table.

`LMFDBDatabase` now asks for exactly the old privileges by name:

```python
kwargs.setdefault("grant_policy", LMFDBGrantPolicy())
```

The import is guarded by `try`/`except ImportError`, so the same source works against both psycodict versions; the fallback is marked for deletion once the requirement is pinned past #137. `LMFDBGrantPolicy` defaults to `missing_role="skip"` (a warning), which is what a development database without those roles wants — whether prod should use `missing_role="error"` instead is a separate decision for after the bump.

### 2. Refresh the cached capability flags on reconnect (roed314/psycodict#135)

`KnowlBackend` and `PostgresUserTable` worked out whether the session may write to knowls and to `userdb` once, at construction, and never asked again. psycodict now rebuilds a broken connection more carefully and recomputes those answers from the replacement — which can reach a standby, or a role whose grants have changed — and calls `_connection_reset()` on every registered object once the replacement and its capability snapshot have been adopted.

Both backends now implement that hook. Without it, after a failover `db` knows it is read-only while the knowl backend still believes it may write (PostgreSQL still refuses the write; what breaks is our own gating and error messages), and after a failback knowl editing stays disabled until the process restarts.

The user backend **fails closed**: the restricted answers are installed first and widened only once the new session has been found able to read and write. It queries `self.conn` directly rather than through `_execute`, since the hook runs while psycodict is recovering from a failure *inside* `_execute`, which it would otherwise re-enter. The query is issued via a plain cursor so that it works under both psycopg2 and psycopg3.

### Tests

`lmfdb/tests/test_connection_reset.py` stands in for a failover: it changes what the database reports about the session, calls the hook psycodict would call, and checks that each backend's cached answer followed — in both directions, and that the user backend fails closed. The grant-policy test skips against a psycodict without `psycodict.grants`. The new file is registered in the CI matrix and the test-file count guard.

### Verification

- Against psycodict 1.0.0rc1, the version we install today: 2 passed, 1 skipped (the policy test, as intended), and `lmfdb/users/test_users.py` still passes.
- Against roed314/psycodict#133–#137 merged: 3 passed. A real `db.reset_connection()` was seen to call both hooks and re-derive the cached answers after they were deliberately poisoned.
- `pyflakes` and `ruff check --preview --select=E722` clean on the changed files.

### Not in this PR

- **Bumping the psycodict requirement** — after this lands.
- **The three read-only pre-upgrade checks** (complete `name`/`name_counts`/`name_stats` families in `meta_tables`, `CHECK` constraints in `meta_constraints`, `meta_tables` rows that are not search tables). All three return empty on **devmirror**, and `hgcwa_per_group_stats` has its full family there; **prod and beta still need checking** before the bump, since any hit makes `refresh_tables()` raise and the database will not connect.
- **Revoking `lmfdb`/`webserver` from the historical `_oldN` backup tables** — the new policy would not grant them, but it does not retroactively remove what is already there. Administrative cleanup, separate from the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
