### PR TITLE
Fix 500 on CM elliptic curve isogeny class pages

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -175,7 +175,9 @@ class ECisog_class():
         if self.cm:
             # set CM field for Properties box.
             D = integer_squarefree_part(ZZ(self.cm))
-            coeffs = [(1-D)//4,-1,1] if D % 4 == 1 else [-D,0,1]
+            # int() everything so that the query list is not a mix of Sage Integers
+            # and Python ints, which psycopg cannot adapt
+            coeffs = [int((1-D)//4),-1,1] if D % 4 == 1 else [int(-D),0,1]
             lab = db.nf_fields.lucky({'coeffs': coeffs}, projection='label')
             self.CMfield = field_pretty(lab)
         else:

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -126,6 +126,16 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/Q/11/a/')
         assert '[0, -1, 1, 0, 0]' in L.get_data(as_text=True)
 
+    def test_cm_isogeny_class(self):
+        # The CM field shown in the Properties box is looked up in nf_fields
+        # by coefficient list; this 500ed when that list mixed Sage Integers
+        # with Python ints (see #7129).  27.a and 32.a exercise the two
+        # branches computing the coefficient list.
+        L = self.tc.get('/EllipticCurve/Q/27/a/')
+        assert r'\Q(\sqrt{-3})' in L.get_data(as_text=True)
+        L = self.tc.get('/EllipticCurve/Q/32/a/')
+        assert r'\Q(\sqrt{-1})' in L.get_data(as_text=True)
+
     def test_dl_qexp(self):
         L = self.tc.get('/EllipticCurve/Q/download_qexp/66.c3/100')
         assert '0,1,1,1,1,-4,1,-2,1,1,-4,1,1,4,-2,-4,1,-2,1,0,-4,-2,1,-6,1,11,4,1,-2,10,-4,-8,1,1,-2,8,1,-2,0,4,-4,2,-2,4,1,-4,-6,-2,1,-3,11,-2,4,4,1,-4,-2,0,10,0,-4,-8,-8,-2,1,-16,1,-12,-2,-6,8,2,1,-6,-2,11,0,-2,4,10,-4,1,2,4,-2,8,4,10,1,10,-4,-8,-6,-8,-2,0,1,-2,-3,1,11' in L.get_data(as_text=True)


### PR DESCRIPTION
All CM elliptic curve isogeny class pages (e.g. https://www.lmfdb.org/EllipticCurve/Q/27/a/, `1728.m`, `74529.y`) currently return a 500 on www.lmfdb.org, with this in the prodweb1 flasklog:

```
psycopg.DataError: cannot dump lists of mixed types; got: Integer, int
  File ".../lmfdb/elliptic_curves/isog_class.py", line 179, in make_class
    lab = db.nf_fields.lucky({'coeffs': coeffs}, projection='label')
... with values [[1, -1, 1], 1]
```

**Diagnosis**: in `make_class`, `D = integer_squarefree_part(ZZ(self.cm))` is a Sage `Integer`, so `coeffs = [(1-D)//4,-1,1]` (resp. `[-D,0,1]`) mixes a Sage `Integer` with Python `int` literals. The psycopg2-based psycodict adapted each element independently, but the psycopg3-based psycodict now on the web servers refuses mixed-type lists (homogeneous lists, including all-`Integer` ones, are fine). The code itself is unchanged since 2020; the rollout of psycopg3 exposed it.

**Fix**: wrap the computed entries in `int()` so the list is homogeneous.

**Verification** (local checkout with psycodict 1.0.0rc1/psycopg3 against devmirror, via the Flask test client):
- Before: `/EllipticCurve/Q/27/a/` raises the same `DataError`; after: 200 with CM field `\(\Q(\sqrt{-3})\)` in the Properties box.
- `/EllipticCurve/Q/1728/m/` and `/EllipticCurve/Q/74529/y/` also 200 with CM fields shown; non-CM control `/EllipticCurve/Q/389/a/` unaffected.
- Checked the other `nf_fields.lucky({'coeffs': ...})` call sites (`web_number_field.from_coeffs`, `discrootfieldcoeffs` friend lookup): those lists are all Python ints in practice, and prod number field pages return 200.

A twin PR targets `web` so production can pick this up immediately: the file is identical on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)