### PR TITLE
Add comment with download link to n=32 transitive groups

### DIFF
--- a/lmfdb/characters/web_character.py
+++ b/lmfdb/characters/web_character.py
@@ -1224,7 +1224,7 @@ class WebDBDirichletOrbit(WebChar, WebDBDirichlet):
         code["character_init"]["comment"] = code["character_init"]["comment"].replace("character", "character orbit")
         for lang in code["character_init"]:
             if lang != "comment":
-                code["character_init"][lang] += code["galois_orbit"][lang] + "\n"
+                code["character_init"][lang] += code["galois_orbit"][lang]
         return code
 
 

--- a/lmfdb/galois_groups/code.yaml
+++ b/lmfdb/galois_groups/code.yaml
@@ -15,6 +15,13 @@ gg:
   oscar: G = transitive_group({n}, {t})
   gap: G := TransitiveGroup({n}, {t});
 
+n32_dbs:
+  comment: Databases for transitive groups of order 32
+  sage: https://www.math.colostate.edu/~hulpke/transgrp/trans32.tgz
+  gap: https://www.math.colostate.edu/~hulpke/transgrp/trans32.tgz
+  magma: https://magma.maths.usyd.edu.au/magma/download/db/TrnGps32.tar.gz
+  oscar: https://www.math.colostate.edu/~hulpke/transgrp/trans32.tgz
+  
 n:
   comment: Degree
   magma: t, n := TransitiveGroupIdentification(G); n;

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -319,7 +319,6 @@ class WebGaloisGroup:
             for lang in n32_dbs:
                 if lang != "comment":
                     self.code['gg'][lang] = f"{comments[lang]} This requires the 32T* database at {n32_dbs[lang]}\n" + self.code['gg'][lang]
-                    print("Name of sage gg key:", self.code['gg']['sage'])
 
 ############  Misc Functions
 

--- a/lmfdb/galois_groups/transitive_group.py
+++ b/lmfdb/galois_groups/transitive_group.py
@@ -309,6 +309,17 @@ class WebGaloisGroup:
             for lang in self.code[prop]:
                 self.code[prop][lang] = self.code[prop][lang].format(**{'n':self.n(), 't':self.t()})
         self.code['show'] = { lang:'' for lang in self.code['prompt'] }
+        # For transitive groups of order 32, the user needs to load an extra package
+        n32_dbs = self.code["n32_dbs"]
+
+        # TODO: Ideally, comment syntax should be resolved automatically in place_code.py, but this is a temporary fix until that is implemented.
+        comments = {'magma': '//', 'sage': '#', 'oscar': '#', 'gap': '#'}
+
+        if self.n() == 32:
+            for lang in n32_dbs:
+                if lang != "comment":
+                    self.code['gg'][lang] = f"{comments[lang]} This requires the 32T* database at {n32_dbs[lang]}\n" + self.code['gg'][lang]
+                    print("Name of sage gg key:", self.code['gg']['sage'])
 
 ############  Misc Functions
 

--- a/lmfdb/groups/abstract/web_groups.py
+++ b/lmfdb/groups/abstract/web_groups.py
@@ -3133,6 +3133,11 @@ class WebAbstractGroup(WebObj):
                     continue
 
                 code[trans][lang] = code["transitive"][lang].format(**trans_data)
+                # Transitive groups of degree 32 require separate database
+                if trans[:2] == "32":
+                    comments = {'magma': '//', 'sage': '#', 'oscar': '#', 'gap': '#', 'sage_gap': '#'}
+                    code[trans][lang] += " " + comments[lang] + " Requires 32T* db, see Galois group page"
+
                 code["transitive_all"][lang] += code[trans][lang]+"\n"
 
         for lang in code['prompt']:

--- a/lmfdb/utils/place_code.py
+++ b/lmfdb/utils/place_code.py
@@ -46,7 +46,9 @@ class CodeSnippet():
         if code[item]:
             for L in code[item]:
                 if isinstance(code[item][L],str):
-                    lines = code[item][L].split('\n')[:-1] if '\n' in code[item][L] else [code[item][L]]
+                    lines = code[item][L].split('\n') if '\n' in code[item][L] else [code[item][L]]
+                    # remove trailing empty line if any
+                    lines = [l for l in lines if l]
                     lines = [line.replace("<", "&lt;").replace(">", "&gt;") for line in lines]
                 else:
                     lines = code[item][L]


### PR DESCRIPTION
Gap currently does not have transitive groups of degree 32. Therefore the code snippets on the pages for these groups will give errors unless the user has installed the relevant databases. 

This PR adds comments with the relevant links to the transitive groups pages, as well as cleans up newline stripping in utils/place_code.py
