### PR TITLE
Fix 500 on CM elliptic curve isogeny class pages (web hotfix)

### DIFF
--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -175,7 +175,9 @@ class ECisog_class():
         if self.cm:
             # set CM field for Properties box.
             D = integer_squarefree_part(ZZ(self.cm))
-            coeffs = [(1-D)//4,-1,1] if D % 4 == 1 else [-D,0,1]
+            # int() everything so that the query list is not a mix of Sage Integers
+            # and Python ints, which psycopg cannot adapt
+            coeffs = [int((1-D)//4),-1,1] if D % 4 == 1 else [int(-D),0,1]
             lab = db.nf_fields.lucky({'coeffs': coeffs}, projection='label')
             self.CMfield = field_pretty(lab)
         else:


### PR DESCRIPTION
Production hotfix twin of #7129 (see there for full diagnosis and verification); the fix is a clean cherry-pick, and `isog_class.py` is identical on `main` and `web`.

TL;DR: every CM isogeny class page (e.g. https://www.lmfdb.org/EllipticCurve/Q/27/a/) 500s on www.lmfdb.org because the CM-field query list mixes a Sage `Integer` with Python `int`s, which the psycopg3-based psycodict refuses to adapt (`psycopg.DataError: cannot dump lists of mixed types; got: Integer, int`). Wrapping the computed entries in `int()` makes the list homogeneous and the pages render again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)