### PR TITLE
Set the web workers' statement timeout explicitly

### DIFF
--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -501,6 +501,22 @@ class LMFDBDatabase(PostgresDatabase):
             # database usually has neither; a deployment that must have both
             # can pass LMFDBGrantPolicy(missing_role="error") instead.
             kwargs.setdefault("grant_policy", LMFDBGrantPolicy())
+        # The web workers connect as the ``webserver`` role and must not run a
+        # query forever.  psycodict used to hand that role a 25 second
+        # statement timeout by inferring it from the role name; a generic
+        # library should not do that, so LMFDB now asks for the timeout
+        # explicitly here.  Passing session_settings (rather than relying on
+        # the old default) works on every psycodict version: a psycodict that
+        # still applies the role default sees an explicit value and uses it,
+        # and one that has dropped the role default gets the value from here.
+        user = kwargs.get("user")
+        if user is None:
+            try:
+                user = config.postgresql_options.get("user")
+            except AttributeError:
+                user = None
+        if user == "webserver":
+            kwargs.setdefault("session_settings", {"statement_timeout": "25s"})
         PostgresDatabase.__init__(self, config, **kwargs)
         self.is_verifying = False  # set to true when importing lmfdb.verify
         self.__editor = config.logging_options.get("editor", "")

--- a/lmfdb/lmfdb_database.py
+++ b/lmfdb/lmfdb_database.py
@@ -20,6 +20,17 @@ except ImportError:
     # fallback once the psycodict requirement is pinned past that PR.
     LMFDBGrantPolicy = None
 
+# Whether this psycodict takes session settings as a constructor argument.  One
+# that predates it (1.0.0rc1, which requirements.txt still allows) forwards
+# unknown keywords to psycopg.connect, where session_settings is not a
+# connection parameter and so would break the connection outright; it also
+# still applies its own 25 second timeout to the webserver role, so there is
+# nothing to restore there.  Delete this flag and its use below once the
+# psycodict requirement is pinned past the first release with the argument.
+_PSYCODICT_HAS_SESSION_SETTINGS = (
+    "session_settings" in inspect.signature(PostgresDatabase.__init__).parameters
+)
+
 
 def overrides(super_class):
     def overrider(method):
@@ -501,22 +512,20 @@ class LMFDBDatabase(PostgresDatabase):
             # database usually has neither; a deployment that must have both
             # can pass LMFDBGrantPolicy(missing_role="error") instead.
             kwargs.setdefault("grant_policy", LMFDBGrantPolicy())
-        # The web workers connect as the ``webserver`` role and must not run a
-        # query forever.  psycodict used to hand that role a 25 second
-        # statement timeout by inferring it from the role name; a generic
-        # library should not do that, so LMFDB now asks for the timeout
-        # explicitly here.  Passing session_settings (rather than relying on
-        # the old default) works on every psycodict version: a psycodict that
-        # still applies the role default sees an explicit value and uses it,
-        # and one that has dropped the role default gets the value from here.
-        user = kwargs.get("user")
-        if user is None:
-            try:
-                user = config.postgresql_options.get("user")
-            except AttributeError:
-                user = None
-        if user == "webserver":
-            kwargs.setdefault("session_settings", {"statement_timeout": "25s"})
+        if _PSYCODICT_HAS_SESSION_SETTINGS:
+            # The web workers connect as the ``webserver`` role and must not
+            # run a query forever.  psycodict used to hand that role a 25
+            # second statement timeout by inferring it from the role name; a
+            # generic library should not act on a role name, so LMFDB asks for
+            # the timeout explicitly here (roed314/psycodict#146).  A keyword
+            # picks the role by being passed at all, not by being truthy, and
+            # session_settings=None asks psycodict for no settings of its own,
+            # which for the LMFDB means these.  An explicit mapping is left
+            # alone, including {} for a caller that wants no timeout.
+            postgresql_options = getattr(config, "postgresql_options", {}) or {}
+            user = kwargs["user"] if "user" in kwargs else postgresql_options.get("user")
+            if user == "webserver" and kwargs.get("session_settings") is None:
+                kwargs["session_settings"] = {"statement_timeout": "25s"}
         PostgresDatabase.__init__(self, config, **kwargs)
         self.is_verifying = False  # set to true when importing lmfdb.verify
         self.__editor = config.logging_options.get("editor", "")

--- a/lmfdb/tests/test_connection_reset.py
+++ b/lmfdb/tests/test_connection_reset.py
@@ -7,10 +7,13 @@
 # lives in the LMFDB.
 
 import unittest
+from unittest.mock import patch
 
-from lmfdb import db
+from lmfdb import db, lmfdb_database
+from lmfdb.lmfdb_database import LMFDBDatabase
 from lmfdb.knowledge.knowl import knowldb
 from lmfdb.users.pwdmanager import userdb
+from psycodict.database import PostgresDatabase
 
 
 class ConnectionResetTest(unittest.TestCase):
@@ -65,3 +68,78 @@ class ConnectionResetTest(unittest.TestCase):
             self.skipTest("this psycodict has no grant policies")
         assert db.grant_policy == LMFDBGrantPolicy(), \
             "the database is not granting what the website needs on the tables it creates"
+
+
+class StatementTimeoutTest(unittest.TestCase):
+    """
+    What LMFDBDatabase asks psycodict for when it builds a connection.
+
+    These check the arguments rather than the resulting session, since the
+    connection the test suite already has was made long before the test ran and
+    a second one is not something a test should open.  Both psycodict APIs are
+    covered by setting the flag by hand: the installed psycodict is only ever
+    one of them, and CI installs the newer one.
+    """
+
+    TIMEOUT = {"statement_timeout": "25s"}
+
+    def _captured_database_kwargs(self, config_user="webserver", supported=True, **kwargs):
+        """
+        The keyword arguments LMFDBDatabase would hand to psycodict for a
+        configuration naming ``config_user``, on a psycodict whose constructor
+        takes session settings iff ``supported``.
+        """
+        captured = {}
+
+        def fake_init(_self, _config, **base_kwargs):
+            captured.update(base_kwargs)
+
+        config = {
+            "postgresql_options": {"user": config_user},
+            "logging_options": {"editor": ""},
+        }
+        with patch.object(PostgresDatabase, "__init__", fake_init), \
+             patch.object(lmfdb_database, "_PSYCODICT_HAS_SESSION_SETTINGS", supported):
+            LMFDBDatabase(config, **kwargs)
+        return captured
+
+    def test_older_psycodict_is_left_to_its_own_default(self):
+        # It has no such argument and would pass this one to psycopg.connect,
+        # which does not know it either; it applies the same timeout itself.
+        captured = self._captured_database_kwargs(supported=False)
+        assert "session_settings" not in captured, \
+            "a psycodict without the argument was passed it anyway"
+
+    def test_configured_webserver_gets_the_timeout(self):
+        captured = self._captured_database_kwargs()
+        assert captured["session_settings"] == self.TIMEOUT, \
+            "the web workers did not ask for a statement timeout"
+
+    def test_keyword_user_beats_the_configuration(self):
+        captured = self._captured_database_kwargs(user="lmfdb")
+        assert captured["user"] == "lmfdb"
+        assert "session_settings" not in captured, \
+            "a connection as another role was given the webserver timeout"
+
+    def test_keyword_webserver_gets_the_timeout(self):
+        captured = self._captured_database_kwargs(config_user="lmfdb", user="webserver")
+        assert captured["session_settings"] == self.TIMEOUT, \
+            "a connection as webserver did not ask for a statement timeout"
+
+    def test_explicit_settings_are_kept(self):
+        settings = {"statement_timeout": "5min", "work_mem": "64MB"}
+        captured = self._captured_database_kwargs(session_settings=settings)
+        assert captured["session_settings"] == settings, \
+            "the caller's session settings were overwritten or merged into"
+
+    def test_none_means_the_lmfdb_default(self):
+        # To psycodict this asks for no settings of its own; the LMFDB's are
+        # what should fill that in.
+        captured = self._captured_database_kwargs(session_settings=None)
+        assert captured["session_settings"] == self.TIMEOUT, \
+            "an unset session_settings lost the web workers their timeout"
+
+    def test_empty_settings_are_kept(self):
+        captured = self._captured_database_kwargs(session_settings={})
+        assert captured["session_settings"] == {}, \
+            "a caller could not turn the timeout off"


### PR DESCRIPTION
psycodict used to hand a connection as the `webserver` role a 25 second
`statement_timeout`, inferring it from the role name. A generic library
shouldn't act on a role name, so psycodict is dropping that special case
([roed314/psycodict#146](https://github.com/roed314/psycodict/pull/146)). This
restores the timeout explicitly in `LMFDBDatabase.__init__` when the connecting
user is `webserver`.

## Why now, and why it's safe on the current psycodict

`requirements.txt` allows `psycodict[pgbinary]>=1.0.0rc1,<2`, and the two APIs
in that range need different treatment, so `LMFDBDatabase` asks which one it has
by looking for a `session_settings` parameter on `PostgresDatabase.__init__`:

- **1.0.0rc1** has no such parameter. It forwards unknown keywords into
  `psycopg.connect`, which rejects this one (`invalid connection option
  "session_settings"`), so passing it there would cost the web workers their
  connection rather than just their timeout. Nothing is passed, and rc1 goes on
  applying the role-name default it still has.
- **rc2 and later** take the argument, so they are given the 25 seconds
  explicitly. That is the value that survives the removal in psycodict#146.

So this is safe to merge now, before the psycodict requirement is bumped, and
the web workers keep their timeout across the eventual upgrade. If it does *not*
land before the bump, the workers silently lose their query timeout, which is
the reason for this PR. The compatibility check goes away once the requirement
is pinned past the first psycodict release with the parameter.

Only the `webserver` role gets the setting; the devmirror/admin connections
(which pass `user=` explicitly) are unaffected, matching the old behavior
exactly. A caller's own `session_settings` is kept as given, including `{}` to
turn the timeout off deliberately, while `session_settings=None` (psycodict for
"no settings of the library's own") selects the LMFDB default.

New cases in `lmfdb/tests/test_connection_reset.py` capture the arguments
`LMFDBDatabase` hands to psycodict, patching the compatibility flag so both
psycodict APIs are covered without opening a second connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
