### PR TITLE
Check the bound in PrimeBound

### DIFF
--- a/lmfdb/tests/test_utils.py
+++ b/lmfdb/tests/test_utils.py
@@ -400,6 +400,8 @@ class UtilsTest(unittest.TestCase):
                 ("artin_reps", {'GaloisLabel': '8T34', 'Conductor': {'$gte': 1, '$lte': 200}}),
                 ("gps_groups", {'order': {'$gte': 300, '$lte': 600}}),
                 ("ec_curvedata", {'rank': 6}),
+                ("ec_curvedata", {'conductor': 1000000007}),   # prime, but past the 300 million prime conductor bound
+                ("ec_curvedata", {'conductor': {'$in': [1000003, 1000000007]}}),   # all prime, but not all within the bound
                 ("hgcwa_passports", {'genus': 6}),
                 ("av_fq_isog", {'g': 6, 'q': 3}),
                 ("belyi_galmaps", {'deg': 8}),

--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -805,7 +805,11 @@ class PrimeBound(Bound):
     """
     def __call__(self, db, Ds):
         Ds = [self.cls(D) for D in Ds]
-        return all(D.is_finite() and all(is_prime(p) for p in D) for D in Ds)
+        # The bound is checked first, both because a value outside it is not certified
+        # complete however prime it is, and because it rules out large ranges without
+        # iterating over them.  ``is_finite`` is still needed: the bounds are typically
+        # unbounded below, so passing it does not make the set enumerable.
+        return super().__call__(db, Ds) and all(D.is_finite() and all(is_prime(p) for p in D) for D in Ds)
 
 
 class Smooth(ColTest):


### PR DESCRIPTION
`PrimeBound.__call__` in `lmfdb/utils/completeness.py` checked that the queried values were finite sets of primes, but never checked them against the bound it was constructed with, unlike its sibling `CPrimeBound.__call__` which calls `super().__call__(db, Ds)`.

The one registered `PrimeBound` checker is

```python
("conductor", PrimeBound(300000000), "elliptic curves with prime conductor at most 300 million"),
```

so any prime conductor was certified complete, however large:

```
sage: results_complete("ec_curvedata", {"conductor": 1000000007}, db)
(True, 'elliptic curves with prime conductor at most 300 million', None)
```

1000000007 is prime but well past the 300 million bound, so that search was wrongly reported as complete.

## Fix

Delegate the range check to `Bound.__call__`, as `CPrimeBound` already does. The bound is checked before primality so that a large range (e.g. `{"$gte": 1, "$lte": 10**12}`) is rejected without iterating over it; `is_finite` is still needed, since the bounds are typically unbounded below.

No previously passing case relied on the missing check: the only `test_complete` case reaching this checker is `{'conductor': 1000003}`, which is inside the bound and still returns the same reason, and `{'conductor': 76204800}` was already falling through `PrimeBound` on primality to the `Smooth(10)` checker. Adding a conjunct can only turn `True` into `False`, so the not-complete cases are unaffected.

## Tests

Two regression cases added to the not-complete list in `test_complete`: the scalar `{'conductor': 1000000007}`, and `{'conductor': {'$in': [1000003, 1000000007]}}` where every value is prime but not all lie under the bound. Both fail on the unpatched code and pass with the fix.

Run against devmirror:

- `lmfdb/tests/test_utils.py` — 19 passed
- `lmfdb/tests/test_cmdline_search.py` — 62 passed

Found while revising a separate branch adding congruence support to the completeness checker; this is independent of that work and is based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)