### PR TITLE
Use American spelling throughout

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -1,5 +1,5 @@
 # This is the list of contributors to LMFDB
-# They are listed on /acknowledgement and maybe elsewhere
+# They are listed on /acknowledgment and maybe elsewhere
 # the 'name' field is mandatory, all others currently optional
 #  - affil: university or company affiliation
 #  - url: homepage

--- a/lmfdb/api2/templates/api2.html
+++ b/lmfdb/api2/templates/api2.html
@@ -18,7 +18,7 @@
 <li><p><a class="uri">/api2/inventory/&lt;searcher&gt;</a> - Describe the list of possible fields that can be returned by a searcher</p></li>
 <li><p><a class="uri">/api2/data/&lt;searcher&gt;</a> - Perform a search using a given searcher. Query parameters taken from the searcher description are provided as an ampersand delimited query string to this endpoint. Non searching parameters are available and are all prepended by “_”</p></li>
 <li><p><a class="uri">/api2/pretty/&lt;other_path&gt;</a> - This takes a valid other API path and produces a human readable (just) HTML page from the data contained. The other path should be the part after “api2” in the URL</p></li>
-<li><p><a class="uri">/api2/singleton/&lt;path&gt;</a> - This is intended to provide a URL that allows canonical reference to a single element of the database. The format of the singletons is not standardised and should not in general be used for machine readable access</p></li>
+<li><p><a class="uri">/api2/singleton/&lt;path&gt;</a> - This is intended to provide a URL that allows canonical reference to a single element of the database. The format of the singletons is not standardized and should not in general be used for machine readable access</p></li>
 <li><p><a class="uri">/api2/livepg/&lt;database&gt;</a> - This is intended to replicate the behavior of the existing API. By specifying a database name and then using a standard search string (as per the /data/&lt;searcher&gt; endpoint) a search is performed on the raw database. This is not intended for normal access, but for debugging and testing purposes only.</p></li>
 </ul>
 <h3 id="api2-singletons">API2 singleton queries</h3>

--- a/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
+++ b/lmfdb/bianchi_modular_forms/templates/bmf-field_dim_table.html
@@ -47,7 +47,7 @@ by norm, over \(K=\) {{info.field_pretty}}.
 {% endif %}
 <p>{{info.report | safe}}
                     {# we have to decide which option is preselected
-                    based on a judgement of what users will want to
+                    based on a judgment of what users will want to
                     switch to, i.e. one of the other two options.  For
                     simplicity I have used the 3-cycle new -> all ->
                     cusp -> new. #}

--- a/lmfdb/bianchi_modular_forms/web_BMF.py
+++ b/lmfdb/bianchi_modular_forms/web_BMF.py
@@ -115,7 +115,7 @@ class WebBMF():
             - dbdata: the data from the database
 
         dbdata is expected to be a database entry from which the class
-        is initialised.
+        is initialized.
 
         """
         self.__dict__.update(dbdata)

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -131,7 +131,7 @@ class DirichletCharactersTest(LmfdbTest):
                     r'<td class="center">\(e\left(\frac{115}{714}\right)\)</td>')
         assert table_row in W.get_data(as_text=True)
 
-        # Tests for URL behaviour of characters
+        # Tests for URL behavior of characters
 
         W = self.tc.get('/Character/Dirichlet/5489/banana/100', follow_redirects=True)
         assert bool_string(True) in W.get_data(as_text=True)

--- a/lmfdb/classical_modular_forms/web_newform.py
+++ b/lmfdb/classical_modular_forms/web_newform.py
@@ -1028,9 +1028,9 @@ function switch_basis(btype) {
                  th_wrap('charpoly', '$F_p(T)$'),
                  '  </tr>', '</thead>', '<tbody>']
         loop_count = 0
-        for p, factorisation in hecke_polys_orbits.items():
-            factorisation.sort(key=lambda elt: (elt[0].degree(), elt[1]))
-            charpoly = raw_typeset_poly_factor(factorisation, decreasing=True)
+        for p, factorization in hecke_polys_orbits.items():
+            factorization.sort(key=lambda elt: (elt[0].degree(), elt[1]))
+            charpoly = raw_typeset_poly_factor(factorization, decreasing=True)
             if loop_count < num_disp:
                 polys.append('  <tr>')
             else:

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -215,12 +215,12 @@ def EC_R_plot_zone(f,h):
         return plot_zone_union(EC_R_plot_zone_piece(f,h,ZF[0],ZF[1]),EC_R_plot_zone_piece(f,h,ZF[2],2*xi-ZF[2]))
     return EC_R_plot_zone_piece(f,h,ZF[0],2*ZF[1]-ZF[0])
 
-def EC_R_plot(ainvs, xmin, xmax, ymin, ymax, colour, legend):
+def EC_R_plot(ainvs, xmin, xmax, ymin, ymax, color, legend):
     x = var('x')
     y = var('y')
     c = (xmin + xmax) / 2
     d = (xmax - xmin)
-    return implicit_plot(y ** 2 + ainvs[0] * x * y + ainvs[2] * y - x ** 3 - ainvs[1] * x ** 2 - ainvs[3] * x - ainvs[4], (x, xmin, xmax), (y, ymin, ymax), plot_points=500, aspect_ratio="automatic", color=colour) + plot(0, xmin=c - 1e-5 * d, xmax=c + 1e-5 * d, ymin=ymin, ymax=ymax, aspect_ratio="automatic", color=colour, legend_label=legend)  # Add an extra plot outside the visible frame because implicit plots are buggy: their legend does not show (https://trac.sagemath.org/ticket/15903)
+    return implicit_plot(y ** 2 + ainvs[0] * x * y + ainvs[2] * y - x ** 3 - ainvs[1] * x ** 2 - ainvs[3] * x - ainvs[4], (x, xmin, xmax), (y, ymin, ymax), plot_points=500, aspect_ratio="automatic", color=color) + plot(0, xmin=c - 1e-5 * d, xmax=c + 1e-5 * d, ymin=ymin, ymax=ymax, aspect_ratio="automatic", color=color, legend_label=legend)  # Add an extra plot outside the visible frame because implicit plots are buggy: their legend does not show (https://trac.sagemath.org/ticket/15903)
 
 Rx = PolynomialRing(RDF,'x')
 

--- a/lmfdb/ecnf/WebEllipticCurve.py
+++ b/lmfdb/ecnf/WebEllipticCurve.py
@@ -238,7 +238,7 @@ def EC_nf_plot(K, ainvs, base_field_gen_name):
         xmax = max([r[1] for r in R])
         ymin = min([r[2] for r in R])
         ymax = max([r[3] for r in R])
-        cols = rainbow(n1) # Default choice of n colours
+        cols = rainbow(n1) # Default choice of n colors
         # However, these tend to be too pale, so we preset them for small values of n
         if n1 == 1:
             cols = ["blue"]

--- a/lmfdb/ecnf/test_ecnf.py
+++ b/lmfdb/ecnf/test_ecnf.py
@@ -59,7 +59,7 @@ class EllCurveTest(LmfdbTest):
         L = self.tc.get('/EllipticCurve/2.0.4.1/5525.5/b/9')
         assert '226834389543384' in L.get_data(as_text=True)
         assert '1490902050625' in L.get_data(as_text=True)
-        L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1') # Test factorisation
+        L = self.tc.get('EllipticCurve/2.2.89.1/81.1/a/1') # Test factorization
         assert '8798344145175011328000' in L.get_data(as_text=True)
 
     def test_download(self):

--- a/lmfdb/elliptic_curves/elliptic_curve.py
+++ b/lmfdb/elliptic_curves/elliptic_curve.py
@@ -654,7 +654,7 @@ def elliptic_curve_search(info, query):
                     info['galois_image'] = ','.join(modell_labels + elladic_labels)
                 query['modell_images'] = { '$contains': modell_labels }
 
-    # The button which used to be labelled Optimal only no/yes"
+    # The button which used to be labeled Optimal only no/yes"
     # (default: no) has been renamed "Curves per isogeny class
     # all/one" (default: all).  When this option is "one" we only list
     # one curve in each class, currently choosing the curve with

--- a/lmfdb/elliptic_curves/isog_class.py
+++ b/lmfdb/elliptic_curves/isog_class.py
@@ -133,7 +133,7 @@ class ECisog_class():
         from sage.matrix.all import Matrix
         M = classdata['isogeny_matrix']
 
-        # permute rows/cols to match labelling: the rows/cols in the
+        # permute rows/cols to match labeling: the rows/cols in the
         # ec_classdata table are with respect to LMFDB ordering.
         if self.label_type == 'Cremona':
             def perm(i): return next(c for c in self.curves if c['Cnumber'] == i+1)['lmfdb_number']-1

--- a/lmfdb/elliptic_curves/templates/congruent_number_data.html
+++ b/lmfdb/elliptic_curves/templates/congruent_number_data.html
@@ -255,7 +255,7 @@ Each file consists of 1,000,000 lines, indexed by the positive integer $n$ and t
   Over half the curves ($574,290$) have trivial &#1064;.  The largest value seen is $7396 = 86^2$, for $n=719057$.
 </p>
 
-<h2>Credit and acknowledgements</h2> 
+<h2>Credit and acknowledgments</h2> 
 
 <p>
 The data files were created by Randall L. Rathbun on February 14, 2013

--- a/lmfdb/elliptic_curves/templates/ec-isoclass.html
+++ b/lmfdb/elliptic_curves/templates/ec-isoclass.html
@@ -121,7 +121,7 @@ Each elliptic curve in class {{info.class_label}} has complex multiplication by 
 <h2> {{ KNOWL('ec.isogeny_graph', title='Isogeny graph') }} </h2>
 {{ place_code('isogeny_graph') }}
 {% if info.class_size > 1 %}
-<p>The vertices are labelled with {{info.label_type}} labels, and the {{ KNOWL('ec.q.optimal', title='\( \Gamma_0(N) \)-optimal') }} curve is highlighted in blue.</p>
+<p>The vertices are labeled with {{info.label_type}} labels, and the {{ KNOWL('ec.q.optimal', title='\( \Gamma_0(N) \)-optimal') }} curve is highlighted in blue.</p>
 {% endif %}
 <div id="isogeny-graph"></div>
 

--- a/lmfdb/elliptic_curves/test_ell_curves.py
+++ b/lmfdb/elliptic_curves/test_ell_curves.py
@@ -174,10 +174,10 @@ class EllCurveTest(LmfdbTest):
 
     def test_990h(self):
         """
-        Test the exceptional 990h/990.i optimal labelling.
+        Test the exceptional 990h/990.i optimal labeling.
         """
-        # The isogeny class 990h (Cremona labelling) or 990.i (LMFDB labelling)
-        # has a different Gamma-optimal curve in its labelling than all others.
+        # The isogeny class 990h (Cremona labeling) or 990.i (LMFDB labeling)
+        # has a different Gamma-optimal curve in its labeling than all others.
         L = self.tc.get('/EllipticCurve/Q/990/i/')
         row = '\n'.join([
             '<td class="center"><a href="/EllipticCurve/Q/990h3/">990h3</a></td>',

--- a/lmfdb/elliptic_curves/web_ec.py
+++ b/lmfdb/elliptic_curves/web_ec.py
@@ -520,7 +520,7 @@ class WebEC():
         # Optimality
 
         # The optimal curve in the class is the curve whose Cremona
-        # label ends in '1' except for '990h' which was labelled
+        # label ends in '1' except for '990h' which was labeled
         # wrongly long ago. This is proved for N up to
         # OPTIMALITY_BOUND (and when there is only one curve in an
         # isogeny class, obviously) and expected for all N.

--- a/lmfdb/groups/abstract/main.py
+++ b/lmfdb/groups/abstract/main.py
@@ -162,7 +162,7 @@ def ctx_abstract_groups():
 
 def learnmore_list():
     return [
-        ("Source and acknowledgements", url_for(".how_computed_page")),
+        ("Source and acknowledgments", url_for(".how_computed_page")),
         ("Completeness of the data", url_for(".completeness_page")),
         ("Reliability of the data", url_for(".reliability_page")),
         ("Abstract  group labeling", url_for(".labels_page")),

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -3050,7 +3050,7 @@ class WebAbstractGroup(WebObj):
             families['sage'] = ['GL','SL','PSL','PGL','Sp','SO','SU','PSp','PSU','Orth','Unitary','PU']
             families['oscar'] = ['GL','SL','Sp','SO','SU','Orth','Unitary']
 
-            # Prioritise displaying the first Lie type representation which is implemented in the language
+            # Prioritize displaying the first Lie type representation which is implemented in the language
             for lie_rep in self.lie_representations:
                 nLie, qLie = ZZ(lie_rep['d']), ZZ(lie_rep['q'])
                 lie_rep_key = (lie_rep['family'], nLie, qLie)

--- a/lmfdb/hecke_algebras/main.py
+++ b/lmfdb/hecke_algebras/main.py
@@ -42,8 +42,8 @@ def hecke_algebras_render_webpage():
         weight_list = list(range(2, 20, 2))
         lvl_list_endpoints = [1, 100, 200, 300, 400, 500]
         lvl_list = ["%s-%s" % (start, end - 1) for start, end in zip(lvl_list_endpoints[:-1], lvl_list_endpoints[1:])]
-        favourite_list = ["1.12.1","139.2.1","239.2.1","9.16.1"]
-        info = {'lvl_list': lvl_list,'wt_list': weight_list, 'favourite_list': favourite_list}
+        favorite_list = ["1.12.1","139.2.1","239.2.1","9.16.1"]
+        info = {'lvl_list': lvl_list,'wt_list': weight_list, 'favorite_list': favorite_list}
         credit = hecke_algebras_credit
         t = 'Hecke algebras'
         bread = [('HeckeAlgebra', url_for(".hecke_algebras_render_webpage"))]

--- a/lmfdb/hecke_algebras/templates/hecke_algebras-index.html
+++ b/lmfdb/hecke_algebras/templates/hecke_algebras-index.html
@@ -40,7 +40,7 @@ By {{ KNOWL('cmf.weight', title='Weight') }}:
 
 <p>
 Some of our favorite {{ KNOWL('hecke_algebra.definition', title='Hecke Algebras') }}:
-{% for rnge in info.favourite_list %}
+{% for rnge in info.favorite_list %}
 <a href="?label={{rnge}}">&nbsp; {{rnge}} &nbsp;</a>
 {% endfor %}
 </p>

--- a/lmfdb/hecke_algebras/templates/hecke_algebras-index.html
+++ b/lmfdb/hecke_algebras/templates/hecke_algebras-index.html
@@ -39,7 +39,7 @@ By {{ KNOWL('cmf.weight', title='Weight') }}:
 </p>
 
 <p>
-Some of our favourite {{ KNOWL('hecke_algebra.definition', title='Hecke Algebras') }}:
+Some of our favorite {{ KNOWL('hecke_algebra.definition', title='Hecke Algebras') }}:
 {% for rnge in info.favourite_list %}
 <a href="?label={{rnge}}">&nbsp; {{rnge}} &nbsp;</a>
 {% endfor %}

--- a/lmfdb/hilbert_modular_forms/web_HMF.py
+++ b/lmfdb/hilbert_modular_forms/web_HMF.py
@@ -34,7 +34,7 @@ class WebHMF():
             - L: a string representing one newform from a raw data file
 
         If dbdata is not None then it is expected to be a database
-        entry from which the class is initialised.  If dbdata is None,
+        entry from which the class is initialized.  If dbdata is None,
         then a form is constructed from the field label or field and
         data string given.
 

--- a/lmfdb/knowledge/main.py
+++ b/lmfdb/knowledge/main.py
@@ -64,7 +64,7 @@ class KnowlTagPatternWithTitle(markdown.inlinepatterns.Pattern):
         return "{{ KNOWL('%s') }}" % kid
 
 
-# Initialise the markdown converter, sending a wikilink [[topic]] to the L-functions wiki
+# Initialize the markdown converter, sending a wikilink [[topic]] to the L-functions wiki
 md = markdown.Markdown(extensions=['markdown.extensions.wikilinks'],
                        extension_configs={'wikilinks': [('base_url', 'https://wiki.l-functions.org/')]})
 # priority above escape (180), but below backtick (190)

--- a/lmfdb/lfunctions/HodgeTransformations.py
+++ b/lmfdb/lfunctions/HodgeTransformations.py
@@ -1,7 +1,7 @@
 
 # A file for passing between
-#  * Hodge structures and Gamma Factors (motivic normalisation)
-#  * different normalisation (GammaFactors vs SelbergParameters)
+#  * Hodge structures and Gamma Factors (motivic normalization)
+#  * different normalization (GammaFactors vs SelbergParameters)
 
 # Copied from Magma code largely for GammaFactors and HodgeStructure
 # Format of HodgeStructure is <p,q,eps>, where eps is 2 when p!=q (else 0,1)
@@ -87,7 +87,7 @@ def tensor_hodge(H1, H2):
     return H
 
 
-def hodge_to_selberg(hodge):  # normalised for s->(1-s)
+def hodge_to_selberg(hodge):  # normalized for s->(1-s)
     """
     Takes a Hodge structure, returns a
     weight, mu, nu

--- a/lmfdb/lfunctions/Lfunction.py
+++ b/lmfdb/lfunctions/Lfunction.py
@@ -1595,7 +1595,7 @@ class TensorProductLfunction(Lfunction):
 
         li = self.tp.an_list(upper_bound=self.numcoeff)
         for n in range(1,len(li)):
-            # now renormalise it for s <-> 1-s as the functional equation
+            # now renormalize it for s <-> 1-s as the functional equation
             li[n] /= sqrt(float(n))
         self.dirichlet_coefficients = li
 

--- a/lmfdb/lfunctions/LfunctionLcalc.py
+++ b/lmfdb/lfunctions/LfunctionLcalc.py
@@ -190,7 +190,7 @@ def createLcalcfile_ver2(L, url):
 ### that the 0-th entry is also listed.
 ###
 ### Complex numbers should be entered, as usual as a pair of numbers, separated
-### by a comma. If no complex numbers appear amongst the Dirichlet coefficients,
+### by a comma. If no complex numbers appear among the Dirichlet coefficients,
 ### lcalc will assume the L-function is self-dual."""
     thefile += "\n\n"
 

--- a/lmfdb/lfunctions/LfunctionPlot.py
+++ b/lmfdb/lfunctions/LfunctionPlot.py
@@ -526,7 +526,7 @@ def paintSvgHoloNew(condmax):
     ans = svgBegin()
     ans += "<g transform='translate(10 0)'>\n"  # give ourselves a little space
 
-    cfw = colorsForWeights(max_k)  # pick our colour palette we need colors for weights 1 (at some point) to max_k inclusive
+    cfw = colorsForWeights(max_k)  # pick our color palette we need colors for weights 1 (at some point) to max_k inclusive
 
     for p in points:
         x = str(p[0])
@@ -804,7 +804,7 @@ def paintSvgHoloGeneral(Nmin, Nmax, kmin, kmax, imagewidth, imageheight):
             # Symmetry types: +1 or -1
             symmetrytype = [1, -1]
             for signtmp in symmetrytype:
-                # urlinfo['space']['orbits'] = [ [] for label in thelabels ] # initialise
+                # urlinfo['space']['orbits'] = [ [] for label in thelabels ] # initialize
                 # an empty list for each orbit
                 urlinfo['space']['orbits'] = []
                 for label in thelabels:  # looping over Galois orbit: one label per orbit

--- a/lmfdb/modlmf/templates/modlmf-index.html
+++ b/lmfdb/modlmf/templates/modlmf-index.html
@@ -44,7 +44,7 @@ By {{ KNOWL('modlmf.weight_grading', title='Weight grading') }}:
 {% endfor %}
 </p>
 <p>
-Some of our favourite {{ KNOWL('modlmf.definition', title="mod &#x2113; modular forms") }}:
+Some of our favorite {{ KNOWL('modlmf.definition', title="mod &#x2113; modular forms") }}:
 {% for rnge in info.label_list%}
 <a href="?label={{rnge}}">&nbsp;{{rnge}}&nbsp;</a>
 {% endfor %}

--- a/lmfdb/nfutils/psort.py
+++ b/lmfdb/nfutils/psort.py
@@ -2,7 +2,7 @@
 # See https://github.com/JohnCremona/sorting
 #
 # This file is code/psort.py from there.  It implements the sorting
-# and labelling of ideals (including prime ideals).
+# and labeling of ideals (including prime ideals).
 #
 from sage.all import ZZ, GF, Set, prod, srange, flatten, cartesian_product_iterator
 

--- a/lmfdb/number_fields/draw_spectrum.py
+++ b/lmfdb/number_fields/draw_spectrum.py
@@ -66,9 +66,9 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
     bottom_line = round((3/4)*height)
 
     # fraction of height of center line around which the primes in spec are centered
-    centre_ratio = 1/2 if gaga else 1/4
+    center_ratio = 1/2 if gaga else 1/4
     # y-coordinate of Spec O_K
-    y_centre = round(centre_ratio*height)
+    y_center = round(center_ratio*height)
 
     line_thickness = .75
 
@@ -91,10 +91,10 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
         x_coord = (n+1)*x_spread
         if l == [0]:
             coords.append(ram_coords(
-                local_alg_dict, p, x_coord, y_centre, y_spread))
+                local_alg_dict, p, x_coord, y_center, y_spread))
         else:
             coords.append(unram_coords(
-                l, x_coord, y_centre, y_spread))
+                l, x_coord, y_center, y_spread))
 
     # draw Spec Z line at the bottom
     if not gaga:
@@ -108,7 +108,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
                 y2=bottom_line))
 
         # a dashed line afterwards to signify generic fiber
-        for y in (bottom_line, y_centre):
+        for y in (bottom_line, y_center):
             elements.append(
                 svg.Line(
                     stroke="black",
@@ -129,7 +129,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
                 text_anchor="middle"))
 
     # draw curves between primes - do this first so points drawn over curve
-    nextpts = coords if gaga else coords + [[Point(width-2*x_spread, y_centre)]]
+    nextpts = coords if gaga else coords + [[Point(width-2*x_spread, y_center)]]
     for n in range(len(nextpts)-1):
         for pt_this in coords[n]:
             for pt_next in nextpts[n + 1]:
@@ -184,7 +184,7 @@ def draw_gaga(frobs, local_alg_dict, colors=True) -> svg.SVG:
     return draw_spec(frobs, local_alg_dict, colors=colors, gaga=True)
 
 
-def unram_coords(frob_cycle_list, x_coord, y_centre, spread) -> list:
+def unram_coords(frob_cycle_list, x_coord, y_center, spread) -> list:
     """
     Given list of Frobenius cycle describing a fixed fiber
     with no ramification, evenly spread points.
@@ -195,19 +195,19 @@ def unram_coords(frob_cycle_list, x_coord, y_centre, spread) -> list:
     N = sum(l[1] for l in frob_cycle_list)
     if N == 1:
         cyc_len = frob_cycle_list[0][0]
-        return [Point(x_coord, y_centre, cyc_len)]
+        return [Point(x_coord, y_center, cyc_len)]
     point_list = []
     point_index = 0         # total index of point
     for cyc_len, num_repeats in frob_cycle_list:
         for _ in range(num_repeats):
             y_offset = round(spread * (2 * point_index / (N - 1) - 1))
-            point = Point(x_coord, y_centre - y_offset, cyc_len)
+            point = Point(x_coord, y_center - y_offset, cyc_len)
             point_list.append(point)
             point_index += 1
     return point_list
 
 
-def ram_coords(local_alg_dict, p, x_coord, y_centre, spread, deg=1):
+def ram_coords(local_alg_dict, p, x_coord, y_center, spread, deg=1):
     """ Given `local_alg_dict` as defined in web_number_field.py, and a prime `p`,
     extract the points in the ramified fiber
     """
@@ -225,7 +225,7 @@ def ram_coords(local_alg_dict, p, x_coord, y_centre, spread, deg=1):
             y_offset = round(spread * (2 * i / (N - 1) - 1))
         else:
             y_offset = 0
-        point = Point(x_coord, y_centre - y_offset, residue_deg, hsl_color(ram_index, max_ram_index))
+        point = Point(x_coord, y_center - y_offset, residue_deg, hsl_color(ram_index, max_ram_index))
         point_list.append(point)
 
     return point_list

--- a/lmfdb/number_fields/draw_spectrum.py
+++ b/lmfdb/number_fields/draw_spectrum.py
@@ -39,7 +39,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
     """ Draw the spectrum of the ring of integers of a number field,
     from data in the lmfdb.
     `frobs` is a list of lists [[p, [frob_cycle1,...,frob_cycleN]]]
-    `local_algs` is a list of strings describing ramification behaviour ['p.deg.(other stuff)', ..., ]
+    `local_algs` is a list of strings describing ramification behavior ['p.deg.(other stuff)', ..., ]
     If `colors` is `True`, color classes which lie in the same Frobenius cycle
     """
     num_primes = min(len(frobs), num_primes)
@@ -58,14 +58,14 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
     # distance between two primes along x-axis
     x_spread = floor(width/(num_primes+1)) if gaga else 50
 
-    # distance between prime ideals in same fibre
+    # distance between prime ideals in same fiber
     # = total distance from top to bottom
     y_spread = 30
 
     # y-coordinate of Spec Z
     bottom_line = round((3/4)*height)
 
-    # fraction of height of centre line around which the primes in spec are centred
+    # fraction of height of center line around which the primes in spec are centered
     centre_ratio = 1/2 if gaga else 1/4
     # y-coordinate of Spec O_K
     y_centre = round(centre_ratio*height)
@@ -85,7 +85,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
     # NB: svg y-coords start from top! eg (0,1) is 1 unit down from top left corner
 
     # list of coordinates, where the n-th member is a
-    # list of Points in the n-th fibre
+    # list of Points in the n-th fiber
     coords = []
     for n, [p, l] in enumerate(frobs):
         x_coord = (n+1)*x_spread
@@ -107,7 +107,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
                 x2=coords[-1][0].x + x_spread,
                 y2=bottom_line))
 
-        # a dashed line afterwards to signify generic fibre
+        # a dashed line afterwards to signify generic fiber
         for y in (bottom_line, y_centre):
             elements.append(
                 svg.Line(
@@ -162,7 +162,7 @@ def draw_spec(frobs, local_alg_dict, colors=True, rings=False, num_primes=100, g
                     text=f'({frobs[n][0]})',
                     text_anchor="middle"))
 
-        # fibre above prime
+        # fiber above prime
         for pt in pts:
             radius = min(dot_radius
                          + residue_factor*(pt.girth-1), y_spread/5, x_spread/5)
@@ -177,7 +177,7 @@ def draw_gaga(frobs, local_alg_dict, colors=True) -> svg.SVG:
     """ Draw the spectrum of the ring of integers of a number field,
     from data in the lmfdb.
     ``frobs`` is a list of lists [[p, [frob_cycle1,...,frob_cycleN]]]
-    ``local_algs`` is a list of strings describing ramification behaviour ['p.deg.(other stuff)', ..., ]
+    ``local_algs`` is a list of strings describing ramification behavior ['p.deg.(other stuff)', ..., ]
     If ``colors`` is ``True``, color classes which lie
     in the same Frobenius cycle
     """
@@ -186,7 +186,7 @@ def draw_gaga(frobs, local_alg_dict, colors=True) -> svg.SVG:
 
 def unram_coords(frob_cycle_list, x_coord, y_centre, spread) -> list:
     """
-    Given list of Frobenius cycle describing a fixed fibre
+    Given list of Frobenius cycle describing a fixed fiber
     with no ramification, evenly spread points.
 
     Returns list of :class:`Point`.
@@ -209,7 +209,7 @@ def unram_coords(frob_cycle_list, x_coord, y_centre, spread) -> list:
 
 def ram_coords(local_alg_dict, p, x_coord, y_centre, spread, deg=1):
     """ Given `local_alg_dict` as defined in web_number_field.py, and a prime `p`,
-    extract the points in the ramified fibre
+    extract the points in the ramified fiber
     """
     # list of lists [e,f]
     algs = local_alg_dict[str(p)]

--- a/lmfdb/number_fields/templates/class_group_data.html
+++ b/lmfdb/number_fields/templates/class_group_data.html
@@ -28,7 +28,7 @@ there is one line per discriminant, with discriminants in order of their absolut
   value.  The discriminants and associated class group data may be extracted as
 follows, where  for $i\ge1$ we define $d_i$ to be the $i$th discriminant of the file:
 <ul>
-<li>Initialise $d_0=-k\cdot2^{28}-r$.
+<li>Initialize $d_0=-k\cdot2^{28}-r$.
 <li>For $i\ge1$, let the data in line $i$ of the file be
 <table>
  <tr><td>$a$</td><td> $b$</td><td> $c_1\ c_2\ \ldots\ c_t$</td></tr>

--- a/lmfdb/number_fields/web_number_field.py
+++ b/lmfdb/number_fields/web_number_field.py
@@ -297,7 +297,7 @@ def field_pretty(label, wnf=None):
                 Ksub = QuadraticField(D, 'sqrtD')
                 sqrtD = Ksub.gen(0)
 
-                # Factorise defining polynomial for K over Q(sqrt(D))
+                # Factorize defining polynomial for K over Q(sqrt(D))
                 Rsub = PolynomialRing(Ksub, 'x')
                 relative_poly = Rsub(wnf.poly()).factor()[0][0]
 

--- a/lmfdb/sato_tate_groups/test_st.py
+++ b/lmfdb/sato_tate_groups/test_st.py
@@ -100,7 +100,7 @@ class SatoTateGroupTest(LmfdbTest):
         L = self.tc.get('/SatoTateGroup/?trace_zero_density=19/24')
         assert '1.4.F.24.14a' in L.get_data(as_text=True)
 
-    def test_favourites(self):
+    def test_favorites(self):
         for label in [ '1.2.1.2.1a','1.2.3.1.1a', '1.4.1.12.4d', '1.4.3.6.2a', '1.4.6.1.1a', '1.4.10.1.1a' ]:
             L = self.tc.get('/SatoTateGroup/'+label, follow_redirects=True)
             assert "Moment sequences" in L.get_data(as_text=True)

--- a/lmfdb/static/lmfdb.js
+++ b/lmfdb/static/lmfdb.js
@@ -127,7 +127,7 @@ function knowl_click_handler($el) {
   var output_id = '#knowl-output-' + uid;
   var $output_id = $(output_id);
 
-  // slightly different behaviour if we are inside a table, but
+  // slightly different behavior if we are inside a table, but
   // not in a knowl inside a table.
   var table_mode = $el.parent().is("td") || $el.parent().is("th");
 

--- a/lmfdb/static/raw_typeset.js
+++ b/lmfdb/static/raw_typeset.js
@@ -12,7 +12,7 @@ function setraw(elt) {
     var properties_rect = $("#properties")[0].getBoundingClientRect();
     // we aim to avoid overlapping properties box
     // we could check for properties_rect.bottom > tset_rect.top
-    // but that creates funny behaviour as the current line
+    // but that creates funny behavior as the current line
     // might have enough space, but not one the parents, e.g. a table
     $ta.css('max-width', properties_rect.left - tset_rect.left - 75);
     $ta.height(0);

--- a/lmfdb/tensor_products/galois_reps.py
+++ b/lmfdb/tensor_products/galois_reps.py
@@ -543,7 +543,7 @@ class GaloisRepresentation( Lfunction):
         else:
             raise ValueError("You asked for a type that we don't have")
 
-    def renormalise_coefficients(self):
+    def renormalize_coefficients(self):
         """
         This turns a list of algebraically normalized coefficients
         as above into a list of automorphically normalized,
@@ -600,7 +600,7 @@ class GaloisRepresentation( Lfunction):
         # take a lot of time. We cut it down and print a warning
         number_of_terms = min(self.numcoeff, self.besancon_bound)
         self.dirichlet_coefficients = self.algebraic_coefficients(number_of_terms+1)
-        self.renormalise_coefficients()
+        self.renormalize_coefficients()
 
         self.texname = "L(s,\\rho)"
         self.texnamecompleteds = "\\Lambda(s,\\rho)"

--- a/lmfdb/tensor_products/galois_reps.py
+++ b/lmfdb/tensor_products/galois_reps.py
@@ -304,7 +304,7 @@ class GaloisRepresentation( Lfunction):
         self.conductor = ZZ(F.level)
         self.bad_semistable_primes = [fa[0] for fa in self.conductor.factor() if fa[1] == 1 ]
         # should be including primes of bad red that are pot good
-        # however I don't know how to recognise them
+        # however I don't know how to recognize them
         self.bad_pot_good = []
         self.langlands = True
         self.mu_fe = []
@@ -518,7 +518,7 @@ class GaloisRepresentation( Lfunction):
         """
         Computes the list [a1,a2,... of coefficients up
         to a bound. Note that [0] is a1.
-        This is in the alg. normalisation, i.e. s <-> w+1-s
+        This is in the alg. normalization, i.e. s <-> w+1-s
         """
 
         if self.object_type == "ellipticcurve":
@@ -545,8 +545,8 @@ class GaloisRepresentation( Lfunction):
 
     def renormalise_coefficients(self):
         """
-        This turns a list of algebraically normalised coefficients
-        as above into a list of automorphically normalised,
+        This turns a list of algebraically normalized coefficients
+        as above into a list of automorphically normalized,
         i.e. s <-> 1-s
         """
         # this also turns them into floats and complex.

--- a/lmfdb/tensor_products/templates/tensor_products_navigate.html
+++ b/lmfdb/tensor_products/templates/tensor_products_navigate.html
@@ -41,7 +41,7 @@
   Once both frames have loaded, you can <button id='submitbutton'>Tensor these</button>
 </form></br>
 
-Modular forms require a choice of embedding, which for now is defaulted to the first embedding.  In any case the tensor product page may take a while to load whilst the zeros are computed.
+Modular forms require a choice of embedding, which for now is defaulted to the first embedding.  In any case the tensor product page may take a while to load as the zeros are computed.
 <script type='text/javascript'>
 function getNiceLabelFromURL(loc)  {
 

--- a/lmfdb/tests/generate_snippet_tests.py
+++ b/lmfdb/tests/generate_snippet_tests.py
@@ -118,7 +118,7 @@ def _start_snippet_procs(langs, chimp_spec=None):
             #
             #  3. The SetPrompt command itself is echoed once (the line editor is still active when it is sent).  If the command
             #     contained the new prompt as a literal string, pexpect would match the *echo* of the command instead of the actual
-            #     prompt and permanently desynchronise.  To avoid this, the prompt string is assembled with 'cat' so that the echoed
+            #     prompt and permanently desynchronize.  To avoid this, the prompt string is assembled with 'cat' so that the echoed
             #     command never contains the full prompt.
             #
             #  SetColumns(0) disables line-wrapping, and SetAutoColumns(false) stops Magma from re-adjusting to the pty width, so that log files are stable across environments.
@@ -183,7 +183,7 @@ def _eval_code_file(data, lang, proc, logfile):
 
     proc.child.logfile = None
 
-    # Matches ANSI escape sequences (colour codes etc.), see e.g. https://en.wikipedia.org/wiki/ANSI_escape_code
+    # Matches ANSI escape sequences (color codes etc.), see e.g. https://en.wikipedia.org/wiki/ANSI_escape_code
     # E.g. this sometimes occurs in the Gap snippet log files
     ANSI_ESCAPE_RE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 

--- a/lmfdb/tests/test_tensor_products.py
+++ b/lmfdb/tests/test_tensor_products.py
@@ -22,7 +22,7 @@ class TensorProductTest(LmfdbTest):
         L1 = self.tc.get("ModularForm/GL2/Q/holomorphic/1/12/1/a/")
         assert "6048q^{6}" in L1.get_data(as_text=True)
         # the following lines need changing after Artin rep
-        # relabelling.  Perhaps "ArtinRepresentation/2.31.3t2.1c1"
+        # relabeling.  Perhaps "ArtinRepresentation/2.31.3t2.1c1"
         L2 = self.tc.get("ArtinRepresentation/2/31/1/")
         assert "(1,2,3)" in L2.get_data(as_text=True)
         L = self.tc.get("TensorProducts/show/?obj1=ModularForm%2FGL2%2FQ%2Fholomorphic%2F1%2F12%2F0%2Fa%2F0&obj2=ArtinRepresentation%2F2%2F31%2F1%2F")

--- a/lmfdb/utils/completeness.py
+++ b/lmfdb/utils/completeness.py
@@ -2411,7 +2411,7 @@ class NFBound(ColTest):
         r2, D, sign = IntegerSet(query.get("r2")), IntegerSet(query.get("disc_abs")), query.get("disc_sign")
         rd, grd, reg = NumberSet(query.get("rd")), NumberSet(query.get("grd")), NumberSet(query.get("regulator"))
 
-        # Initialise list of r2, of possible signatures (n-2*r2, r2)
+        # Initialize list of r2, of possible signatures (n-2*r2, r2)
         r2opts = list(r2.intersection(IntegerSet([0, n//2])))
         if sign == 1:
             r2opts = [r2 for r2 in r2opts if r2 % 2 == 0]

--- a/lmfdb/utils/search_wrapper.py
+++ b/lmfdb/utils/search_wrapper.py
@@ -238,7 +238,7 @@ class Wrapper:
             one_per = [one_per]
         return query, sort, table, title, err_title, template, one_per
 
-    def query_cancelled_error(
+    def query_canceled_error(
         self, info, query, err, err_title, template, template_kwds
     ):
         ctx = ctx_proc_userdata()
@@ -421,7 +421,7 @@ class SearchWrapper(Wrapper):
                     split_ors=split_ors,
                 )
         except QueryCanceledError as err:
-            return self.query_cancelled_error(
+            return self.query_canceled_error(
                 info, query, err, err_title, template, template_kwds
             )
         except SearchParsingError as err:
@@ -644,7 +644,7 @@ class SearchWrapper(Wrapper):
                 one_per=one_per,
             )
         except QueryCanceledError as err:
-            return self.query_cancelled_error(
+            return self.query_canceled_error(
                 info, query, err, err_title, template, template_kwds
             )
         except SearchParsingError as err:
@@ -784,7 +784,7 @@ class CountWrapper(Wrapper):
                         tuple(key[i] for i in perm): val for (key, val) in res.items()
                     }
         except QueryCanceledError as err:
-            return self.query_cancelled_error(
+            return self.query_canceled_error(
                 info, query, err, err_title, template, template_kwds
             )
         else:
@@ -869,7 +869,7 @@ class EmbedWrapper(Wrapper):
                 one_per=one_per,
             )
         except QueryCanceledError as err:
-            return self.query_cancelled_error(
+            return self.query_canceled_error(
                 info, query, err, err_title, template, template_kwds
             )
         except SearchParsingError as err:

--- a/lmfdb/utils/utilities.py
+++ b/lmfdb/utils/utilities.py
@@ -605,7 +605,7 @@ def format_percentage(num, denom):
 
 def signtocolour(sign):
     """
-    Assigns an rgb string colour to a complex number based on its argument.
+    Assigns an rgb string color to a complex number based on its argument.
     """
     argument = cmath.phase(CC(str(sign)))
     r = int(255.0 * (math.cos((1.0 * math.pi / 3.0) - (argument / 2.0))) ** 2)

--- a/scripts/abvar/g1.m
+++ b/scripts/abvar/g1.m
@@ -10,7 +10,7 @@ For each label, and for each field of characteristic 2 or 3 and j-invariant not 
 it lists a representative for each isomorphism class in the isogeny class.
 
 For characteristics 2 or 3 and j-invariant equal to 0 or 1728, we use 
-John Cremona's sage package to pick a favourite curve of each isomorphism class.
+John Cremona's sage package to pick a favorite curve of each isomorphism class.
 See g1_char23_j_0.sage.
 */
 

--- a/scripts/genus2_curves/g2LocSolv.py
+++ b/scripts/genus2_curves/g2LocSolv.py
@@ -9,7 +9,7 @@ def IsSquareInQp(x, p):
     v=valuation(x,p)
     if v%2:
         return False
-    # Renormalise to get a unit
+    # Renormalize to get a unit
     x//=p**v
     # Reduce mod p and conclude
     if p==2:
@@ -29,7 +29,7 @@ def HasFinitePointAt(F, p, c):
         R = F.parent()(1)
         S = F.parent()(1)
         for X in (F.base_extend(Fp)/Fp(F.leading_coefficient())).squarefree_decomposition():
-            [G,v] = X # Term of the form G(x)^v in the factorisation of F(x) mod p
+            [G,v] = X # Term of the form G(x)^v in the factorization of F(x) mod p
             S *= G**(v%2)
             R *= G**(v//2)
         r = R.degree()
@@ -81,13 +81,13 @@ def IsSolubleAt(F, p):
             return True
         # If we have a point (x,y) with v_p(x) = -A, then v_p(f(x)) = v_p(a6*x^6) = -6A so v_p(y) = -3A
         # So we have x = x'/p^A, y = y'/p^3A, with x' and y' p-adic units
-        # Renormalise : y'² = a_d x'^6 + a5 p^A x'^5 + a4 p^2A x'^4 + ...
+        # Renormalize : y'² = a_d x'^6 + a5 p^A x'^5 + a4 p^2A x'^4 + ...
         if p > 2:
             # Then a6 must be a square mod p, hence a square in Qp, contradiction
             # So x and y must be in Zp
             return HasFinitePointAt(F, p, 1)
         else:
-            # x'6 = y'² = 1 mod 8, so if A >= 3, then a6 = 1 mod 8, contradiction. So A <= 2, renormalise.
+            # x'6 = y'² = 1 mod 8, so if A >= 3, then a6 = 1 mod 8, contradiction. So A <= 2, renormalize.
             t = F.variables()[0]
             Zx = PolynomialRing(ZZ,'x')
             return HasFinitePointAt(Zx(4**6*F(t/4)),2,1)
@@ -101,7 +101,7 @@ def IsSolubleAt(F, p):
         # So if A >= 2, then 1-6A dominates, so v_p(f(x))=1-6A is odd, contradiction.
         # So A=1, and there must be cancellation mod p to prevent v_p(f(x)) = 5
         # --> x = -a5/a6 + O(p^0), and v_p(y) >= -2
-        # Just renormalise
+        # Just renormalize
         a5 = F[F.degree()-1]
         if a5 % p == 0:
             return False

--- a/scripts/hmf/hmf-count-aps.sage
+++ b/scripts/hmf/hmf-count-aps.sage
@@ -88,7 +88,7 @@ def binary_search(L,x):
         i = k
     return L[i]
 
-#note: could be optimised by precomputing the number of primes up to each norm
+#note: could be optimized by precomputing the number of primes up to each norm
 def truncation_bound(f):
     """Given an HMF f or its label, compute a bound X on the norm 
     of the primes at which the list of eigenvalues should be truncated 


### PR DESCRIPTION
LMFDB uses American spelling, but British forms had accumulated in comments, docstrings, page text, and a few identifiers. This sweeps them up.

Two commits, so the second can be dropped on its own if you would rather not touch identifiers:

**1. Prose** (58 lines, 38 files) — comments, docstrings, and user-facing text: `behaviour`, `centre`/`centred`, `colour`, `favourite`, `fibre`, `judgement`, `labelled`/`labelling`, `amongst`, `whilst`, `acknowledgements`, and the `-ise` family (`initialise`, `normalise`, `renormalise`, `factorise`, `recognise`, `prioritise`, `optimise`, `standardise`, `desynchronise`).

Two of these were also wrong on the facts:

- The `CONTRIBUTORS.yaml` header points readers at `/acknowledgement`, but the route is `/acknowledgment` (`lmfdb/app.py:443`).
- Abstract groups was the only section of roughly twenty-five offering "Source and acknowledgements". Every other one already said "acknowledgments".

One rewrite rather than a straight swap: `tensor_products_navigate.html` said "may take a while to load whilst the zeros are computed", where "while ... while" would have read badly, so it is now "as the zeros are computed".

**2. Identifiers** (27 lines, 8 files) — every name here has all of its references inside one file, or for `favourite_list` one view and its template, so each rename moves the definition and its uses together:

| | |
|---|---|
| `draw_spectrum.py` | `centre_ratio`, `y_centre` → `center_ratio`, `y_center` |
| `WebEllipticCurve.py` | `EC_R_plot`'s `colour` parameter → `color` |
| `web_newform.py` | `factorisation` loop variable → `factorization` |
| `galois_reps.py` | `renormalise_coefficients` → `renormalize_coefficients` |
| `search_wrapper.py` | `query_cancelled_error` → `query_canceled_error` |
| `hecke_algebras` | `favourite_list` → `favorite_list` (view + template) |
| `test_st.py` | `test_favourites` → `test_favorites` |

`query_cancelled_error` is worth a look: it handles psycopg's `QueryCanceledError`, which spells it with one `l`, so the handler and the exception it catches now agree.

## Deliberately left alone

- **`signtocolour`**, which `lmfdb/utils/__init__.py` exports in `__all__` and five modules import. Renaming it is an API change rather than a spelling fix, so it and the locals built on it (`signcolour`, `thiscolour`, `colourplus`, `colourminus`, `test_signtocolour`) are left for a separate decision.
- **`grey`**, a valid matplotlib color name and already the spelling the plotting code uses (`abvar/fq/isog_class.py`, `hypergm/web_family.py`, `local_fields/main.py`, and a `grey` attribute in `utils/color.py`).
- **Proper names**: the "Catalogue of Lattices" (also a knowl id, `lattice.catalogue_of_lattices`), and the `International Centre ...` / `Centre De Recherches Mathematiques` institution names in `workshops.html`.
- **Not ours**: `maths.*` URLs and e-mail addresses, the sympow readme quoted in `symL/sympowlmfdb.py`, and the vendored `snap.svg-min.js` / `jquery.markitup.js`.
- **Correct in American English anyway**: `cancellation`, `characteristic`, `totally`, `analogue`, and `labellist` (which is a label list, not a labelling).

## How the list was built

Three independent passes over every tracked text file, so a gap in one is caught by another: an explicit British-to-American word list; a suffix sweep (`-ise`, `-our`, `-tre`, `-lled`, `-ogue`, `-yse`) over every distinct word, which is what caught `test_favourites`, a plural the word list missed; and a substring sweep for British stems buried inside identifiers, which caught `favourite_list` and `query_cancelled_error`. Each hit was checked by hand before being changed.

## Checks

`pyflakes` clean on all 34 changed Python files, all 8 changed templates parse, `CONTRIBUTORS.yaml` still loads (123 documents), and no reference to any renamed identifier remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
