### PR TITLE
Small cosmetic tweak to the blue left sidebar

### DIFF
--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -24,7 +24,7 @@
     {%- endif -%}
     {%- if entry.collapsible and entry.part2 -%}
       <span class="collapsible-container">
-        {{entry.url | safe}}
+        {{entry.title | safe}}
 	<div class="collapsible-content">
       {%- for pt2 in entry.part2 -%}
         {%- if not BETA and pt2.status == "notonbeta" -%}
@@ -95,11 +95,8 @@
       $('.collapsible-container').each(function(index) {
           var $container = $(this);
           var $content   = $container.find('.collapsible-content');
-          // Key from the container's own label, excluding the submenu itself.
-          // (The label may be a link, so we cannot just drop all children.)
-          var $label = $container.clone();
-          $label.find('.collapsible-content').remove();
-          var ownText = $.trim($label.text());
+          // Key from the container's OWN text only, excluding child elements
+          var ownText = $.trim($container.clone().children().remove().end().text());
           var key = 'lmfdb_sidebar_entry_' +
               ownText.replace(/\s+/g, '_').substring(0, 30);
           var contentId = 'lmfdb-sidebar-entry-' + index;
@@ -120,8 +117,6 @@
           $container.on('click', function(e) {
               // Let clicks inside the submenu through (links must work)
               if ($(e.target).closest('.collapsible-content').length) return;
-              // Let the parent's own link through as well
-              if ($(e.target).closest('a').length) return;
 
               e.stopPropagation();
               e.preventDefault();

--- a/lmfdb/templates/sidebar.html
+++ b/lmfdb/templates/sidebar.html
@@ -24,7 +24,7 @@
     {%- endif -%}
     {%- if entry.collapsible and entry.part2 -%}
       <span class="collapsible-container">
-        {{entry.title | safe}}
+        {{entry.url | safe}}
 	<div class="collapsible-content">
       {%- for pt2 in entry.part2 -%}
         {%- if not BETA and pt2.status == "notonbeta" -%}
@@ -51,13 +51,13 @@
           {%- for pt3 in pt2.part3 -%}
             {%- if (BETA and pt3.status == 'beta') or not pt3.status -%}
             {%- if pt3.status == "beta" -%}
-            <span class="beta", class="subitem">
+            <span class="beta subitem">
             {%- else -%}
             <span class="subitem">
             {%- endif -%}
-            {%- endif -%}
             {{ pt3.url | safe}}
             </span>
+            {%- endif -%}
           {%- endfor -%}{# for pt3 in pt2.part3 #}
         </div>
       {%- endif -%} {# if pt2.part3 #}
@@ -95,14 +95,17 @@
       $('.collapsible-container').each(function(index) {
           var $container = $(this);
           var $content   = $container.find('.collapsible-content');
-          // Key from the container's OWN text only, excluding child elements
-          var ownText = $.trim($container.clone().children().remove().end().text());
+          // Key from the container's own label, excluding the submenu itself.
+          // (The label may be a link, so we cannot just drop all children.)
+          var $label = $container.clone();
+          $label.find('.collapsible-content').remove();
+          var ownText = $.trim($label.text());
           var key = 'lmfdb_sidebar_entry_' +
               ownText.replace(/\s+/g, '_').substring(0, 30);
           var contentId = 'lmfdb-sidebar-entry-' + index;
           $content.attr('id', contentId);
 
-          var $chev = $('<button type="button" class="collapsible-chevron open"><svg aria-hidden="true" focusable="false" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="3"/></svg></button>');
+          var $chev = $('<button type="button" class="collapsible-chevron open"><svg aria-hidden="true" focusable="false" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="2.5"/></svg></button>');
           $chev.attr('aria-controls', contentId);
           $content.before($chev);
 
@@ -117,6 +120,8 @@
           $container.on('click', function(e) {
               // Let clicks inside the submenu through (links must work)
               if ($(e.target).closest('.collapsible-content').length) return;
+              // Let the parent's own link through as well
+              if ($(e.target).closest('a').length) return;
 
               e.stopPropagation();
               e.preventDefault();
@@ -141,7 +146,7 @@
           $section.attr('id', sectionId);
 
           // Append the chevron into the h2
-          var $chev = $('<button type="button" class="collapsible-chevron open"><svg aria-hidden="true" focusable="false" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="3"/></svg></button>');
+          var $chev = $('<button type="button" class="collapsible-chevron open"><svg aria-hidden="true" focusable="false" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="2.5"/></svg></button>');
           $chev.attr('aria-controls', sectionId);
           $h2.append($chev);
           $h2.css('cursor', 'pointer');

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1699,7 +1699,7 @@ div.maassformplot img {
 
 #sidebar .collapsible-content .subtitle a {
     display: block;
-    padding: 2px 6px;
+    padding: 3px 6px;
 }
 
 #sidebar .section-content {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1610,7 +1610,7 @@ div.maassformplot img {
 
 #sidebar table td a {
     display: block;
-    padding: 2px;
+    padding: 3px 6px;
 }
 
 #sidebar table td .subtitle {
@@ -1641,10 +1641,19 @@ div.maassformplot img {
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    cursor: pointer;
     min-width: 100%;
-    padding-left: 2pt;
-    color: {{color.col_sidebar_header_links}}
+    color: {{color.col_sidebar_links}};
+}
+
+/* The label is a link to the section's own page; let it fill the row so the
+   chevron stays flush right, as in the h2 headings. */
+#sidebar .collapsible-container > a {
+    flex: 1;
+    min-width: 0;
+}
+
+#sidebar .collapsible-container > .collapsible-chevron {
+    color: {{color.col_sidebar_links}};
 }
 
 #sidebar .collapsible-chevron {
@@ -1655,7 +1664,7 @@ div.maassformplot img {
     border: 0;
     border-radius: 0;
     min-width: 0;
-    padding: 0;
+    padding: 2px;
     margin-right: 4px;
     margin-left: auto;
     display: flex;
@@ -1664,8 +1673,8 @@ div.maassformplot img {
 
 
 #sidebar .collapsible-chevron > svg {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     object-fit: contain;
     transform: rotate(0deg);
     transition: transform 0.15s ease;
@@ -1678,8 +1687,8 @@ div.maassformplot img {
 
 #sidebar .collapsible-content {
     flex-basis: 100%;
-    border-left: 2px solid {{color.col_sidebar_header_links}};
-    margin-left: 2px;
+    border-left: 2px solid {{color.col_main_l}};
+    margin-left: 10px;
     margin-top: 2px;
     padding-left: 6px;
 }
@@ -1690,7 +1699,7 @@ div.maassformplot img {
 
 #sidebar .collapsible-content .subtitle a {
     display: block;
-    padding: 2px;
+    padding: 3px 6px;
 }
 
 #sidebar .section-content {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1640,6 +1640,8 @@ div.maassformplot img {
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+    /* border-box, so padding-left does not push the row past its own cell */
+    box-sizing: border-box;
     width: 100%;
     cursor: pointer;
     min-width: 100%;
@@ -1649,6 +1651,9 @@ div.maassformplot img {
 
 #sidebar .collapsible-container > .collapsible-chevron {
     color: {{color.col_sidebar_links}};
+    /* 2px less than the h2 chevron, cancelling the table cell's own padding,
+       so this chevron lines up with the section chevron above it */
+    margin-right: 2px;
 }
 
 #sidebar .collapsible-chevron {

--- a/lmfdb/templates/style.css
+++ b/lmfdb/templates/style.css
@@ -1610,7 +1610,7 @@ div.maassformplot img {
 
 #sidebar table td a {
     display: block;
-    padding: 3px 6px;
+    padding: 2px 6px;
 }
 
 #sidebar table td .subtitle {
@@ -1641,15 +1641,10 @@ div.maassformplot img {
     justify-content: space-between;
     align-items: center;
     width: 100%;
+    cursor: pointer;
     min-width: 100%;
+    padding-left: 6px;
     color: {{color.col_sidebar_links}};
-}
-
-/* The label is a link to the section's own page; let it fill the row so the
-   chevron stays flush right, as in the h2 headings. */
-#sidebar .collapsible-container > a {
-    flex: 1;
-    min-width: 0;
 }
 
 #sidebar .collapsible-container > .collapsible-chevron {
@@ -1664,7 +1659,7 @@ div.maassformplot img {
     border: 0;
     border-radius: 0;
     min-width: 0;
-    padding: 2px;
+    padding: 0;
     margin-right: 4px;
     margin-left: auto;
     display: flex;
@@ -1673,8 +1668,8 @@ div.maassformplot img {
 
 
 #sidebar .collapsible-chevron > svg {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     object-fit: contain;
     transform: rotate(0deg);
     transition: transform 0.15s ease;
@@ -1688,7 +1683,7 @@ div.maassformplot img {
 #sidebar .collapsible-content {
     flex-basis: 100%;
     border-left: 2px solid {{color.col_main_l}};
-    margin-left: 10px;
+    margin-left: 4px;
     margin-top: 2px;
     padding-left: 6px;
 }
@@ -1699,7 +1694,7 @@ div.maassformplot img {
 
 #sidebar .collapsible-content .subtitle a {
     display: block;
-    padding: 3px 6px;
+    padding: 2px 6px;
 }
 
 #sidebar .section-content {


### PR DESCRIPTION
This PR just makes some very small cosmetic tweaks to the blue left sidebar, in particular how the vertical indent guide looks in the collapsible submenus.  I've just shifted the vertical indent guide a small amount to the right, made it a slightly lighter shade of blue, and added 1px of vertical padding in the submenus.

This is certainly a very subjective (and very nitpicky) thing, so please feel free to suggest any changes! :)

E.g. here's a before and after for the "Varieties" section (using Chrome on Windows):

<img width="1039" height="302" alt="image" src="https://github.com/user-attachments/assets/42fc3276-e84b-4317-a2d7-d19093f30710" />



