### PR TITLE
Cancel superseded Tests runs for a pull request

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [ main, dev, web ]
 
+# Only one Tests run per pull request at a time: a new push supersedes the
+# run for the commit it replaces, instead of leaving it to occupy job slots
+# to completion.  Pushes keep their own group (keyed by ref rather than PR
+# number), so the push and pull_request runs of a commit do not cancel each
+# other, and nothing is cancelled on main/dev/web, where every commit should
+# be tested.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   matrix_prep:
     name: Initial setup

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ on:
 # run for the commit it replaces, instead of leaving it to occupy job slots
 # to completion.  Pushes keep their own group (keyed by ref rather than PR
 # number), so the push and pull_request runs of a commit do not cancel each
-# other, and nothing is cancelled on main/dev/web, where every commit should
+# other, and nothing is canceled on main/dev/web, where every commit should
 # be tested.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Adds a `concurrency` group to the Tests workflow so that pushing a new commit to a pull request cancels the run for the commit it replaces.

### Why

The Tests workflow currently has no concurrency group, so every superseded run holds its jobs to completion: 13 jobs for a fork PR (`secrets.LMFDB_CI_ACCESS` is unavailable, so the matrix filter keeps only the `devmirror` rows) or 23 for a same-repo branch. Those jobs occupy slots against the account-wide 20-concurrent-job limit, and the run for the commit you actually care about queues behind them.

Measured on recent history of this repo, one fork-PR run is about 104 job-minutes across 13 jobs, so a single superseded run costs roughly five minutes of the entire 20-slot pool. That is invisible at this repo's normal traffic (~2.8 Tests runs/day), and very visible during a review round where several PRs are being revised at once: on a fork running the same workflow, a burst of updates pushed the median job queue wait to 3.6 hours while the tests themselves ran at normal speed.

### Details

`cancel-in-progress` is gated on the event so that pushes to `main`, `dev` and `web` are never cancelled. Every commit on a deploy branch should still get a full test run; only PR iterations are superseded.

The group key is the PR number for `pull_request` runs and `github.ref` otherwise. Since the workflow triggers on both `push: ['**']` and `pull_request`, a commit on a same-repo PR branch produces two runs; the differing keys keep them in separate groups so they do not cancel each other.

No test, matrix or job definition is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)