### PR TITLE
Remove obsolete callback-AJAX machinery

### DIFF
--- a/lmfdb/app.py
+++ b/lmfdb/app.py
@@ -788,7 +788,6 @@ def WhiteListedRoutes():
         'alive',
         'api',
         'bigpicture',
-        'callback_ajax',
         'citation',
         'contact',
         'editorial-board',

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -892,34 +892,6 @@ def ajax_result(id):
         return "<expired>"
 
 
-def ajax_more(callback, *arg_list, **kwds):
-    from .web_display import web_latex
-    inline = kwds.get('inline', True)
-    text = kwds.get('text', 'more')
-    nonce = hex(random.randint(0, 1 << 128))
-    if inline:
-        args = arg_list[0]
-        arg_list = arg_list[1:]
-        if isinstance(args, tuple):
-            res = callback(*arg_list)
-        elif isinstance(args, dict):
-            res = callback(**args)
-        else:
-            res = callback(args)
-        res = web_latex(res)
-    else:
-        res = ''
-    if arg_list:
-        url = ajax_url(ajax_more, callback, *arg_list, inline=True, text=text)
-        return """<span id='%(nonce)s'>%(res)s <a onclick="$('#%(nonce)s').load('%(url)s', function() { renderMathInElement($('#%(nonce)s').get(0),katexOpts);}); return false;" href="#">%(text)s</a></span>""" % locals()
-    else:
-        return res
-
-
-def image_src(G):
-    return ajax_url(image_callback, G, _ajax_sticky=True)
-
-
 def image_callback(G):
     P = G.plot()
     _, filename = tempfile.mkstemp('.png')

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -1,10 +1,8 @@
 import cmath
 import math
 import os
-import random
 import re
 import tempfile
-import time
 from copy import copy
 from itertools import islice
 from types import GeneratorType
@@ -35,7 +33,7 @@ from sage.all import (
 from sage.misc.functional import round
 from sage.structure.element import Element
 
-from lmfdb.app import app, is_beta, is_debug_mode, _url_source
+from lmfdb.app import is_beta, is_debug_mode, _url_source
 
 
 def integer_divisors(n):
@@ -800,96 +798,6 @@ def flash_info(errmsg, *args):
 def flash_success(msg, *args):
     """ flash information in green with args in black; msg may contain markup, including latex math mode"""
     flash(Markup(msg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)), "success")
-
-
-################################################################################
-#  Ajax utilities
-################################################################################
-
-# LinkedList is used in Ajax below
-class LinkedList():
-    __slots__ = ('value', 'next', 'timestamp')
-
-    def __init__(self, value, nxt):
-        self.value = value
-        self.next = nxt
-        self.timestamp = time.time()
-
-    def append(self, value):
-        self.next = LinkedList(value, self)
-        return self.next
-
-
-class AjaxPool():
-    def __init__(self, size=1e4, expiration=3600):
-        self._size = size
-        self._key_list = self._head = LinkedList(None, None)
-        self._expiration = expiration
-        self._all = {}
-
-    def get(self, key, value=None):
-        return self._all.get(key, value)
-
-    def __contains__(self, key):
-        return key in self._all
-
-    def __setitem__(self, key, value):
-        self._key_list = self._key_list.append(key)
-        self._all[key] = value
-
-    def __getitem__(self, key):
-        res = self._all[key]
-        self.purge()
-        return res
-
-    def __delitem__(self, key):
-        del self._all[key]
-
-    def pop_key(self):
-        head = self._head
-        if head.next is None:
-            return None
-        else:
-            key = head.value
-            self._head = head.next
-            return key
-
-    def purge(self):
-        if self._size:
-            while len(self._all) > self._size:
-                key = self.pop_key()
-                if key in self._all:
-                    del self._all[key]
-        if self._expiration:
-            oldest = time.time() - self._expiration
-            while self._head.timestamp < oldest:
-                key = self.pop_key()
-                if key in self._all:
-                    del self._all[key]
-
-
-pending = AjaxPool()
-def ajax_url(callback, *args, **kwds):
-    if '_ajax_sticky' in kwds:
-        _ajax_sticky = kwds.pop('_ajax_sticky')
-    else:
-        _ajax_sticky = False
-    if not isinstance(args, tuple):
-        args = args,
-    nonce = hex(random.randint(0, 1 << 128))
-    pending[nonce] = callback, args, kwds, _ajax_sticky
-    return url_for('ajax_result', id=nonce)
-
-
-@app.route('/callback_ajax/<id>')
-def ajax_result(id):
-    if id in pending:
-        f, args, kwds, _ajax_sticky = pending[id]
-        if not _ajax_sticky:
-            del pending[id]
-        return f(*args, **kwds)
-    else:
-        return "<expired>"
 
 
 def image_callback(G):


### PR DESCRIPTION
Found while auditing `lmfdb/utils` for an upcoming refactor.

`ajax_more` and `image_src` in `lmfdb/utils/utilities.py` have no callers anywhere in the repository (Python, templates, or JS), and neither is exported in `lmfdb/utils/__init__.py`. Once they are gone, nothing calls `ajax_url` either, which makes the whole callback pool unreachable. So this removes:

- `ajax_more`, `image_src`
- `LinkedList`, `AjaxPool`, `pending`, `ajax_url`, and the `/callback_ajax/<id>` endpoint `ajax_result`
- the now-unused `random`, `time`, and `app` imports in `utilities.py`
- the stale `'callback_ajax'` entry in `WhiteListedRoutes()` in `lmfdb/app.py`

`image_callback` is kept: it is called directly by the crystals and hypergeometric-motive image routes, not through the callback pool. (An earlier version of this description said otherwise; that was wrong.)

The removed `/callback_ajax/<id>` URLs were nonce-keyed and generated per request, so no durable link can point at them.

Verified: repository-wide searches find no remaining references to any removed identifier; `pyflakes start-lmfdb.py user-manager.py lmfdb/` is clean; both edited files compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)