### PR TITLE
Strip stale hst when canonicalizing legacy abstract-group search URLs

### DIFF
--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -796,7 +796,12 @@ def index():
         if search_type in legacy_searches:
             endpoint, new_search_type = legacy_searches[search_type]
             args = request.args.to_dict(flat=False)
-            args.pop("search_type", None)
+            # Drop both mode parameters: the destination route encodes the
+            # object type, and SearchWrapper falls back to hst when there is
+            # no explicit search_type, so a stale hidden hst would otherwise
+            # override the mode we just resolved.
+            for key in ("search_type", "hst"):
+                args.pop(key, None)
             if new_search_type is not None:
                 args["search_type"] = [new_search_type]
             return redirect(url_for(endpoint, **args), 307)

--- a/lmfdb/groups/abstract/test_browse_page.py
+++ b/lmfdb/groups/abstract/test_browse_page.py
@@ -19,7 +19,9 @@ class AbGpsHomeTest(LmfdbTest):
     def test_legacy_search_urls(self):
         r"""
         Check that old search URLs redirect to the new landing pages without
-        dropping their filters.
+        dropping their filters.  The hidden hst field records the previous
+        search mode, so it must not survive the redirect: SearchWrapper falls
+        back to hst when there is no explicit search_type.
         """
         cases = [
             ("/Groups/Abstract/?search_type=Subgroups&ambient=128.207",
@@ -34,11 +36,25 @@ class AbGpsHomeTest(LmfdbTest):
              {"dim": ["3"], "search_type": ["RandomComplexCharacter"]}),
             ("/Groups/Abstract/?search_type=ConjugacyClasses&group=12.4",
              "/Groups/Abstract/ConjugacyClasses", {"group": ["12.4"]}),
+            # The legacy mode may only be present in the hidden hst field.
+            ("/Groups/Abstract/?hst=Subgroups&ambient=128.207",
+             "/Groups/Abstract/Subgroups", {"ambient": ["128.207"]}),
+            ("/Groups/Abstract/?hst=RandomSubgroup&ambient=128.207",
+             "/Groups/Abstract/Subgroups",
+             {"ambient": ["128.207"], "search_type": ["RandomSubgroup"]}),
+            # An explicit search_type must keep winning over a stale hst.
+            ("/Groups/Abstract/?search_type=Subgroups&hst=RandomSubgroup&ambient=128.207",
+             "/Groups/Abstract/Subgroups", {"ambient": ["128.207"]}),
+            ("/Groups/Abstract/?search_type=ComplexCharacters&hst=RandomComplexCharacter&dim=3",
+             "/Groups/Abstract/ComplexCharacters", {"dim": ["3"]}),
+            # Repeated values of a non-routing parameter are preserved.
+            ("/Groups/Abstract/?search_type=Subgroups&order=8&order=16",
+             "/Groups/Abstract/Subgroups", {"order": ["8", "16"]}),
         ]
         for source, expected_path, expected_query in cases:
             response = self.tc.get(source)
-            target = urlsplit(response.location)
             assert response.status_code == 307
+            target = urlsplit(response.location)
             assert target.path == expected_path
             assert parse_qs(target.query) == expected_query
 


### PR DESCRIPTION
Follow-up to #7009, which added the legacy-URL redirect in `lmfdb/groups/abstract/index()`. The redirect resolves the search mode from an explicit `search_type`, falling back to the hidden `hst` field, but then copies every query parameter to the object-specific route while removing only `search_type`. `SearchWrapper` itself falls back to `hst` when no explicit `search_type` is present (`lmfdb/utils/search_wrapper.py:322,928`), so a stale `hst` becomes authoritative at the destination and overrides the mode that was just resolved.

### Symptom

```
/Groups/Abstract/?search_type=Subgroups&hst=RandomSubgroup&ambient=128.207
```

The root route correctly gives precedence to the explicit `search_type=Subgroups`, but redirects to `/Groups/Abstract/Subgroups?hst=RandomSubgroup&ambient=128.207`, which has no explicit `search_type` and so performs a random lookup instead. Verified against the current `main` with the Flask test client:

| | final page |
|---|---|
| before | `/Groups/Abstract/sub/128.207.8.k1.a1` — "Non-normal subgroup $C_2\times C_8 \subseteq C_4^2.D_4$" |
| after | `/Groups/Abstract/Subgroups?ambient=128.207` — "Subgroup search results" |

This is reachable in normal use, not just by hand-editing a URL: a random search renders a results/refinement form whose hidden `hst` records the random mode, and submitting the ordinary "Search again" action then supplies an explicit non-random `search_type`.

### Fix

Drop `hst` alongside `search_type` before building the canonical destination URL. The destination route already encodes the object type, and the deliberate `RandomSubgroup` / `RandomComplexCharacter` search types are still re-added explicitly, so random lookups are unaffected.

### Tests

`AbGpsHomeTest.test_legacy_search_urls` gains five cases: `hst`-only ordinary mode, `hst`-only random mode, the two conflicting explicit-vs-hidden mode cases, and one case checking that a repeated non-routing filter stays repeated (the reason the code uses `to_dict(flat=False)`). The status assertion now precedes parsing `response.location`, so a missing redirect fails at the more informative assertion.

The new cases fail on `main` and pass with the fix.

### Validation

- `sage -python -m pytest -q lmfdb/groups/abstract/` — 78 passed
- `python3 -m compileall -q lmfdb`, `pyflakes`, `ruff check --preview --select=E722`, `git diff --check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
