### PR TITLE
Add "verified" annotations for the 97 genus 2 curves where Sha is rigorously known

### DIFF
--- a/lmfdb/genus2_curves/templates/g2c_curve.html
+++ b/lmfdb/genus2_curves/templates/g2c_curve.html
@@ -188,7 +188,7 @@ function show_eqns(invstyle) {
     <tr><td>{{ KNOWL('lfunction.leading_coeff', 'Leading coefficient') }}:</td>
         <td>{% if data.leading_coefficient == 'unknown' %} unknown {% else %} \( {{ data.leading_coeff }} \) {% endif %}</td></tr>
     <tr><td>{{ KNOWL('g2c.analytic_sha', 'Analytic order of &#1064;') }}:</td>
-        <td>{% if data.analytic_sha != 0 %} \( {{data.analytic_sha}} \) &nbsp;&nbsp;(rounded) {% else %} unknown {% endif %}</td></tr>
+        <td>{% if data.analytic_sha != 0 %} \( {{data.analytic_sha}} \) &nbsp;&nbsp;{% if data.sha_proved %}(verified) {% else %}(rounded){% endif %} {% else %}unknown{% endif %}</td></tr>
     <tr><td>{{ KNOWL('g2c.has_square_sha', 'Order of &#1064;') }}:</td><td>{{data.has_square_sha}}</td></tr>
 </table>
 </p>

--- a/lmfdb/genus2_curves/web_g2c.py
+++ b/lmfdb/genus2_curves/web_g2c.py
@@ -858,6 +858,7 @@ class WebG2C():
         data['mw_rank_proved'] = curve['mw_rank_proved']
         data['analytic_rank_proved'] = curve['analytic_rank_proved']
         data['hasse_weil_proved'] = curve['hasse_weil_proved']
+        data['sha_proved'] = curve.get('sha_proved',False)
         data['st_group'] = curve['st_group']
         data['st_group_link'] = st_display_knowl(curve['st_label'])
         data['st0_group_name'] = st0_group_name(curve['real_geom_end_alg'])


### PR DESCRIPTION
This PR modifies the display of analytic sha to replace "(rounded)" with "(verified)" when the newly added `sha_proved` column of `g2c_curves` is set to True (which holds for the 97 curves listed in https://github.com/TimoKellerMath/strongBSDgenus2/blob/main/LMFDB-sha-data.txt)