### PR TITLE
Fix input/output shuffling in code snippet tests

### DIFF
--- a/.github/workflows/snippet_generate.yml
+++ b/.github/workflows/snippet_generate.yml
@@ -1,6 +1,7 @@
 name: Generate Snippet Code Files
 
 on:
+  workflow_dispatch: {}
   push:
     branches: 
       - main

--- a/lmfdb/tests/generate_snippet_tests.py
+++ b/lmfdb/tests/generate_snippet_tests.py
@@ -4,12 +4,8 @@
 #
 # Author: Håvard Damm-Johnsen <havard-dj@proton.me>
 
-#  NB: Note regarding Magma:
-#  The Magma snippets are evaluated interactively via pexpect.
-#    But since Magma's default prompt "> " also occurs in ordinary output (and in the ">> " markers of error messages),
-#    the prompt is changed to a unique string at startup. See _start_snippet_procs for details.
-#  Some Magma code snippets also require CHIMP (https://github.com/edgarcosta/CHIMP) to be installed.
-#  To install CHIMP and generate the Magma snippet log files with CHIMP, run:
+# Some Magma code snippets also require CHIMP (https://github.com/edgarcosta/CHIMP) to be installed.
+# To install CHIMP and generate the Magma snippet log files with CHIMP, run:
 #    git clone --recurse-submodules -j8 https://github.com/edgarcosta/CHIMP.git ~/CHIMP
 #    sage -python lmfdb/tests/generate_snippet_tests.py generate -o magma --chimp ~/CHIMP
 
@@ -35,7 +31,16 @@ exec_dict = {'sage': 'sage --simple-prompt',
              'gp': "sage -gp -D prompt='gp> ' -D breakloop=0 -D colors='no,no,no,no,no,no,no' -D readline=0 -q",
              'gap': """sage -gap -b -T -r -A -m 256m -o 512m -x 800 -c 'SetUserPreference("UseColorsInTerminal",false); SetUserPreference("UseColorPrompt",false); ColorPrompt(false);'""",
              }
-prompt_dict = {'sage': 'sage:', 'sage_gap': 'sage:', 'magma': 'magma> ', 'oscar': 'julia>', 'gp': 'gp> ', 'gap': 'gap> '}
+prompt_dict = {'sage': 'sage:', 'sage_gap': 'sage:', 'magma': 'magma> ', 'oscar': 'julia> ', 'gp': 'gp> ', 'gap': 'gap> '}
+version_cmd_dict = {
+    "sage": "print(version())",
+    "sage_gap": 'print(gap.eval("GAPInfo.Version"))',
+    "magma": "GetVersion();",
+    "oscar": 'println("Oscar ", Base.pkgversion(Oscar), "; Julia ", VERSION)',
+    "gp": r"\v",
+    "pari": r"\v",
+    "gap": "GAPInfo.Version;",
+}
 
 # Continuation prompts, i.e. what the REPL prints when a statement is left unfinished at the end of a line (e.g. a record or list spanning several lines).
 # Note: Oscar has no continuation prompt, so multi-line Oscar snippets are not yet supported.
@@ -43,6 +48,18 @@ continuation_dict = {'gap': '\n> ', 'magma': 'magma> ', 'sage': '....: ', 'sage_
 
 comment_dict = {'magma': '//', 'sage': '#', 'sage_gap': '#',
                          'gp': '\\\\', 'pari': '\\\\', 'oscar': '#', 'gap': '#'}
+
+# Commands to print a unique token, used by _resync to re-align pexpect with the REPL if it gets out of sync.
+# The token is assembled from pieces by the REPL to prevent the string occuring verbatim
+# in the echo of the command (similarly to the SetPrompt call for Magma above).
+SYNC_TOKEN = 'LMFDB_SYNC_OK'
+sync_cmd_dict = {'sage': 'print("LMFDB" + "_SYNC" + "_OK")',
+                 'sage_gap': 'print("LMFDB" + "_SYNC" + "_OK")',
+                 'magma': 'print "LMFDB" cat "_SYNC" cat "_OK";',
+                 'oscar': 'println("LMFDB" * "_SYNC" * "_OK")',
+                 'gap': 'Print("LMFDB", "_SYNC", "_OK", "\\n");',
+                 'gp': 'print(Str("LMFDB", "_SYNC", "_OK"))',
+                 }
 
 # To ensure output is fully deterministic and the log files don't change between runs,
 # we set the random seed to 1 before each test run
@@ -100,16 +117,26 @@ def _start_snippet_procs(langs, chimp_spec=None):
     processes = {}
     for lang in langs:
         if lang == 'oscar':
-            print("Loading Oscar, this might take a while:")
-            spawn = pexpect.spawn(exec_dict['oscar'], ['-q', '--color=no', '--banner=no'],
-                                  echo=False, env=os.environ | {'TERM':'dumb'},
-                                  encoding="utf8")
+            print("Loading Oscar, this might take a while.")
+            # Ensure that Oscar uses its own Singular, not the system-wide one
+            julia_env = os.environ | {'TERM':'dumb', 'NO_COLOR': '1'}
+            julia_env.pop('SINGULAR_BIN_DIR', None)
+            spawn = pexpect.spawn(exec_dict['oscar'],
+                                  ['-q', '--color=no', '--banner=no'],
+                                  env = julia_env,
+                                  echo=False,
+                                  encoding="utf8",
+                                  )
             # for ease of debugging julia output
             spawn.logfile = sys.stdout
 
             processes['oscar'] = pexpect.replwrap.REPLWrapper(spawn, prompt_dict[lang], None)
             processes['oscar'].run_command('using Pkg; Pkg.add("Oscar"); using Oscar', timeout=60*10)
             # conservative timeout of 10 minutes
+            # _resync since Pkg's output may contain "julia> " 
+            
+            _resync(processes['oscar'], 'oscar', timeout=60*10)
+            spawn.logfile = None
             print("\nOscar loaded")
 
         elif lang == 'magma':
@@ -160,6 +187,23 @@ def _start_snippet_procs(langs, chimp_spec=None):
     return processes
 
 
+def _resync(proc, lang, timeout=60*3):
+    """
+    Resynchronize process 'proc' for language 'lang', using SYNC_TOKEN.
+    Explicitly unsets the logfile to prevent token from being printed, then reattaches it afterwards.
+    """
+    sync_cmd = sync_cmd_dict.get(lang)
+    if sync_cmd is None:
+        return
+    logfile, proc.child.logfile = proc.child.logfile, None
+    try:
+        proc.child.sendline(sync_cmd)
+        proc.child.expect_exact(SYNC_TOKEN, timeout=timeout)
+        proc.child.expect_exact(prompt_dict[lang], timeout=timeout)
+    finally:
+        proc.child.logfile = logfile
+
+
 def _eval_code_file(data, lang, proc, logfile):
     """ Evaluate code in 'data' using process 'proc' in language
     'lang', writing output to 'logfile'.
@@ -181,36 +225,52 @@ def _eval_code_file(data, lang, proc, logfile):
             # Raise error if unable to set the random seed
             raise RuntimeError(f"Error: could not reset random state in {lang} with {seed_cmd!r}") from exc
 
+    # Resync files so a desynchronized REPL does not corrupt
+    # all files evaluated after it.
+    try:
+        _resync(proc, lang)
+    except Exception:
+        print(f"Warning: could not resynchronize {lang} before {logfile}")
+
     with logfile.open('w') as f:
         proc.child.logfile = f
         proc.run_command(cmt + " snippet evaluation file generated by generate_snippet_tests.py")
+        proc.run_command(version_cmd_dict[lang])
 
         for line in lines:
             try:
-                #proc.run_command(line, timeout=60*3)
-
-                # Send 'line' and and check if REPL is left at its continuation prompt, i.e. the statement is unfinished
+                # Send 'line' and wait for either new prompt or continuation prompt
                 proc.child.sendline(line)
                 proc.child.expect_exact(patterns, timeout=60*3)
 
             except Exception:
                 print("Timeout while running line:")
                 print(line)
+                # The REPL may still be busy with the line that timed out; realign before
+                # continuing, otherwise every later line is logged next to the wrong output.
+                try:
+                    _resync(proc, lang)
+                except Exception:
+                    print(f"Warning: could not resynchronize {lang}, "
+                          f"the remainder of {logfile} is unreliable")
 
     proc.child.logfile = None
+    _remove_escape_chars(logfile)
 
+def _remove_escape_chars(logfile):
     # Matches ANSI escape sequences (color codes etc.), see e.g. https://en.wikipedia.org/wiki/ANSI_escape_code
     # E.g. this sometimes occurs in the Gap snippet log files
     ANSI_ESCAPE_RE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
-    # Remove stray ANSI escape sequences from logfile
-    with logfile.open('r') as f:
+    # Remove stray ANSI escape sequences from logfile and normalize newline characters (UNIX style)
+    # set newline='' so "\r\n" is actually read into the string
+    with logfile.open('r', encoding="utf-8", newline='') as f:
         contents = f.read()
-    stripped = ANSI_ESCAPE_RE.sub('', contents)
+    stripped = ANSI_ESCAPE_RE.sub('', contents).replace('\r\n', '\n').replace('\r', '')
     if stripped != contents:
-        with logfile.open('w') as f:
+        with logfile.open('w', encoding="utf-8", newline="\n") as f:
             f.write(stripped)
-
+    
 
 def raise_error_warning(logfile, lang, error_file=None):
     with logfile.open('r') as f:


### PR DESCRIPTION
This is an attempt to fix some of the issues with the snippet test functionality, particularly:
- Input and output occasionally being out-of-order 
- Improved handling of ANSI escape sequences and newline characters
- Explicitly adding version numbers to the snippet test log files

Collaborative effort with @rvisser7 and various (varyingly useful) chatbots.
