### PR TITLE
Stop CI jobs hanging for hours on a slow database query

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: matrix_prep
+    # A healthy job finishes well inside half an hour; the slowest green ones
+    # observed are around 25 minutes, and that includes building the conda
+    # environment on a cache miss.  GitHub's default is six hours, which is long
+    # enough for a job stuck on the database to hold a runner all morning -- one
+    # recently ran for five and a half.  Fail such a job in an hour instead.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -35,18 +35,28 @@ class DirichletSearchTest(LmfdbTest):
         assert '46.d' in W.get_data(as_text=True)
 
     def test_search(self):
+        # Fixing both the conductor and the order matches an index prefix, which
+        # leaves the index supplying the sort as well, so this page comes back
+        # from a handful of index entries.  Keep it strictly asserted: it is the
+        # smoke test that the search works at all.
         W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4')
         assert r'15.e' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7')
-        assert r'25.d' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes')
-        assert r'25.d' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No')
-        assert r'50.d' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd')
-        assert r'56.n' in W.get_data(as_text=True)
-        W = self.tc.get('/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even')
-        assert r'50.d' in W.get_data(as_text=True)
+        # Ranges do not match a prefix, so the searches below match every
+        # modulus admitting a character of conductor 25 to 50, upwards of half a
+        # million orbits, every one of which has to be read before the sort by
+        # modulus can pick the first page.  That is seconds against an idle
+        # server and far worse against a loaded one, so accept the timeout page
+        # too: what is under test is the search parsing, not the server.
+        self.check_args_with_timeout(
+            '/Character/Dirichlet/?conductor=25-50&order=5-7', r'25.d')
+        self.check_args_with_timeout(
+            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes', r'25.d')
+        self.check_args_with_timeout(
+            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No', r'50.d')
+        self.check_args_with_timeout(
+            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd', r'56.n')
+        self.check_args_with_timeout(
+            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even', r'50.d')
 
     def test_condsearch(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=111')

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -35,27 +35,13 @@ class DirichletSearchTest(LmfdbTest):
         assert '46.d' in W.get_data(as_text=True)
 
     def test_search(self):
-        # The primitivity and parity filters are read from is_primitive=yes|no
-        # and parity=even|odd; the older primitive=Yes|No and parity=Odd|Even
-        # spellings set nothing at all, so searches using them silently ran the
-        # unfiltered query and asserted labels that were on its first page
-        # anyway.  Every filter below is therefore checked in both directions,
-        # by a label it must keep and one it must drop, so a parameter that
-        # stops being parsed widens the search and fails here.
-        #
-        # Labels are matched with their surrounding tags: 416 is also a multiple
-        # of 16, so a bare '16.e' would match the '416.e' further down the page.
-        #
-        # Fixing both conductor and order matches an index prefix, which leaves
-        # the index supplying the sort as well, so all of these come back from a
-        # handful of index entries.
+        # Each filter is checked in both directions, so a parameter that stops
+        # being parsed widens the search and trips a negative assertion.
+        # Conductor 16, order 4 has a primitive even orbit (16.e), a primitive
+        # odd one (16.f), and imprimitive counterparts at modulus 32.  Labels
+        # carry their tags, since a bare '16.e' also matches '416.e'.
         page = self.tc.get('/Character/Dirichlet/?conductor=15&order=4').get_data(as_text=True)
         assert '>15.e<' in page
-        # conductor 16 and order 4 gives a primitive even orbit (16.e), a
-        # primitive odd one (16.f), and imprimitive even and odd ones at
-        # modulus 32, so each filter is visible in the labels it selects.  All
-        # four are asserted present by one filtered search or another, so no
-        # unfiltered control page is needed.
         page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&is_primitive=no').get_data(as_text=True)
         assert '>32.e<' in page and '>32.f<' in page
         assert '>16.e<' not in page and '>16.f<' not in page
@@ -68,13 +54,8 @@ class DirichletSearchTest(LmfdbTest):
         page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&is_primitive=no&parity=odd').get_data(as_text=True)
         assert '>32.f<' in page
         assert '>16.e<' not in page and '>16.f<' not in page and '>32.e<' not in page
-        # Ranges match no index prefix, so this one matches every modulus
-        # admitting a character of conductor 25 to 50, upwards of half a million
-        # orbits, every one of which is read before the sort by modulus can pick
-        # the first page.  It is the only search here that costs that, and the
-        # only one allowed to settle for the timeout page.  Range parsing is
-        # also covered cheaply by test_order and test_modbrowse, which range
-        # over a single column.
+        # A conductor range matches no index prefix, so this one reads every
+        # orbit of conductor 25-50 before it can sort; allow the timeout page.
         self.check_args_with_timeout(
             '/Character/Dirichlet/?conductor=25-50&order=5-7', '>25.d<')
 

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -35,28 +35,48 @@ class DirichletSearchTest(LmfdbTest):
         assert '46.d' in W.get_data(as_text=True)
 
     def test_search(self):
-        # Fixing both the conductor and the order matches an index prefix, which
-        # leaves the index supplying the sort as well, so this page comes back
-        # from a handful of index entries.  Keep it strictly asserted: it is the
-        # smoke test that the search works at all.
-        W = self.tc.get('/Character/Dirichlet/?conductor=15&order=4')
-        assert r'15.e' in W.get_data(as_text=True)
-        # Ranges do not match a prefix, so the searches below match every
-        # modulus admitting a character of conductor 25 to 50, upwards of half a
-        # million orbits, every one of which has to be read before the sort by
-        # modulus can pick the first page.  That is seconds against an idle
-        # server and far worse against a loaded one, so accept the timeout page
-        # too: what is under test is the search parsing, not the server.
+        # The primitivity and parity filters are read from is_primitive=yes|no
+        # and parity=even|odd; the older primitive=Yes|No and parity=Odd|Even
+        # spellings set nothing at all, so searches using them silently ran the
+        # unfiltered query and asserted labels that were on its first page
+        # anyway.  Every filter below is therefore checked in both directions,
+        # by a label it must keep and one it must drop, so a parameter that
+        # stops being parsed widens the search and fails here.
+        #
+        # Labels are matched with their surrounding tags: 416 is also a multiple
+        # of 16, so a bare '16.e' would match the '416.e' further down the page.
+        #
+        # Fixing both conductor and order matches an index prefix, which leaves
+        # the index supplying the sort as well, so all of these come back from a
+        # handful of index entries.
+        page = self.tc.get('/Character/Dirichlet/?conductor=15&order=4').get_data(as_text=True)
+        assert '>15.e<' in page
+        # conductor 16 and order 4 gives a primitive even orbit (16.e), a
+        # primitive odd one (16.f), and imprimitive even and odd ones at
+        # modulus 32, so each filter is visible in the labels it selects.  All
+        # four are asserted present by one filtered search or another, so no
+        # unfiltered control page is needed.
+        page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&is_primitive=no').get_data(as_text=True)
+        assert '>32.e<' in page and '>32.f<' in page
+        assert '>16.e<' not in page and '>16.f<' not in page
+        page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&parity=even').get_data(as_text=True)
+        assert '>16.e<' in page and '>32.e<' in page
+        assert '>16.f<' not in page and '>32.f<' not in page
+        page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&parity=odd').get_data(as_text=True)
+        assert '>16.f<' in page and '>32.f<' in page
+        assert '>16.e<' not in page and '>32.e<' not in page
+        page = self.tc.get('/Character/Dirichlet/?conductor=16&order=4&is_primitive=no&parity=odd').get_data(as_text=True)
+        assert '>32.f<' in page
+        assert '>16.e<' not in page and '>16.f<' not in page and '>32.e<' not in page
+        # Ranges match no index prefix, so this one matches every modulus
+        # admitting a character of conductor 25 to 50, upwards of half a million
+        # orbits, every one of which is read before the sort by modulus can pick
+        # the first page.  It is the only search here that costs that, and the
+        # only one allowed to settle for the timeout page.  Range parsing is
+        # also covered cheaply by test_order and test_modbrowse, which range
+        # over a single column.
         self.check_args_with_timeout(
-            '/Character/Dirichlet/?conductor=25-50&order=5-7', r'25.d')
-        self.check_args_with_timeout(
-            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=Yes', r'25.d')
-        self.check_args_with_timeout(
-            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No', r'50.d')
-        self.check_args_with_timeout(
-            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Odd', r'56.n')
-        self.check_args_with_timeout(
-            '/Character/Dirichlet/?conductor=25-50&order=5-7&primitive=No&parity=Even', r'50.d')
+            '/Character/Dirichlet/?conductor=25-50&order=5-7', '>25.d<')
 
     def test_condsearch(self):
         W = self.tc.get('/Character/Dirichlet/?conductor=111')

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,26 @@ passenv =
     SAGE_LOCAL
     HOME
 
+# Bound how long a single database query may run.  The suite talks to a shared
+# server (devmirror by default) that has no statement_timeout of its own, and
+# psycodict only hands one to connections made as the "webserver" role, so a
+# pathological query otherwise runs unbounded: a Dirichlet character search that
+# takes seconds on an idle server has held a CI job for over five hours.
+#
+# libpq reads PGOPTIONS when it opens a connection, including the ones psycodict
+# opens when it resets a broken one, so this needs no cooperation from the test
+# harness and cannot be lost on a reconnect.  A query stopped this way raises
+# the same QueryCanceledError the search pages already handle, so a slow search
+# renders the usual timeout page instead of hanging.
+#
+# This is a hang catcher, not a performance budget.  120s is far above anything
+# the suite issues against a healthy server and far below the hangs it exists to
+# stop; the job-level timeout-minutes in .github/workflows/python-package.yml
+# backstops the case where many queries are slow at once.  Export PGOPTIONS to
+# override, e.g. PGOPTIONS='-c statement_timeout=0' for the old behavior.
+setenv =
+    PGOPTIONS = {env:PGOPTIONS:-c statement_timeout=120s}
+
 commands =
     parallel --group 'echo "Running test on {}"; sage -python -m pytest -vv --durations=0 {}' ::: {posargs}
 


### PR DESCRIPTION
Six of the currently open PRs are red, all on the same job and the same single
assertion, and none of them touch the code under test. This is the operational
half of that: it does not make the query faster, it stops a slow query from
costing hours and a red build.

### What happens today

`DirichletSearchTest::test_search` searches `conductor=25-50&order=5-7`. That
matches every modulus admitting a character of conductor 25 to 50, **537,164
orbits**, every one of which must be read before the sort by modulus can pick
the first page. `EXPLAIN ANALYZE` on devmirror: 434,307 buffer reads, about
3.4GB, 6.7s against an idle server. Under CI load it is much worse, and nothing
stops it, because devmirror's `statement_timeout` is `0` and psycodict only sets
one for connections made as the `webserver` role. The tests connect as `lmfdb`.

On 2026-08-06 that produced this, for one job whose eleven siblings hit the same
database and finished in 3 to 20 minutes throughout:

| job started (UTC) | duration | result |
|---|---|---|
| 08:50 | 154 min | fail |
| 09:27 | 118 min | fail |
| 09:56 | 88 min | fail |
| 10:11 | 74 min | fail |
| 10:58 | 26 min | fail |

Five jobs that started up to two hours apart all ended between 11:24:54 and
11:25:50 reporting a cancelled query. Earlier ones the same morning ran up to
5h22m and passed.

### The three changes

**`tox.ini`: `PGOPTIONS = {env:PGOPTIONS:-c statement_timeout=120s}`.** libpq
applies `PGOPTIONS` to every connection it opens, including the ones psycodict
opens when it resets a broken one, so the timeout survives reconnects and the
test harness needs to know nothing about it. A query stopped this way raises the
`QueryCanceledError` the search pages already catch, so a slow search renders
the ordinary timeout page rather than hanging. 120s is a hang catcher, not a
performance budget. Export `PGOPTIONS` to override, `-c statement_timeout=0`
restores today's behavior.

**`test_characters.py`: make `test_search` actually test something, and stop it
scanning five times.** The searches it issued used `primitive=Yes|No` and
`parity=Odd|Even`. `common_parse` reads primitivity from `is_primitive` via
`parse_bool`, which accepts `"yes"`/`"no"` and not `"Yes"`/`"No"`, and compares
parity against lowercase `"even"`/`"odd"`. None of those four were recognised,
so all five searches ran the same unfiltered conductor-and-order query and
passed because 25.d, 50.d and 56.n are all on that one query's first page.

Now each filter is checked in both directions against `conductor=16&order=4`,
which has a primitive even orbit (16.e), a primitive odd one (16.f), and
imprimitive even and odd ones at modulus 32. A filter that stops being parsed
widens the search and trips a negative assertion. Both columns are pinned to
single values, which matches an index prefix and leaves the index supplying the
sort, so these replace the expensive scan rather than repeating it. One range
search remains, and it is the only one allowed to settle for the timeout page,
via the existing `check_args_with_timeout` helper. The test issues six requests,
the same as before.

Labels are matched with their surrounding tags (`'>16.e<'`), because 416 is also
a multiple of 16 and a bare `'16.e'` matches the `416.e` further down the page.
`test_even_odd` in the same file already uses that anchor style.

**`python-package.yml`: `timeout-minutes: 60`.** GitHub's default is 360.

### Verification

- `test_search` passes against devmirror, and the four label sets are exactly as
  asserted (checked independently against `char_dirichlet` over SQL and against
  the live site).
- The parsing bug and its detection were both confirmed empirically:
  `/Character/Dirichlet/?conductor=16&order=4&primitive=no` still returns the
  primitive orbits 16.e and 16.f, so the old spellings really were inert and the
  new negative assertions really do catch them.
- The `PGOPTIONS` mechanism was checked end to end against a throwaway PG 18
  cluster: unset gives `statement_timeout = 0`; set gives the requested value
  through the same explicit-parameter connection shape psycodict uses; a
  `pg_sleep` past the limit raises `canceling statement due to statement
  timeout`, which is the error class `search_wrapper` renders as the timeout
  page; `-c statement_timeout=0` overrides back to unbounded.
- `tox config -e tests` resolves the default and honors an exported override.
- pyflakes clean; workflow YAML parses and the key lands on the `test` job.
- **CI has not run on this PR**: GitHub Actions has been in a major outage since
  15:22 UTC on 2026-08-06, and no workflow run has been created. The local run
  above is the only evidence so far.

### Three things worth knowing

- A statement timeout converts *any* query slower than 120s from a wait into a
  failure. That is the point, but if some other test has been quietly relying on
  a very slow query succeeding, this is where it will surface.
- `is_primitive=yes` combined with a conductor is itself pathological: with the
  conductor pinned but the modulus free it walks every multiple of the conductor
  to find the primitive rows. `?conductor=16&order=4&is_primitive=yes` times out
  on production today. That is the shape #7143 fixes, so the cheap coverage here
  deliberately uses `is_primitive=no`.
- This does not conflict with #7131, which adds a `webserver` timeout in
  `LMFDBDatabase.__init__`. Different roles, different files.

Related but out of scope: #7143 speeds up the `is_primitive=yes` half of this
query mathematically, from 6.7s to 232ms measured; the `is_primitive=no` and
bare range cases still read all 537k rows. Since devmirror was retuned (16GB
shared_buffers, and the rest), the remaining broad search is 1.40s warm rather
than 6.7s, which is why it is still worth tolerating a timeout on it under CI
load but no longer worth much alarm on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
